### PR TITLE
Removing Scenario::getEndTimeNode() and removing TimeProcess getStartState() and getEndState() accessors

### DIFF
--- a/base/plugins/iscore-plugin-js/JS/JSProcess.cpp
+++ b/base/plugins/iscore-plugin-js/JS/JSProcess.cpp
@@ -20,9 +20,7 @@ namespace Executor
 {
 ProcessExecutor::ProcessExecutor(
         const Explorer::DeviceDocumentPlugin& devices):
-    m_devices{devices.list()},
-    m_start{OSSIA::State::create()},
-    m_end{OSSIA::State::create()}
+    m_devices{devices.list()}
 {
     m_engine.globalObject().setProperty("iscore", m_engine.newQObject(new JS::APIWrapper{m_engine, devices}));
 }

--- a/base/plugins/iscore-plugin-js/JS/JSProcess.hpp
+++ b/base/plugins/iscore-plugin-js/JS/JSProcess.hpp
@@ -45,24 +45,10 @@ class ProcessExecutor final :
                 const OSSIA::TimeValue&,
                 const OSSIA::TimeValue&) override;
 
-        const std::shared_ptr<OSSIA::State>& getStartState() const override
-        {
-            return m_start;
-        }
-
-        const std::shared_ptr<OSSIA::State>& getEndState() const override
-        {
-            return m_end;
-        }
-
-
     private:
         const Device::DeviceList& m_devices;
         QJSEngine m_engine;
         QJSValue m_tickFun;
-
-        std::shared_ptr<OSSIA::State> m_start;
-        std::shared_ptr<OSSIA::State> m_end;
 };
 
 

--- a/base/plugins/iscore-plugin-ossia/OSSIA/Executor/ScenarioElement.cpp
+++ b/base/plugins/iscore-plugin-ossia/OSSIA/Executor/ScenarioElement.cpp
@@ -162,10 +162,6 @@ void ScenarioElement::on_timeNodeCreated(const Scenario::TimeNodeModel& tn)
     {
         ossia_tn = ossia_scenario.getStartTimeNode();
     }
-    else if(&tn == &iscore_scenario.endTimeNode())
-    {
-        ossia_tn = ossia_scenario.getEndTimeNode();
-    }
     else
     {
         ossia_tn = OSSIA::TimeNode::create();

--- a/base/plugins/iscore-plugin-ossia/SimpleProcess/SimpleProcess.hpp
+++ b/base/plugins/iscore-plugin-ossia/SimpleProcess/SimpleProcess.hpp
@@ -13,30 +13,13 @@ class TimeConstraint;
 class SimpleProcess : public TimeProcessWithConstraint
 {
     public:
-        SimpleProcess():
-            m_start{OSSIA::State::create()},
-            m_end{OSSIA::State::create()}
-        {
-
-        }
+        SimpleProcess()
+        {}
 
         std::shared_ptr<OSSIA::StateElement> state(
                 const OSSIA::TimeValue&,
                 const OSSIA::TimeValue&) override;
 
-        const std::shared_ptr<OSSIA::State>& getStartState() const override
-        {
-            return m_start;
-        }
-
-        const std::shared_ptr<OSSIA::State>& getEndState() const override
-        {
-            return m_end;
-        }
-
-
     private:
         std::shared_ptr<OSSIA::TimeConstraint> m_constraint;
-        std::shared_ptr<OSSIA::State> m_start;
-        std::shared_ptr<OSSIA::State> m_end;
 };

--- a/base/plugins/iscore-plugin-scenario/Scenario/Document/BaseScenario/BaseScenarioContainer.hpp
+++ b/base/plugins/iscore-plugin-scenario/Scenario/Document/BaseScenario/BaseScenarioContainer.hpp
@@ -19,7 +19,8 @@ class ConstraintModel;
 class EventModel;
 class StateModel;
 class TimeNodeModel;
-class ISCORE_PLUGIN_SCENARIO_EXPORT BaseScenarioContainer : public ScenarioInterface
+class ISCORE_PLUGIN_SCENARIO_EXPORT BaseScenarioContainer :
+        public ScenarioInterface
 {
         ISCORE_SERIALIZE_FRIENDS(BaseScenarioContainer, DataStream)
         ISCORE_SERIALIZE_FRIENDS(BaseScenarioContainer, JSONObject)
@@ -63,7 +64,7 @@ class ISCORE_PLUGIN_SCENARIO_EXPORT BaseScenarioContainer : public ScenarioInter
         ConstraintModel& constraint() const;
 
         TimeNodeModel& startTimeNode() const final override;
-        TimeNodeModel& endTimeNode() const final override;
+        TimeNodeModel& endTimeNode() const;
 
         EventModel& startEvent() const;
         EventModel& endEvent() const;

--- a/base/plugins/iscore-plugin-scenario/Scenario/Process/ScenarioGlobalCommandManager.cpp
+++ b/base/plugins/iscore-plugin-scenario/Scenario/Process/ScenarioGlobalCommandManager.cpp
@@ -48,6 +48,7 @@ void Scenario::clearContentFromSelection(
     cleaner.commit();
 }
 
+
 void Scenario::removeSelection(
         const Scenario::ScenarioModel& scenario,
         iscore::CommandStackFacade& stack)
@@ -56,10 +57,7 @@ void Scenario::removeSelection(
 
     // We have to remove the first / last timenodes / events from the selection.
     erase_if(sel, [&] (auto&& elt) {
-        return elt == &scenario.startEvent()
-            || elt == &scenario.endEvent()
-            || elt == &scenario.startTimeNode()
-            || elt == &scenario.endTimeNode();
+        return elt->id_val() == startId_val();
     });
 
     if(!sel.empty())

--- a/base/plugins/iscore-plugin-scenario/Scenario/Process/ScenarioInterface.hpp
+++ b/base/plugins/iscore-plugin-scenario/Scenario/Process/ScenarioInterface.hpp
@@ -22,17 +22,25 @@ class ISCORE_PLUGIN_SCENARIO_EXPORT ScenarioInterface
         virtual StateModel& state(const Id<StateModel>& stId) const = 0;
 
         virtual TimeNodeModel& startTimeNode() const = 0;
-        virtual TimeNodeModel& endTimeNode() const = 0;
 };
 
+static inline auto startId_val()
+{
+    return 0;
+}
+
+static inline auto endId_val()
+{
+    return 1;
+}
 template<typename T>
 static auto startId()
 {
-    return Id<T>{0};
+    return Id<T>{startId_val()};
 }
 template<typename T>
 static auto endId()
 {
-    return Id<T>{1};
+    return Id<T>{endId_val()};
 }
 }

--- a/base/plugins/iscore-plugin-scenario/Scenario/Process/ScenarioModel.hpp
+++ b/base/plugins/iscore-plugin-scenario/Scenario/Process/ScenarioModel.hpp
@@ -116,10 +116,7 @@ class ISCORE_PLUGIN_SCENARIO_EXPORT ScenarioModel final :
         {
             return timeNodes.at(m_startTimeNodeId);
         }
-        TimeNodeModel& endTimeNode() const override
-        {
-            return timeNodes.at(m_endTimeNodeId);
-        }
+
         EventModel& startEvent() const
         {
             return event(m_startEventId);


### PR DESCRIPTION
as proposed in https://github.com/OSSIA/API/issues/18 I have removed Scenario::getEndTimeNode.

but in the process I've noticed there were also useless accessors for TimeProcess (getStartState() and getEndState()). Those states were added behind the scene to start and end time events when a TimeProcess was added to a TimeCosntraint. but it seems those states was never used in i-score and I'm pretty sure they are useless as it is to the API user to decide what to put into the start and end events.

what do you think @jcelerier and @nvuaille ?
let me know if it is ok to merge feature/api_clean ?
