### PR TITLE
Add libqt5websockets5-dev to Linux dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ Your compiler need to be C++11 compliant (gcc5.x should work).
 
 ## Debian-like systems
 
-    $ sudo apt-get install cmake qtbase5-dev qtdeclarative5-dev qttools5-dev libqt5svg5-dev libboost-dev build-essential g++
+    $ sudo apt-get install cmake qtbase5-dev qtdeclarative5-dev qttools5-dev libqt5svg5-dev libqt5websockets5-dev libboost-dev build-essential g++
     $ mkdir -p build_folder
     $ cd build_folder
     $ cmake path/to/i-score/repo


### PR DESCRIPTION
On my system, I needed to install this to build.
