### PR TITLE
Joystick Device in score

### DIFF
--- a/base/plugins/score-plugin-engine/CMakeLists.txt
+++ b/base/plugins/score-plugin-engine/CMakeLists.txt
@@ -263,6 +263,20 @@ set(AUDIO_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Executor/Dataflow/DataflowClock.cpp"
 )
 
+set(JOYSTICK_HDRS
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickDevice.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickProtocolFactory.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickSpecificSettings.hpp"
+)
+
+set(JOYSTICK_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickDevice.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickProtocolFactory.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Engine/Protocols/Joystick/JoystickSpecificSettingsSerialization.cpp"
+)
+
 add_library(${PROJECT_NAME} ${SRCS} ${HDRS})
 
 if(OSSIA_PROTOCOL_MIDI)
@@ -286,6 +300,11 @@ endif()
 if(OSSIA_PROTOCOL_PHIDGETS)
     target_sources(${PROJECT_NAME} PRIVATE ${PHIDGETS_HDRS} ${PHIDGETS_SRCS})
 endif()
+
+if(OSSIA_PROTOCOL_JOYSTICK)
+    target_sources(${PROJECT_NAME} PRIVATE ${JOYSTICK_HDRS} ${JOYSTICK_SRCS})
+endif()
+
 if(OSSIA_DATAFLOW)
     target_sources(${PROJECT_NAME} PRIVATE ${AUDIO_HDRS} ${AUDIO_SRCS})
 endif()

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
@@ -7,7 +7,7 @@
 
 W_OBJECT_IMPL(Engine::Network::JoystickDevice)
 
-namespace Engine::Netwok {
+namespace Engine::Network {
 
 JoystickDevice::JoystickDevice(const Device::DeviceSettings& settings)
     : OwningDeviceInterface{settings}

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
@@ -1,0 +1,60 @@
+
+#include "JoystickDevice.hpp"
+#include "JoystickSpecificSettings.hpp"
+#include <ossia/network/joystick/joystick_protocol.hpp>
+
+
+W_OBJECT_IMPL(Engine::Network::JoystickDevice)
+
+namespace Engine {
+
+    namespace Network {
+
+        JoystickDevice::JoystickDevice(const Device::DeviceSettings& settings)
+        :   OwningDeviceInterface{settings}
+        {
+            m_capas.canRefreshTree = true;
+            m_capas.canAddNode = false;
+            m_capas.canRemoveNode = false;
+            m_capas.canRenameNode = false;
+            m_capas.canSetProperties = false;
+            m_capas.canSerialize = false;
+        }
+
+        JoystickDevice::~JoystickDevice()
+        {
+        }
+
+        bool JoystickDevice::reconnect()
+        {
+            disconnect();
+
+            try {
+                auto stgs =
+                   settings().deviceSpecificSettings.value<JoystickSpecificSettings>();
+
+                m_dev = std::make_unique<ossia::net::generic_device>(
+                    std::make_unique<ossia::net::joystick_protocol>(
+                        stgs.joystick_id, stgs.joystick_index),
+                        settings().name.toStdString());
+            }
+            catch (...)
+            {
+                SCORE_TODO;
+                std::printf("WALALALALALLALALALALAL\n");
+            }        
+
+            return connected();
+        }
+
+        void JoystickDevice::disconnect()
+        {
+            OwningDeviceInterface::disconnect();
+        }
+
+    }
+
+}
+
+
+

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
@@ -1,59 +1,54 @@
 
 #include "JoystickDevice.hpp"
-#include "JoystickSpecificSettings.hpp"
-#include <ossia/network/joystick/joystick_protocol.hpp>
 
+#include "JoystickSpecificSettings.hpp"
+
+#include <ossia/network/joystick/joystick_protocol.hpp>
 
 W_OBJECT_IMPL(Engine::Network::JoystickDevice)
 
-namespace Engine {
+namespace Engine::Netwok {
 
-    namespace Network {
-
-        JoystickDevice::JoystickDevice(const Device::DeviceSettings& settings)
-        :   OwningDeviceInterface{settings}
-        {
-            m_capas.canRefreshTree = true;
-            m_capas.canAddNode = false;
-            m_capas.canRemoveNode = false;
-            m_capas.canRenameNode = false;
-            m_capas.canSetProperties = false;
-            m_capas.canSerialize = false;
-        }
-
-        JoystickDevice::~JoystickDevice()
-        {
-        }
-
-        bool JoystickDevice::reconnect()
-        {
-            disconnect();
-
-            try {
-                auto stgs =
-                   settings().deviceSpecificSettings.value<JoystickSpecificSettings>();
-
-                m_dev = std::make_unique<ossia::net::generic_device>(
-                    std::make_unique<ossia::net::joystick_protocol>(
-                        stgs.joystick_id, stgs.joystick_index),
-                        settings().name.toStdString());
-            }
-            catch (...)
-            {
-                SCORE_TODO;
-            }        
-
-            return connected();
-        }
-
-        void JoystickDevice::disconnect()
-        {
-            OwningDeviceInterface::disconnect();
-        }
-
-    }
-
+JoystickDevice::JoystickDevice(const Device::DeviceSettings& settings)
+    : OwningDeviceInterface{settings}
+{
+  m_capas.canRefreshTree = true;
+  m_capas.canAddNode = false;
+  m_capas.canRemoveNode = false;
+  m_capas.canRenameNode = false;
+  m_capas.canSetProperties = false;
+  m_capas.canSerialize = false;
 }
 
+JoystickDevice::~JoystickDevice()
+{
+}
 
+bool JoystickDevice::reconnect()
+{
+  disconnect();
 
+  try
+  {
+    auto stgs
+        = settings().deviceSpecificSettings.value<JoystickSpecificSettings>();
+
+    m_dev = std::make_unique<ossia::net::generic_device>(
+        std::make_unique<ossia::net::joystick_protocol>(
+            stgs.joystick_id, stgs.joystick_index),
+        settings().name.toStdString());
+  }
+  catch (...)
+  {
+    SCORE_TODO;
+  }
+
+  return connected();
+}
+
+void JoystickDevice::disconnect()
+{
+  OwningDeviceInterface::disconnect();
+}
+
+}

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.cpp
@@ -41,7 +41,6 @@ namespace Engine {
             catch (...)
             {
                 SCORE_TODO;
-                std::printf("WALALALALALLALALALALAL\n");
             }        
 
             return connected();

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.hpp
@@ -1,19 +1,17 @@
 #pragma once
 #include <Device/Protocol/DeviceInterface.hpp>
 
-namespace Engine {
+namespace Engine::Network {
 
-    namespace Network {
-    
-        class JoystickDevice final : public Device::OwningDeviceInterface
-        {
-            W_OBJECT(JoystickDevice)
-            public:
-                JoystickDevice(const Device::DeviceSettings& settings);
-                ~JoystickDevice();
-                
-                bool reconnect() override;
-                void disconnect() override;
-        };
-    }
+class JoystickDevice final : public Device::OwningDeviceInterface
+{
+  W_OBJECT(JoystickDevice)
+public:
+  JoystickDevice(const Device::DeviceSettings& settings);
+  ~JoystickDevice();
+
+  bool reconnect() override;
+  void disconnect() override;
+};
+
 }

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickDevice.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <Device/Protocol/DeviceInterface.hpp>
+
+namespace Engine {
+
+    namespace Network {
+    
+        class JoystickDevice final : public Device::OwningDeviceInterface
+        {
+            W_OBJECT(JoystickDevice)
+            public:
+                JoystickDevice(const Device::DeviceSettings& settings);
+                ~JoystickDevice();
+                
+                bool reconnect() override;
+                void disconnect() override;
+        };
+    }
+}

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.cpp
@@ -1,0 +1,68 @@
+
+#include "JoystickSpecificSettings.hpp"
+#include "JoystickProtocolFactory.hpp"
+#include "JoystickDevice.hpp"
+#include "JoystickProtocolSettingsWidget.hpp"
+
+#include <QObject>
+
+namespace Engine {
+
+    namespace Network {
+        
+        QString JoystickProtocolFactory::prettyName() const
+        {
+            return QObject::tr("Joystick");
+        }
+
+        Device::DeviceInterface *JoystickProtocolFactory::makeDevice(
+            const Device::DeviceSettings& settings, 
+            const score::DocumentContext& ctx)
+        {
+            std::printf("Creating new JoystickDevice\n");
+            return new JoystickDevice{settings};
+        }
+
+        const Device::DeviceSettings& JoystickProtocolFactory::defaultSettings() const
+        {
+            static const Device::DeviceSettings& settings = [&](){
+                Device::DeviceSettings s;
+                s.protocol = concreteKey();
+                s.name = "Joystick";
+                JoystickSpecificSettings settings;
+                s.deviceSpecificSettings = QVariant::fromValue(settings);
+                return s;
+            }();
+    
+            return settings;
+        }
+
+        Device::ProtocolSettingsWidget *JoystickProtocolFactory::makeSettingsWidget()
+        {
+            return new JoystickProtocolSettingsWidget;
+        }
+
+        QVariant 
+            JoystickProtocolFactory::makeProtocolSpecificSettings(const VisitorVariant& visitor) const 
+        {
+            return makeProtocolSpecificSettings_T<JoystickSpecificSettings>(visitor);
+        }
+
+        void JoystickProtocolFactory::serializeProtocolSpecificSettings(
+                const QVariant& data, const VisitorVariant& visitor) const
+        {
+            serializeProtocolSpecificSettings_T<JoystickSpecificSettings>(data, visitor);
+        }
+
+        bool JoystickProtocolFactory::checkCompatibility(
+            const Device::DeviceSettings& a,
+            const Device::DeviceSettings& b) const
+        {
+            auto a_ = a.deviceSpecificSettings.value<JoystickSpecificSettings>();
+            auto b_ = b.deviceSpecificSettings.value<JoystickSpecificSettings>();
+            return a_.joystick_id != b_.joystick_id;
+        }
+        
+    }
+
+}

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.cpp
@@ -19,7 +19,6 @@ namespace Engine {
             const Device::DeviceSettings& settings, 
             const score::DocumentContext& ctx)
         {
-            std::printf("Creating new JoystickDevice\n");
             return new JoystickDevice{settings};
         }
 

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.cpp
@@ -1,67 +1,62 @@
 
-#include "JoystickSpecificSettings.hpp"
 #include "JoystickProtocolFactory.hpp"
+
 #include "JoystickDevice.hpp"
 #include "JoystickProtocolSettingsWidget.hpp"
+#include "JoystickSpecificSettings.hpp"
 
 #include <QObject>
 
-namespace Engine {
+namespace Engine::Network {
 
-    namespace Network {
-        
-        QString JoystickProtocolFactory::prettyName() const
-        {
-            return QObject::tr("Joystick");
-        }
+QString JoystickProtocolFactory::prettyName() const
+{
+  return QObject::tr("Joystick");
+}
 
-        Device::DeviceInterface *JoystickProtocolFactory::makeDevice(
-            const Device::DeviceSettings& settings, 
-            const score::DocumentContext& ctx)
-        {
-            return new JoystickDevice{settings};
-        }
+Device::DeviceInterface* JoystickProtocolFactory::makeDevice(
+    const Device::DeviceSettings& settings, const score::DocumentContext& ctx)
+{
+  return new JoystickDevice{settings};
+}
 
-        const Device::DeviceSettings& JoystickProtocolFactory::defaultSettings() const
-        {
-            static const Device::DeviceSettings& settings = [&](){
-                Device::DeviceSettings s;
-                s.protocol = concreteKey();
-                s.name = "Joystick";
-                JoystickSpecificSettings settings;
-                s.deviceSpecificSettings = QVariant::fromValue(settings);
-                return s;
-            }();
-    
-            return settings;
-        }
+const Device::DeviceSettings& JoystickProtocolFactory::defaultSettings() const
+{
+  static const Device::DeviceSettings& settings = [&]() {
+    Device::DeviceSettings s;
+    s.protocol = concreteKey();
+    s.name = "Joystick";
+    JoystickSpecificSettings settings;
+    s.deviceSpecificSettings = QVariant::fromValue(settings);
+    return s;
+  }();
 
-        Device::ProtocolSettingsWidget *JoystickProtocolFactory::makeSettingsWidget()
-        {
-            return new JoystickProtocolSettingsWidget;
-        }
+  return settings;
+}
 
-        QVariant 
-            JoystickProtocolFactory::makeProtocolSpecificSettings(const VisitorVariant& visitor) const 
-        {
-            return makeProtocolSpecificSettings_T<JoystickSpecificSettings>(visitor);
-        }
+Device::ProtocolSettingsWidget* JoystickProtocolFactory::makeSettingsWidget()
+{
+  return new JoystickProtocolSettingsWidget;
+}
 
-        void JoystickProtocolFactory::serializeProtocolSpecificSettings(
-                const QVariant& data, const VisitorVariant& visitor) const
-        {
-            serializeProtocolSpecificSettings_T<JoystickSpecificSettings>(data, visitor);
-        }
+QVariant JoystickProtocolFactory::makeProtocolSpecificSettings(
+    const VisitorVariant& visitor) const
+{
+  return makeProtocolSpecificSettings_T<JoystickSpecificSettings>(visitor);
+}
 
-        bool JoystickProtocolFactory::checkCompatibility(
-            const Device::DeviceSettings& a,
-            const Device::DeviceSettings& b) const
-        {
-            auto a_ = a.deviceSpecificSettings.value<JoystickSpecificSettings>();
-            auto b_ = b.deviceSpecificSettings.value<JoystickSpecificSettings>();
-            return a_.joystick_id != b_.joystick_id;
-        }
-        
-    }
+void JoystickProtocolFactory::serializeProtocolSpecificSettings(
+    const QVariant& data, const VisitorVariant& visitor) const
+{
+  serializeProtocolSpecificSettings_T<JoystickSpecificSettings>(data, visitor);
+}
+
+bool JoystickProtocolFactory::checkCompatibility(
+    const Device::DeviceSettings& a, const Device::DeviceSettings& b) const
+{
+  auto a_ = a.deviceSpecificSettings.value<JoystickSpecificSettings>();
+  auto b_ = b.deviceSpecificSettings.value<JoystickSpecificSettings>();
+  return a_.joystick_id != b_.joystick_id;
+}
 
 }

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.hpp
@@ -2,34 +2,31 @@
 
 #include <Engine/Protocols/DefaultProtocolFactory.hpp>
 
-namespace Engine
+namespace Engine::Network {
+
+class JoystickProtocolFactory final : public DefaultProtocolFactory
 {
-    namespace Network {
+  SCORE_CONCRETE("2b9c9f9d-f0fa-41a0-8e7a-0eedd4c48b35")
 
-        class JoystickProtocolFactory final : public DefaultProtocolFactory 
-        {
-            SCORE_CONCRETE("2b9c9f9d-f0fa-41a0-8e7a-0eedd4c48b35") 
+  QString prettyName() const override;
 
-            QString prettyName() const override;
+  Device::DeviceInterface* makeDevice(
+      const Device::DeviceSettings& settings,
+      const score::DocumentContext& ctx) override;
 
-            Device::DeviceInterface *makeDevice(
-                const Device::DeviceSettings& settings,
-                const score::DocumentContext& ctx) override;
+  const Device::DeviceSettings& defaultSettings() const override;
 
-            const Device::DeviceSettings& defaultSettings() const override;
+  Device::ProtocolSettingsWidget* makeSettingsWidget() override;
 
-            Device::ProtocolSettingsWidget* makeSettingsWidget() override;
+  QVariant
+  makeProtocolSpecificSettings(const VisitorVariant& visitor) const override;
 
-            QVariant 
-            makeProtocolSpecificSettings(const VisitorVariant& visitor) const override;
+  void serializeProtocolSpecificSettings(
+      const QVariant& data, const VisitorVariant& visitor) const override;
 
-            void serializeProtocolSpecificSettings(
-                const QVariant& data, const VisitorVariant& visitor) const override;
+  bool checkCompatibility(
+      const Device::DeviceSettings& a,
+      const Device::DeviceSettings& b) const override;
+};
 
-            bool checkCompatibility(
-                const Device::DeviceSettings& a,
-                const Device::DeviceSettings& b) const override;
-        };
-
-    }
-} 
+}

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolFactory.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Engine/Protocols/DefaultProtocolFactory.hpp>
+
+namespace Engine
+{
+    namespace Network {
+
+        class JoystickProtocolFactory final : public DefaultProtocolFactory 
+        {
+            SCORE_CONCRETE("2b9c9f9d-f0fa-41a0-8e7a-0eedd4c48b35") 
+
+            QString prettyName() const override;
+
+            Device::DeviceInterface *makeDevice(
+                const Device::DeviceSettings& settings,
+                const score::DocumentContext& ctx) override;
+
+            const Device::DeviceSettings& defaultSettings() const override;
+
+            Device::ProtocolSettingsWidget* makeSettingsWidget() override;
+
+            QVariant 
+            makeProtocolSpecificSettings(const VisitorVariant& visitor) const override;
+
+            void serializeProtocolSpecificSettings(
+                const QVariant& data, const VisitorVariant& visitor) const override;
+
+            bool checkCompatibility(
+                const Device::DeviceSettings& a,
+                const Device::DeviceSettings& b) const override;
+        };
+
+    }
+} 

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
@@ -1,0 +1,85 @@
+
+#include <QVariant>
+#include <QComboBox>
+#include <QPushButton>
+
+#include <State/Widgets/AddressFragmentLineEdit.hpp>
+
+#include "JoystickProtocolSettingsWidget.hpp"
+#include "JoystickSpecificSettings.hpp"
+
+#include <ossia/network/joystick/joystick_protocol.hpp>
+
+#include <wobjectimpl.h>
+W_OBJECT_IMPL(Engine::Network::JoystickProtocolSettingsWidget)
+
+namespace Engine {
+
+    namespace Network {
+
+        JoystickProtocolSettingsWidget::JoystickProtocolSettingsWidget(QWidget *parent)
+        :   Device::ProtocolSettingsWidget(parent)
+        {
+            m_deviceNameEdit =
+                new State::AddressFragmentLineEdit{this};
+            m_deviceNameEdit->setText("essai");
+
+            m_deviceChoice =
+                    new QComboBox{this};
+
+            auto update_button = new QPushButton{"Update", this};
+
+            auto layout = new QFormLayout;
+            layout->addRow(tr("Device name"), m_deviceNameEdit);
+            layout->addRow(tr("Joystick"), m_deviceChoice);
+            layout->addRow(update_button);
+
+            setLayout(layout);
+
+            connect(
+                update_button,
+                &QAbstractButton::released,
+                this,
+                &JoystickProtocolSettingsWidget::update_device_list);
+
+            update_device_list();
+        }
+
+        JoystickProtocolSettingsWidget::~JoystickProtocolSettingsWidget()
+        {
+            
+        }
+
+        Device::DeviceSettings JoystickProtocolSettingsWidget::getSettings() const
+        {
+            Device::DeviceSettings s;    
+            s.name = m_deviceNameEdit->text();
+
+            const int index = m_deviceChoice->currentIndex();
+            const int32_t id =
+                ossia::net::joystick_protocol::get_joystick_id(index);
+
+            JoystickSpecificSettings settings{id, index};
+            s.deviceSpecificSettings = QVariant::fromValue(settings);
+            return s;
+        }
+        
+        void JoystickProtocolSettingsWidget::setSettings(const Device::DeviceSettings& settings)
+        {
+            m_deviceNameEdit->setText(settings.name);
+        }
+
+        void JoystickProtocolSettingsWidget::update_device_list()
+        {
+            m_deviceChoice->clear();
+
+            const unsigned int joystick_count =
+                ossia::net::joystick_protocol::get_joystick_count();
+
+            for (unsigned int i = 0; i < joystick_count; ++i) {
+                const char *s = ossia::net::joystick_protocol::get_joystick_name(i);
+                m_deviceChoice->addItem(s);
+            }
+        }
+    }
+}

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
@@ -2,7 +2,6 @@
 #include <QVariant>
 #include <QComboBox>
 #include <QPushButton>
-
 #include <State/Widgets/AddressFragmentLineEdit.hpp>
 
 #include "JoystickProtocolSettingsWidget.hpp"
@@ -11,6 +10,7 @@
 #include <ossia/network/joystick/joystick_protocol.hpp>
 
 #include <wobjectimpl.h>
+
 W_OBJECT_IMPL(Engine::Network::JoystickProtocolSettingsWidget)
 
 namespace Engine {
@@ -22,7 +22,7 @@ namespace Engine {
         {
             m_deviceNameEdit =
                 new State::AddressFragmentLineEdit{this};
-            m_deviceNameEdit->setText("essai");
+            m_deviceNameEdit->setText("Joystick");
 
             m_deviceChoice =
                     new QComboBox{this};

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
@@ -1,85 +1,79 @@
 
-#include <QVariant>
-#include <QComboBox>
-#include <QPushButton>
-#include <State/Widgets/AddressFragmentLineEdit.hpp>
-
 #include "JoystickProtocolSettingsWidget.hpp"
+
 #include "JoystickSpecificSettings.hpp"
 
 #include <ossia/network/joystick/joystick_protocol.hpp>
 
+#include <QComboBox>
+#include <QPushButton>
+#include <QVariant>
+#include <State/Widgets/AddressFragmentLineEdit.hpp>
 #include <wobjectimpl.h>
 
 W_OBJECT_IMPL(Engine::Network::JoystickProtocolSettingsWidget)
 
-namespace Engine {
+namespace Engine::Network {
 
-    namespace Network {
+JoystickProtocolSettingsWidget::JoystickProtocolSettingsWidget(QWidget* parent)
+    : Device::ProtocolSettingsWidget(parent)
+{
+  m_deviceNameEdit = new State::AddressFragmentLineEdit{this};
+  m_deviceNameEdit->setText("Joystick");
 
-        JoystickProtocolSettingsWidget::JoystickProtocolSettingsWidget(QWidget *parent)
-        :   Device::ProtocolSettingsWidget(parent)
-        {
-            m_deviceNameEdit =
-                new State::AddressFragmentLineEdit{this};
-            m_deviceNameEdit->setText("Joystick");
+  m_deviceChoice = new QComboBox{this};
 
-            m_deviceChoice =
-                    new QComboBox{this};
+  auto update_button = new QPushButton{"Update", this};
 
-            auto update_button = new QPushButton{"Update", this};
+  auto layout = new QFormLayout;
+  layout->addRow(tr("Device name"), m_deviceNameEdit);
+  layout->addRow(tr("Joystick"), m_deviceChoice);
+  layout->addRow(update_button);
 
-            auto layout = new QFormLayout;
-            layout->addRow(tr("Device name"), m_deviceNameEdit);
-            layout->addRow(tr("Joystick"), m_deviceChoice);
-            layout->addRow(update_button);
+  setLayout(layout);
 
-            setLayout(layout);
+  connect(
+      update_button, &QAbstractButton::released, this,
+      &JoystickProtocolSettingsWidget::update_device_list);
 
-            connect(
-                update_button,
-                &QAbstractButton::released,
-                this,
-                &JoystickProtocolSettingsWidget::update_device_list);
+  update_device_list();
+}
 
-            update_device_list();
-        }
+JoystickProtocolSettingsWidget::~JoystickProtocolSettingsWidget()
+{
+}
 
-        JoystickProtocolSettingsWidget::~JoystickProtocolSettingsWidget()
-        {
-            
-        }
+Device::DeviceSettings JoystickProtocolSettingsWidget::getSettings() const
+{
+  Device::DeviceSettings s;
+  s.name = m_deviceNameEdit->text();
 
-        Device::DeviceSettings JoystickProtocolSettingsWidget::getSettings() const
-        {
-            Device::DeviceSettings s;    
-            s.name = m_deviceNameEdit->text();
+  const int index = m_deviceChoice->currentIndex();
+  const int32_t id = ossia::net::joystick_protocol::get_joystick_id(index);
 
-            const int index = m_deviceChoice->currentIndex();
-            const int32_t id =
-                ossia::net::joystick_protocol::get_joystick_id(index);
+  JoystickSpecificSettings settings{id, index};
+  s.deviceSpecificSettings = QVariant::fromValue(settings);
+  return s;
+}
 
-            JoystickSpecificSettings settings{id, index};
-            s.deviceSpecificSettings = QVariant::fromValue(settings);
-            return s;
-        }
-        
-        void JoystickProtocolSettingsWidget::setSettings(const Device::DeviceSettings& settings)
-        {
-            m_deviceNameEdit->setText(settings.name);
-        }
+void JoystickProtocolSettingsWidget::setSettings(
+    const Device::DeviceSettings& settings)
+{
+  m_deviceNameEdit->setText(settings.name);
+}
 
-        void JoystickProtocolSettingsWidget::update_device_list()
-        {
-            m_deviceChoice->clear();
+void JoystickProtocolSettingsWidget::update_device_list()
+{
+  m_deviceChoice->clear();
 
-            const unsigned int joystick_count =
-                ossia::net::joystick_protocol::get_joystick_count();
+  const unsigned int joystick_count
+      = ossia::net::joystick_protocol::get_joystick_count();
 
-            for (unsigned int i = 0; i < joystick_count; ++i) {
-                const char *s = ossia::net::joystick_protocol::get_joystick_name(i);
-                m_deviceChoice->addItem(s);
-            }
-        }
-    }
+  for (unsigned int i = 0; i < joystick_count; ++i)
+  {
+    const char* s = ossia::net::joystick_protocol::get_joystick_name(i);
+    m_deviceChoice->addItem(s);
+  }
+}
+
 }

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
@@ -23,8 +23,8 @@ public:
   void update_device_list();
 
 protected:
-  QLineEdit* m_deviceNameEdit;
-  QComboBox* m_deviceChoice;
+  QLineEdit* m_deviceNameEdit{};
+  QComboBox* m_deviceChoice{};
 };
 
 }

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
@@ -1,33 +1,30 @@
 #pragma once
 #include <Device/Protocol/DeviceSettings.hpp>
-#include <wobjectdefs.h>
 #include <Device/Protocol/ProtocolSettingsWidget.hpp>
+#include <wobjectdefs.h>
 
 class QLineEdit;
 class QComboBox;
 
-namespace Engine {
+namespace Engine::Network {
 
-    namespace Network {
+class JoystickProtocolSettingsWidget final
+    : public Device::ProtocolSettingsWidget
+{
+  W_OBJECT(JoystickProtocolSettingsWidget)
 
-        class JoystickProtocolSettingsWidget final : 
-            public Device::ProtocolSettingsWidget 
-        {
-            W_OBJECT(JoystickProtocolSettingsWidget)
+public:
+  JoystickProtocolSettingsWidget(QWidget* parent = nullptr);
+  virtual ~JoystickProtocolSettingsWidget();
+  Device::DeviceSettings getSettings() const override;
+  void setSettings(const Device::DeviceSettings& settings) override;
 
-            public:
-                JoystickProtocolSettingsWidget(QWidget *parent = nullptr);
-                virtual ~JoystickProtocolSettingsWidget();
-                Device::DeviceSettings getSettings() const override;
-                void setSettings(const Device::DeviceSettings& settings) override;
+public:
+  void update_device_list();
 
-            public:
-                void update_device_list();
+protected:
+  QLineEdit* m_deviceNameEdit;
+  QComboBox* m_deviceChoice;
+};
 
-            protected:
-                QLineEdit *m_deviceNameEdit;
-                QComboBox *m_deviceChoice;
-
-        };
-    }
 }

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
@@ -25,7 +25,6 @@ namespace Engine {
                 void update_device_list();
 
             protected:
-
                 QLineEdit *m_deviceNameEdit;
                 QComboBox *m_deviceChoice;
 

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickProtocolSettingsWidget.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <Device/Protocol/DeviceSettings.hpp>
+#include <wobjectdefs.h>
+#include <Device/Protocol/ProtocolSettingsWidget.hpp>
+
+class QLineEdit;
+class QComboBox;
+
+namespace Engine {
+
+    namespace Network {
+
+        class JoystickProtocolSettingsWidget final : 
+            public Device::ProtocolSettingsWidget 
+        {
+            W_OBJECT(JoystickProtocolSettingsWidget)
+
+            public:
+                JoystickProtocolSettingsWidget(QWidget *parent = nullptr);
+                virtual ~JoystickProtocolSettingsWidget();
+                Device::DeviceSettings getSettings() const override;
+                void setSettings(const Device::DeviceSettings& settings) override;
+
+            public:
+                void update_device_list();
+
+            protected:
+
+                QLineEdit *m_deviceNameEdit;
+                QComboBox *m_deviceChoice;
+
+        };
+    }
+}

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettings.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettings.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QMetaType>
+#include <wobjectdefs.h>
+
+namespace Engine {
+
+    namespace Network {
+
+        struct JoystickSpecificSettings {
+            int32_t joystick_id;
+            int joystick_index;
+        };
+    }
+}
+
+Q_DECLARE_METATYPE(Engine::Network::JoystickSpecificSettings)
+W_REGISTER_ARGTYPE(Engine::Network::JoystickSpecificSettings)

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettings.hpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettings.hpp
@@ -3,15 +3,14 @@
 #include <QMetaType>
 #include <wobjectdefs.h>
 
-namespace Engine {
+namespace Engine::Network {
 
-    namespace Network {
+struct JoystickSpecificSettings
+{
+  int32_t joystick_id;
+  int32_t joystick_index;
+};
 
-        struct JoystickSpecificSettings {
-            int32_t joystick_id;
-            int joystick_index;
-        };
-    }
 }
 
 Q_DECLARE_METATYPE(Engine::Network::JoystickSpecificSettings)

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettingsSerialization.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettingsSerialization.cpp
@@ -7,8 +7,6 @@
 #include <score/serialization/DataStreamVisitor.hpp>
 #include <score/serialization/JSONVisitor.hpp>
 
-
-
 template <>
 void DataStreamReader::read(const Engine::Network::JoystickSpecificSettings& n)
 {
@@ -24,11 +22,9 @@ void DataStreamWriter::write(Engine::Network::JoystickSpecificSettings& n)
 template <>
 void JSONObjectReader::read(const Engine::Network::JoystickSpecificSettings& n)
 {
-
 }
 
 template <>
 void JSONObjectWriter::write(Engine::Network::JoystickSpecificSettings& n)
 {
-
 }

--- a/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettingsSerialization.cpp
+++ b/base/plugins/score-plugin-engine/Engine/Protocols/Joystick/JoystickSpecificSettingsSerialization.cpp
@@ -1,0 +1,34 @@
+
+#include "JoystickSpecificSettings.hpp"
+
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QString>
+#include <score/serialization/DataStreamVisitor.hpp>
+#include <score/serialization/JSONVisitor.hpp>
+
+
+
+template <>
+void DataStreamReader::read(const Engine::Network::JoystickSpecificSettings& n)
+{
+  insertDelimiter();
+}
+
+template <>
+void DataStreamWriter::write(Engine::Network::JoystickSpecificSettings& n)
+{
+  checkDelimiter();
+}
+
+template <>
+void JSONObjectReader::read(const Engine::Network::JoystickSpecificSettings& n)
+{
+
+}
+
+template <>
+void JSONObjectWriter::write(Engine::Network::JoystickSpecificSettings& n)
+{
+
+}

--- a/base/plugins/score-plugin-engine/score_plugin_engine.cpp
+++ b/base/plugins/score-plugin-engine/score_plugin_engine.cpp
@@ -59,6 +59,9 @@
 #if defined(OSSIA_PROTOCOL_PHIDGETS)
 #  include <Engine/Protocols/Phidgets/PhidgetsProtocolFactory.hpp>
 #endif
+#if defined(OSSIA_PROTOCOL_JOYSTICK)
+#  include <Engine/Protocols/Joystick/JoystickProtocolFactory.hpp>
+#endif
 
 #include <Engine/Executor/Dataflow/DataflowClock.hpp>
 #include <Engine/Protocols/Audio/AudioDevice.hpp>
@@ -148,6 +151,10 @@ score_plugin_engine::factories(
 #if defined(OSSIA_PROTOCOL_AUDIO)
          ,
          Dataflow::AudioProtocolFactory
+#endif
+#if defined(OSSIA_PROTOCOL_JOYSTICK)
+        ,
+        Network::JoystickProtocolFactory
 #endif
          >,
       FW<Engine::Execution::ProcessComponentFactory,


### PR DESCRIPTION

Here is the Joystick device integration in Score, using the Ossia Joystick Protocol. 

This is working well excepted that removing a joystick device often lead to a 'Resource deadlock avoided' exception.  It append before the protocol destructor, when the parameters are destroyed, whereas there are not used anymore at this time (because of the protocol::stop function implementation). I am still looking for the cause of this bug.

This protocol is not serialized for now because I use an instance Joystick ID which is just valid for a score session. I have seen that SDL can provide a GUID for a Joystick but I wonder if it would make sense to save a score that work only with one specific Joystick.

