### PR TITLE
Artnet DMX integration

### DIFF
--- a/base/plugins/score-plugin-engine/CMakeLists.txt
+++ b/base/plugins/score-plugin-engine/CMakeLists.txt
@@ -273,6 +273,20 @@ set(WIIMOTE_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Wiimote/WiimoteSpecificSettingsSerialization.cpp"
 )
 
+set(ARTNET_HDRS
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetDevice.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetProtocolFactory.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetProtocolSettingsWidget.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetSpecificSettings.hpp"
+)
+
+set(ARTNET_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetDevice.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetProtocolFactory.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetProtocolSettingsWidget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Artnet/ArtnetSpecificSettingsSerialization.cpp"
+)
+
 add_library(${PROJECT_NAME} ${SRCS} ${HDRS})
 
 if(OSSIA_PROTOCOL_OSC)
@@ -317,6 +331,11 @@ endif()
 
 if(OSSIA_PROTOCOL_WIIMOTE)
     target_sources(${PROJECT_NAME} PRIVATE ${WIIMOTE_HDRS} ${WIIMOTE_SRCS})
+endif()
+
+
+if(OSSIA_PROTOCOL_ARTNET)
+    target_sources(${PROJECT_NAME} PRIVATE ${ARTNET_HDRS} ${ARTNET_SRCS})
 endif()
 
 if(OSSIA_PROTOCOL_AUDIO)

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.cpp
@@ -1,0 +1,54 @@
+
+#include "ArtnetDevice.hpp"
+#include "ArtnetSpecificSettings.hpp"
+#include <ossia/network/artnet/artnet_protocol.hpp>
+
+
+W_OBJECT_IMPL(Engine::Network::ArtnetDevice)
+
+namespace Engine::Network {
+
+ArtnetDevice::ArtnetDevice(const Device::DeviceSettings& settings)
+    : OwningDeviceInterface{settings}
+{
+  m_capas.canRefreshTree = true;
+  m_capas.canAddNode = false;
+  m_capas.canRemoveNode = false;
+  m_capas.canRenameNode = false;
+  m_capas.canSetProperties = false;
+  m_capas.canSerialize = false;
+}
+
+ArtnetDevice::~ArtnetDevice()
+{
+}
+
+bool ArtnetDevice::reconnect()
+{
+    disconnect();
+  
+    try
+    {
+        auto addr =
+            std::make_unique<ossia::net::generic_device>(
+                std::make_unique<ossia::net::artnet_protocol>(false),
+                settings().name.toStdString());
+        m_dev = std::move(addr);
+        deviceChanged(nullptr, m_dev.get());
+    }
+    catch (...)
+    {
+      SCORE_TODO;
+    }
+
+
+  return connected();
+}
+
+void ArtnetDevice::disconnect()
+{
+  OwningDeviceInterface::disconnect();
+}
+
+
+}

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.cpp
@@ -1,12 +1,15 @@
 
 #include "ArtnetDevice.hpp"
-#include "ArtnetSpecificSettings.hpp"
-#include <ossia/network/artnet/artnet_protocol.hpp>
 
+#include "ArtnetSpecificSettings.hpp"
+
+#include <ossia/network/artnet/artnet_protocol.hpp>
+#include <ossia/network/generic/generic_device.hpp>
 
 W_OBJECT_IMPL(Engine::Network::ArtnetDevice)
 
-namespace Engine::Network {
+namespace Engine::Network
+{
 
 ArtnetDevice::ArtnetDevice(const Device::DeviceSettings& settings)
     : OwningDeviceInterface{settings}
@@ -25,22 +28,21 @@ ArtnetDevice::~ArtnetDevice()
 
 bool ArtnetDevice::reconnect()
 {
-    disconnect();
-  
-    try
-    {
-        auto addr =
-            std::make_unique<ossia::net::generic_device>(
-                std::make_unique<ossia::net::artnet_protocol>(40),  //  40 Hz update rate
-                settings().name.toStdString());
-        m_dev = std::move(addr);
-        deviceChanged(nullptr, m_dev.get());
-    }
-    catch (...)
-    {
-      SCORE_TODO;
-    }
+  disconnect();
 
+  try
+  {
+    auto addr = std::make_unique<ossia::net::generic_device>(
+        std::make_unique<ossia::net::artnet_protocol>(
+            20), //  20 Hz update rate : TODO add control on widget
+        settings().name.toStdString());
+    m_dev = std::move(addr);
+    deviceChanged(nullptr, m_dev.get());
+  }
+  catch (...)
+  {
+    SCORE_TODO;
+  }
 
   return connected();
 }
@@ -49,6 +51,4 @@ void ArtnetDevice::disconnect()
 {
   OwningDeviceInterface::disconnect();
 }
-
-
 }

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.cpp
@@ -31,7 +31,7 @@ bool ArtnetDevice::reconnect()
     {
         auto addr =
             std::make_unique<ossia::net::generic_device>(
-                std::make_unique<ossia::net::artnet_protocol>(false),
+                std::make_unique<ossia::net::artnet_protocol>(40),  //  40 Hz update rate
                 settings().name.toStdString());
         m_dev = std::move(addr);
         deviceChanged(nullptr, m_dev.get());

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <Device/Protocol/DeviceInterface.hpp>
+
+namespace Engine::Network {
+
+
+class ArtnetDevice final : public Device::OwningDeviceInterface
+{
+
+  W_OBJECT(ArtnetDevice)
+public:
+  ArtnetDevice(const Device::DeviceSettings& settings);
+  ~ArtnetDevice();
+
+  bool reconnect() override;
+  void disconnect() override;
+};
+
+}

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetDevice.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <Device/Protocol/DeviceInterface.hpp>
 
-namespace Engine::Network {
-
+namespace Engine::Network
+{
 
 class ArtnetDevice final : public Device::OwningDeviceInterface
 {
@@ -15,5 +15,4 @@ public:
   bool reconnect() override;
   void disconnect() override;
 };
-
 }

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.cpp
@@ -1,0 +1,60 @@
+
+#include "ArtnetProtocolFactory.hpp"
+
+#include "ArtnetDevice.hpp"
+#include "ArtnetProtocolSettingsWidget.hpp"
+#include "ArtnetSpecificSettings.hpp"
+
+#include <QObject>
+
+namespace Engine::Network {
+
+QString ArtnetProtocolFactory::prettyName() const
+{
+  return QObject::tr("Artnet");
+}
+
+Device::DeviceInterface* ArtnetProtocolFactory::makeDevice(
+    const Device::DeviceSettings& settings, const score::DocumentContext& ctx)
+{
+  return new ArtnetDevice{settings};
+}
+
+const Device::DeviceSettings& ArtnetProtocolFactory::defaultSettings() const
+{
+  static const Device::DeviceSettings& settings = [&]() {
+    Device::DeviceSettings s;
+    s.protocol = concreteKey();
+    s.name = "Artnet";
+    ArtnetSpecificSettings settings;
+    s.deviceSpecificSettings = QVariant::fromValue(settings);
+    return s;
+  }();
+
+  return settings;
+}
+
+Device::ProtocolSettingsWidget* ArtnetProtocolFactory::makeSettingsWidget()
+{
+  return new ArtnetProtocolSettingsWidget;
+}
+
+QVariant ArtnetProtocolFactory::makeProtocolSpecificSettings(
+    const VisitorVariant& visitor) const
+{
+  return makeProtocolSpecificSettings_T<ArtnetSpecificSettings>(visitor);
+}
+
+void ArtnetProtocolFactory::serializeProtocolSpecificSettings(
+    const QVariant& data, const VisitorVariant& visitor) const
+{
+  serializeProtocolSpecificSettings_T<ArtnetSpecificSettings>(data, visitor);
+}
+
+bool ArtnetProtocolFactory::checkCompatibility(
+    const Device::DeviceSettings& a, const Device::DeviceSettings& b) const
+{
+  return false; //  TODO
+}
+
+}

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.cpp
@@ -7,7 +7,8 @@
 
 #include <QObject>
 
-namespace Engine::Network {
+namespace Engine::Network
+{
 
 QString ArtnetProtocolFactory::prettyName() const
 {
@@ -56,5 +57,4 @@ bool ArtnetProtocolFactory::checkCompatibility(
 {
   return false; //  TODO
 }
-
 }

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.hpp
@@ -2,7 +2,8 @@
 
 #include <Protocols/DefaultProtocolFactory.hpp>
 
-namespace Engine::Network {
+namespace Engine::Network
+{
 
 class ArtnetProtocolFactory final : public DefaultProtocolFactory
 {
@@ -28,5 +29,4 @@ class ArtnetProtocolFactory final : public DefaultProtocolFactory
       const Device::DeviceSettings& a,
       const Device::DeviceSettings& b) const override;
 };
-
 }

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolFactory.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Protocols/DefaultProtocolFactory.hpp>
+
+namespace Engine::Network {
+
+class ArtnetProtocolFactory final : public DefaultProtocolFactory
+{
+  SCORE_CONCRETE("1c199b75-8052-4d5b-9f85-1b2b0d7e26a9")
+
+  QString prettyName() const override;
+
+  Device::DeviceInterface* makeDevice(
+      const Device::DeviceSettings& settings,
+      const score::DocumentContext& ctx) override;
+
+  const Device::DeviceSettings& defaultSettings() const override;
+
+  Device::ProtocolSettingsWidget* makeSettingsWidget() override;
+
+  QVariant
+  makeProtocolSpecificSettings(const VisitorVariant& visitor) const override;
+
+  void serializeProtocolSpecificSettings(
+      const QVariant& data, const VisitorVariant& visitor) const override;
+
+  bool checkCompatibility(
+      const Device::DeviceSettings& a,
+      const Device::DeviceSettings& b) const override;
+};
+
+}

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.cpp
@@ -1,17 +1,18 @@
 
 #include "ArtnetProtocolSettingsWidget.hpp"
+
 #include "ArtnetSpecificSettings.hpp"
+
+#include <State/Widgets/AddressFragmentLineEdit.hpp>
 
 #include <QVariant>
 
-#include <State/Widgets/AddressFragmentLineEdit.hpp>
 #include <wobjectimpl.h>
-
-
 
 W_OBJECT_IMPL(Engine::Network::ArtnetProtocolSettingsWidget)
 
-namespace Engine::Network {
+namespace Engine::Network
+{
 
 ArtnetProtocolSettingsWidget::ArtnetProtocolSettingsWidget(QWidget* parent)
     : Device::ProtocolSettingsWidget(parent)
@@ -36,7 +37,7 @@ Device::DeviceSettings ArtnetProtocolSettingsWidget::getSettings() const
 
   ArtnetSpecificSettings settings{};
   s.deviceSpecificSettings = QVariant::fromValue(settings);
-  
+
   return s;
 }
 
@@ -45,5 +46,4 @@ void ArtnetProtocolSettingsWidget::setSettings(
 {
   m_deviceNameEdit->setText(settings.name);
 }
-
 }

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.cpp
@@ -1,0 +1,49 @@
+
+#include "ArtnetProtocolSettingsWidget.hpp"
+#include "ArtnetSpecificSettings.hpp"
+
+#include <QVariant>
+
+#include <State/Widgets/AddressFragmentLineEdit.hpp>
+#include <wobjectimpl.h>
+
+
+
+W_OBJECT_IMPL(Engine::Network::ArtnetProtocolSettingsWidget)
+
+namespace Engine::Network {
+
+ArtnetProtocolSettingsWidget::ArtnetProtocolSettingsWidget(QWidget* parent)
+    : Device::ProtocolSettingsWidget(parent)
+{
+  m_deviceNameEdit = new State::AddressFragmentLineEdit{this};
+  m_deviceNameEdit->setText("Artnet");
+
+  auto layout = new QFormLayout;
+  layout->addRow(tr("Device name"), m_deviceNameEdit);
+
+  setLayout(layout);
+}
+
+ArtnetProtocolSettingsWidget::~ArtnetProtocolSettingsWidget()
+{
+}
+
+Device::DeviceSettings ArtnetProtocolSettingsWidget::getSettings() const
+{
+  Device::DeviceSettings s;
+  s.name = m_deviceNameEdit->text();
+
+  ArtnetSpecificSettings settings{};
+  s.deviceSpecificSettings = QVariant::fromValue(settings);
+  
+  return s;
+}
+
+void ArtnetProtocolSettingsWidget::setSettings(
+    const Device::DeviceSettings& settings)
+{
+  m_deviceNameEdit->setText(settings.name);
+}
+
+}

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.hpp
@@ -1,12 +1,14 @@
 #pragma once
 #include <Device/Protocol/DeviceSettings.hpp>
 #include <Device/Protocol/ProtocolSettingsWidget.hpp>
+
 #include <wobjectdefs.h>
 
 class QLineEdit;
 class QComboBox;
 
-namespace Engine::Network {
+namespace Engine::Network
+{
 
 class ArtnetProtocolSettingsWidget final
     : public Device::ProtocolSettingsWidget
@@ -22,5 +24,4 @@ public:
 protected:
   QLineEdit* m_deviceNameEdit{};
 };
-
 }

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetProtocolSettingsWidget.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <Device/Protocol/DeviceSettings.hpp>
+#include <Device/Protocol/ProtocolSettingsWidget.hpp>
+#include <wobjectdefs.h>
+
+class QLineEdit;
+class QComboBox;
+
+namespace Engine::Network {
+
+class ArtnetProtocolSettingsWidget final
+    : public Device::ProtocolSettingsWidget
+{
+  W_OBJECT(ArtnetProtocolSettingsWidget)
+
+public:
+  ArtnetProtocolSettingsWidget(QWidget* parent = nullptr);
+  virtual ~ArtnetProtocolSettingsWidget();
+  Device::DeviceSettings getSettings() const override;
+  void setSettings(const Device::DeviceSettings& settings) override;
+
+protected:
+  QLineEdit* m_deviceNameEdit{};
+};
+
+}

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettings.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettings.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <QMetaType>
+
 #include <wobjectdefs.h>
 
-namespace Engine::Network {
+namespace Engine::Network
+{
 
 struct ArtnetSpecificSettings
 {
   int dummy;
 };
-
 }
 
 Q_DECLARE_METATYPE(Engine::Network::ArtnetSpecificSettings)

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettings.hpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettings.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QMetaType>
+#include <wobjectdefs.h>
+
+namespace Engine::Network {
+
+struct ArtnetSpecificSettings
+{
+  int dummy;
+};
+
+}
+
+Q_DECLARE_METATYPE(Engine::Network::ArtnetSpecificSettings)
+W_REGISTER_ARGTYPE(Engine::Network::ArtnetSpecificSettings)

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettingsSerialization.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettingsSerialization.cpp
@@ -1,0 +1,29 @@
+#include "ArtnetSpecificSettings.hpp"
+
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QString>
+#include <score/serialization/DataStreamVisitor.hpp>
+#include <score/serialization/JSONVisitor.hpp>
+
+template <>
+void DataStreamReader::read(const Engine::Network::ArtnetSpecificSettings& n)
+{
+  insertDelimiter();
+}
+
+template <>
+void DataStreamWriter::write(Engine::Network::ArtnetSpecificSettings& n)
+{
+  checkDelimiter();
+}
+
+template <>
+void JSONObjectReader::read(const Engine::Network::ArtnetSpecificSettings& n)
+{
+}
+
+template <>
+void JSONObjectWriter::write(Engine::Network::ArtnetSpecificSettings& n)
+{
+}

--- a/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettingsSerialization.cpp
+++ b/base/plugins/score-plugin-engine/Protocols/Artnet/ArtnetSpecificSettingsSerialization.cpp
@@ -1,10 +1,11 @@
 #include "ArtnetSpecificSettings.hpp"
 
+#include <score/serialization/DataStreamVisitor.hpp>
+#include <score/serialization/JSONVisitor.hpp>
+
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QString>
-#include <score/serialization/DataStreamVisitor.hpp>
-#include <score/serialization/JSONVisitor.hpp>
 
 template <>
 void DataStreamReader::read(const Engine::Network::ArtnetSpecificSettings& n)

--- a/base/plugins/score-plugin-engine/score_plugin_engine.cpp
+++ b/base/plugins/score-plugin-engine/score_plugin_engine.cpp
@@ -67,7 +67,7 @@
 #  include <Protocols/Wiimote/WiimoteProtocolFactory.hpp>
 #endif
 #if defined(OSSIA_PROTOCOL_ARTNET)
-#  include <Protocols/Wiimote/ArtnetProtocolFactory.hpp>
+#  include <Protocols/Artnet/ArtnetProtocolFactory.hpp>
 #endif
 
 #include <Protocols/Audio/AudioDevice.hpp>

--- a/base/plugins/score-plugin-engine/score_plugin_engine.cpp
+++ b/base/plugins/score-plugin-engine/score_plugin_engine.cpp
@@ -66,6 +66,9 @@
 #if defined(OSSIA_PROTOCOL_WIIMOTE)
 #  include <Protocols/Wiimote/WiimoteProtocolFactory.hpp>
 #endif
+#if defined(OSSIA_PROTOCOL_ARTNET)
+#  include <Protocols/Wiimote/ArtnetProtocolFactory.hpp>
+#endif
 
 #include <Protocols/Audio/AudioDevice.hpp>
 
@@ -160,6 +163,10 @@ score_plugin_engine::factories(
 #if defined(OSSIA_PROTOCOL_WIIMOTE)
         ,
         Network::WiimoteProtocolFactory
+#endif
+#if defined(OSSIA_PROTOCOL_ARTNET)
+        ,
+        Network::ArtnetProtocolFactory
 #endif
          >,
 


### PR DESCRIPTION
The DMX implementation being basic, the only setting is the device name and there is no serialization.
It is a base work for future enhancement.