### PR TITLE
necessary deletion

### DIFF
--- a/base/lib/core/document/Document.cpp
+++ b/base/lib/core/document/Document.cpp
@@ -26,10 +26,6 @@ class Selection;
 W_OBJECT_IMPL(score::Document)
 namespace score
 {
-DocumentContext DocumentContext::fromDocument(Document& d)
-{
-  return score::DocumentContext{d};
-}
 
 DocumentContext::DocumentContext(Document& d)
     : app{score::GUIAppContext()}


### PR DESCRIPTION
I was had a little error in the last build

```
score/base/lib/core/document/Document.cpp:29:58: error: no ‘score::DocumentContext score::DocumentContext::fromDocument(score::Document&)’ member function declared in class ‘score::DocumentContext’
 DocumentContext DocumentContext::fromDocument(Document& d)
``` 

And it seemed that these couple lines where doubling up with the following few.
builds fine on Ubuntu 18.04 with this tiny deletion.
