### PR TITLE
MIDI Pitch in Midi categorie

### DIFF
--- a/base/plugins/score-plugin-fx/Fx/MidiUtil.hpp
+++ b/base/plugins/score-plugin-fx/Fx/MidiUtil.hpp
@@ -379,7 +379,7 @@ struct Node
   {
     static const constexpr auto prettyName = "MIDI Pitch";
     static const constexpr auto objectKey = "PitchToValue";
-    static const constexpr auto category = "MIDI";
+    static const constexpr auto category = "Midi";
     static const constexpr auto author = "ossia score";
     static const constexpr auto kind = Process::ProcessCategory::MidiEffect;
     static const constexpr auto description = "Extract a MIDI pitch";


### PR DESCRIPTION
Tiniest clean-up.
Midi Pitch had it's own metadata category.
Here it is in the same category as all other midi processes.