### PR TITLE
Joystick & wiimote support as default

### DIFF
--- a/base/plugins/score-plugin-scenario/Scenario/Settings/ScenarioSettingsModel.cpp
+++ b/base/plugins/score-plugin-scenario/Scenario/Settings/ScenarioSettingsModel.cpp
@@ -26,7 +26,7 @@ SETTINGS_PARAMETER_IMPL(DefaultDuration){
 SETTINGS_PARAMETER_IMPL(SnapshotOnCreate){
     QStringLiteral("Scenario/SnapshotOnCreate"), false};
 SETTINGS_PARAMETER_IMPL(AutoSequence){QStringLiteral("Scenario/AutoSequence"),
-                                      true};
+                                      false};
 SETTINGS_PARAMETER_IMPL(TimeBar){QStringLiteral("Scenario/TimeBar"), true};
 
 static auto list()


### PR DESCRIPTION
Since Joystick and wiimote support where actually more tested than atnet (witch already builds by default), maybe it would be good to add them to the default config.

If it is only to make sure that it continues to build with future commits.

This is just a suggestion.