### PR TITLE
added XYZSlider widget

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -259,6 +259,7 @@ set(HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsSliderBase.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsToggle.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsXYChooser.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsXYZChooser.hpp"
 
     "${CMAKE_CURRENT_SOURCE_DIR}/score/widgets/ClearLayout.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/widgets/ComboBox.hpp"
@@ -421,6 +422,7 @@ set(SRCS
 "${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsSlider.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsToggle.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsXYChooser.cpp"
+"${CMAKE_CURRENT_SOURCE_DIR}/score/graphics/widgets/QGraphicsXYZChooser.cpp"
 
 
 "${CMAKE_CURRENT_SOURCE_DIR}/score/widgets/ClearLayout.cpp"

--- a/src/lib/score/graphics/GraphicWidgets.hpp
+++ b/src/lib/score/graphics/GraphicWidgets.hpp
@@ -18,3 +18,4 @@
 #include <score/graphics/widgets/QGraphicsSliderBase.hpp>
 #include <score/graphics/widgets/QGraphicsToggle.hpp>
 #include <score/graphics/widgets/QGraphicsXYChooser.hpp>
+#include <score/graphics/widgets/QGraphicsXYZChooser.hpp>

--- a/src/lib/score/graphics/widgets/QGraphicsXYZChooser.cpp
+++ b/src/lib/score/graphics/widgets/QGraphicsXYZChooser.cpp
@@ -14,14 +14,10 @@ namespace score
 {
 
 QGraphicsXYZChooser::QGraphicsXYZChooser(QGraphicsItem* parent)
-  : m_min{0.f, 0.f, 0.f}
-  , m_max{1.f, 1.f, 1.f}
 {
   auto& skin = score::Skin::instance();
   setCursor(skin.CursorPointingHand);
-  prev_v[0] = 0.f;
-  prev_v[1] = 0.f;
-  prev_v[2] = 0.f;
+  setRange();
 }
 
 void QGraphicsXYZChooser::paint(
@@ -69,6 +65,9 @@ void QGraphicsXYZChooser::setRange(ossia::vec3f min, ossia::vec3f max)
 {
   m_min = min;
   m_max = max;
+  prev_v[0] = (m_value[0] - m_min[0]) / (m_max[0] - m_min[0]);
+  prev_v[1] = (m_value[1] - m_min[2]) / (m_max[1] - m_min[1]);
+  prev_v[2] = (m_value[2] - m_min[2]) / (m_max[2] - m_min[2]);
 }
 
 void QGraphicsXYZChooser::mousePressEvent(QGraphicsSceneMouseEvent* event)

--- a/src/lib/score/graphics/widgets/QGraphicsXYZChooser.cpp
+++ b/src/lib/score/graphics/widgets/QGraphicsXYZChooser.cpp
@@ -1,0 +1,156 @@
+#include <score/graphics/widgets/QGraphicsXYZChooser.hpp>
+#include <score/model/Skin.hpp>
+#include <score/tools/Debug.hpp>
+
+#include <ossia/detail/math.hpp>
+
+#include <QGraphicsSceneMouseEvent>
+#include <QPainter>
+
+#include <wobjectimpl.h>
+W_OBJECT_IMPL(score::QGraphicsXYZChooser);
+
+namespace score
+{
+
+QGraphicsXYZChooser::QGraphicsXYZChooser(QGraphicsItem* parent)
+  : m_min{0.f, 0.f, 0.f}
+  , m_max{1.f, 1.f, 1.f}
+{
+  auto& skin = score::Skin::instance();
+  setCursor(skin.CursorPointingHand);
+  prev_v[0] = 0.f;
+  prev_v[1] = 0.f;
+  prev_v[2] = 0.f;
+}
+
+void QGraphicsXYZChooser::paint(
+    QPainter* painter,
+    const QStyleOptionGraphicsItem* option,
+    QWidget* widget)
+{
+  painter->fillRect(
+      QRectF{0, 0, 100, 100}, score::Skin::instance().Dark.main.brush);
+  painter->fillRect(
+      QRectF{110, 0, 20, 100}, score::Skin::instance().Dark.main.brush);
+
+  auto [x, y, z] = m_value;
+  x = 100. * (x - m_min[0]) / (m_max[0] - m_min[0]);
+  y = 100. * (y - m_min[1]) / (m_max[1] - m_min[1]);
+  z = 100. * (z - m_min[2]) / (m_max[2] - m_min[2]);
+
+  painter->setPen(score::Skin::instance().DarkGray.main.pen0);
+  painter->drawLine(QPointF{x, 0.}, QPointF{x, 100.});
+  painter->drawLine(QPointF{0., y}, QPointF{100., y});
+  painter->drawLine(QPointF{110., z}, QPointF{130., z});
+}
+
+std::array<float, 3> QGraphicsXYZChooser::value() const
+{
+  return m_value;
+}
+
+ossia::vec3f QGraphicsXYZChooser::scaledValue(float x, float y, float z) const noexcept
+{
+  return {
+    m_min[0] + x * (m_max[0] - m_min[0]),
+    m_min[1] + y * (m_max[1] - m_min[1]),
+    m_min[2] + z * (m_max[2] - m_min[2])
+  };
+}
+
+void QGraphicsXYZChooser::setValue(ossia::vec3f v)
+{
+  m_value = v;
+  update();
+}
+
+void QGraphicsXYZChooser::setRange(ossia::vec3f min, ossia::vec3f max)
+{
+  m_min = min;
+  m_max = max;
+}
+
+void QGraphicsXYZChooser::mousePressEvent(QGraphicsSceneMouseEvent* event)
+{
+  const auto p = event->pos();
+  if (p.x() < 100.)
+  {
+    prev_v[0] = qBound(0., p.x() / 100., 1.);
+    prev_v[1] = qBound(0., p.y() / 100., 1.);
+  }
+  else if (p.x() >= 110 && p.x() < 130)
+  {
+    prev_v[2] = qBound(0., p.y() / 100., 1.);
+  }
+  m_grab = true;
+
+  const ossia::vec3f newValue = scaledValue(prev_v[0], prev_v[1], prev_v[2]);
+  if (m_value != newValue)
+  {
+    m_value = newValue;
+    sliderMoved();
+    update();
+  }
+  event->accept();
+}
+
+void QGraphicsXYZChooser::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
+{
+  if (m_grab)
+  {
+    const auto p = event->pos();
+    if (p.x() < 100.)
+    {
+      prev_v[0] = qBound(0., p.x() / 100., 1.);
+      prev_v[1] = qBound(0., p.y() / 100., 1.);
+    }
+    else if (p.x() >= 110 && p.x() <= 130)
+    {
+      prev_v[2] = qBound(0., p.y() / 100., 1.);
+    }
+    m_grab = true;
+
+    const ossia::vec3f newValue = scaledValue(prev_v[0], prev_v[1], prev_v[2]);
+    if (m_value != newValue)
+    {
+      m_value = newValue;
+      sliderMoved();
+      update();
+    }
+  }
+  event->accept();
+}
+
+void QGraphicsXYZChooser::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
+{
+  if (m_grab)
+  {
+    const auto p = event->pos();
+    if (p.x() < 100.)
+    {
+      prev_v[0] = qBound(0., p.x() / 100., 1.);
+      prev_v[1] = qBound(0., p.y() / 100., 1.);
+    }
+    else if (p.x() >= 110 && p.x() < 130)
+    {
+      prev_v[2] = qBound(0., p.y() / 100., 1.);
+    }
+
+    const ossia::vec3f newValue = scaledValue(prev_v[0], prev_v[1], prev_v[2]);
+    if (m_value != newValue)
+    {
+      m_value = newValue;
+      update();
+    }
+    sliderReleased();
+    m_grab = false;
+  }
+  event->accept();
+}
+
+QRectF QGraphicsXYZChooser::boundingRect() const
+{
+  return QRectF{0, 0, 140, 100};
+}
+}

--- a/src/lib/score/graphics/widgets/QGraphicsXYZChooser.hpp
+++ b/src/lib/score/graphics/widgets/QGraphicsXYZChooser.hpp
@@ -30,7 +30,8 @@ public:
 
   void setPoint(const QPointF& r);
   void setValue(ossia::vec3f v);
-  void setRange(ossia::vec3f min, ossia::vec3f max);
+  void setRange(ossia::vec3f min = {0.f, 0.f, 0.f},
+                ossia::vec3f max = {1.f, 1.f, 1.f});
   ossia::vec3f value() const;
 
   bool moving = false;

--- a/src/lib/score/graphics/widgets/QGraphicsXYZChooser.hpp
+++ b/src/lib/score/graphics/widgets/QGraphicsXYZChooser.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <score/graphics/widgets/Constants.hpp>
+
+#include <ossia-qt/value_metatypes.hpp>
+
+#include <QGraphicsItem>
+#include <QObject>
+
+#include <score_lib_base_export.h>
+
+#include <verdigris>
+
+namespace score
+{
+class SCORE_LIB_BASE_EXPORT QGraphicsXYZChooser final
+    : public QObject
+    , public QGraphicsItem
+{
+  W_OBJECT(QGraphicsXYZChooser)
+  Q_INTERFACES(QGraphicsItem)
+  QRectF m_rect{0., 0., 140., 100.};
+
+private:
+  ossia::vec3f m_value{}, m_min{}, m_max{};
+  float prev_v[3]{};
+  bool m_grab{};
+
+public:
+  QGraphicsXYZChooser(QGraphicsItem* parent);
+
+  void setPoint(const QPointF& r);
+  void setValue(ossia::vec3f v);
+  void setRange(ossia::vec3f min, ossia::vec3f max);
+  ossia::vec3f value() const;
+
+  bool moving = false;
+
+public:
+  void sliderMoved() E_SIGNAL(SCORE_LIB_BASE_EXPORT, sliderMoved)
+  void sliderReleased() E_SIGNAL(SCORE_LIB_BASE_EXPORT, sliderReleased)
+
+private:
+  ossia::vec3f scaledValue(float x, float y, float z) const noexcept;
+  void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+  void mouseMoveEvent(QGraphicsSceneMouseEvent* event) override;
+  void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
+  QRectF boundingRect() const override;
+  void paint(
+      QPainter* painter,
+      const QStyleOptionGraphicsItem* option,
+      QWidget* widget) override;
+};
+}

--- a/src/plugins/score-lib-process/Control/Widgets.hpp
+++ b/src/plugins/score-lib-process/Control/Widgets.hpp
@@ -690,15 +690,4 @@ struct RGBAEdit final
   std::array<float, 4> init{};
   void setup_exec(ossia::value_inlet& v) const { }
 };
-
-// TODO XYZEdit
-struct XYZEdit final
-    : ossia::safe_nodes::control_in
-    , WidgetFactory::XYZEdit
-{
-  static const constexpr bool must_validate = false;
-  using type = std::array<float, 3>;
-  std::array<float, 3> init{};
-  void setup_exec(ossia::value_inlet& v) const { }
-};
 }

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -459,6 +459,7 @@ struct Button
     return toggle;
   }
 };
+
 struct ChooserToggle
 {
   template <typename T>
@@ -849,11 +850,6 @@ struct RGBAEdit
   // TODO
 };
 
-struct XYZEdit
-{
-  // TODO
-};
-
 struct HSVSlider
 {
   template <typename T, typename Control_T>
@@ -953,6 +949,56 @@ struct XYSlider
           if (!sl->moving)
             sl->setValue(ossia::convert<ossia::vec2f>(val));
         });
+
+    return sl;
+  }
+};
+
+struct XYZSlider
+{
+  template <typename T, typename Control_T>
+  static auto make_widget(
+      const T& slider,
+      Control_T& inlet,
+      const score::DocumentContext& ctx,
+      QWidget* parent,
+      QObject* context)
+  {
+    SCORE_TODO;
+    return nullptr; // TODO
+  }
+
+  template <typename T, typename Control_T>
+  static QGraphicsItem* make_item(
+      const T& slider,
+      Control_T& inlet,
+      const score::DocumentContext& ctx,
+      QGraphicsItem* parent,
+      QObject* context)
+  {
+    auto sl = new score::QGraphicsXYZChooser{nullptr};
+    sl->setValue(ossia::convert<ossia::vec3f>(inlet.value()));
+
+    QObject::connect(
+          sl,
+          &score::QGraphicsXYZChooser::sliderMoved,
+          context,
+          [=, &inlet, &ctx] {
+      sl->moving = true;
+      ctx.dispatcher.submit<SetControlValue<Control_T>>(
+            inlet, sl->value());
+    });
+    QObject::connect(
+          sl, &score::QGraphicsXYZChooser::sliderReleased, context, [&ctx, sl]() {
+      ctx.dispatcher.commit();
+      sl->moving = false;
+    });
+
+    QObject::connect(
+          &inlet, &Control_T::valueChanged, sl, [=](ossia::value val) {
+      if (!sl->moving)
+        sl->setValue(ossia::convert<ossia::vec3f>(val));
+    });
 
     return sl;
   }

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -978,6 +978,7 @@ struct XYZSlider
   {
     auto sl = new score::QGraphicsXYZChooser{nullptr};
     sl->setValue(ossia::convert<ossia::vec3f>(inlet.value()));
+    bindVec3Domain(slider, inlet, *sl);
 
     QObject::connect(
           sl,

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -317,6 +317,36 @@ XYSlider::XYSlider(
 
 XYSlider::~XYSlider() { }
 
+XYZSlider::XYZSlider(
+    ossia::vec3f init,
+    const QString& name,
+    Id<Port> id,
+    QObject* parent)
+    : ControlInlet{id, parent}
+{
+  hidden = true;
+  setValue(init);
+  setName(name);
+  setDomain(ossia::make_domain(ossia::vec3f{0., 0., 0.}, ossia::vec3f{1., 1., 1.}));
+}
+
+XYZSlider::XYZSlider(
+    ossia::vec3f min,
+    ossia::vec3f max,
+    ossia::vec3f init,
+    const QString& name,
+    Id<Port> id,
+    QObject* parent)
+  : ControlInlet{id, parent}
+{
+  hidden = true;
+  setValue(init);
+  setName(name);
+  setDomain(ossia::make_domain(min, max));
+}
+
+XYZSlider::~XYZSlider() { }
+
 MultiSlider::MultiSlider(
     ossia::value init,
     const QString& name,
@@ -687,6 +717,29 @@ JSONReader::read<Process::XYSlider>(const Process::XYSlider& p)
 template <>
 SCORE_LIB_PROCESS_EXPORT void
 JSONWriter::write<Process::XYSlider>(Process::XYSlider& p)
+{
+}
+
+template <>
+SCORE_LIB_PROCESS_EXPORT void
+DataStreamReader::read<Process::XYZSlider>(const Process::XYZSlider& p)
+{
+  read((const Process::ControlInlet&)p);
+}
+template <>
+SCORE_LIB_PROCESS_EXPORT void
+DataStreamWriter::write<Process::XYZSlider>(Process::XYZSlider& p)
+{
+}
+template <>
+SCORE_LIB_PROCESS_EXPORT void
+JSONReader::read<Process::XYZSlider>(const Process::XYZSlider& p)
+{
+  read((const Process::ControlInlet&)p);
+}
+template <>
+SCORE_LIB_PROCESS_EXPORT void
+JSONWriter::write<Process::XYZSlider>(Process::XYZSlider& p)
 {
 }
 

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
@@ -21,6 +21,7 @@ struct Button;
 struct ImpulseButton;
 struct HSVSlider;
 struct XYSlider;
+struct XYZSlider;
 struct MultiSlider;
 
 struct Bargraph;
@@ -105,6 +106,11 @@ UUID_METADATA(
     Process::Port,
     Process::XYSlider,
     "8093743c-584f-4bb9-97d4-6c7602f87116")
+UUID_METADATA(
+    SCORE_LIB_PROCESS_EXPORT,
+    Process::Port,
+    Process::XYZSlider,
+    "bae00244-cd93-4893-a4ad-71489adb3fa1")
 UUID_METADATA(
     SCORE_LIB_PROCESS_EXPORT,
     Process::Port,
@@ -363,6 +369,29 @@ struct SCORE_LIB_PROCESS_EXPORT XYSlider : public Process::ControlInlet
 
   auto getMin() const noexcept { return domain().get().convert_min<ossia::vec2f>(); }
   auto getMax() const noexcept { return domain().get().convert_max<ossia::vec2f>(); }
+  using Process::ControlInlet::ControlInlet;
+};
+
+struct SCORE_LIB_PROCESS_EXPORT XYZSlider : public Process::ControlInlet
+{
+  MODEL_METADATA_IMPL(XYZSlider)
+      using control_type = WidgetFactory::XYZSlider;
+  XYZSlider(
+        ossia::vec3f init,
+        const QString& name,
+        Id<Process::Port> id,
+        QObject* parent);
+  XYZSlider(
+        ossia::vec3f min,
+        ossia::vec3f max,
+        ossia::vec3f init,
+        const QString& name,
+        Id<Process::Port> id,
+        QObject* parent);
+  ~XYZSlider();
+
+  auto getMin() const noexcept { return domain().get().convert_min<ossia::vec3f>(); }
+  auto getMax() const noexcept { return domain().get().convert_max<ossia::vec3f>(); }
   using Process::ControlInlet::ControlInlet;
 };
 

--- a/src/plugins/score-plugin-controlsurface/ControlSurface/Process.cpp
+++ b/src/plugins/score-plugin-controlsurface/ControlSurface/Process.cpp
@@ -62,9 +62,10 @@ Process::ControlInlet* makeControlFromType(
     case ossia::val_type::STRING:
       return new Process::LineEdit{id, parent};
     case ossia::val_type::VEC2F:
-    case ossia::val_type::VEC3F:
     case ossia::val_type::VEC4F:
       return new Process::MultiSlider{id, parent};
+  case ossia::val_type::VEC3F:
+    return new Process::XYZSlider{id, parent};
     default:
       return new Process::ControlInlet(id, parent);
   }

--- a/src/plugins/score-plugin-dataflow/score_plugin_dataflow.cpp
+++ b/src/plugins/score-plugin-dataflow/score_plugin_dataflow.cpp
@@ -59,6 +59,7 @@ score_plugin_dataflow::factories(
          Dataflow::WidgetInletFactory<Process::Enum>,
          Dataflow::WidgetInletFactory<Process::HSVSlider>,
          Dataflow::WidgetInletFactory<Process::XYSlider>,
+         Dataflow::WidgetInletFactory<Process::XYZSlider>,
          Dataflow::WidgetInletFactory<Process::MultiSlider>,
          Dataflow::WidgetOutletFactory<Process::Bargraph>>>(ctx, key);
 }


### PR DESCRIPTION
This is basically a mix between the HSVSlider and the XYSlider.
The "final" piece I think would be for the ```bindVec2Domain``` to extend to vec3f.
https://github.com/ossia/score/blob/81d54f78790ce4805b8d074b40fe8a06cf986171/src/plugins/score-lib-process/Process/Dataflow/ControlWidgetDomains.hpp#L197
here, vec2f are hard coded, but maybe they could be replaced by another template argument ?
Or maybe, the type could be deduced from one of the other template argument ?