### PR TITLE
invert Y axis at the widget level

### DIFF
--- a/src/lib/score/graphics/widgets/QGraphicsXYChooser.cpp
+++ b/src/lib/score/graphics/widgets/QGraphicsXYChooser.cpp
@@ -31,7 +31,7 @@ void QGraphicsXYChooser::paint(
 
   auto [x, y] = m_value;
   x = 100. * (x - m_min[0]) / (m_max[0] - m_min[0]);
-  y = 100. * (y - m_min[1]) / (m_max[1] - m_min[1]);
+  y = 100. * (1. - ((y - m_min[1]) / (m_max[1] - m_min[1])));
 
   painter->setPen(score::Skin::instance().DarkGray.main.pen0);
   painter->drawLine(QPointF{x, 0.}, QPointF{x, 100.});
@@ -67,7 +67,7 @@ void QGraphicsXYChooser::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
   const auto p = event->pos();
   float newX = qBound(0., p.x() / 100., 1.);
-  float newY = qBound(0., p.y() / 100., 1.);
+  float newY = qBound(0., 1. - (p.y() / 100.), 1.);
   m_grab = true;
 
   const ossia::vec2f newValue = scaledValue(newX, newY);
@@ -86,7 +86,7 @@ void QGraphicsXYChooser::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
   {
     const auto p = event->pos();
     float newX = qBound(0., p.x() / 100., 1.);
-    float newY = qBound(0., p.y() / 100., 1.);
+    float newY = qBound(0., 1. - (p.y() / 100.), 1.);
     m_grab = true;
 
     const ossia::vec2f newValue = scaledValue(newX, newY);
@@ -106,7 +106,7 @@ void QGraphicsXYChooser::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   {
     const auto p = event->pos();
     float newX = qBound(0., p.x() / 100., 1.);
-    float newY = qBound(0., p.y() / 100., 1.);
+    float newY = qBound(0., 1. - (p.y() / 100.), 1.);
     m_grab = true;
 
     const ossia::vec2f newValue = scaledValue(newX, newY);

--- a/src/lib/score/graphics/widgets/QGraphicsXYZChooser.cpp
+++ b/src/lib/score/graphics/widgets/QGraphicsXYZChooser.cpp
@@ -32,8 +32,8 @@ void QGraphicsXYZChooser::paint(
 
   auto [x, y, z] = m_value;
   x = 100. * (x - m_min[0]) / (m_max[0] - m_min[0]);
-  y = 100. * (y - m_min[1]) / (m_max[1] - m_min[1]);
-  z = 100. * (z - m_min[2]) / (m_max[2] - m_min[2]);
+  y = 100. * (1. - ((y - m_min[1]) / (m_max[1] - m_min[1])));
+  z = 100. * (1. - ((z - m_min[2]) / (m_max[2] - m_min[2])));
 
   painter->setPen(score::Skin::instance().DarkGray.main.pen0);
   painter->drawLine(QPointF{x, 0.}, QPointF{x, 100.});
@@ -76,11 +76,11 @@ void QGraphicsXYZChooser::mousePressEvent(QGraphicsSceneMouseEvent* event)
   if (p.x() < 100.)
   {
     prev_v[0] = qBound(0., p.x() / 100., 1.);
-    prev_v[1] = qBound(0., p.y() / 100., 1.);
+    prev_v[1] = qBound(0., 1 - (p.y() / 100.), 1.);
   }
   else if (p.x() >= 110 && p.x() < 130)
   {
-    prev_v[2] = qBound(0., p.y() / 100., 1.);
+    prev_v[2] = qBound(0., 1 - (p.y() / 100.), 1.);
   }
   m_grab = true;
 
@@ -102,11 +102,11 @@ void QGraphicsXYZChooser::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
     if (p.x() < 100.)
     {
       prev_v[0] = qBound(0., p.x() / 100., 1.);
-      prev_v[1] = qBound(0., p.y() / 100., 1.);
+      prev_v[1] = qBound(0., 1 - (p.y() / 100.), 1.);
     }
     else if (p.x() >= 110 && p.x() <= 130)
     {
-      prev_v[2] = qBound(0., p.y() / 100., 1.);
+      prev_v[2] = qBound(0., 1 - (p.y() / 100.), 1.);
     }
     m_grab = true;
 
@@ -129,11 +129,11 @@ void QGraphicsXYZChooser::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
     if (p.x() < 100.)
     {
       prev_v[0] = qBound(0., p.x() / 100., 1.);
-      prev_v[1] = qBound(0., p.y() / 100., 1.);
+      prev_v[1] = qBound(0., 1 - (p.y() / 100.), 1.);
     }
     else if (p.x() >= 110 && p.x() < 130)
     {
-      prev_v[2] = qBound(0., p.y() / 100., 1.);
+      prev_v[2] = qBound(0., 1 - (p.y() / 100.), 1.);
     }
 
     const ossia::vec3f newValue = scaledValue(prev_v[0], prev_v[1], prev_v[2]);

--- a/src/plugins/score-plugin-gfx/Gfx/Images/Process.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Images/Process.cpp
@@ -70,7 +70,7 @@ Model::Model(
     auto pos = new Process::XYSlider{Id<Process::Port>(2), this};
     pos->setName(tr("Position"));
     pos->setDomain(
-      ossia::make_domain(ossia::vec2f{-5.0, 5.0}, ossia::vec2f{5.0, -5.0}));
+      ossia::make_domain(ossia::vec2f{-5.0, -5.0}, ossia::vec2f{5.0, 5.0}));
 
     m_inlets.push_back(pos);
   }

--- a/src/plugins/score-plugin-gfx/Gfx/Text/Process.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Text/Process.cpp
@@ -51,7 +51,7 @@ Model::Model(
     auto pos = new Process::XYSlider{Id<Process::Port>(4), this};
     pos->setName(tr("Position"));
     pos->setDomain(
-      ossia::make_domain(ossia::vec2f{-5.0, 5.0}, ossia::vec2f{5.0,-5.0}));
+      ossia::make_domain(ossia::vec2f{-5.0, -5.0}, ossia::vec2f{5.0, 5.0}));
 
     m_inlets.push_back(pos);
   }


### PR DESCRIPTION
This PR addresses a problem raised in #1270 
It was tested with GFX processes Images, Text and GLSL "Basic shapes" generator.
The XY position is now consistent with either the mouse input or the spline process. 