### PR TITLE
Attempt at improving UX with the package manager

### DIFF
--- a/src/plugins/score-plugin-library/Library/LibrarySettings.cpp
+++ b/src/plugins/score-plugin-library/Library/LibrarySettings.cpp
@@ -113,6 +113,9 @@ void Model::firstTimeLibraryDownload()
 
             rescanLibrary();
           },
+      [] (qint64 bytesRecieved, qint64 bytesTotal) {
+        qDebug() << (((bytesRecieved / 1024.) / (bytesTotal / 1024.)) * 100)
+                 << "% downloaded"; },
           [] {});
     }
   }

--- a/src/plugins/score-plugin-packagemanager/PackageManager/PluginItemModel.cpp
+++ b/src/plugins/score-plugin-packagemanager/PackageManager/PluginItemModel.cpp
@@ -20,47 +20,15 @@
 
 namespace PM
 {
-LocalPackagesModel::LocalPackagesModel(const score::ApplicationContext& ctx)
+void PackagesModel::clear()
 {
-  auto registerAddon = [this](const QString& p) {
-    QFileInfo path{p};
-    if (!path.exists() || !path.isDir())
-    {
-      // Check for removal of an addon
-    }
-    else
-    {
-      QFile addon{p + "/package.json"};
-      if (addon.open(QIODevice::ReadOnly))
-      {
-        auto add = RemotePackage::fromJson(
-            QJsonDocument::fromJson(score::mapAsByteArray(addon)).object());
-        if (add)
-        {
-          beginResetModel();
-          m_vec.push_back(std::move(*add));
-          endResetModel();
-        }
-      }
-    }
-  };
-
-  const QString addons_path
-      = ctx.settings<Library::Settings::Model>().getPackagesPath();
-  con(m_addonsWatch,
-      &QFileSystemWatcher::directoryChanged,
-      this,
-      registerAddon);
-
-  QDirIterator addons{addons_path};
-  while (addons.hasNext())
-  {
-    registerAddon(addons.next());
-  }
+  beginResetModel();
+  m_vec.clear();
+  endResetModel();
 }
 
 QModelIndex
-LocalPackagesModel::index(int row, int column, const QModelIndex& parent) const
+PackagesModel::index(int row, int column, const QModelIndex& parent) const
 {
   if (row >= std::ssize(m_vec) || row < 0)
     return {};
@@ -71,22 +39,53 @@ LocalPackagesModel::index(int row, int column, const QModelIndex& parent) const
   return createIndex(row, column, nullptr);
 }
 
-QModelIndex LocalPackagesModel::parent(const QModelIndex& child) const
+QModelIndex PackagesModel::parent(const QModelIndex& child) const
 {
   return {};
 }
 
-int LocalPackagesModel::rowCount(const QModelIndex& parent) const
+int PackagesModel::rowCount(const QModelIndex& parent) const
 {
   return m_vec.size();
 }
 
-int LocalPackagesModel::columnCount(const QModelIndex& parent) const
+int PackagesModel::columnCount(const QModelIndex& parent) const
 {
   return ColumnCount;
 }
 
-QVariant LocalPackagesModel::data(const QModelIndex& index, int role) const
+QVariant PackagesModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+  switch (role)
+  {
+  case Qt::DisplayRole:
+  {
+    switch ((Column)section)
+    {
+    case Column::Name:
+      return tr("Name");
+      break;
+    case Column::ShortDesc:
+      return tr("Description");
+      break;
+    case Column::Version:
+      return tr("Version");
+      break;
+    case Column::Size:
+      return tr("Size");
+      break;
+    default:
+      break;
+    }
+
+    return {};
+    break;
+  }
+  }
+  return {};
+}
+
+QVariant PackagesModel::data(const QModelIndex& index, int role) const
 {
   auto row = index.row();
   auto column = (Column)index.column();
@@ -100,52 +99,58 @@ QVariant LocalPackagesModel::data(const QModelIndex& index, int role) const
 
   switch (role)
   {
-    case Qt::DisplayRole:
+  case Qt::DisplayRole:
+  {
+    switch (column)
     {
-      switch (column)
-      {
-        case Column::Name:
-          return addon.name;
-          break;
-        case Column::ShortDesc:
-          return addon.shortDescription;
-          break;
-        default:
-          break;
-      }
+    case Column::Name:
+      return addon.name;
+      break;
+    case Column::ShortDesc:
+      return addon.shortDescription;
+      break;
+    case Column::Version:
+      return addon.version;
+      break;
+    case Column::Size:
+      return addon.size;
+      break;
+    default:
+      break;
+    }
 
+    return {};
+    break;
+  }
+
+  case Qt::FontRole:
+  {
+    QFont f;
+    if (column == Column::Name)
+    {
+      f.setBold(true);
+    }
+    return f;
+  }
+
+  case Qt::DecorationRole:
+  {
+    switch (column)
+    {
+    case Column::Name:
+    {
+      if (!addon.smallImage.isNull())
+      {
+        return QIcon{QPixmap::fromImage(addon.smallImage)};
+      }
       return {};
-      break;
+    }
+    default:
+      return {};
     }
 
-    case Qt::FontRole:
-    {
-      QFont f;
-      if (column == Column::Name)
-      {
-        f.setBold(true);
-      }
-      return f;
-    }
-
-    case Qt::DecorationRole:
-    {
-      switch (column)
-      {
-        case Column::Name:
-        {
-          if (!addon.smallImage.isNull())
-          {
-            return QIcon{QPixmap::fromImage(addon.smallImage)};
-          }
-          return {};
-        }
-        default:
-          return {};
-      }
-
-      break;
-    }/*
+    break;
+  }/*
     case Qt::CheckStateRole:
     {
       if (column == Column::Name)
@@ -163,7 +168,7 @@ QVariant LocalPackagesModel::data(const QModelIndex& index, int role) const
   return {};
 }
 
-Qt::ItemFlags LocalPackagesModel::flags(const QModelIndex& index) const
+Qt::ItemFlags PackagesModel::flags(const QModelIndex& index) const
 {
   return QAbstractItemModel::flags(index);
 
@@ -174,136 +179,76 @@ Qt::ItemFlags LocalPackagesModel::flags(const QModelIndex& index) const
   // return flags;
 }
 
-QModelIndex RemotePackagesModel::index(
-    int row,
-    int column,
-    const QModelIndex& parent) const
+LocalPackagesModel::LocalPackagesModel(const score::ApplicationContext& ctx)
 {
-  if (row >= std::ssize(m_vec) || row < 0)
-    return {};
+  const auto& addons_path
+      = ctx.settings<Library::Settings::Model>();
 
-  if (column >= ColumnCount || column < 0)
-    return {};
-
-  return createIndex(row, column, nullptr);
-}
-
-QModelIndex RemotePackagesModel::parent(const QModelIndex& child) const
-{
-  return {};
-}
-
-int RemotePackagesModel::rowCount(const QModelIndex& parent) const
-{
-  return m_vec.size();
-}
-
-int RemotePackagesModel::columnCount(const QModelIndex& parent) const
-{
-  return ColumnCount;
-}
-
-QVariant RemotePackagesModel::data(const QModelIndex& index, int role) const
-{
-  auto row = index.row();
-  auto column = (Column)index.column();
-  if (row >= int(m_vec.size()) || row < 0)
-    return {};
-
-  if (index.column() >= ColumnCount || index.column() < 0)
-    return {};
-
-  const RemotePackage& addon = m_vec[row];
-
-  switch (role)
+  QDirIterator addons{addons_path.getPackagesPath()};
+  while (addons.hasNext())
   {
-    case Qt::DisplayRole:
-    {
-      switch (column)
-      {
-        case Column::Name:
-          return addon.name;
-          break;
-        case Column::ShortDesc:
-          return addon.shortDescription;
-          break;
-        default:
-          break;
-      }
-
-      return {};
-    }
-
-    case Qt::FontRole:
-    {
-      QFont f;
-      if (column == Column::Name)
-      {
-        f.setBold(true);
-      }
-      return f;
-    }
-
-    case Qt::DecorationRole:
-    {
-      switch (column)
-      {
-        case Column::Name:
-        {
-          if (!addon.smallImage.isNull())
-          {
-            return QIcon{QPixmap::fromImage(addon.smallImage)};
-          }
-          return {};
-        }
-        default:
-          return {};
-      }
-
-      return {};
-    }
-    default:
-      return {};
+    registerAddon(addons.next());
   }
-
-  return {};
 }
 
-void RemotePackagesModel::addAddon(RemotePackage e)
+void LocalPackagesModel::registerAddon(const QString& p)
+{
+  QFileInfo path{p};
+  if (!path.exists() || !path.isDir())
+  {
+    // Check for removal of an addon
+  }
+  else
+  {
+    QFile addon{p + "/package.json"};
+    if (addon.open(QIODevice::ReadOnly))
+    {
+      auto add = Package::fromJson(
+            QJsonDocument::fromJson(score::mapAsByteArray(addon)).object());
+      if (add)
+      {
+        addAddon(*add);
+      }
+    }
+  }
+}
+
+void PackagesModel::addAddon(Package e)
 {
   beginResetModel();
   m_vec.push_back(std::move(e));
   endResetModel();
 }
 
-void RemotePackagesModel::clear()
+void PackagesModel::removeAddon(Package e)
 {
   beginResetModel();
-  m_vec.clear();
+  std::erase_if(m_vec, [&e](auto p){ return e.name == p.name; });
   endResetModel();
 }
 
-std::optional<RemotePackage>
-RemotePackage::fromJson(const QJsonObject& obj) noexcept
+std::optional<Package>
+Package::fromJson(const QJsonObject& obj) noexcept
 {
-  RemotePackage add;
+  Package add;
 
   using Funmap = ossia::flat_map<QString, std::function<void(QJsonValue)>>;
   const Funmap funmap{
-      {"file", [&](QJsonValue v) { add.file = v.toString(); }},
-      {"src", [&](QJsonValue v) { add.file = v.toString(); }},
-      {"name", [&](QJsonValue v) { add.name = v.toString(); }},
-      {"raw_name", [&](QJsonValue v) { add.raw_name = v.toString(); }},
-      {"version", [&](QJsonValue v) { add.version = v.toInt(); }},
-      {"kind", [&](QJsonValue v) { add.kind = v.toString(); }},
-      {"url", [&](QJsonValue v) { add.url = v.toString(); }},
-      {"short", [&](QJsonValue v) { add.shortDescription = v.toString(); }},
-      {"long", [&](QJsonValue v) { add.longDescription = v.toString(); }},
-      {"small", [&](QJsonValue v) { add.smallImagePath = v.toString(); }},
-      {"large", [&](QJsonValue v) { add.largeImagePath = v.toString(); }},
-      {"key", [&](QJsonValue v) {
-         add.key = UuidKey<score::Addon>::fromString(v.toString());
-       }}};
+    {"file", [&](QJsonValue v) { add.file = v.toString(); }},
+    {"src", [&](QJsonValue v) { add.file = v.toString(); }},
+    {"name", [&](QJsonValue v) { add.name = v.toString(); }},
+    {"raw_name", [&](QJsonValue v) { add.raw_name = v.toString(); }},
+    {"version", [&](QJsonValue v) { add.version = v.toInt(); }},
+    {"kind", [&](QJsonValue v) { add.kind = v.toString(); }},
+    {"url", [&](QJsonValue v) { add.url = v.toString(); }},
+    {"short", [&](QJsonValue v) { add.shortDescription = v.toString(); }},
+    {"long", [&](QJsonValue v) { add.longDescription = v.toString(); }},
+    {"small", [&](QJsonValue v) { add.smallImagePath = v.toString(); }},
+    {"large", [&](QJsonValue v) { add.largeImagePath = v.toString(); }},
+    {"size", [&](QJsonValue v) { add.size = v.toString(); }},
+    {"key", [&](QJsonValue v) {
+        add.key = UuidKey<score::Addon>::fromString(v.toString());
+      }}};
 
   // Add metadata keys
   for (const auto& k : obj.keys())

--- a/src/plugins/score-plugin-packagemanager/PackageManager/Presenter.cpp
+++ b/src/plugins/score-plugin-packagemanager/PackageManager/Presenter.cpp
@@ -14,10 +14,12 @@
 #include <QListView>
 #include <QStandardItemModel>
 #include <QStyle>
+#include <QHeaderView>
 
 #include <PackageManager/FileDownloader.hpp>
 #include <wobjectimpl.h>
 W_OBJECT_IMPL(PM::PluginSettingsPresenter)
+
 namespace score
 {
 class SettingsDelegateModel;
@@ -36,13 +38,17 @@ PluginSettingsPresenter::PluginSettingsPresenter(
   auto& ps_view = static_cast<PluginSettingsView&>(view);
 
   ps_view.localView()->setModel(&ps_model.localPlugins);
-  ps_view.localView()->setColumnWidth(0, 150);
-  ps_view.localView()->setColumnWidth(1, 400);
-  ps_view.localView()->setColumnWidth(2, 400);
+  ps_view.localView()->setColumnWidth(0, 200);
+  ps_view.localView()->setColumnWidth(1, 40);
+  ps_view.localView()->setColumnWidth(2, 40);
+  ps_view.localView()->horizontalHeader()->setStretchLastSection(true);
 
   ps_view.remoteView()->setModel(&ps_model.remotePlugins);
-  ps_view.remoteView()->setColumnWidth(0, 150);
-  ps_view.remoteView()->setColumnWidth(1, 400);
+  ps_view.remoteView()->setColumnWidth(0, 200);
+  ps_view.remoteView()->setColumnWidth(1, 40);
+  ps_view.remoteView()->setColumnWidth(2, 40);
+  ps_view.remoteView()->horizontalHeader()->setStretchLastSection(true);
+
   ps_view.remoteView()->setSelectionModel(&ps_model.remoteSelection);
 
   connect(
@@ -50,7 +56,7 @@ PluginSettingsPresenter::PluginSettingsPresenter(
       &QItemSelectionModel::currentRowChanged,
       this,
       [&](const QModelIndex& current, const QModelIndex& previous) {
-        RemotePackage& addon
+        Package& addon
             = ps_model.remotePlugins.addons().at(current.row());
 
         ps_view.installButton().setEnabled(

--- a/src/plugins/score-plugin-packagemanager/PackageManager/View.hpp
+++ b/src/plugins/score-plugin-packagemanager/PackageManager/View.hpp
@@ -1,5 +1,7 @@
 #pragma once
+#include <score/application/ApplicationContext.hpp>
 #include <score/plugins/settingsdelegate/SettingsDelegateView.hpp>
+#include <Library/LibrarySettings.hpp>
 
 #include <QGridLayout>
 #include <QNetworkAccessManager>
@@ -8,6 +10,8 @@
 #include <QTabWidget>
 #include <QTableView>
 #include <QWidget>
+#include <QStorageInfo>
+#include <QLabel>
 
 #include <PackageManager/PluginItemModel.hpp>
 
@@ -34,27 +38,40 @@ private:
   void handleAddonList(const QJsonObject&);
   void handleAddon(const QJsonObject&);
 
-  void installAddon(const RemotePackage& addon);
-  void installLibrary(const RemotePackage& addon);
-  void installSDK(const RemotePackage& addon);
+  PackagesModel* getCurrentModel();
+  int getCurrentRow(const QTableView* t);
+  Package selectedPackage(const PackagesModel* model, int row);
 
+  void installAddon(const Package& addon);
+  void installLibrary(const Package& addon);
+  void installSDK(const Package& addon);
+
+  void openLink();
   void install();
+  void uninstall();
   void on_message(QNetworkReply* rep);
 
-  void on_packageInstallSuccess(const RemotePackage& addon, const QDir& destination, const std::vector<QString>& res);
-  void on_packageInstallFailure(const RemotePackage& addon);
+  void on_packageInstallSuccess(const Package& addon, const QDir& destination, const std::vector<QString>& res);
+  void on_packageInstallFailure(const Package& addon);
 
-  QTabWidget* m_widget = new QTabWidget;
+  void set_info();
+  void reset_progress();
+  void progress_from_bytes(qint64 bytesRecieved, qint64 bytesTotal);
+
+  QWidget* m_widget{new QWidget};
 
   QTableView* m_addonsOnSystem{new QTableView};
-
   QTableView* m_remoteAddons{new QTableView};
-  QPushButton* m_refresh{new QPushButton{tr("Refresh")}};
+
+  QPushButton* m_link{new QPushButton{tr("Open link")}};
   QPushButton* m_install{new QPushButton{tr("Install")}};
+  QPushButton* m_uninstall{new QPushButton{tr("Uninstall")}};
 
   QProgressBar* m_progress{new QProgressBar};
   QNetworkAccessManager mgr;
-
   int m_addonsToRetrieve = 0;
+
+  QStorageInfo storage;
+  QLabel* m_storage{new QLabel};
 };
 }


### PR DESCRIPTION
* show remote packages size
* reshape packages Tableview to display version numbers and leave more room for descriptions
* "open Link" button
* separate table and buttons, as the "open Link" works for both tabs. The progress was also moved to the bottom of the view to minimize resizing.   
* PackagesModel class to avoid redundancy
* The signal sent by https://github.com/ossia/score/blob/master/src/plugins/score-plugin-packagemanager/PackageManager/PluginItemModel.cpp#L51 never actually ended up registering the add-on dynamically. I suspect the reason to be that the signal triggers when the new package folder is created, but the addon.json file might not yet be downloaded. Instead, I propose for registerAddon to be called after the package was successfully installed https://github.com/thibaudk/score/blob/wip/pkgMng/src/plugins/score-plugin-packagemanager/PackageManager/View.cpp#L444

