### PR TITLE
[addition] Virtual Midi Device Creation + midi devices bugfixes

### DIFF
--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
@@ -51,7 +51,8 @@ DeviceEditDialog::DeviceEditDialog(
 {
   const auto& skin = score::Skin::instance();
   const QColor textHeaderColor = QColor("#D5D5D5");
-  auto setHeaderTextFormat = [&](QLabel* label) {
+  auto setHeaderTextFormat = [&](QLabel* label)
+  {
     label->setFont(skin.TitleFont);
     auto p = label->palette();
     p.setColor(QPalette::WindowText, textHeaderColor);
@@ -78,7 +79,7 @@ DeviceEditDialog::DeviceEditDialog(
   m_protocols = new QTreeWidget{this};
   m_protocols->header()->hide();
   m_protocols->setSelectionMode(QAbstractItemView::SingleSelection);
-  if(m_mode == Mode::Editing)
+  if (m_mode == Mode::Editing)
   {
     m_protocols->setVisible(false);
   }
@@ -106,7 +107,8 @@ DeviceEditDialog::DeviceEditDialog(
   {
     m_protocolNameLabel = new QLabel{tr("Settings"), this};
     setHeaderTextFormat(m_protocolNameLabel);
-    gridLayout->addWidget(m_protocolNameLabel, 0, 2, -1, -1, Qt::AlignLeft | Qt::AlignTop);
+    gridLayout->addWidget(
+        m_protocolNameLabel, 0, 2, -1, -1, Qt::AlignLeft | Qt::AlignTop);
   }
   m_main = new QWidget{this};
   gridLayout->addWidget(m_main, 1, 2, -1, -1);
@@ -118,12 +120,16 @@ DeviceEditDialog::DeviceEditDialog(
 
   initAvailableProtocols();
 
-  connect(m_protocols, &QTreeView::activated, this, [this] {
-    selectedProtocolChanged();
-  });
-  connect(m_devices, &QListWidget::currentRowChanged, this, [this] {
-    selectedDeviceChanged();
-  });
+  connect(
+      m_protocols,
+      &QTreeView::activated,
+      this,
+      [this] { selectedProtocolChanged(); });
+  connect(
+      m_devices,
+      &QListWidget::currentRowChanged,
+      this,
+      [this] { selectedDeviceChanged(); });
 
   if (m_protocols->topLevelItemCount() > 0)
   {
@@ -152,9 +158,9 @@ void DeviceEditDialog::initAvailableProtocols()
   }
 
   ossia::sort(
-      sorted, [](Device::ProtocolFactory* lhs, Device::ProtocolFactory* rhs) {
-        return lhs->visualPriority() > rhs->visualPriority();
-      });
+      sorted,
+      [](Device::ProtocolFactory* lhs, Device::ProtocolFactory* rhs)
+      { return lhs->visualPriority() > rhs->visualPriority(); });
   for (const auto& prot_pair : sorted)
   {
     auto& prot = *prot_pair;
@@ -256,13 +262,15 @@ void DeviceEditDialog::selectedProtocolChanged()
     m_devices->setVisible(true);
     m_devicesLabel->setVisible(true);
 
-    auto addItem = [&](const Device::DeviceSettings& settings) {
+    auto addItem = [&](const Device::DeviceSettings& settings)
+    {
       auto item = new QListWidgetItem;
       item->setText(settings.name);
       item->setData(Qt::UserRole, QVariant::fromValue(settings));
       m_devices->addItem(item);
     };
-    auto rmItem = [&](const QString& name) {
+    auto rmItem = [&](const QString& name)
+    {
       auto items = m_devices->findItems(name, Qt::MatchExactly);
       for (auto item : items)
         delete m_devices->takeItem(m_devices->row(item));
@@ -284,12 +292,13 @@ void DeviceEditDialog::selectedProtocolChanged()
     m_devices->setVisible(false);
     m_devicesLabel->setVisible(false);
   }
-  m_protocolNameLabel->setText(tr("Settings (%1)").arg(protocol->prettyName()));
+  m_protocolNameLabel->setText(
+      tr("Settings (%1)").arg(protocol->prettyName()));
   m_protocolWidget = protocol->makeSettingsWidget();
-
 
   if (m_protocolWidget)
   {
+    m_protocolWidget->setSettings(protocol->defaultSettings());
     connect(
         m_protocolWidget,
         &Device::ProtocolSettingsWidget::changed,

--- a/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIDevice.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIDevice.cpp
@@ -48,12 +48,14 @@ bool MIDIDevice::reconnect()
   m_capas.canSerialize = !set.createWholeTree;
   try
   {
-    auto proto
-        = std::make_unique<ossia::net::midi::midi_protocol>(m_ctx, set.api);
+    auto proto = std::make_unique<ossia::net::midi::midi_protocol>(
+        m_ctx, set.name.toStdString(), set.api);
     bool res = proto->set_info(ossia::net::midi::midi_info(
         static_cast<ossia::net::midi::midi_info::Type>(set.io),
         set.endpoint.toStdString(),
-        set.port));
+        set.name.toStdString(),
+        set.port,
+        set.virtualPort));
     if (!res)
       return false;
 

--- a/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolFactory.cpp
@@ -5,11 +5,12 @@
 #include "MIDIDevice.hpp"
 #include "MIDIProtocolSettingsWidget.hpp"
 
-#include <score/application/GUIApplicationContext.hpp>
 #include <Device/Protocol/DeviceSettings.hpp>
 #include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
 #include <Protocols/MIDI/MIDISpecificSettings.hpp>
 #include <Protocols/Settings/Model.hpp>
+
+#include <score/application/GUIApplicationContext.hpp>
 
 #include <QObject>
 #if defined(__EMSCRIPTEN__)
@@ -37,7 +38,8 @@ class MidiEnumerator : public Device::DeviceEnumerator
     libremidi::observer::callbacks cb;
     if constexpr (Type == ossia::net::midi::midi_info::Type::Input)
     {
-      cb.input_added = [this](int port, const std::string& device) {
+      cb.input_added = [this](int port, const std::string& device)
+      {
         Device::DeviceSettings set;
         MIDISpecificSettings specif;
         set.name = QString::fromStdString(device);
@@ -55,7 +57,8 @@ class MidiEnumerator : public Device::DeviceEnumerator
     }
     else
     {
-      cb.output_added = [this](int port, const std::string& device) {
+      cb.output_added = [this](int port, const std::string& device)
+      {
         Device::DeviceSettings set;
         MIDISpecificSettings specif;
         set.name = QString::fromStdString(device);
@@ -159,11 +162,14 @@ Device::DeviceInterface* MIDIInputProtocolFactory::makeDevice(
 const Device::DeviceSettings&
 MIDIInputProtocolFactory::defaultSettings() const noexcept
 {
-  static const Device::DeviceSettings settings = [&]() {
+  static const Device::DeviceSettings settings = [&]()
+  {
     Device::DeviceSettings s;
     s.protocol = concreteKey();
     s.name = "Midi";
     MIDISpecificSettings specif;
+    specif.io = MIDISpecificSettings::IO::In;
+    specif.virtualPort = false;
     s.deviceSpecificSettings = QVariant::fromValue(specif);
     return s;
   }();
@@ -239,11 +245,14 @@ Device::DeviceInterface* MIDIOutputProtocolFactory::makeDevice(
 const Device::DeviceSettings&
 MIDIOutputProtocolFactory::defaultSettings() const noexcept
 {
-  static const Device::DeviceSettings settings = [&]() {
+  static const Device::DeviceSettings settings = [&]()
+  {
     Device::DeviceSettings s;
     s.protocol = concreteKey();
     s.name = "Midi";
     MIDISpecificSettings specif;
+    specif.io = MIDISpecificSettings::IO::Out;
+    specif.virtualPort = false;
     s.deviceSpecificSettings = QVariant::fromValue(specif);
     return s;
   }();

--- a/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolFactory.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolFactory.hpp
@@ -20,7 +20,7 @@ namespace Protocols
 class MIDIInputProtocolFactory final : public Device::ProtocolFactory
 {
   SCORE_CONCRETE("f5e04ef0-16dd-4997-8f81-f5a04b8702bc")
-
+public:
   // Implement with OSSIA::Device
   Device::ProtocolFactory::Flags flags() const noexcept override;
   QString prettyName() const noexcept override;
@@ -61,7 +61,7 @@ class MIDIInputProtocolFactory final : public Device::ProtocolFactory
 class MIDIOutputProtocolFactory final : public Device::ProtocolFactory
 {
   SCORE_CONCRETE("d5a4a701-d152-4b3b-be05-4d847b623451")
-
+public:
   // Implement with OSSIA::Device
   QString prettyName() const noexcept override;
   QString category() const noexcept override;

--- a/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolSettingsWidget.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolSettingsWidget.hpp
@@ -35,6 +35,7 @@ private:
 
   State::AddressFragmentLineEdit* m_name{};
   QCheckBox* m_createWhole{};
+  QCheckBox* m_virtualPort{};
   Device::DeviceSettings m_current;
 };
 class MIDIOutputSettingsWidget final : public Device::ProtocolSettingsWidget
@@ -51,6 +52,7 @@ private:
 
   State::AddressFragmentLineEdit* m_name{};
   QCheckBox* m_createWhole{};
+  QCheckBox* m_virtualPort{};
   Device::DeviceSettings m_current;
 };
 }

--- a/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDISpecificSettings.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDISpecificSettings.hpp
@@ -15,9 +15,11 @@ struct MIDISpecificSettings
     Out
   } io{};
   QString endpoint;
+  QString name;
   int port{};
   libremidi::API api{};
   bool createWholeTree{};
+  bool virtualPort{};
 };
 }
 Q_DECLARE_METATYPE(Protocols::MIDISpecificSettings)

--- a/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDISpecificSettingsSerialization.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDISpecificSettingsSerialization.cpp
@@ -9,14 +9,14 @@
 template <>
 void DataStreamReader::read(const Protocols::MIDISpecificSettings& n)
 {
-  m_stream << n.io << n.endpoint << n.port << n.api << n.createWholeTree;
+  m_stream << n.io << n.endpoint << n.port << n.api << n.createWholeTree << n.virtualPort;
   insertDelimiter();
 }
 
 template <>
 void DataStreamWriter::write(Protocols::MIDISpecificSettings& n)
 {
-  m_stream >> n.io >> n.endpoint >> n.port >> n.api >> n.createWholeTree;
+  m_stream >> n.io >> n.endpoint >> n.port >> n.api >> n.createWholeTree >> n.virtualPort;
   checkDelimiter();
 }
 
@@ -28,6 +28,7 @@ void JSONReader::read(const Protocols::MIDISpecificSettings& n)
   obj["Endpoint"] = n.endpoint;
   obj["Port"] = (int)n.port;
   obj["CreateWholeTree"] = n.createWholeTree;
+  obj["VirtualPort"] = n.virtualPort;
 }
 
 template <>
@@ -44,4 +45,8 @@ void JSONWriter::write(Protocols::MIDISpecificSettings& n)
     n.api = (libremidi::API)it->toInt();
   else
     n.api = libremidi::default_platform_api();
+  if (auto it = obj.tryGet("VirtualPort"))
+    n.virtualPort = it->toBool();
+  else
+    n.virtualPort = false;
 }


### PR DESCRIPTION
- Enabled creation of virtual Midi device from device explorer
- Fixed a bug where Devices weren't having their default settings applied
- Modified default settings for `MIDIInput` and `MIDIOutput` devices to set the correct port direction and added the new virtual parameter 
- Made so that the name of the device is also the name of the device in JACK
- made `MIDIInputProtocolFactory` and `MIDIOutputProtocolFactory` classes member public