### PR TITLE
[wip] Supporting more midi messages in MidiDrop plugin

### DIFF
--- a/src/plugins/score-plugin-midi/Midi/Commands/AddNote.cpp
+++ b/src/plugins/score-plugin-midi/Midi/Commands/AddNote.cpp
@@ -69,7 +69,7 @@ void AddNotes::deserializeImpl(DataStreamOutput& s)
 
 ReplaceNotes::ReplaceNotes(
     const ProcessModel& model,
-    const std::vector<NoteData>& n,
+    const MidiTrackNotes& n,
     int min,
     int max,
     TimeVal d)

--- a/src/plugins/score-plugin-midi/Midi/Commands/AddNote.hpp
+++ b/src/plugins/score-plugin-midi/Midi/Commands/AddNote.hpp
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <Midi/Commands/CommandFactory.hpp>
 #include <Midi/MidiNote.hpp>
+#include "Midi/MidiDrop.hpp"
 #include <Process/TimeValue.hpp>
 
 #include <score/model/path/Path.hpp>
@@ -52,7 +54,7 @@ class SCORE_PLUGIN_MIDI_EXPORT ReplaceNotes final : public score::Command
 public:
   ReplaceNotes(
       const ProcessModel& model,
-      const std::vector<NoteData>& note,
+      const MidiTrackNotes& note,
       int min,
       int max,
       TimeVal dur);

--- a/src/plugins/score-plugin-midi/Midi/MidiDrop.cpp
+++ b/src/plugins/score-plugin-midi/Midi/MidiDrop.cpp
@@ -69,7 +69,7 @@ void DropHandler::dropData(
               track.notes.apply_scale_ratio(ratio);
             }
             disp.submit(new Midi::ReplaceNotes{
-                          midi, track.notes, track.min, track.max, actualDuration});
+                          midi, track.notes, track.notes.minimum_pitch_noticed(), track.notes.maximum_pitch_noticed(), actualDuration});
           };
           vec.push_back(std::move(p));
         }
@@ -273,11 +273,7 @@ static void parseEvent_format0(const libremidi::track_event& ev, std::vector<Mid
         note.setStart(delta * (tick / total));
         note.setPitch(pitch);
         note.setVelocity(vel);
-        if (note.pitch() < nv.min)
-          nv.min = note.pitch();
-        else if (note.pitch() > nv.max)
-          nv.max = note.pitch();
-
+        nv.notes.notice_pitch(note.pitch());
         notes.insert({note.pitch(), note});
       }
       else
@@ -287,7 +283,7 @@ static void parseEvent_format0(const libremidi::track_event& ev, std::vector<Mid
         {
           NoteData note = it->second;
           note.setDuration(delta * (tick / total - note.start()));
-          nv.notes.push_back(note);
+          nv.notes.append(note);
         }
         notes.erase(pitch);
       }
@@ -305,7 +301,7 @@ static void parseEvent_format0(const libremidi::track_event& ev, std::vector<Mid
       {
         NoteData note = it->second;
         note.setDuration(delta * (tick / total - note.start()));
-        nv.notes.push_back(note);
+        nv.notes.append(note);
       }
       notes.erase(ev.m.bytes[1]);
       break;
@@ -356,11 +352,7 @@ void parseEvent(const libremidi::track_event& ev, MidiTrack& nv, midi_note_map& 
         note.setStart(delta * (tick / total));
         note.setPitch(pitch);
         note.setVelocity(vel);
-        if (note.pitch() < nv.min)
-          nv.min = note.pitch();
-        else if (note.pitch() > nv.max)
-          nv.max = note.pitch();
-
+        nv.notes.notice_pitch(note.pitch());
         notes.insert({note.pitch(), note});
       }
       else
@@ -370,7 +362,7 @@ void parseEvent(const libremidi::track_event& ev, MidiTrack& nv, midi_note_map& 
         {
           NoteData note = it->second;
           note.setDuration(delta * (tick / total - note.start()));
-          nv.notes.push_back(note);
+          nv.notes.append(note);
         }
         notes.erase(pitch);
       }
@@ -383,7 +375,7 @@ void parseEvent(const libremidi::track_event& ev, MidiTrack& nv, midi_note_map& 
       {
         NoteData note = it->second;
         note.setDuration(delta * (tick / total - note.start()));
-        nv.notes.push_back(note);
+        nv.notes.append(note);
       }
       notes.erase(ev.m.bytes[1]);
 

--- a/src/plugins/score-plugin-midi/Midi/MidiDrop.hpp
+++ b/src/plugins/score-plugin-midi/Midi/MidiDrop.hpp
@@ -18,11 +18,101 @@ public:
       const score::DocumentContext& ctx) const noexcept override;
 };
 
+struct PitchbendData{
+  int16_t bend;
+};
+struct ControllerData {
+  midi_size_t channel;
+  midi_size_t number;
+  midi_size_t value;
+  static ControllerData make_cc(const midi_size_t channel, const midi_size_t controller, const midi_size_t value)
+  {
+    SCORE_ASSERT(channel >= 0 && channel < 16);
+    return ControllerData{channel, controller, value};
+  }
+};
+
+struct NoteOnData {
+  midi_size_t channel;
+  midi_size_t note;
+  midi_size_t velocity;
+};
+struct NoteOffData {
+  midi_size_t channel;
+  midi_size_t note;
+  midi_size_t velocity;
+};
+struct MidiTrackEvent {
+  static MidiTrackEvent make_note_off(const double start, const midi_size_t ch, const midi_size_t n, const midi_size_t v){
+    return MidiTrackEvent{m_start: start, m_message:  Midi::NoteOffData{channel: ch, note: n, velocity: v}};
+  }
+  static MidiTrackEvent make_note_on(const double start, const midi_size_t ch, const midi_size_t n, const midi_size_t v){
+    return MidiTrackEvent{m_start: start, m_message:  Midi::NoteOnData{channel: ch, note: n, velocity: v}};
+  }
+  double m_start{};
+
+  void setStart(const double start){ m_start = start; }
+  const double start(){return m_start; }
+  std::variant<Midi::NoteOnData, Midi::NoteOffData, Midi::ControllerData,Midi::PitchbendData> m_message;
+};
+
+struct MidiTrackEvents {
+  void push_back(double delta, int tick, double total, Midi::ControllerData c){
+    const double start = delta * (tick / total);
+    trackEvents.push_back(MidiTrackEvent{m_start:start, m_message: c});
+  }
+
+  void push_back(double delta, int tick, double total, Midi::NoteOnData n){
+    const double start = delta * (tick / total);
+    trackEvents.push_back(MidiTrackEvent{m_start:start, m_message: n});
+  }
+
+  void push_back(double delta, int tick, double total, Midi::NoteOffData n){
+    const double start = delta * (tick / total);
+    trackEvents.push_back(MidiTrackEvent{m_start:start, m_message: n});
+  }
+
+  void apply_scale_ratio(const double ratio){
+    for (auto& event : trackEvents)
+    {
+      event.setStart(ratio * event.start());
+    }
+  }
+  auto size() const { return trackEvents.size(); }
+  std::vector<Midi::MidiTrackEvent> trackEvents;
+};
+
+struct MidiTrackNotes {
+  std::vector<Midi::NoteData> notes;
+  void push_back(Midi::NoteData note){
+    notes.push_back(note);
+  }
+
+  auto begin() { return notes.begin(); }
+  auto end() { return notes.end(); }
+  auto cbegin() const { return notes.begin(); }
+  auto cend() const { return notes.end(); }
+  auto begin() const { return notes.begin(); }
+  auto end() const { return notes.end(); }
+
+  auto size() const { return notes.size(); }
+  auto empty() const { return notes.empty(); }
+  void apply_scale_ratio(const double ratio){
+     for (auto& note : notes)
+     {
+       note.setStart(ratio * note.start());
+       note.setDuration(ratio * note.duration());
+     }
+  }
+};
+
+
 struct MidiTrack
 {
   QString name;
 
-  std::vector<Midi::NoteData> notes;
+  MidiTrackNotes notes;
+  MidiTrackEvents trackEvents;
   int min{127}, max{0};
 
   struct MidiSong

--- a/src/plugins/score-plugin-midi/Midi/MidiDrop.hpp
+++ b/src/plugins/score-plugin-midi/Midi/MidiDrop.hpp
@@ -45,10 +45,10 @@ struct NoteOffData {
 };
 struct MidiTrackEvent {
   static MidiTrackEvent make_note_off(const double start, const midi_size_t ch, const midi_size_t n, const midi_size_t v){
-    return MidiTrackEvent{m_start: start, m_message:  Midi::NoteOffData{channel: ch, note: n, velocity: v}};
+    return MidiTrackEvent{.m_start = start, .m_message =   Midi::NoteOffData{.channel = ch, .note =  n, .velocity =  v}};
   }
   static MidiTrackEvent make_note_on(const double start, const midi_size_t ch, const midi_size_t n, const midi_size_t v){
-    return MidiTrackEvent{m_start: start, m_message:  Midi::NoteOnData{channel: ch, note: n, velocity: v}};
+    return MidiTrackEvent{.m_start = start, .m_message =   Midi::NoteOnData{.channel = ch, .note =  n, .velocity =  v}};
   }
   double m_start{};
 
@@ -60,17 +60,17 @@ struct MidiTrackEvent {
 struct MidiTrackEvents {
   void push_back(double delta, int tick, double total, Midi::ControllerData c){
     const double start = delta * (tick / total);
-    trackEvents.push_back(MidiTrackEvent{m_start:start, m_message: c});
+    trackEvents.push_back(MidiTrackEvent{.m_start = start, .m_message =  c});
   }
 
   void push_back(double delta, int tick, double total, Midi::NoteOnData n){
     const double start = delta * (tick / total);
-    trackEvents.push_back(MidiTrackEvent{m_start:start, m_message: n});
+    trackEvents.push_back(MidiTrackEvent{.m_start = start, .m_message =  n});
   }
 
   void push_back(double delta, int tick, double total, Midi::NoteOffData n){
     const double start = delta * (tick / total);
-    trackEvents.push_back(MidiTrackEvent{m_start:start, m_message: n});
+    trackEvents.push_back(MidiTrackEvent{.m_start = start, .m_message =  n});
   }
 
   void apply_scale_ratio(const double ratio){
@@ -84,11 +84,23 @@ struct MidiTrackEvents {
 };
 
 struct MidiTrackNotes {
+  using pitch = int;
   std::vector<Midi::NoteData> notes;
-  void push_back(Midi::NoteData note){
+  pitch min{127}, max{0};
+  pitch minimum_pitch_noticed() const { return min; }
+  pitch maximum_pitch_noticed() const { return max; }
+  void append(Midi::NoteData note){
     notes.push_back(note);
   }
 
+  void notice_pitch(int pitch){
+    if (pitch < min) {
+      min = pitch;
+    }
+    else if (pitch > max) {
+      max = pitch;
+    }
+  }
   auto begin() { return notes.begin(); }
   auto end() { return notes.end(); }
   auto cbegin() const { return notes.begin(); }
@@ -114,7 +126,6 @@ struct MidiTrack
 
   MidiTrackNotes notes;
   MidiTrackEvents trackEvents;
-  int min{127}, max{0};
 
   struct MidiSong
   {

--- a/src/plugins/score-plugin-midi/Midi/MidiDrop.hpp
+++ b/src/plugins/score-plugin-midi/Midi/MidiDrop.hpp
@@ -2,6 +2,7 @@
 #include <Midi/MidiNote.hpp>
 #include <Process/Drop/ProcessDropHandler.hpp>
 #include <Process/TimeValue.hpp>
+#include <mpark/variant.hpp>
 namespace Midi
 {
 
@@ -53,7 +54,7 @@ struct MidiTrackEvent {
 
   void setStart(const double start){ m_start = start; }
   const double start(){return m_start; }
-  std::variant<Midi::NoteOnData, Midi::NoteOffData, Midi::ControllerData,Midi::PitchbendData> m_message;
+  mpark::variant<Midi::NoteOnData, Midi::NoteOffData, Midi::ControllerData,Midi::PitchbendData> m_message;
 };
 
 struct MidiTrackEvents {

--- a/src/plugins/score-plugin-midi/Midi/MidiPresenter.cpp
+++ b/src/plugins/score-plugin-midi/Midi/MidiPresenter.cpp
@@ -375,7 +375,7 @@ void Presenter::on_drop(const QPointF& pos, const QMimeData& md)
   track.notes.apply_scale_ratio(ratio);
   track.trackEvents.apply_scale_ratio(ratio);
   disp.submit<Midi::ReplaceNotes>(
-      model(), track.notes, track.min, track.max, model().duration());
+      model(), track.notes, track.notes.minimum_pitch_noticed(), track.notes.maximum_pitch_noticed(), model().duration());
 }
 
 std::vector<Id<Note>> Presenter::selectedNotes() const

--- a/src/plugins/score-plugin-midi/Midi/MidiPresenter.cpp
+++ b/src/plugins/score-plugin-midi/Midi/MidiPresenter.cpp
@@ -372,11 +372,8 @@ void Presenter::on_drop(const QPointF& pos, const QMimeData& md)
   // Scale notes so that the durations are relative to the ratio of the song
   // duration & constraint duration
   const double ratio = song.durationInMs / model().duration().msec();
-  for (auto& note : track.notes)
-  {
-    note.setStart(ratio * note.start());
-    note.setDuration(ratio * note.duration());
-  }
+  track.notes.apply_scale_ratio(ratio);
+  track.trackEvents.apply_scale_ratio(ratio);
   disp.submit<Midi::ReplaceNotes>(
       model(), track.notes, track.min, track.max, model().duration());
 }


### PR DESCRIPTION
This is wip of a first iteration on supporting a bit more of the midi messages in Score.

# current scope

* [ ] parsing
  * [x] cc
  * [ ] pitchbend
* [ ] ui
  * [ ] display enveloppes in the track
  * [ ] show notes with different colour per midi channel
* [ ] playback
  * [ ] output the additional events

Guidance appreciated, including pointers for:
* how to deal with the streaming of midi data on the output port of the track
* how to deal with the UI, to add a display of enveloppes for cc and pitchbend data