### PR TITLE
[ui] fixed drag and drop functionality in lineedit

### DIFF
--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -65,14 +65,13 @@ public:
   }
 
   void dropEvent(QGraphicsSceneDragDropEvent* drop) override
-     {
-         QGraphicsTextItem::dropEvent(drop);
-         QList<QUrl> urlList = drop->mimeData()->urls();
-         if(!urlList.isEmpty()){
-            QUrl newFileUrl = urlList[0];
-            this->setPlainText(newFileUrl.toLocalFile());
-         }
-     }
+  {
+    QGraphicsTextItem::dropEvent(drop);
+    const auto urlList = drop->mimeData()->urls();
+    if(!urlList.isEmpty()) {
+      this->setPlainText(urlList[0].toLocalFile());
+    }
+   }
 
   void sizeChanged(QSizeF sz) E_SIGNAL(SCORE_LIB_PROCESS_EXPORT, sizeChanged, sz)
 };

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -22,6 +22,7 @@
 
 #include <QCheckBox>
 #include <QGraphicsItem>
+#include <QGraphicsSceneDragDropEvent>
 #include <QLineEdit>
 #include <QPalette>
 #include <QTextDocument>
@@ -62,6 +63,16 @@ public:
       ctl->setAcceptRichText(false);
     }
   }
+
+  void dropEvent(QGraphicsSceneDragDropEvent* drop) override
+     {
+         QGraphicsTextItem::dropEvent(drop);
+         QList<QUrl> urlList = drop->mimeData()->urls();
+         if(!urlList.isEmpty()){
+            QUrl newFileUrl = urlList[0];
+            this->setPlainText(newFileUrl.toLocalFile());
+         }
+     }
 
   void sizeChanged(QSizeF sz) E_SIGNAL(SCORE_LIB_PROCESS_EXPORT, sizeChanged, sz)
 };

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -67,11 +67,12 @@ public:
   void dropEvent(QGraphicsSceneDragDropEvent* drop) override
   {
     QGraphicsTextItem::dropEvent(drop);
-    const auto urlList = drop->mimeData()->urls();
+    const auto& urlList = drop->mimeData()->urls();
+    
     if(!urlList.isEmpty()) {
       this->setPlainText(urlList[0].toLocalFile());
     }
-   }
+  }
 
   void sizeChanged(QSizeF sz) E_SIGNAL(SCORE_LIB_PROCESS_EXPORT, sizeChanged, sz)
 };


### PR DESCRIPTION
Clean pull request that fixes the drag-and-drop functionality of a text field to always convert a file URL to a local path, clearing the text field and deleting the "file://" prefix.