### PR TITLE
[ui] Make device disconnected state more visible

### DIFF
--- a/src/plugins/score-lib-device/Device/ItemModels/NodeDisplayMethods.cpp
+++ b/src/plugins/score-lib-device/Device/ItemModels/NodeDisplayMethods.cpp
@@ -127,11 +127,12 @@ QVariant deviceNameColumnData(const Device::Node& node, bool connected, int role
 
   switch(role)
   {
-    case Qt::DisplayRole:
-    case Qt::EditRole: {
+    case Qt::DisplayRole: {
       const auto& name = node.get<DeviceSettings>().name;
       return connected ? name : name + " (disconnected)";
     }
+    case Qt::EditRole:
+      return node.get<DeviceSettings>().name;
     case Qt::FontRole: {
       if(!connected)
         return italicFont;

--- a/src/plugins/score-lib-device/Device/ItemModels/NodeDisplayMethods.cpp
+++ b/src/plugins/score-lib-device/Device/ItemModels/NodeDisplayMethods.cpp
@@ -128,8 +128,10 @@ QVariant deviceNameColumnData(const Device::Node& node, bool connected, int role
   switch(role)
   {
     case Qt::DisplayRole:
-    case Qt::EditRole:
-      return node.get<DeviceSettings>().name;
+    case Qt::EditRole: {
+      const auto& name = node.get<DeviceSettings>().name;
+      return connected ? name : name + " (disconnected)";
+    }
     case Qt::FontRole: {
       if(!connected)
         return italicFont;


### PR DESCRIPTION
This patch is a proposed fix for #477: the `(disconnected)` string is appended to a device's name in the Device Explorer if it's disconnected.

This is my first contribution the Score project - and one of my first to OSS projects -, so I apologize in advance if I'm doing something wrong haha