### PR TITLE
[avendish] frist attempt at making devices with avendish addons

### DIFF
--- a/src/plugins/score-plugin-avnd/AvndDevice/Device.hpp
+++ b/src/plugins/score-plugin-avnd/AvndDevice/Device.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include <Device/Protocol/DeviceInterface.hpp>
+
+#include <ossia/network/generic/generic_device.hpp>
+#include <ossia/network/local/local.hpp>
+#include <ossia/network/generic/wrapped_parameter.hpp>
+#include <ossia/network/base/parameter_data.hpp>
+
+#include "avnd_protocol.hpp"
+
+namespace oscr
+{
+class DeviceImplementation final : public Device::OwningDeviceInterface
+{
+public:
+  DeviceImplementation(const Device::DeviceSettings& settings)
+    : OwningDeviceInterface{settings}
+  {
+    m_capas.canRefreshTree = false;
+    m_capas.canAddNode = false;
+    m_capas.canRemoveNode = false;
+    m_capas.canRenameNode = false;
+    m_capas.canSetProperties = false;
+    m_capas.canSerialize = false;
+  }
+
+  ~DeviceImplementation() {}
+
+  bool reconnect() override
+  {
+    disconnect();
+
+    try
+    {
+      auto protocol = std::make_unique<avnd_protocol>();
+      auto dev = std::make_unique<ossia::net::generic_device>(
+            std::move(protocol), settings().name.toStdString());
+
+      m_dev = std::move(dev);
+      deviceChanged(nullptr, m_dev.get());
+
+      enableCallbacks();
+    }
+    catch (const std::runtime_error& e)
+    {
+      qDebug() << e.what();
+    }
+    catch (...)
+    {
+      qDebug() << "error";
+    }
+
+    return connected();
+  }
+
+  void disconnect() override
+  {
+    OwningDeviceInterface::disconnect();
+  }
+};
+}

--- a/src/plugins/score-plugin-avnd/AvndDevice/ProtocolFactory.hpp
+++ b/src/plugins/score-plugin-avnd/AvndDevice/ProtocolFactory.hpp
@@ -1,0 +1,72 @@
+#pragma once
+#include <Explorer/DefaultProtocolFactory.hpp>
+#include <Crousti/Concepts.hpp>
+
+#include <State/Widgets/AddressFragmentLineEdit.hpp>
+//#include <Protocols/LibraryDeviceEnumerator.hpp>
+
+#include <score/application/ApplicationContext.hpp>
+#include <score/widgets/SignalUtils.hpp>
+
+#include <ossia/detail/config.hpp>
+
+#include "Device.hpp"
+
+namespace oscr
+{
+template <typename Node>
+class ProtocolFactory final : public Protocols::DefaultProtocolFactory
+{
+  SCORE_CONCRETE(avnd::get_uuid<Node>())
+
+  QString prettyName() const noexcept override
+  {
+    return QObject::tr(avnd::get_name<Node>());
+  }
+
+  QString category() const noexcept override
+  {
+    return avnd::get_category<Node>();
+  }
+
+  Device::DeviceEnumerator*
+  getEnumerator(const score::DocumentContext& ctx) const override
+  {
+    return nullptr;
+  }
+
+  Device::DeviceInterface* makeDevice(
+      const Device::DeviceSettings& settings,
+      const Explorer::DeviceDocumentPlugin& plugin,
+      const score::DocumentContext& ctx) override
+  {
+    return new DeviceImplementation{settings};
+  }
+
+  const Device::DeviceSettings& defaultSettings() const noexcept override
+  {
+    static const Device::DeviceSettings& settings = [&]
+    {
+      Device::DeviceSettings s;
+      s.protocol = concreteKey();
+      s.name = avnd::get_name<Node>;
+      return s;
+    }();
+
+    return settings;
+  }
+
+  Device::ProtocolSettingsWidget* makeSettingsWidget() override;
+
+  QVariant
+  makeProtocolSpecificSettings(const VisitorVariant& visitor) const override;
+
+  void serializeProtocolSpecificSettings(
+      const QVariant& data,
+      const VisitorVariant& visitor) const override;
+
+  bool checkCompatibility(
+      const Device::DeviceSettings& a,
+      const Device::DeviceSettings& b) const noexcept override;
+};
+}

--- a/src/plugins/score-plugin-avnd/AvndDevice/avnd_protocol.hpp
+++ b/src/plugins/score-plugin-avnd/AvndDevice/avnd_protocol.hpp
@@ -1,0 +1,61 @@
+#ifndef AVND_PROTOCOL_H
+#define AVND_PROTOCOL_H
+
+#include <QObject>
+
+#include <verdigris>
+
+#include <ossia/network/generic/wrapped_parameter.hpp>
+#include <ossia/network/base/protocol.hpp>
+#include <ossia/detail/logger.hpp>
+
+namespace oscr
+{
+struct avnd_parameter_data final
+    : public ossia::net::parameter_data
+{
+  avnd_parameter_data() = default;
+  avnd_parameter_data(const avnd_parameter_data&) = delete;
+  avnd_parameter_data(avnd_parameter_data&&) = default;
+  avnd_parameter_data& operator=(const avnd_parameter_data&) = delete;
+  avnd_parameter_data& operator=(avnd_parameter_data&&) = delete;
+
+  avnd_parameter_data(const std::string& name)
+    : parameter_data{name}
+  {
+  }
+
+  bool valid() const noexcept
+  {
+    if (type) return true;
+    return false;
+  }
+};
+
+using avnd_parameter = ossia::net::wrapped_parameter<avnd_parameter_data>;
+using avnd_node = ossia::net::wrapped_node<avnd_parameter_data, avnd_parameter>;
+
+class avnd_protocol final
+    : public QObject
+    , public ossia::net::protocol_base
+{
+public:
+  avnd_protocol() {};
+
+  ~avnd_protocol() override;
+
+  bool pull(ossia::net::parameter_base&) override { return false; };
+  bool push(const ossia::net::parameter_base& parameter_base,
+            const ossia::value& v) override { return false; };
+  bool push_raw(const ossia::net::full_parameter_data& parameter_base) override { return false; };
+  void set_device(ossia::net::device_base& dev) override { m_device = &dev; };
+  bool observe(ossia::net::parameter_base&, bool b) override { return false; };
+  bool update(ossia::net::node_base& node_base) override { return true; };
+
+private:
+  ossia::net::device_base* m_device{};
+  QObject* m_object{};
+};
+
+}
+#endif // AVND_PROTOCOL_H


### PR DESCRIPTION
!!! for reviews only at the moment !!!

I am trying to make a generic device with a avendish "Node" as a template argument. This may be a complete wrong way to go about it.
for example, I am trying to provide the name and uuid from ```avnd::get_uuid<Node>()``` and ```avnd::get_name<Node>()``` 
