### PR TITLE
Change layout from QGridLayout to QHBoxLayout to add QSplitter

### DIFF
--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
@@ -96,7 +96,6 @@ DeviceEditDialog::DeviceEditDialog(
   m_devices = new QTreeWidget{this};
   m_devices->header()->hide();
   m_devices->setSelectionMode(QAbstractItemView::SingleSelection);
-  qDebug() << "m_devices initialized : " << m_devices;
   column2_layout->addWidget(m_devices);
   column2->setLayout(column2_layout);
   splitter->addWidget(column2);
@@ -314,7 +313,6 @@ void DeviceEditDialog::selectedProtocolChanged()
   }
   else
   {
-    qDebug() << "m_devices is not initialized!";
     m_devices->setVisible(false);
     m_devicesLabel->setVisible(false);
   }

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
@@ -59,11 +59,11 @@ DeviceEditDialog::DeviceEditDialog(
   };
 
   setWindowTitle(tr("Add device"));
-  auto base_layout = new QVBoxLayout{this};
+  auto base_layout = new QHBoxLayout{this};
   setLayout(base_layout);
   setModal(true);
 
-  auto splitter = new QSplitter{this};
+  splitter = new QSplitter{this};
   base_layout->addWidget(splitter);
 
   auto column1 = new QWidget;
@@ -78,12 +78,15 @@ DeviceEditDialog::DeviceEditDialog(
   m_protocols->setSelectionMode(QAbstractItemView::SingleSelection);
   column1_layout->addWidget(m_protocols);
   column1->setLayout(column1_layout);
-  splitter->addWidget(column1);
+  column1->setFixedWidth(200);
+  base_layout->addWidget(column1);
 
   if(m_mode == Mode::Editing)
   {
     column1->setVisible(false);
   }
+
+  base_layout->addWidget(splitter);
 
   // Column 2: Devices
   auto column2 = new QWidget;
@@ -126,6 +129,16 @@ DeviceEditDialog::DeviceEditDialog(
   column3->setLayout(column3_layout);
   splitter->addWidget(column3);
 
+  m_devices->setMinimumWidth(40);
+  m_main->setMinimumWidth(100);
+
+  splitter->setCollapsible(0, false);
+  splitter->setCollapsible(1, false);
+
+  splitter->setStretchFactor(0, 1);
+  splitter->setStretchFactor(1, 2);
+
+
   connect(m_buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
   connect(m_buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
@@ -137,13 +150,11 @@ DeviceEditDialog::DeviceEditDialog(
 
   if(m_protocols->topLevelItemCount() > 0)
   {
-    //  m_protocols->setCurrentItem();
-    //  m_index = m_protocols->currentRow();
     selectedProtocolChanged();
   }
 
-  setMinimumWidth(700);
-  setMinimumHeight(400);
+  setMinimumWidth(850);
+  setMinimumHeight(550);
 
   setAcceptEnabled(false);
 }
@@ -237,8 +248,6 @@ void DeviceEditDialog::selectedProtocolChanged()
   // Recreate
   if(m_protocols->selectedItems().isEmpty())
   {
-    //m_devices->setVisible(false);
-    //m_devicesLabel->setVisible(false);
     return;
   }
   auto selected_item = m_protocols->selectedItems().first();
@@ -257,7 +266,6 @@ void DeviceEditDialog::selectedProtocolChanged()
   if(m_protocolWidget)
   {
     SCORE_ASSERT(m_index < m_previousSettings.count());
-
     m_previousSettings[m_index] = m_protocolWidget->getSettings();
     delete m_protocolWidget;
     m_protocolWidget = nullptr;
@@ -272,6 +280,8 @@ void DeviceEditDialog::selectedProtocolChanged()
     m_devicesLabel->setVisible(true);
     m_devices->setRootIsDecorated(false);
     m_devices->setExpandsOnDoubleClick(false);
+    splitter->widget(0)->show();
+    splitter->widget(0)->setMinimumWidth(200);
 
     for(auto& [name, e] : m_enumerators)
     {
@@ -315,6 +325,7 @@ void DeviceEditDialog::selectedProtocolChanged()
   {
     m_devices->setVisible(false);
     m_devicesLabel->setVisible(false);
+    splitter->widget(0)->hide();
   }
   m_protocolNameLabel->setText(tr("Settings (%1)").arg(protocol->prettyName()));
   m_protocolWidget = protocol->makeSettingsWidget();

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
@@ -68,11 +68,11 @@ DeviceEditDialog::DeviceEditDialog(
 
   auto column1 = new QWidget;
   auto column1_layout = new QVBoxLayout{column1};
-  auto protocolsLabel = new QLabel{tr("Protocols"), this};
-  setHeaderTextFormat(protocolsLabel);
-  column1_layout->addWidget(protocolsLabel);
-  protocolsLabel->setAlignment(Qt::AlignTop);
-  protocolsLabel->setAlignment(Qt::AlignHCenter);
+  m_protocolsLabel = new QLabel{tr("Protocols"), this};
+  setHeaderTextFormat(m_protocolsLabel);
+  column1_layout->addWidget(m_protocolsLabel);
+  m_protocolsLabel->setAlignment(Qt::AlignTop);
+  m_protocolsLabel->setAlignment(Qt::AlignHCenter);
   m_protocols = new QTreeWidget{this};
   m_protocols->header()->hide();
   m_protocols->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -88,11 +88,11 @@ DeviceEditDialog::DeviceEditDialog(
   // Column 2: Devices
   auto column2 = new QWidget;
   auto column2_layout = new QVBoxLayout{column2};
-  auto devicesLabel = new QLabel{tr("Devices"), this};
-  setHeaderTextFormat(devicesLabel);
-  column2_layout->addWidget(devicesLabel);
-  devicesLabel->setAlignment(Qt::AlignTop);
-  devicesLabel->setAlignment(Qt::AlignHCenter);
+  m_devicesLabel = new QLabel{tr("Devices"), this};
+  setHeaderTextFormat(m_devicesLabel);
+  column2_layout->addWidget(m_devicesLabel);
+  m_devicesLabel->setAlignment(Qt::AlignTop);
+  m_devicesLabel->setAlignment(Qt::AlignHCenter);
   m_devices = new QTreeWidget{this};
   m_devices->header()->hide();
   m_devices->setSelectionMode(QAbstractItemView::SingleSelection);
@@ -103,11 +103,11 @@ DeviceEditDialog::DeviceEditDialog(
   // Column 3: Settings
   auto column3 = new QWidget;
   auto column3_layout = new QVBoxLayout{column3};
-  auto settingsLabel = new QLabel{tr("Settings"), this};
-  setHeaderTextFormat(settingsLabel);
-  column3_layout->addWidget(settingsLabel);
-  settingsLabel->setAlignment(Qt::AlignTop);
-  settingsLabel->setAlignment(Qt::AlignHCenter);
+  m_protocolNameLabel = new QLabel{tr("Settings"), this};
+  setHeaderTextFormat(m_protocolNameLabel);
+  column3_layout->addWidget(m_protocolNameLabel);
+  m_protocolNameLabel->setAlignment(Qt::AlignTop);
+  m_protocolNameLabel->setAlignment(Qt::AlignHCenter);
   m_main = new QWidget{this};
   m_layout = new QFormLayout;
   m_layout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.hpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.hpp
@@ -5,6 +5,7 @@
 
 #include <QDialog>
 #include <QList>
+#include <QSplitter>
 
 #include <score_plugin_deviceexplorer_export.h>
 
@@ -82,5 +83,6 @@ private:
 
   QString m_originalName{};
   int m_index{};
+  QSplitter* splitter;
 };
 }


### PR DESCRIPTION
Changing QGridLayout to QVBoxLayout to provide resizable panes

issue with this implementation: when one of the panes isn't populates, such as with audio device, it leaves a gap 
QGridLayout
![image](https://github.com/user-attachments/assets/f8b3fb6c-e942-4451-af63-5f6a6b295b18)
QVBoxLayout
![image](https://github.com/user-attachments/assets/7fad28d1-d152-4798-97f0-97df47c52f71)
