### PR TITLE
Add 'NSBluetoothAlwaysUsageDescription' to info.plist to fix BLE on Mac

### DIFF
--- a/src/app/Info.plist.in
+++ b/src/app/Info.plist.in
@@ -47,6 +47,9 @@
     <key>NSCameraUsageDescription</key>
     <string>ossia score needs camera permission for video input.</string>
 
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>ossia score needs bluetooth permission for the BLE device.</string>
+    
     <key>CFBundleDocumentTypes</key>
     <array>
         <dict>


### PR DESCRIPTION
Ossia Score crashes on OSX when adding the BLE input because the OS terminates you for not providing a description on the Info.plist

<img width="656" alt="Screenshot 2024-06-17 at 09 27 45" src="https://github.com/ossia/score/assets/2163363/9778e0a5-9b22-45d2-89a4-d118912389d6">

This adds this to the templated info.plist that's used for the Mac build.