### PR TITLE
refactor StartScreen

### DIFF
--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -75,10 +75,10 @@ int qInitResources_qtconf();
 #if !defined(SCORE_DEBUG) && !defined(__EMSCRIPTEN__)
 #define SCORE_SPLASH_SCREEN 1
 #endif
-#include <phantom/phantomstyle.h>
-
-#if defined(SCORE_SPLASH_SCREEN)
 #include "StartScreen.hpp"
+
+#include <phantom/phantomstyle.h>
+#if defined(SCORE_SPLASH_SCREEN)
 #else
 namespace score
 {

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -74,10 +74,10 @@ int qInitResources_qtconf();
 #if !defined(SCORE_DEBUG) && !defined(__EMSCRIPTEN__)
 #define SCORE_SPLASH_SCREEN 1
 #endif
-#include <phantom/phantomstyle.h>
-
-#if defined(SCORE_SPLASH_SCREEN)
 #include "StartScreen.hpp"
+
+#include <phantom/phantomstyle.h>
+#if defined(SCORE_SPLASH_SCREEN)
 #else
 namespace score
 {

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -75,10 +75,11 @@ int qInitResources_qtconf();
 #if !defined(SCORE_DEBUG) && !defined(__EMSCRIPTEN__)
 #define SCORE_SPLASH_SCREEN 1
 #endif
-#include "StartScreen.hpp"
 
 #include <phantom/phantomstyle.h>
+
 #if defined(SCORE_SPLASH_SCREEN)
+#include "StartScreen.hpp"
 #else
 namespace score
 {

--- a/src/app/StartScreen.hpp
+++ b/src/app/StartScreen.hpp
@@ -6,16 +6,21 @@
 
 #include <QApplication>
 #include <QDesktopServices>
+#include <QIcon>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QListWidget>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QPainter>
 #include <QPixmap>
 #include <QPointer>
+#include <QPushButton>
 #include <QSettings>
+#include <QStackedWidget>
 #include <QTextLayout>
+#include <QVBoxLayout>
 
 #include <score_git_info.hpp>
 
@@ -224,7 +229,6 @@ void InteractiveLabel::enterEvent(QEnterEvent* event)
     return;
 
   m_currentColor = m_activeColor;
-  m_font.setUnderline(true);
   m_currentPixmap = m_pixmapOn;
 
   repaint();
@@ -236,7 +240,6 @@ void InteractiveLabel::leaveEvent(QEvent* event)
     return;
 
   m_currentColor = m_inactiveColor;
-  m_font.setUnderline(false);
   m_currentPixmap = m_pixmap;
 
   repaint();
@@ -266,6 +269,7 @@ public:
   void exitApp() W_SIGNAL(exitApp)
 
   void addLoadCrashedSession();
+  void setupTabs();
 
 protected:
   void paintEvent(QPaintEvent* event) override;
@@ -294,53 +298,263 @@ struct StartScreenLink
 StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget* parent)
     : QWidget(parent)
 {
-// Workaround until https://bugreports.qt.io/browse/QTBUG-103225 is fixed
 #if defined(__APPLE__)
   static constexpr double font_factor = 96. / 72.;
 #else
   static constexpr double font_factor = 1.;
 #endif
-  QFont f("Ubuntu", 14  * font_factor, QFont::Light);
-  f.setHintingPreference(QFont::HintingPreference::PreferFullHinting);
-  f.setStyleStrategy(QFont::PreferAntialias);
 
-  QFont titleFont("Montserrat", 14  * font_factor, QFont::DemiBold);
-  titleFont.setHintingPreference(QFont::HintingPreference::PreferFullHinting);
-  titleFont.setStyleStrategy(QFont::PreferAntialias);
+  QFont navFont("Montserrat", 12 * font_factor, QFont::DemiBold);
+  QFont headerFont("Montserrat", 12 * font_factor);
+  QFont labelFont("Montserrat", 11 * font_factor, QFont::Normal);
+  labelFont.setHintingPreference(QFont::HintingPreference::PreferFullHinting);
+  labelFont.setStyleStrategy(QFont::PreferAntialias);
 
-  this->setEnabled(true);
-  setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint); //| Qt::WindowStaysOnTopHint);
-  setWindowModality(Qt::ApplicationModal);
+  // Header Widget
+  QWidget* headerWidget = new QWidget(this);
+  QHBoxLayout* headerLayout = new QHBoxLayout(headerWidget);
 
-  m_background = score::get_pixmap(":/startscreen/startscreensplash.png");
+  QLabel* logoLabel = new QLabel(headerWidget);
 
-  if(QPainter painter; painter.begin(&m_background))
+  QPixmap placeholderPixmap(300, 100); // TODO: Replace with actual logo when available
+  placeholderPixmap.fill(Qt::gray);
+  logoLabel->setPixmap(placeholderPixmap);
+  logoLabel->setFixedSize(placeholderPixmap.size());
+  headerLayout->addWidget(logoLabel, 0, Qt::AlignLeft);
+
+  //Donate label
+  InteractiveLabel* donateLabel = new InteractiveLabel(
+      navFont, tr("Donate"), "https://opencollective.com/ossia", this);
+  donateLabel->setOpenExternalLink(true);
+  donateLabel->setPixmaps(
+      score::get_pixmap(":/icons/new_file_off.png"),
+      score::get_pixmap(":/icons/new_file_on.png")); // TODO: Replace with  heart icon
+  headerLayout->addWidget(donateLabel);
+
+  // side nav list and stacked widget
+  QListWidget* navigationList = new QListWidget(this);
+  QStackedWidget* stackedWidget = new QStackedWidget(this);
+
+  navigationList->setFixedWidth(155);
+  navigationList->setSpacing(8);
+  navigationList->setFont(navFont);
+
+  navigationList->addItem(new QListWidgetItem(
+      QIcon(score::get_pixmap(":/icons/new_file_off.png")), tr("Home")));
+  navigationList->addItem(new QListWidgetItem(
+      QIcon(score::get_pixmap(":/icons/load_examples_off.png")), tr("Learn")));
+  navigationList->addItem(new QListWidgetItem(
+      QIcon(score::get_pixmap(":/icons/forum_off.png")), tr("Community")));
+
+  navigationList->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  navigationList->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+  navigationList->setStyleSheet(
+      "QListWidget { background-color: black;color: white; border: none;}"
+      "QListWidget::item { padding: 10px 10; margin: 8px 0; color: white;}"
+      "QListWidget::item:selected { background-color: #211f1f; color: white;"
+      "padding:00px; margin: 00px 0; }");
+
+  // Home View
+  QWidget* homeView = new QWidget;
+  QVBoxLayout* homeLayout = new QVBoxLayout(homeView);
+  homeView->setStyleSheet("background-color: #211f1f;");
+
+  // Left Col
+  QLabel* createNewLabel = new QLabel(tr("Create score"));
+  createNewLabel->setFont(headerFont);
+
+  QVBoxLayout* leftColumnLayout = new QVBoxLayout;
+  leftColumnLayout->addWidget(createNewLabel);
+
+  leftColumnLayout->addSpacing(10);
+
+  InteractiveLabel* newLabel
+      = new InteractiveLabel{labelFont, qApp->tr("Empty score"), "", this};
+  newLabel->setPixmaps(
+      score::get_pixmap(":/icons/new_file_off.png"),
+      score::get_pixmap(":/icons/new_file_on.png"));
+  newLabel->setTextOption(QTextOption(Qt::AlignLeft));
+  connect(
+      newLabel, &score::InteractiveLabel::labelPressed, this,
+      &StartScreen::openNewDocument);
+  leftColumnLayout->addWidget(newLabel);
+
+  for(const auto& action : recentFiles->actions())
   {
-    painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setRenderHint(QPainter::TextAntialiasing, true);
-    painter.setPen(QPen(QColor("#0092CF")));
+    auto* fileLabel = new InteractiveLabel{
+        labelFont, action->text(), action->data().toString(), this};
+    fileLabel->setTextOption(QTextOption(Qt::AlignLeft));
+    fileLabel->setPixmaps(
+        score::get_pixmap(":/icons/new_file_off.png"),
+        score::get_pixmap(":/icons/new_file_off.png"));
+    fileLabel->setInactiveColor(QColor{"#f0f0f0"});
+    fileLabel->setActiveColor(QColor{"#03C3DD"});
+    connect(
+        fileLabel, &score::InteractiveLabel::labelPressed, this, &StartScreen::openFile);
+    leftColumnLayout->addWidget(fileLabel);
+  }
+  leftColumnLayout->addStretch();
 
-    painter.setFont(f);
-    //painter.drawText(QPointF(250, 170), QCoreApplication::applicationVersion());
-    painter.drawText(QPointF(217, 188), QCoreApplication::applicationVersion());
-    painter.end();
+  // Right Column - Load Score
+  QLabel* loadScoreLabel = new QLabel(tr("Load a score"));
+  loadScoreLabel->setFont(headerFont);
+
+  QVBoxLayout* rightColumnLayout = new QVBoxLayout;
+  rightColumnLayout->addWidget(loadScoreLabel);
+  rightColumnLayout->addSpacing(10);
+
+  for(const auto& action : recentFiles->actions())
+  {
+    auto* fileLabel = new InteractiveLabel{
+        labelFont, action->text(), action->data().toString(), this};
+    fileLabel->setTextOption(QTextOption(Qt::AlignLeft));
+    fileLabel->setInactiveColor(QColor{"#f0f0f0"});
+    fileLabel->setActiveColor(QColor{"#03C3DD"});
+    connect(
+        fileLabel, &score::InteractiveLabel::labelPressed, this, &StartScreen::openFile);
+
+    rightColumnLayout->addWidget(fileLabel);
+  }
+  rightColumnLayout->addStretch();
+
+  InteractiveLabel* openScoreLabel
+      = new InteractiveLabel(labelFont, tr("Open.."), "", this);
+  openScoreLabel->setPixmaps(
+      score::get_pixmap(":/icons/load_off.png"),
+      score::get_pixmap(":/icons/load_on.png"));
+  openScoreLabel->setTextOption(QTextOption(Qt::AlignLeft));
+  connect(
+      openScoreLabel, &score::InteractiveLabel::labelPressed, this,
+      &StartScreen::openFileDialog);
+
+  rightColumnLayout->addWidget(openScoreLabel);
+
+  m_crashLabel
+      = new InteractiveLabel{labelFont, qApp->tr("Restore last session"), "", this};
+  m_crashLabel->setTextOption(QTextOption(Qt::AlignLeft));
+  m_crashLabel->setPixmaps(
+      score::get_pixmap(":/icons/reload_crash_off.png"),
+      score::get_pixmap(":/icons/reload_crash_on.png"));
+  m_crashLabel->setFixedWidth(250);
+  m_crashLabel->setInactiveColor(QColor{"#f0f0f0"});
+  m_crashLabel->setActiveColor(QColor{"#f6a019"});
+  m_crashLabel->setDisabled(true);
+  m_crashLabel->hide();
+  connect(
+      m_crashLabel, &score::InteractiveLabel::labelPressed, this,
+      &score::StartScreen::loadCrashedSession);
+
+  rightColumnLayout->addWidget(m_crashLabel);
+
+  QHBoxLayout* mainRowLayout = new QHBoxLayout;
+  mainRowLayout->addLayout(leftColumnLayout);
+  mainRowLayout->addLayout(rightColumnLayout);
+
+  homeLayout->addLayout(mainRowLayout);
+  homeView->setLayout(homeLayout);
+  stackedWidget->addWidget(homeView);
+
+  // Learn View
+  QWidget* learnView = new QWidget;
+  QVBoxLayout* learnLayout = new QVBoxLayout(learnView);
+  learnView->setStyleSheet("background-color: #211f1f;");
+
+  QLabel* learnLabel = new QLabel(tr("Browse examples"));
+  learnLabel->setFont(headerFont);
+  learnLayout->addWidget(learnLabel);
+  learnLayout->addSpacing(10);
+
+  // Add "Tutorials" link to the Learn section
+  InteractiveLabel* tutorialsLabel = new InteractiveLabel(
+      navFont, tr("Tutorials"), "https://www.youtube.com/...", learnView);
+  tutorialsLabel->setOpenExternalLink(true);
+  tutorialsLabel->setPixmaps(
+      score::get_pixmap(":/icons/tutorials_off.png"),
+      score::get_pixmap(":/icons/tutorials_on.png"));
+  tutorialsLabel->setStyleSheet(
+      "QLabel { padding: 8px; background-color: #161514; color: white; }"
+      "QLabel:hover { color: #f6a019; }");
+  learnLayout->addWidget(tutorialsLabel);
+
+  learnLayout->addStretch();
+  learnView->setLayout(learnLayout);
+  stackedWidget->addWidget(learnView);
+
+  // Community View
+  QWidget* communityView = new QWidget;
+  QVBoxLayout* communityLayout = new QVBoxLayout(communityView);
+  communityView->setStyleSheet("background-color: #211f1f;");
+
+  QLabel* communityLabel = new QLabel(tr("Get involved"));
+  communityLabel->setFont(headerFont);
+
+  communityLayout->addWidget(communityLabel);
+  communityLayout->addSpacing(10);
+
+  std::array<score::StartScreenLink, 3> communityMenus
+      = {{{tr("ossia Forum"), "http://forum.ossia.io/", ":/icons/forum_off.png",
+           ":/icons/forum_on.png"},
+          {tr("Contribute"), "https://opencollective.com/ossia/contribute",
+           ":/icons/contribute_off.png", ":/icons/contribute_on.png"},
+          {tr("Discord chat"), "https://discord.gg/ossia",
+           ":/icons/chat_off.png", // TODO : replace by Discord icon
+           ":/icons/chat_on.png"}}};
+
+  for(const auto& m : communityMenus)
+  {
+    InteractiveLabel* menuLabel
+        = new InteractiveLabel(navFont, m.name, m.url, communityView);
+    menuLabel->setOpenExternalLink(true);
+    menuLabel->setPixmaps(score::get_pixmap(m.pixmap), score::get_pixmap(m.pixmapOn));
+
+    menuLabel->setStyleSheet(
+        "QLabel {padding: 8px; background-color: #161514; color: white;}"
+        "QLabel:hover {color: #f6a019;}");
+
+    communityLayout->addWidget(menuLabel);
   }
 
+  communityLayout->addStretch();
+  communityView->setLayout(communityLayout);
+  stackedWidget->addWidget(communityView);
+
+  // Connect navigation list to stacked widget
+  connect(
+      navigationList, &QListWidget::currentRowChanged, stackedWidget,
+      &QStackedWidget::setCurrentIndex);
+  navigationList->setCurrentRow(0);
+
+  QHBoxLayout* contentLayout = new QHBoxLayout;
+  contentLayout->addWidget(navigationList);
+  contentLayout->addWidget(stackedWidget);
+
+  QVBoxLayout* mainLayout = new QVBoxLayout(this);
+  mainLayout->addWidget(headerWidget);
+  mainLayout->addLayout(contentLayout);
+  setLayout(mainLayout);
+
+  mainLayout->addStretch();
+
+  this->setEnabled(true);
+  setWindowModality(Qt::ApplicationModal);
+
   // Weird code here is because the window size seems to scale only to integer ratios.
-  setFixedSize(m_background.size() / m_background.devicePixelRatioF());
+  setFixedSize(QSize(600, 400) / m_background.devicePixelRatioF());
 
   {
+    // TODO : make this work
     // new version
     auto m_getLastVersion = new HTTPGet{
         QUrl("https://ossia.io/score-last-version.txt"),
-        [this, titleFont](const QByteArray& data) {
+        [this, navFont](const QByteArray& data) {
       auto version = QString::fromUtf8(data.simplified());
       if(SCORE_TAG_NO_V < version)
       {
         QString text
             = qApp->tr("New version %1 is available, click to update !").arg(version);
         QString url = "https://github.com/ossia/score/releases/latest/";
-        InteractiveLabel* label = new InteractiveLabel{titleFont, text, url, this};
+        InteractiveLabel* label = new InteractiveLabel{navFont, text, url, this};
         label->setPixmaps(
             score::get_pixmap(":/icons/version_on.png"),
             score::get_pixmap(":/icons/version_off.png"));
@@ -351,132 +565,8 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
         label->move(280, 170);
         label->show();
       }
-    }, [] {}};
-  }
-
-  float label_x = 300;
-  float label_y = 215;
-
-  { // recent files
-    auto label = new InteractiveLabel{titleFont, qApp->tr("Recent files"), "", this};
-    label->setTextOption(QTextOption(Qt::AlignRight));
-    label->setPixmaps(
-        score::get_pixmap(":/icons/recent_files.png"),
-        score::get_pixmap(":/icons/recent_files.png"));
-    label->setInactiveColor(QColor{"#f0f0f0"});
-    label->setActiveColor(QColor{"#03C3DD"});
-    label->disableInteractivity();
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
-  f.setPointSize(12);
-
-  // label_x += 40;
-  for(const auto& action : recentFiles->actions())
-  {
-    auto fileLabel
-        = new InteractiveLabel{f, action->text(), action->data().toString(), this};
-    fileLabel->setTextOption(QTextOption(Qt::AlignRight));
-    connect(
-        fileLabel, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::openFile);
-
-    auto textHeight = std::max(25, (int)fileLabel->textBoundingBox(200).height() + 7);
-    fileLabel->setFixedSize(200, textHeight);
-    fileLabel->move(label_x, label_y);
-    label_y += textHeight + 1;
-  }
-  // label_x = 160;
-  label_y += 10;
-
-  m_crashLabel
-      = new InteractiveLabel{titleFont, qApp->tr("Restore last session"), "", this};
-  m_crashLabel->setTextOption(QTextOption(Qt::AlignRight));
-  m_crashLabel->setPixmaps(
-      score::get_pixmap(":/icons/reload_crash_off.png"),
-      score::get_pixmap(":/icons/reload_crash_on.png"));
-  m_crashLabel->move(label_x - 100, label_y);
-  m_crashLabel->setFixedWidth(300);
-  m_crashLabel->setInactiveColor(QColor{"#f0f0f0"});
-  m_crashLabel->setActiveColor(QColor{"#f6a019"});
-  m_crashLabel->setDisabled(true);
-  m_crashLabel->hide();
-  connect(
-      m_crashLabel, &score::InteractiveLabel::labelPressed, this,
-      &score::StartScreen::loadCrashedSession);
-
-  label_x = 510;
-  label_y = 215;
-  { // Create new
-    InteractiveLabel* label = new InteractiveLabel{titleFont, qApp->tr("New"), "", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/new_file_off.png"),
-        score::get_pixmap(":/icons/new_file_on.png"));
-    connect(
-        label, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::openNewDocument);
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
-  { // Load file
-    InteractiveLabel* label
-        = new InteractiveLabel{titleFont, qApp->tr("Load"), "", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/load_off.png"),
-        score::get_pixmap(":/icons/load_on.png"));
-    connect(
-        label, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::openFileDialog);
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
-  { // Load Examples
-    QSettings settings;
-    auto library_path = settings.value("Library/RootPath").toString();
-    InteractiveLabel* label = new InteractiveLabel{
-        titleFont, qApp->tr("Examples"), "https://ossia.io/score-docs/examples", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/load_examples_off.png"),
-        score::get_pixmap(":/icons/load_examples_on.png"));
-    label->setOpenExternalLink(true);
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
-
-  label_y += 20;
-
-  std::array<score::StartScreenLink, 4> menus
-      = {{{qApp->tr("Tutorials"),
-           "https://www.youtube.com/"
-           "watch?v=R-3d8K6gQkw&list=PLIHLSiZpIa6YoY1_aW1yetDgZ7tZcxfEC&index=1",
-           ":/icons/tutorials_off.png", ":/icons/tutorials_on.png"},
-          {qApp->tr("Contribute"), "https://opencollective.com/ossia/contribute",
-           ":/icons/contribute_off.png", ":/icons/contribute_on.png"},
-          {qApp->tr("Forum"), "http://forum.ossia.io/", ":/icons/forum_off.png",
-           ":/icons/forum_on.png"},
-          {qApp->tr("Chat"), "https://gitter.im/ossia/score", ":/icons/chat_off.png",
-           ":/icons/chat_on.png"}}};
-  for(const auto& m : menus)
-  {
-    InteractiveLabel* menu_url = new InteractiveLabel{titleFont, m.name, m.url, this};
-    menu_url->setOpenExternalLink(true);
-    menu_url->setPixmaps(score::get_pixmap(m.pixmap), score::get_pixmap(m.pixmapOn));
-    menu_url->move(label_x, label_y);
-    label_y += 35;
-  }
-
-  label_y += 10;
-
-  { // Exit App
-    InteractiveLabel* label
-        = new InteractiveLabel{titleFont, qApp->tr("Exit"), "", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/exit_off.png"),
-        score::get_pixmap(":/icons/exit_on.png"));
-    connect(
-        label, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::exitApp);
-    label->move(label_x, label_y);
+    },
+        [] {}};
   }
 }
 
@@ -491,7 +581,7 @@ void StartScreen::paintEvent(QPaintEvent* event)
 {
   QPainter painter(this);
   painter.setRenderHint(QPainter::RenderHint::SmoothPixmapTransform);
-  painter.drawPixmap(0, 0, m_background);
+  painter.fillRect(rect(), Qt::black);
 }
 
 void StartScreen::keyPressEvent(QKeyEvent* event)

--- a/src/app/StartScreen.hpp
+++ b/src/app/StartScreen.hpp
@@ -356,16 +356,20 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
   navigationList->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   navigationList->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
+#ifndef QT_NO_STYLE_STYLESHEET
   navigationList->setStyleSheet(
       "QListWidget { background-color: black;color: white; border: none;}"
       "QListWidget::item { padding: 10px 10; margin: 8px 0; color: white;}"
       "QListWidget::item:selected { background-color: #211f1f; color: white;"
       "padding:00px; margin: 00px 0; }");
+#endif
 
   // Home View
   QWidget* homeView = new QWidget;
   QVBoxLayout* homeLayout = new QVBoxLayout(homeView);
+#ifndef QT_NO_STYLE_STYLESHEET
   homeView->setStyleSheet("background-color: #211f1f;");
+#endif
 
   // Left Col
   QLabel* createNewLabel = new QLabel(tr("Create score"));
@@ -465,7 +469,9 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
   // Learn View
   QWidget* learnView = new QWidget;
   QVBoxLayout* learnLayout = new QVBoxLayout(learnView);
+#ifndef QT_NO_STYLE_STYLESHEET
   learnView->setStyleSheet("background-color: #211f1f;");
+#endif
 
   QLabel* learnLabel = new QLabel(tr("Browse examples"));
   learnLabel->setFont(headerFont);
@@ -479,9 +485,11 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
   tutorialsLabel->setPixmaps(
       score::get_pixmap(":/icons/tutorials_off.png"),
       score::get_pixmap(":/icons/tutorials_on.png"));
+#ifndef QT_NO_STYLE_STYLESHEET
   tutorialsLabel->setStyleSheet(
       "QLabel { padding: 8px; background-color: #161514; color: white; }"
       "QLabel:hover { color: #f6a019; }");
+#endif
   learnLayout->addWidget(tutorialsLabel);
 
   learnLayout->addStretch();
@@ -491,7 +499,9 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
   // Community View
   QWidget* communityView = new QWidget;
   QVBoxLayout* communityLayout = new QVBoxLayout(communityView);
+#ifndef QT_NO_STYLE_STYLESHEET
   communityView->setStyleSheet("background-color: #211f1f;");
+#endif
 
   QLabel* communityLabel = new QLabel(tr("Get involved"));
   communityLabel->setFont(headerFont);
@@ -515,9 +525,11 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
     menuLabel->setOpenExternalLink(true);
     menuLabel->setPixmaps(score::get_pixmap(m.pixmap), score::get_pixmap(m.pixmapOn));
 
+#ifndef QT_NO_STYLE_STYLESHEET
     menuLabel->setStyleSheet(
         "QLabel {padding: 8px; background-color: #161514; color: white;}"
         "QLabel:hover {color: #f6a019;}");
+#endif
 
     communityLayout->addWidget(menuLabel);
   }

--- a/src/app/StartScreen.hpp
+++ b/src/app/StartScreen.hpp
@@ -7,6 +7,7 @@
 
 #include <QApplication>
 #include <QDesktopServices>
+#include <QHBoxLayout>
 #include <QIcon>
 #include <QKeyEvent>
 #include <QLabel>
@@ -25,6 +26,8 @@
 #include <QVBoxLayout>
 
 #include <score_git_info.hpp>
+
+#include <array>
 
 #include <optional>
 #include <verdigris>
@@ -547,30 +550,42 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
   setFixedSize(QSize(600, 400) / m_background.devicePixelRatioF());
 
   {
-    // TODO : make this work
-    // new version
-    auto m_getLastVersion = new HTTPGet{
-        QUrl("https://ossia.io/score-last-version.txt"),
-        [this, navFont](const QByteArray& data) {
-      auto version = QString::fromUtf8(data.simplified());
-      if(SCORE_TAG_NO_V < version)
-      {
-        QString text
-            = qApp->tr("New version %1 is available, click to update !").arg(version);
-        QString url = "https://github.com/ossia/score/releases/latest/";
-        InteractiveLabel* label = new InteractiveLabel{navFont, text, url, this};
-        label->setPixmaps(
-            score::get_pixmap(":/icons/version_on.png"),
-            score::get_pixmap(":/icons/version_off.png"));
-        label->setOpenExternalLink(true);
-        label->setInactiveColor(QColor{"#f6a019"});
-        label->setActiveColor(QColor{"#f0f0f0"});
-        label->setFixedWidth(600);
-        label->move(280, 170);
-        label->show();
-      }
-    },
-        [] {}};
+    auto& tp = score::ThreadPool::instance();
+    auto t = tp.acquireThread();
+    QMetaObject::invokeMethod(t, [t, self = QPointer{this}, navFont] {
+      auto getLastVersion = new HTTPGet{
+          QUrl("https://ossia.io/score-last-version.txt"),
+          [self, navFont](const QByteArray& data) {
+        auto version = QString::fromUtf8(data.simplified());
+        if(SCORE_TAG_NO_V < version)
+        {
+          QString text
+              = qApp->tr("New version %1 is available, click to update !").arg(version);
+          QString url = "https://github.com/ossia/score/releases/latest/";
+          QMetaObject::invokeMethod(
+              QCoreApplication::instance(), [self, navFont, text, url] {
+            if(!self)
+              return;
+            auto label = new InteractiveLabel{navFont, text, url, self};
+            label->setPixmaps(
+                score::get_pixmap(":/icons/version_on.png"),
+                score::get_pixmap(":/icons/version_off.png"));
+            label->setOpenExternalLink(true);
+            label->setInactiveColor(QColor{"#f6a019"});
+            label->setActiveColor(QColor{"#f0f0f0"});
+            label->setFixedWidth(600);
+            label->move(280, 170);
+            label->show();
+          });
+        }
+      }, [] { }};
+      connect(getLastVersion, &QObject::destroyed, t, [] {
+        QMetaObject::invokeMethod(QCoreApplication::instance(), [] {
+          auto& tp = score::ThreadPool::instance();
+          tp.releaseThread();
+        });
+      });
+    });
   }
 }
 

--- a/src/app/StartScreen.hpp
+++ b/src/app/StartScreen.hpp
@@ -7,17 +7,22 @@
 
 #include <QApplication>
 #include <QDesktopServices>
+#include <QIcon>
 #include <QKeyEvent>
 #include <QLabel>
+#include <QListWidget>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QPainter>
 #include <QPixmap>
 #include <QPointer>
+#include <QPushButton>
 #include <QSettings>
+#include <QStackedWidget>
 #include <QTextLayout>
 #include <QThread>
+#include <QVBoxLayout>
 
 #include <score_git_info.hpp>
 
@@ -225,7 +230,6 @@ void InteractiveLabel::enterEvent(QEnterEvent* event)
     return;
 
   m_currentColor = m_activeColor;
-  m_font.setUnderline(true);
   m_currentPixmap = m_pixmapOn;
 
   repaint();
@@ -237,7 +241,6 @@ void InteractiveLabel::leaveEvent(QEvent* event)
     return;
 
   m_currentColor = m_inactiveColor;
-  m_font.setUnderline(false);
   m_currentPixmap = m_pixmap;
 
   repaint();
@@ -267,6 +270,7 @@ public:
   void exitApp() W_SIGNAL(exitApp)
 
   void addLoadCrashedSession();
+  void setupTabs();
 
 protected:
   void paintEvent(QPaintEvent* event) override;
@@ -303,118 +307,140 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
 #else
   static constexpr double font_factor = 1.;
 #endif
-  QFont f("Ubuntu", 14  * font_factor, QFont::Light);
-  f.setHintingPreference(QFont::HintingPreference::PreferFullHinting);
-  f.setStyleStrategy(QFont::PreferAntialias);
 
-  QFont titleFont("Montserrat", 14  * font_factor, QFont::DemiBold);
-  titleFont.setHintingPreference(QFont::HintingPreference::PreferFullHinting);
-  titleFont.setStyleStrategy(QFont::PreferAntialias);
+  QFont navFont("Montserrat", 12 * font_factor, QFont::DemiBold);
+  QFont headerFont("Montserrat", 12 * font_factor);
+  QFont labelFont("Montserrat", 11 * font_factor, QFont::Normal);
+  labelFont.setHintingPreference(QFont::HintingPreference::PreferFullHinting);
+  labelFont.setStyleStrategy(QFont::PreferAntialias);
 
-  this->setEnabled(true);
-  setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint); //| Qt::WindowStaysOnTopHint);
-  setWindowModality(Qt::ApplicationModal);
+  // Header Widget
+  QWidget* headerWidget = new QWidget(this);
+  QHBoxLayout* headerLayout = new QHBoxLayout(headerWidget);
 
-  m_background = score::get_pixmap(":/startscreen/startscreensplash.png");
+  QLabel* logoLabel = new QLabel(headerWidget);
 
-  if(QPainter painter; painter.begin(&m_background))
-  {
-    painter.setRenderHint(QPainter::Antialiasing, true);
-    painter.setRenderHint(QPainter::TextAntialiasing, true);
-    painter.setPen(QPen(QColor("#0092CF")));
+  QPixmap placeholderPixmap(300, 100); // TODO: Replace with actual logo when available
+  placeholderPixmap.fill(Qt::gray);
+  logoLabel->setPixmap(placeholderPixmap);
+  logoLabel->setFixedSize(placeholderPixmap.size());
+  headerLayout->addWidget(logoLabel, 0, Qt::AlignLeft);
 
-    painter.setFont(f);
-    //painter.drawText(QPointF(250, 170), QCoreApplication::applicationVersion());
-    painter.drawText(QPointF(217, 188), QCoreApplication::applicationVersion());
-    painter.end();
-  }
+  //Donate label
+  InteractiveLabel* donateLabel = new InteractiveLabel(
+      navFont, tr("Donate"), "https://opencollective.com/ossia", this);
+  donateLabel->setOpenExternalLink(true);
+  donateLabel->setPixmaps(
+      score::get_pixmap(":/icons/new_file_off.png"),
+      score::get_pixmap(":/icons/new_file_on.png")); // TODO: Replace with  heart icon
+  headerLayout->addWidget(donateLabel);
 
-  // Weird code here is because the window size seems to scale only to integer ratios.
-  setFixedSize(m_background.size() / m_background.devicePixelRatioF());
+  // side nav list and stacked widget
+  QListWidget* navigationList = new QListWidget(this);
+  QStackedWidget* stackedWidget = new QStackedWidget(this);
 
-  {
-    // new version
-    auto& tp = score::ThreadPool::instance();
-    auto t = tp.acquireThread();
-    QMetaObject::invokeMethod(t, [t, self = QPointer{this}, titleFont] {
-      auto m_getLastVersion = new HTTPGet{
-          QUrl("https://ossia.io/score-last-version.txt"),
-          [self, titleFont](const QByteArray& data) {
-        auto version = QString::fromUtf8(data.simplified());
-        if(SCORE_TAG_NO_V < version)
-        {
-          QString text
-              = qApp->tr("New version %1 is available, click to update !").arg(version);
-          QString url = "https://github.com/ossia/score/releases/latest/";
-          QMetaObject::invokeMethod(
-              QCoreApplication::instance(), [self, titleFont, text, url] {
-            if(!self)
-              return;
-            InteractiveLabel* label = new InteractiveLabel{titleFont, text, url, self};
-            label->setPixmaps(
-                score::get_pixmap(":/icons/version_on.png"),
-                score::get_pixmap(":/icons/version_off.png"));
-            label->setOpenExternalLink(true);
-            label->setInactiveColor(QColor{"#f6a019"});
-            label->setActiveColor(QColor{"#f0f0f0"});
-            label->setFixedWidth(600);
-            label->move(280, 170);
-            label->show();
-          });
-        }
-      }, [] { }};
-      connect(m_getLastVersion, &QObject::destroyed, t, [] {
-        QMetaObject::invokeMethod(QCoreApplication::instance(), [] {
-          auto& tp = score::ThreadPool::instance();
-          tp.releaseThread();
-        });
-      });
-    });
-  }
+  navigationList->setFixedWidth(155);
+  navigationList->setSpacing(8);
+  navigationList->setFont(navFont);
 
-  float label_x = 300;
-  float label_y = 215;
+  navigationList->addItem(new QListWidgetItem(
+      QIcon(score::get_pixmap(":/icons/new_file_off.png")), tr("Home")));
+  navigationList->addItem(new QListWidgetItem(
+      QIcon(score::get_pixmap(":/icons/load_examples_off.png")), tr("Learn")));
+  navigationList->addItem(new QListWidgetItem(
+      QIcon(score::get_pixmap(":/icons/forum_off.png")), tr("Community")));
 
-  { // recent files
-    auto label = new InteractiveLabel{titleFont, qApp->tr("Recent files"), "", this};
-    label->setTextOption(QTextOption(Qt::AlignRight));
-    label->setPixmaps(
-        score::get_pixmap(":/icons/recent_files.png"),
-        score::get_pixmap(":/icons/recent_files.png"));
-    label->setInactiveColor(QColor{"#f0f0f0"});
-    label->setActiveColor(QColor{"#03C3DD"});
-    label->disableInteractivity();
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
-  f.setPointSize(12);
+  navigationList->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  navigationList->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
-  // label_x += 40;
+  navigationList->setStyleSheet(
+      "QListWidget { background-color: black;color: white; border: none;}"
+      "QListWidget::item { padding: 10px 10; margin: 8px 0; color: white;}"
+      "QListWidget::item:selected { background-color: #211f1f; color: white;"
+      "padding:00px; margin: 00px 0; }");
+
+  // Home View
+  QWidget* homeView = new QWidget;
+  QVBoxLayout* homeLayout = new QVBoxLayout(homeView);
+  homeView->setStyleSheet("background-color: #211f1f;");
+
+  // Left Col
+  QLabel* createNewLabel = new QLabel(tr("Create score"));
+  createNewLabel->setFont(headerFont);
+
+  QVBoxLayout* leftColumnLayout = new QVBoxLayout;
+  leftColumnLayout->addWidget(createNewLabel);
+
+  leftColumnLayout->addSpacing(10);
+
+  InteractiveLabel* newLabel
+      = new InteractiveLabel{labelFont, qApp->tr("Empty score"), "", this};
+  newLabel->setPixmaps(
+      score::get_pixmap(":/icons/new_file_off.png"),
+      score::get_pixmap(":/icons/new_file_on.png"));
+  newLabel->setTextOption(QTextOption(Qt::AlignLeft));
+  connect(
+      newLabel, &score::InteractiveLabel::labelPressed, this,
+      &StartScreen::openNewDocument);
+  leftColumnLayout->addWidget(newLabel);
+
   for(const auto& action : recentFiles->actions())
   {
-    auto fileLabel
-        = new InteractiveLabel{f, action->text(), action->data().toString(), this};
-    fileLabel->setTextOption(QTextOption(Qt::AlignRight));
+    auto* fileLabel = new InteractiveLabel{
+        labelFont, action->text(), action->data().toString(), this};
+    fileLabel->setTextOption(QTextOption(Qt::AlignLeft));
+    fileLabel->setPixmaps(
+        score::get_pixmap(":/icons/new_file_off.png"),
+        score::get_pixmap(":/icons/new_file_off.png"));
+    fileLabel->setInactiveColor(QColor{"#f0f0f0"});
+    fileLabel->setActiveColor(QColor{"#03C3DD"});
     connect(
-        fileLabel, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::openFile);
-
-    auto textHeight = std::max(25, (int)fileLabel->textBoundingBox(200).height() + 7);
-    fileLabel->setFixedSize(200, textHeight);
-    fileLabel->move(label_x, label_y);
-    label_y += textHeight + 1;
+        fileLabel, &score::InteractiveLabel::labelPressed, this, &StartScreen::openFile);
+    leftColumnLayout->addWidget(fileLabel);
   }
-  // label_x = 160;
-  label_y += 10;
+  leftColumnLayout->addStretch();
+
+  // Right Column - Load Score
+  QLabel* loadScoreLabel = new QLabel(tr("Load a score"));
+  loadScoreLabel->setFont(headerFont);
+
+  QVBoxLayout* rightColumnLayout = new QVBoxLayout;
+  rightColumnLayout->addWidget(loadScoreLabel);
+  rightColumnLayout->addSpacing(10);
+
+  for(const auto& action : recentFiles->actions())
+  {
+    auto* fileLabel = new InteractiveLabel{
+        labelFont, action->text(), action->data().toString(), this};
+    fileLabel->setTextOption(QTextOption(Qt::AlignLeft));
+    fileLabel->setInactiveColor(QColor{"#f0f0f0"});
+    fileLabel->setActiveColor(QColor{"#03C3DD"});
+    connect(
+        fileLabel, &score::InteractiveLabel::labelPressed, this, &StartScreen::openFile);
+
+    rightColumnLayout->addWidget(fileLabel);
+  }
+  rightColumnLayout->addStretch();
+
+  InteractiveLabel* openScoreLabel
+      = new InteractiveLabel(labelFont, tr("Open.."), "", this);
+  openScoreLabel->setPixmaps(
+      score::get_pixmap(":/icons/load_off.png"),
+      score::get_pixmap(":/icons/load_on.png"));
+  openScoreLabel->setTextOption(QTextOption(Qt::AlignLeft));
+  connect(
+      openScoreLabel, &score::InteractiveLabel::labelPressed, this,
+      &StartScreen::openFileDialog);
+
+  rightColumnLayout->addWidget(openScoreLabel);
 
   m_crashLabel
-      = new InteractiveLabel{titleFont, qApp->tr("Restore last session"), "", this};
-  m_crashLabel->setTextOption(QTextOption(Qt::AlignRight));
+      = new InteractiveLabel{labelFont, qApp->tr("Restore last session"), "", this};
+  m_crashLabel->setTextOption(QTextOption(Qt::AlignLeft));
   m_crashLabel->setPixmaps(
       score::get_pixmap(":/icons/reload_crash_off.png"),
       score::get_pixmap(":/icons/reload_crash_on.png"));
-  m_crashLabel->move(label_x - 100, label_y);
-  m_crashLabel->setFixedWidth(300);
+  m_crashLabel->setFixedWidth(250);
   m_crashLabel->setInactiveColor(QColor{"#f0f0f0"});
   m_crashLabel->setActiveColor(QColor{"#f6a019"});
   m_crashLabel->setDisabled(true);
@@ -423,78 +449,128 @@ StartScreen::StartScreen(const QPointer<QRecentFilesMenu>& recentFiles, QWidget*
       m_crashLabel, &score::InteractiveLabel::labelPressed, this,
       &score::StartScreen::loadCrashedSession);
 
-  label_x = 510;
-  label_y = 215;
-  { // Create new
-    InteractiveLabel* label = new InteractiveLabel{titleFont, qApp->tr("New"), "", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/new_file_off.png"),
-        score::get_pixmap(":/icons/new_file_on.png"));
-    connect(
-        label, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::openNewDocument);
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
-  { // Load file
-    InteractiveLabel* label
-        = new InteractiveLabel{titleFont, qApp->tr("Load"), "", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/load_off.png"),
-        score::get_pixmap(":/icons/load_on.png"));
-    connect(
-        label, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::openFileDialog);
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
-  { // Load Examples
-    QSettings settings;
-    auto library_path = settings.value("Library/RootPath").toString();
-    InteractiveLabel* label = new InteractiveLabel{
-        titleFont, qApp->tr("Examples"), "https://ossia.io/score-docs/examples", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/load_examples_off.png"),
-        score::get_pixmap(":/icons/load_examples_on.png"));
-    label->setOpenExternalLink(true);
-    label->move(label_x, label_y);
-    label_y += 35;
-  }
+  rightColumnLayout->addWidget(m_crashLabel);
 
-  label_y += 20;
+  QHBoxLayout* mainRowLayout = new QHBoxLayout;
+  mainRowLayout->addLayout(leftColumnLayout);
+  mainRowLayout->addLayout(rightColumnLayout);
 
-  std::array<score::StartScreenLink, 4> menus
-      = {{{qApp->tr("Tutorials"),
-           "https://www.youtube.com/"
-           "watch?v=R-3d8K6gQkw&list=PLIHLSiZpIa6YoY1_aW1yetDgZ7tZcxfEC&index=1",
-           ":/icons/tutorials_off.png", ":/icons/tutorials_on.png"},
-          {qApp->tr("Contribute"), "https://opencollective.com/ossia/contribute",
-           ":/icons/contribute_off.png", ":/icons/contribute_on.png"},
-          {qApp->tr("Forum"), "http://forum.ossia.io/", ":/icons/forum_off.png",
+  homeLayout->addLayout(mainRowLayout);
+  homeView->setLayout(homeLayout);
+  stackedWidget->addWidget(homeView);
+
+  // Learn View
+  QWidget* learnView = new QWidget;
+  QVBoxLayout* learnLayout = new QVBoxLayout(learnView);
+  learnView->setStyleSheet("background-color: #211f1f;");
+
+  QLabel* learnLabel = new QLabel(tr("Browse examples"));
+  learnLabel->setFont(headerFont);
+  learnLayout->addWidget(learnLabel);
+  learnLayout->addSpacing(10);
+
+  // Add "Tutorials" link to the Learn section
+  InteractiveLabel* tutorialsLabel = new InteractiveLabel(
+      navFont, tr("Tutorials"), "https://www.youtube.com/...", learnView);
+  tutorialsLabel->setOpenExternalLink(true);
+  tutorialsLabel->setPixmaps(
+      score::get_pixmap(":/icons/tutorials_off.png"),
+      score::get_pixmap(":/icons/tutorials_on.png"));
+  tutorialsLabel->setStyleSheet(
+      "QLabel { padding: 8px; background-color: #161514; color: white; }"
+      "QLabel:hover { color: #f6a019; }");
+  learnLayout->addWidget(tutorialsLabel);
+
+  learnLayout->addStretch();
+  learnView->setLayout(learnLayout);
+  stackedWidget->addWidget(learnView);
+
+  // Community View
+  QWidget* communityView = new QWidget;
+  QVBoxLayout* communityLayout = new QVBoxLayout(communityView);
+  communityView->setStyleSheet("background-color: #211f1f;");
+
+  QLabel* communityLabel = new QLabel(tr("Get involved"));
+  communityLabel->setFont(headerFont);
+
+  communityLayout->addWidget(communityLabel);
+  communityLayout->addSpacing(10);
+
+  std::array<score::StartScreenLink, 3> communityMenus
+      = {{{tr("ossia Forum"), "http://forum.ossia.io/", ":/icons/forum_off.png",
            ":/icons/forum_on.png"},
-          {qApp->tr("Chat"), "https://gitter.im/ossia/score", ":/icons/chat_off.png",
+          {tr("Contribute"), "https://opencollective.com/ossia/contribute",
+           ":/icons/contribute_off.png", ":/icons/contribute_on.png"},
+          {tr("Discord chat"), "https://discord.gg/ossia",
+           ":/icons/chat_off.png", // TODO : replace by Discord icon
            ":/icons/chat_on.png"}}};
-  for(const auto& m : menus)
+
+  for(const auto& m : communityMenus)
   {
-    InteractiveLabel* menu_url = new InteractiveLabel{titleFont, m.name, m.url, this};
-    menu_url->setOpenExternalLink(true);
-    menu_url->setPixmaps(score::get_pixmap(m.pixmap), score::get_pixmap(m.pixmapOn));
-    menu_url->move(label_x, label_y);
-    label_y += 35;
+    InteractiveLabel* menuLabel
+        = new InteractiveLabel(navFont, m.name, m.url, communityView);
+    menuLabel->setOpenExternalLink(true);
+    menuLabel->setPixmaps(score::get_pixmap(m.pixmap), score::get_pixmap(m.pixmapOn));
+
+    menuLabel->setStyleSheet(
+        "QLabel {padding: 8px; background-color: #161514; color: white;}"
+        "QLabel:hover {color: #f6a019;}");
+
+    communityLayout->addWidget(menuLabel);
   }
 
-  label_y += 10;
+  communityLayout->addStretch();
+  communityView->setLayout(communityLayout);
+  stackedWidget->addWidget(communityView);
 
-  { // Exit App
-    InteractiveLabel* label
-        = new InteractiveLabel{titleFont, qApp->tr("Exit"), "", this};
-    label->setPixmaps(
-        score::get_pixmap(":/icons/exit_off.png"),
-        score::get_pixmap(":/icons/exit_on.png"));
-    connect(
-        label, &score::InteractiveLabel::labelPressed, this,
-        &score::StartScreen::exitApp);
-    label->move(label_x, label_y);
+  // Connect navigation list to stacked widget
+  connect(
+      navigationList, &QListWidget::currentRowChanged, stackedWidget,
+      &QStackedWidget::setCurrentIndex);
+  navigationList->setCurrentRow(0);
+
+  QHBoxLayout* contentLayout = new QHBoxLayout;
+  contentLayout->addWidget(navigationList);
+  contentLayout->addWidget(stackedWidget);
+
+  QVBoxLayout* mainLayout = new QVBoxLayout(this);
+  mainLayout->addWidget(headerWidget);
+  mainLayout->addLayout(contentLayout);
+  setLayout(mainLayout);
+
+  mainLayout->addStretch();
+
+  this->setEnabled(true);
+  setWindowModality(Qt::ApplicationModal);
+
+  // Weird code here is because the window size seems to scale only to integer ratios.
+  setFixedSize(QSize(600, 400) / m_background.devicePixelRatioF());
+
+  {
+    // TODO : make this work
+    // new version
+    auto m_getLastVersion = new HTTPGet{
+        QUrl("https://ossia.io/score-last-version.txt"),
+        [this, navFont](const QByteArray& data) {
+      auto version = QString::fromUtf8(data.simplified());
+      if(SCORE_TAG_NO_V < version)
+      {
+        QString text
+            = qApp->tr("New version %1 is available, click to update !").arg(version);
+        QString url = "https://github.com/ossia/score/releases/latest/";
+        InteractiveLabel* label = new InteractiveLabel{navFont, text, url, this};
+        label->setPixmaps(
+            score::get_pixmap(":/icons/version_on.png"),
+            score::get_pixmap(":/icons/version_off.png"));
+        label->setOpenExternalLink(true);
+        label->setInactiveColor(QColor{"#f6a019"});
+        label->setActiveColor(QColor{"#f0f0f0"});
+        label->setFixedWidth(600);
+        label->move(280, 170);
+        label->show();
+      }
+    },
+        [] {}};
   }
 }
 
@@ -509,7 +585,7 @@ void StartScreen::paintEvent(QPaintEvent* event)
 {
   QPainter painter(this);
   painter.setRenderHint(QPainter::RenderHint::SmoothPixmapTransform);
-  painter.drawPixmap(0, 0, m_background);
+  painter.fillRect(rect(), Qt::black);
 }
 
 void StartScreen::keyPressEvent(QKeyEvent* event)


### PR DESCRIPTION
Reproducing the figma design below with tabs for the Splash screen 
- [x] fix tab content
- [x] remove manual widget positioning 
- [x]  removed the exit Label, finally 🥹
- [ ] re-add fallen soldier `m_getLastVersion` along the way... 
 it isn't added to the layout, not sure how to do it
- [ ] fix text&icon alignment
- [ ] Add logo & playback green img, add new icons (is there a guide?)
- [ ] remove `setStyleSheet` blocks
- [ ] bind window close button to actual close button? 

<img width="460" alt="home tab" src="https://github.com/user-attachments/assets/b17379d9-2e7c-45c7-ba34-5418f083372a">

<img width="462" alt="learn tab" src="https://github.com/user-attachments/assets/60269ac6-e3f8-41c9-9022-4e6815d9536e">

<img width="465" alt="community tab" src="https://github.com/user-attachments/assets/ade0aa55-7717-4e74-9cac-b9263a4d0c18">

