### PR TITLE
vst3: fix crash when removing JUCE-based plugin PlugFrame. Fixes #162…

### DIFF
--- a/src/plugins/score-plugin-vst3/Vst3/EffectModel.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/EffectModel.hpp
@@ -6,6 +6,7 @@
 #include <Control/DefaultEffectItem.hpp>
 #include <Effect/EffectFactory.hpp>
 #include <Vst3/Plugin.hpp>
+#include <Vst3/UI/WindowContainer.hpp>
 
 #include <score/tools/std/Invoke.hpp>
 
@@ -36,7 +37,8 @@ namespace vst3
 class CreateVSTControl;
 class ControlInlet;
 struct PortCreationVisitor;
-
+class PlugFrame;
+class Window;
 class Model final : public Process::ProcessModel
 {
   W_OBJECT(Model)

--- a/src/plugins/score-plugin-vst3/Vst3/Plugin.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Plugin.cpp
@@ -2,6 +2,8 @@
 #include <Vst3/DataStream.hpp>
 #include <Vst3/EditHandler.hpp>
 #include <Vst3/Plugin.hpp>
+#include <Vst3/UI/Linux/PlugFrame.hpp>
+#include <Vst3/UI/PlugFrame.hpp>
 #include <Vst3/UI/Window.hpp>
 
 #include <ossia/detail/algorithms.hpp>
@@ -240,6 +242,12 @@ void Plugin::start(double_t sample_rate, int max_bs)
 
 void Plugin::stop()
 {
+#if (!(defined(__APPLE__) || defined(_WIN32))) && __has_include(<xcb/xcb.h>)
+  if(plugFrame)
+  {
+    plugFrame->cleanup();
+  }
+#endif
   if(!component)
     return;
 
@@ -263,6 +271,11 @@ void Plugin::stop()
 
   component->terminate();
   component = nullptr;
+
+  if(plugFrame)
+  {
+    QTimer::singleShot(100, [=] { delete plugFrame; });
+  }
 }
 
 Plugin::~Plugin() { }

--- a/src/plugins/score-plugin-vst3/Vst3/Plugin.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Plugin.hpp
@@ -38,7 +38,7 @@ inline QString fromString(const Steinberg::Vst::String128& str)
 }
 
 using MIDIControls = ossia::flat_map<std::pair<int, int>, Steinberg::Vst::ParamID>;
-
+class PlugFrame;
 struct Plugin
 {
   Plugin() = default;
@@ -61,6 +61,7 @@ struct Plugin
   Steinberg::Vst::IEditController* controller{};
   Steinberg::Vst::IUnitInfo* units{};
   Steinberg::IPlugView* view{};
+  PlugFrame* plugFrame{};
 
   void loadAudioProcessor(ApplicationPlugin& ctx);
   void loadEditController(Model& model, ApplicationPlugin& ctx);

--- a/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
@@ -25,7 +25,7 @@ public:
   QDialog* w;
   WindowContainer wc;
   PlugFrame(QDialog& w, WindowContainer& wc)
-      : w{w}
+      : w{&w}
       , wc{wc}
   {
   }
@@ -55,7 +55,7 @@ public:
   QDialog* w;
   WindowContainer wc;
   PlugFrame(QDialog& w, WindowContainer& wc)
-      : w{w}
+      : w{&w}
       , wc{wc}
   {
   }

--- a/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
@@ -22,7 +22,7 @@ public:
   Steinberg::uint32 addRef() override { return 1; }
   Steinberg::uint32 release() override { return 1; }
 
-  QDialog& w;
+  QDialog* w;
   WindowContainer wc;
   PlugFrame(QDialog& w, WindowContainer& wc)
       : w{w}
@@ -33,7 +33,7 @@ public:
   Steinberg::tresult
   resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override
   {
-    wc.setSizeFromVst(*view, *newSize, w);
+    wc.setSizeFromVst(*view, *newSize, *w);
     return Steinberg::kResultOk;
   }
 };
@@ -52,7 +52,7 @@ public:
   Steinberg::uint32 addRef() override { return 1; }
   Steinberg::uint32 release() override { return 1; }
 
-  QDialog& w;
+  QDialog* w;
   WindowContainer wc;
   PlugFrame(QDialog& w, WindowContainer& wc)
       : w{w}
@@ -63,7 +63,7 @@ public:
   Steinberg::tresult
   resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override
   {
-    wc.setSizeFromVst(*view, *newSize, w);
+    wc.setSizeFromVst(*view, *newSize, *w);
     return Steinberg::kResultOk;
   }
 };

--- a/src/plugins/score-plugin-vst3/Vst3/UI/Window.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/Window.cpp
@@ -18,7 +18,14 @@ WindowContainer createVstWindowContainer(
   wc.qwindow = parentWindow.windowHandle();
   wc.container = nullptr;
 
-  wc.frame = new PlugFrame{parentWindow, wc};
+  if(!e.fx.plugFrame)
+    const_cast<Model&>(e).fx.plugFrame = new PlugFrame{parentWindow, wc};
+  else
+  {
+    e.fx.plugFrame->w = &parentWindow;
+    e.fx.plugFrame->wc = wc;
+  }
+  wc.frame = e.fx.plugFrame;
   view.setFrame(wc.frame);
   view.attached((void*)wc.qwindow->winId(), currentPlatform());
 

--- a/src/plugins/score-plugin-vst3/Vst3/UI/WindowCommon.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/WindowCommon.cpp
@@ -22,9 +22,14 @@ Window::Window(const Model& e, const score::DocumentContext& ctx, QWidget* paren
 
 Window::~Window()
 {
+  if(m_model.fx.view)
+  {
+    m_model.fx.view->setFrame(nullptr);
+    m_model.fx.view->removed();
+  }
+
   if(container.frame)
   {
-    delete container.frame;
     container.frame = nullptr;
   }
 }
@@ -39,9 +44,9 @@ void Window::resizeEvent(QResizeEvent* event)
 void Window::closeEvent(QCloseEvent* event)
 {
   QPointer<Window> p(this);
+  m_model.fx.view->setFrame(nullptr);
   if(auto view = m_model.fx.view)
     view->removed();
-  delete container.frame;
   container.frame = nullptr;
 
   const_cast<QWidget*&>(m_model.externalUI) = nullptr;


### PR DESCRIPTION
Fixes #1620 (and a whole lot of other VST3 issues)