### PR TITLE
Open code in external editor

### DIFF
--- a/src/plugins/score-lib-process/Process/Script/MultiScriptEditor.hpp
+++ b/src/plugins/score-lib-process/Process/Script/MultiScriptEditor.hpp
@@ -27,7 +27,7 @@ public:
   void setText(int idx, const QString& str);
   void setError(const QString& str);
   void clearError();
-  void openInExternalEditor();
+  void openInExternalEditor(const QString& editorPath);
 
 protected:
   virtual void on_accepted() = 0;

--- a/src/plugins/score-lib-process/Process/Script/MultiScriptEditor.hpp
+++ b/src/plugins/score-lib-process/Process/Script/MultiScriptEditor.hpp
@@ -27,6 +27,7 @@ public:
   void setText(int idx, const QString& str);
   void setError(const QString& str);
   void clearError();
+  void openInExternalEditor();
 
 protected:
   virtual void on_accepted() = 0;

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
@@ -2,7 +2,8 @@
 
 #include "MultiScriptEditor.hpp"
 #include "ScriptWidget.hpp"
-#include "score/tools/FileWatch.hpp"
+
+#include <score/tools/FileWatch.hpp>
 
 #include <QCodeEditor>
 #include <QCoreApplication>
@@ -230,6 +231,7 @@ void ScriptDialog::stopWatchingFile(const QString& tempFile)
 
   auto& w = score::FileWatch::instance();
   w.remove(tempFile, m_fileHandle);
+  m_fileHandle.reset();
 }
 void MultiScriptDialog::openInExternalEditor(const QString& editorPath)
 {

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
@@ -4,6 +4,7 @@
 #include "ScriptWidget.hpp"
 
 #include <score/tools/FileWatch.hpp>
+#include <score/widgets/SetIcons.hpp>
 
 #include <QCodeEditor>
 #include <QCoreApplication>
@@ -44,6 +45,22 @@ ScriptDialog::ScriptDialog(
   lay->setStretch(1, 1);
   auto bbox = new QDialogButtonBox{
       QDialogButtonBox::Ok | QDialogButtonBox::Reset | QDialogButtonBox::Close, this};
+  if(auto editorPath = QSettings{}.value("Skin/DefaultEditor").toString();
+     !editorPath.isEmpty())
+  {
+    auto openExternalBtn = new QPushButton{tr("Edit in default editor"), this};
+    connect(openExternalBtn, &QPushButton::clicked, this, [this, editorPath] {
+      openInExternalEditor(editorPath);
+    });
+    bbox->addButton(openExternalBtn, QDialogButtonBox::HelpRole);
+    openExternalBtn->setToolTip(
+        tr("Edit in the default editor set in Score Settings > User Interface"));
+    auto icon = makeIcons(
+        QStringLiteral(":/icons/undock_on.png"),
+        QStringLiteral(":/icons/undock_off.png"),
+        QStringLiteral(":/icons/undock_off.png"));
+    openExternalBtn->setIcon(icon);
+  }
   bbox->button(QDialogButtonBox::Ok)->setText(tr("Compile"));
   bbox->button(QDialogButtonBox::Reset)->setText(tr("Clear log"));
   connect(bbox->button(QDialogButtonBox::Reset), &QPushButton::clicked, this, [this] {
@@ -58,16 +75,6 @@ ScriptDialog::ScriptDialog(
   connect(
       bbox->button(QDialogButtonBox::Close), &QPushButton::clicked, this,
       &QDialog::close);
-
-  if(auto editorPath = QSettings{}.value("Skin/DefaultEditor").toString();
-     !editorPath.isEmpty())
-  {
-    auto openExternalBtn = new QPushButton{tr("Edit in default editor"), this};
-    connect(openExternalBtn, &QPushButton::clicked, this, [this, editorPath] {
-      openInExternalEditor(editorPath);
-    });
-    lay->addWidget(openExternalBtn);
-  }
 }
 
 QString ScriptDialog::text() const noexcept

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
@@ -138,7 +138,14 @@ MultiScriptDialog::MultiScriptDialog(const score::DocumentContext& ctx, QWidget*
     connect(openExternalBtn, &QPushButton::clicked, this, [this, editorPath] {
       openInExternalEditor(editorPath);
     });
-    lay->addWidget(openExternalBtn);
+    bbox->addButton(openExternalBtn, QDialogButtonBox::HelpRole);
+    openExternalBtn->setToolTip(
+        tr("Edit in the default editor set in Score Settings > User Interface"));
+    auto icon = makeIcons(
+        QStringLiteral(":/icons/undock_on.png"),
+        QStringLiteral(":/icons/undock_off.png"),
+        QStringLiteral(":/icons/undock_off.png"));
+    openExternalBtn->setIcon(icon);
   }
 }
 

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
@@ -170,13 +170,26 @@ void ScriptDialog::openInExternalEditor()
     return;
   }
 
+  if(!QFile::exists(editorPath))
+  {
+    QMessageBox::warning(
+        this, tr("Error"), tr("the configured external editor does not exist."));
+    return;
+  }
+
   QString tempDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
   QString tempFile = tempDir + "/ossia_script_temp.js";
 
   QFile file(tempFile);
+  if(!file.open(QIODevice::WriteOnly))
+  {
+    QMessageBox::warning(this, tr("Error"), tr("failed to create temporary file."));
+    return;
+  }
 
   QTextStream stream(&file);
-  stream << "Temporary file content for testing.";
+  QString scriptContent = this->text();
+  stream << scriptContent;
   file.close();
 
   if(!QProcess::startDetached(editorPath, QStringList() << tempFile))

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
@@ -10,6 +10,7 @@
 #include <QPlainTextEdit>
 #include <QProcess>
 #include <QPushButton>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QTabWidget>
 #include <QVBoxLayout>
@@ -160,8 +161,7 @@ void MultiScriptDialog::clearError()
 
 void ScriptDialog::openInExternalEditor()
 {
-  QString editorPath
-      = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code";
+  QString editorPath = QSettings{}.value("Skin/DefaultEditor").toString();
 
   if(editorPath.isEmpty())
   {

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
@@ -6,6 +6,7 @@
 #include <QCodeEditor>
 #include <QDialogButtonBox>
 #include <QFile>
+#include <QMessageBox>
 #include <QPlainTextEdit>
 #include <QProcess>
 #include <QPushButton>
@@ -54,7 +55,8 @@ ScriptDialog::ScriptDialog(
       &QDialog::close);
 
   auto openExternalBtn = new QPushButton{tr("Open in external editor.."), this};
-  connect(openExternalBtn, &QPushButton::clicked, this, [this] {});
+  connect(
+      openExternalBtn, &QPushButton::clicked, this, [this] { openInExternalEditor(); });
   lay->addWidget(openExternalBtn);
 }
 
@@ -156,4 +158,30 @@ void MultiScriptDialog::clearError()
   m_error->clear();
 }
 
-void ScriptDialog::openInExternalEditor() { }
+void ScriptDialog::openInExternalEditor()
+{
+  QString editorPath
+      = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code";
+
+  if(editorPath.isEmpty())
+  {
+    QMessageBox::warning(
+        this, tr("Error"), tr("no 'Default editor' configured in score settings"));
+    return;
+  }
+
+  QString tempDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+  QString tempFile = tempDir + "/ossia_script_temp.js";
+
+  QFile file(tempFile);
+
+  QTextStream stream(&file);
+  stream << "Temporary file content for testing.";
+  file.close();
+
+  if(!QProcess::startDetached(editorPath, QStringList() << tempFile))
+  {
+    QMessageBox::warning(this, tr("Error"), tr("Failed to launch external editor"));
+  }
+}
+}

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.cpp
@@ -7,7 +7,9 @@
 #include <QDialogButtonBox>
 #include <QFile>
 #include <QPlainTextEdit>
+#include <QProcess>
 #include <QPushButton>
+#include <QStandardPaths>
 #include <QTabWidget>
 #include <QVBoxLayout>
 
@@ -50,6 +52,10 @@ ScriptDialog::ScriptDialog(
   connect(
       bbox->button(QDialogButtonBox::Close), &QPushButton::clicked, this,
       &QDialog::close);
+
+  auto openExternalBtn = new QPushButton{tr("Open in external editor.."), this};
+  connect(openExternalBtn, &QPushButton::clicked, this, [this] {});
+  lay->addWidget(openExternalBtn);
 }
 
 QString ScriptDialog::text() const noexcept
@@ -150,4 +156,4 @@ void MultiScriptDialog::clearError()
   m_error->clear();
 }
 
-}
+void ScriptDialog::openInExternalEditor() { }

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
@@ -29,6 +29,7 @@ public:
   void setText(const QString& str);
   void setError(int line, const QString& str);
   void openInExternalEditor();
+  void stopWatchingFile(const QString& tempFile);
 
 protected:
   virtual void on_accepted() = 0;
@@ -36,6 +37,9 @@ protected:
   const score::DocumentContext& m_context;
   QTextEdit* m_textedit{};
   QPlainTextEdit* m_error{};
+
+private:
+  std::shared_ptr<std::function<void()>> m_fileHandle;
 };
 
 template <typename Process_T, typename Property_T, typename Spec_T>

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
@@ -76,9 +76,7 @@ public:
 
 protected:
   const Process_T& m_process;
-  void closeEvent(QCloseEvent* event) override { reject(); }
-
-  void reject() override
+  void closeEvent(QCloseEvent* event) override
   {
     const_cast<QWidget*&>(m_process.externalUI) = nullptr;
     m_process.externalUIVisible(false);

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
@@ -28,6 +28,7 @@ public:
 
   void setText(const QString& str);
   void setError(int line, const QString& str);
+  void openInExternalEditor();
 
 protected:
   virtual void on_accepted() = 0;

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
@@ -76,7 +76,9 @@ public:
 
 protected:
   const Process_T& m_process;
-  void closeEvent(QCloseEvent* event) override
+  void closeEvent(QCloseEvent* event) override { reject(); }
+
+  void reject() override
   {
     const_cast<QWidget*&>(m_process.externalUI) = nullptr;
     m_process.externalUIVisible(false);

--- a/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
+++ b/src/plugins/score-lib-process/Process/Script/ScriptEditor.hpp
@@ -28,7 +28,7 @@ public:
 
   void setText(const QString& str);
   void setError(int line, const QString& str);
-  void openInExternalEditor();
+  void openInExternalEditor(const QString& editorPath);
   void stopWatchingFile(const QString& tempFile);
 
 protected:


### PR DESCRIPTION
- [ ] Reuse previous editor instance instead of launching a new one each time and ending up with 30 sublime / vscode files open for each edit :')
   - [ ] before creating a new file, check if it exists?