### PR TITLE
Minimise build on snmalloc.

### DIFF
--- a/3rdparty/mimalloc.cmake
+++ b/3rdparty/mimalloc.cmake
@@ -10,9 +10,6 @@ if(SCORE_HAS_SANITIZERS)
   return()
 endif()
 
-if("${CMAKE_CXX_FLAGS}" MATCHES ".*_FORTIFY_SOURCE.*")
-  return()
-endif()
 if("${CMAKE_CXX_FLAGS}" MATCHES ".*_GLIBCXX_ASSERTIONS.*")
   return()
 endif()
@@ -24,6 +21,6 @@ else()
   set(SNMALLOC_BUILD_TESTING
       OFF
       CACHE INTERNAL "" FORCE)
-  add_subdirectory(3rdparty/snmalloc SYSTEM)
+  add_subdirectory(3rdparty/snmalloc EXCLUDE_FROM_ALL SYSTEM)
   endblock()
 endif()


### PR DESCRIPTION
The `EXCLUDE_FROM_ALL` target on `add_subdirectory` means that it will only build items that are required to build other targets.  This means that it will not build the `memcpy` version that you are not using in this project, hence remove the issue with FORTIFY_SOURCE. This should also mildly improve your build times.