### PR TITLE
fix/improve perf fpe

### DIFF
--- a/src/plugins/score-plugin-analysis/Analysis/GistState.hpp
+++ b/src/plugins/score-plugin-analysis/Analysis/GistState.hpp
@@ -211,7 +211,7 @@ struct GistState
         if(g1.getAudioFrameSize() != samples)
           g1.setAudioFrameSize(samples);
 
-        g1.processAudioFrame(data(c0), samples, gain, gate);
+        g1.processAudioFrame(data(c1), samples, gain, gate);
         ret[1] = (g1.*Func)();
       }
     }

--- a/src/plugins/score-plugin-jit/JitCpp/AvndJit.cpp
+++ b/src/plugins/score-plugin-jit/JitCpp/AvndJit.cpp
@@ -313,6 +313,7 @@ __attribute__ ((visibility("default")))
 extern "C" ossia::graph_node* avnd_factory(int buffersize, double rate) {{
   using type = decltype(avnd::configure<oscr::config, Node>())::type;
   auto n = new oscr::safe_node<type>(buffersize, rate, 0);
+  n->set_not_fp_safe();
   n->finish_init();
   n->audio_configuration_changed();
   return n;

--- a/src/plugins/score-plugin-lv2/LV2/Node.hpp
+++ b/src/plugins/score-plugin-lv2/LV2/Node.hpp
@@ -39,6 +39,8 @@ struct lv2_node final : public ossia::graph_node
       , on_start{os}
       , on_finished{of}
   {
+    this->set_not_fp_safe();
+
     const std::size_t audio_in_size = data.audio_in_ports.size();
     const std::size_t audio_out_size = data.audio_out_ports.size();
     const std::size_t control_in_size = data.control_in_ports.size();

--- a/src/plugins/score-plugin-vst/Vst/Node.hpp
+++ b/src/plugins/score-plugin-vst/Vst/Node.hpp
@@ -20,6 +20,7 @@ protected:
   explicit vst_node_base(std::shared_ptr<AEffectWrapper>&& ptr)
       : fx{std::move(ptr)}
   {
+    this->set_not_fp_safe();
     m_inlets.reserve(10);
     controls.reserve(10);
   }

--- a/src/plugins/score-plugin-vst3/Vst3/Node.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Node.hpp
@@ -131,6 +131,7 @@ protected:
   explicit vst_node_base(const Plugin& ptr)
       : fx{std::move(ptr)}
   {
+    this->set_not_fp_safe();
     m_inlets.reserve(10);
     controls.reserve(10);
 


### PR DESCRIPTION
- **rms: fix that computation was broken in stereo mode**
- **faust: enable denormals when compiling faust code**
- **fp: enable fpe safety for select plug-ins**
