### PR TITLE
feature/various bugfixing asan

### DIFF
--- a/src/lib/score/application/GUIApplicationContext.hpp
+++ b/src/lib/score/application/GUIApplicationContext.hpp
@@ -68,12 +68,14 @@ struct GUIApplicationContext : public score::ApplicationContext
   template <typename T>
   T& applicationPlugin() const
   {
+    static_assert(std::is_base_of_v<score::ApplicationPlugin, T>);
     return components.applicationPlugin<T>();
   }
 
   template <typename T>
   T* findApplicationPlugin() const
   {
+    static_assert(std::is_base_of_v<score::ApplicationPlugin, T>);
     return components.findApplicationPlugin<T>();
   }
 
@@ -85,12 +87,14 @@ struct GUIApplicationContext : public score::ApplicationContext
   template <typename T>
   T& guiApplicationPlugin() const
   {
+    static_assert(std::is_base_of_v<score::GUIApplicationPlugin, T>);
     return components.guiApplicationPlugin<T>();
   }
 
   template <typename T>
   T* findGuiApplicationPlugin() const
   {
+    static_assert(std::is_base_of_v<score::GUIApplicationPlugin, T>);
     return components.findGuiApplicationPlugin<T>();
   }
 

--- a/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
@@ -136,7 +136,7 @@ public:
     Process::Inlet* port = avnd_input_idx_to_model_ports(idx)[0];
     auto pp = safe_cast<Process::ControlInlet*>(port);
 
-    if(pp->value().target<std::string>())
+    if(auto val = pp->value(); bool(val.target<std::string>()))
     {
       pp->setValue(custom.toStdString());
     }

--- a/src/plugins/score-plugin-dataflow/Dataflow/PortItem.cpp
+++ b/src/plugins/score-plugin-dataflow/Dataflow/PortItem.cpp
@@ -172,11 +172,20 @@ bool AutomatablePortItem::on_createAutomation(
   auto lay_cmd = new Scenario::Command::AddLayerInNewSlot{cst, make_cmd->processId()};
   macro(lay_cmd);
 
-  auto val = ossia::convert<float>(ctrl->value());
-
   auto dom = ctrl->domain();
   auto min = dom.get().convert_min<float>();
   auto max = dom.get().convert_max<float>();
+  auto val = ossia::convert<float>(ctrl->value());
+  if(ossia::safe_isnan(min) || ossia::safe_isinf(min))
+    return false;
+  if(ossia::safe_isnan(max) || ossia::safe_isinf(max))
+    return false;
+  if(ossia::safe_isnan(val) || ossia::safe_isinf(val))
+    return false;
+
+  if(min >= max)
+    max = min + 1;
+
   auto segt = Curve::flatCurveSegment(val, min, max);
 
   State::Unit unit = ctrl->address().qualifiers.get().unit;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
@@ -117,6 +117,10 @@ void RenderList::release()
   }
 
   m_vertexBuffers.clear();
+  for(auto& [k, v] : m_customMeshCache)
+  {
+    delete v;
+  }
   m_customMeshCache.clear();
 
   delete m_outputUBO;

--- a/src/plugins/score-plugin-gfx/Gfx/TexturePort.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/TexturePort.cpp
@@ -140,21 +140,29 @@ TextureInlet::TextureInlet(DataStream::Deserializer& vis, QObject* parent)
     : Inlet{vis, parent}
 {
   vis.writeTo(*this);
+  if(m_textureFilter == ossia::texture_filter::NONE)
+    m_textureFilter = ossia::texture_filter::NEAREST;
 }
 TextureInlet::TextureInlet(JSONObject::Deserializer& vis, QObject* parent)
     : Inlet{vis, parent}
 {
   vis.writeTo(*this);
+  if(m_textureFilter == ossia::texture_filter::NONE)
+    m_textureFilter = ossia::texture_filter::NEAREST;
 }
 TextureInlet::TextureInlet(DataStream::Deserializer&& vis, QObject* parent)
     : Inlet{vis, parent}
 {
   vis.writeTo(*this);
+  if(m_textureFilter == ossia::texture_filter::NONE)
+    m_textureFilter = ossia::texture_filter::NEAREST;
 }
 TextureInlet::TextureInlet(JSONObject::Deserializer&& vis, QObject* parent)
     : Inlet{vis, parent}
 {
   vis.writeTo(*this);
+  if(m_textureFilter == ossia::texture_filter::NONE)
+    m_textureFilter = ossia::texture_filter::NEAREST;
 }
 
 std::optional<QSize> TextureInlet::renderSize() const noexcept
@@ -409,23 +417,22 @@ void TextureInletFactory::setupInletInspector(
   {
     using enum ossia::texture_filter;
     auto combo = new QComboBox{parent};
-    combo->addItem("None", ossia::texture_filter::NONE);
     combo->addItem("Nearest", ossia::texture_filter::NEAREST);
     combo->addItem("Linear", ossia::texture_filter::LINEAR);
-    combo->setCurrentIndex((int)inlet.textureFilter());
+    combo->setCurrentIndex((int(inlet.textureFilter()) - 1));
 
     QObject::connect(
         &inlet, &TextureInlet::textureFilterChanged, combo,
         [combo](ossia::texture_filter fmt) {
       if((int)fmt != combo->currentData())
-        combo->setCurrentIndex((int)fmt);
+        combo->setCurrentIndex((int)fmt - 1);
     });
     QObject::connect(
         combo, &QComboBox::currentIndexChanged, &inlet, [&ctx, &inlet](int idx) {
-      auto mode = (ossia::texture_filter)idx;
+      auto mode = (ossia::texture_filter)(idx + 1);
       if(mode != inlet.textureFilter())
         CommandDispatcher<>{ctx.commandStack}.submit<ChangeTextureInletFilter>(
-            inlet, (ossia::texture_filter)idx);
+            inlet, mode);
     });
 
     lay.addRow("Filter", combo);

--- a/src/plugins/score-plugin-js/JS/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-js/JS/ApplicationPlugin.cpp
@@ -3,6 +3,7 @@
 #include <JS/Qml/DeviceContext.hpp>
 #include <JS/Qml/EditContext.hpp>
 #include <JS/Qml/Utils.hpp>
+#include <Library/LibrarySettings.hpp>
 
 #if __has_include(<QQuickWindow>)
 #include <QGuiApplication>
@@ -24,6 +25,16 @@ ApplicationPlugin::~ApplicationPlugin() { }
 
 void ApplicationPlugin::afterStartup()
 {
+  // Dummy engine setup for JS processes
+  // eng.importModule(
+  //     "/home/jcelerier/Documents/ossia/score/packages/default/Scripts/include/"
+  //     "tonal.mjs");
+  for(auto& p :
+      score::AppContext().settings<Library::Settings::Model>().getIncludePaths())
+  {
+    m_dummyEngine.addImportPath(p);
+  }
+
 #if __has_include(<QQuickWindow>)
   if(QFileInfo f{context.applicationSettings.ui}; f.isFile())
   {

--- a/src/plugins/score-plugin-js/JS/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-js/JS/ApplicationPlugin.hpp
@@ -22,6 +22,7 @@ public:
   void afterStartup() override;
 
   QQmlEngine m_engine;
+  QQmlEngine m_dummyEngine;
   QQmlComponent* m_comp{};
   QQuickWindow* m_window{};
 };

--- a/src/plugins/score-plugin-js/JS/JSProcessModel.cpp
+++ b/src/plugins/score-plugin-js/JS/JSProcessModel.cpp
@@ -10,6 +10,7 @@
 #include <Process/Dataflow/Port.hpp>
 #include <Process/PresetHelpers.hpp>
 
+#include <JS/ApplicationPlugin.hpp>
 #include <JS/Qml/QmlObjects.hpp>
 #include <Library/LibrarySettings.hpp>
 
@@ -35,18 +36,6 @@
 W_OBJECT_IMPL(JS::ProcessModel)
 namespace JS
 {
-
-void setupEngineImportPaths(QQmlEngine& eng) noexcept
-{
-  // eng.importModule(
-  //     "/home/jcelerier/Documents/ossia/score/packages/default/Scripts/include/"
-  //     "tonal.mjs");
-  for(auto& p :
-      score::AppContext().settings<Library::Settings::Model>().getIncludePaths())
-  {
-    eng.addImportPath(p);
-  }
-}
 
 ProcessModel::ProcessModel(
     const TimeVal& duration, const QString& data, const Id<Process::ProcessModel>& id,
@@ -297,9 +286,9 @@ Script* ComponentCache::get(
   }
   else
   {
-    static QQmlEngine dummyEngine;
-    std::call_once(qml_dummy_engine_setup, [] { setupEngineImportPaths(dummyEngine); });
-
+    auto& dummyEngine = score::GUIAppContext()
+                            .guiApplicationPlugin<JS::ApplicationPlugin>()
+                            .m_dummyEngine;
     auto comp = std::make_unique<QQmlComponent>(&dummyEngine);
     if(!isFile)
     {

--- a/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
+++ b/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
@@ -4,6 +4,7 @@
 
 #include <Media/MediaFileHandle.hpp>
 
+#include <nano_observer.hpp>
 #include <score_plugin_media_export.h>
 namespace Media::Sound
 {
@@ -15,6 +16,7 @@ namespace score
 class SCORE_PLUGIN_MEDIA_EXPORT QGraphicsWaveformButton final
     : public QObject
     , public QGraphicsItem
+    , public Nano::Observer
 {
   W_OBJECT(QGraphicsWaveformButton)
 

--- a/src/plugins/score-plugin-media/Mixer/MixerPanel.cpp
+++ b/src/plugins/score-plugin-media/Mixer/MixerPanel.cpp
@@ -155,7 +155,8 @@ public:
     auto addr = QString::fromStdString(param.get_node().osc_address());
     label.setText(addr);
 
-    slider.setValue(*param.value().target<float>());
+    const auto val = param.value();
+    slider.setValue(*val.target<float>());
     con(slider, &AudioSliderWidget::valueChanged, this,
         [&](double d) { param.push_value(d); });
     idx = param.add_callback(

--- a/src/plugins/score-plugin-midi/Patternist/PatternModel.cpp
+++ b/src/plugins/score-plugin-midi/Patternist/PatternModel.cpp
@@ -262,6 +262,8 @@ template <>
 void DataStreamWriter::write(Patternist::ProcessModel& proc)
 {
   proc.outlet = Process::load_midi_outlet(*this, &proc);
+  proc.accent = Process::load_value_outlet(*this, &proc);
+  proc.slide = Process::load_value_outlet(*this, &proc);
   m_stream >> proc.m_channel >> *proc.accent >> *proc.slide >> proc.m_currentPattern
       >> proc.m_patterns;
 

--- a/src/plugins/score-plugin-protocols/Protocols/Evdev/EvdevDevice.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/Evdev/EvdevDevice.cpp
@@ -248,8 +248,9 @@ public:
       if(ec)
         return;
 
-      auto const n = bytes_transferred / sizeof(::input_event);
-      for(auto& ev : events | boost::adaptors::sliced(0, n))
+      const auto n = bytes_transferred / sizeof(::input_event);
+      const auto& slice = events | boost::adaptors::sliced(0, n);
+      for(auto& ev : slice)
       {
         switch(ev.type)
         {
@@ -281,7 +282,8 @@ public:
                 std::vector<ossia::value>{ev.type, ev.code, ev.value});
             if(this->params.mouse_xy)
             {
-              if(auto cur = this->params.mouse_xy->value().target<ossia::vec2f>())
+              auto val = this->params.mouse_xy->value();
+              if(auto cur = val.target<ossia::vec2f>())
               {
                 if(ev.code == REL_X)
                   (*cur)[0] = ev.value;
@@ -298,7 +300,8 @@ public:
                 std::vector<ossia::value>{ev.type, ev.code, ev.value});
             if(this->params.tablet_xy)
             {
-              if(auto cur = this->params.tablet_xy->value().target<ossia::vec2f>())
+              auto val = this->params.tablet_xy->value();
+              if(auto cur = val.target<ossia::vec2f>())
               {
                 if(ev.code == ABS_X)
                   (*cur)[0] = ev.value;


### PR DESCRIPTION
- **core: enforce checking of correct type in AppContext helpers**
- **value: do not call target<>() on a rvalue**
- **gfx: clear mesh cache upon renderlist deletion**
- **gfx: none mode is actually invalid as a texture filter and enforced as assertions in qt**
- **js: static QQmlEngine is not valid as deletion must occur before QApp destruction**
- **media: fix missing inheritance from Nano::Observer**
- **patternist: fix missing reload of new ports in datastream serialization**
- **3rdparty: update libossia**
- **automation: prevent creating automations when port min = port max = 0**
