### PR TITLE
feature/various bugfixing asan 2

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -525,6 +525,7 @@ static void setup_locale()
 
 static void setup_app_flags()
 {
+  qputenv("QT_NO_GLIB", "1");
   qputenv("QSG_USE_SIMPLE_ANIMATION_DRIVER", "1");
   qputenv("QSG_RENDER_LOOP", "basic");
   // Consistency in looks across macOS, Windows (which prevents the horrible 125% scaling) and Linux

--- a/src/lib/core/document/Document.cpp
+++ b/src/lib/core/document/Document.cpp
@@ -131,6 +131,8 @@ void Document::ready()
     m_backupMgr = new DocumentBackupManager{saveAsByteArray(), *this};
     m_backupMgr->updateBackupData();
   }
+
+  m_loaded = true;
 }
 
 Document::~Document()

--- a/src/lib/core/document/Document.hpp
+++ b/src/lib/core/document/Document.hpp
@@ -103,6 +103,8 @@ public:
   // Update the various internal timers rate after settings changes
   void updateTimers();
 
+  bool loaded() const noexcept { return m_loaded; }
+
 private:
   // These are to be constructed by DocumentBuilder.
   Document(
@@ -152,6 +154,9 @@ private:
   std::optional<score::RestorableDocument> m_initialData{};
   bool m_virgin{false}; // Used to check if we can safely close it
   // if we want to load a document instead upon opening score.
+  bool m_loaded{false}; // Used to check if the document has finished loading.
+  // Can be useful to turn some async operations into sync - creation of dynamic ports,
+  // loading of vst plug-ins controls etc.
 };
 }
 

--- a/src/plugins/score-plugin-analysis/Analysis/Kurtosis.hpp
+++ b/src/plugins/score-plugin-analysis/Analysis/Kurtosis.hpp
@@ -10,9 +10,8 @@ namespace Analysis
 {
 struct Kurtosis : Analysis::GistState
 {
-  
-  halp_meta(name, "Complex Spectral Difference")
-  halp_meta(c_name, "CSD")
+  halp_meta(name, "Kurtosis")
+  halp_meta(c_name, "kurtosis")
   halp_meta(category, "Analysis/Spectrum")
   halp_meta(author, "ossia score, Gist library")
   halp_meta(manual_url, "https://ossia.io/score-docs/processes/analysis.html#spectral-parameters")
@@ -33,7 +32,7 @@ struct Kurtosis : Analysis::GistState
 
   void operator()(int frames)
   {
-    process<&Gist<double>::complexSpectralDifference>(
+    process<&Gist<double>::spectralKurtosis>(
         inputs.audio, inputs.gain, inputs.gate, outputs.result, frames);
   }
 };

--- a/src/plugins/score-plugin-avnd/Crousti/GpuComputeNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuComputeNode.hpp
@@ -356,8 +356,10 @@ struct GpuComputeRenderer final : ComputeRendererBaseType<Node_T>
 
     // Release the allocated rts
     // TODO investigate why reference does not work here:
-    // for(auto [port, rt] : m_rts)
-    //   rt.release();
+    for(auto& e : m_rts)
+    {
+      e.second.release();
+    }
     m_rts.clear();
 
     // Release the allocated pipelines

--- a/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
+++ b/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
@@ -707,6 +707,8 @@ extract_glsl_function_definitions(std::string_view str)
 
   // :upside-down-face:
   ossia::flat_set<std::string> defs;
+  // FIXME: this is leaky due to some strdup calls.
+  // Calling glsl_parse_dealloc(&context); crashes.
   bool error = glsl_parse_string(&context, str.data());
   if(!error && context.root
      && context.root->code == (int)glsl_tokentype::TRANSLATION_UNIT)

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
@@ -460,6 +460,7 @@ void RenderList::render(QRhiCommandBuffer& commands, bool force)
         {
           SCORE_ASSERT(!updateBatch);
           updateBatch = state.rhi->nextResourceUpdateBatch();
+          SCORE_ASSERT(updateBatch);
         }
         node_was_rendered = true;
       }
@@ -485,7 +486,10 @@ void RenderList::render(QRhiCommandBuffer& commands, bool force)
     if(this->output.configuration().outputNeedsRenderPass)
     {
       if(!updateBatch)
+      {
         updateBatch = state.rhi->nextResourceUpdateBatch();
+        SCORE_ASSERT(updateBatch);
+      }
 
       // FIXME remove this hack
       score::gfx::Port p;

--- a/src/plugins/score-plugin-js/JS/Executor/CPUNode.cpp
+++ b/src/plugins/score-plugin-js/JS/Executor/CPUNode.cpp
@@ -30,7 +30,13 @@ js_node::js_node(ossia::execution_state& st)
 
 js_node::~js_node()
 {
+  SCORE_ASSERT(!m_engine);
+}
+
+void js_node::clear() noexcept
+{
   delete m_engine;
+  m_engine = nullptr;
 }
 
 void js_node::setupComponent()

--- a/src/plugins/score-plugin-js/JS/Executor/CPUNode.hpp
+++ b/src/plugins/score-plugin-js/JS/Executor/CPUNode.hpp
@@ -37,6 +37,7 @@ public:
   [[nodiscard]] std::string label() const noexcept override { return "javascript"; }
 
   void run(const ossia::token_request& t, ossia::exec_state_facade) noexcept override;
+  void clear() noexcept override;
   void setupComponent();
   void setScript(const QString& val);
 

--- a/src/plugins/score-plugin-js/JS/Executor/GPUNode.cpp
+++ b/src/plugins/score-plugin-js/JS/Executor/GPUNode.cpp
@@ -420,8 +420,6 @@ void main ()
 
     auto rt = renderer.renderTargetForOutput(e).renderTarget;
     SCORE_ASSERT(rt);
-    cb.beginPass(rt, QColor(Qt::transparent), {}, res);
-    res = nullptr;
 
     cd->syncSceneGraph();
     rc->rc->endSync();
@@ -439,8 +437,6 @@ void main ()
 
     QEvent* updateRequest = new QEvent(QEvent::UpdateRequest);
     QCoreApplication::postEvent(m_window, updateRequest);
-    // cb.endPass(); // < called by renderSceneGraph
-    res = renderer.state.rhi->nextResourceUpdateBatch();
   }
 
   void runRenderPass(

--- a/src/plugins/score-plugin-media/Video/VideoDecoder.cpp
+++ b/src/plugins/score-plugin-media/Video/VideoDecoder.cpp
@@ -489,15 +489,15 @@ void VideoDecoder::close_file() noexcept
 
 ReadFrame LibAVDecoder::read_one_frame_raw(AVPacket& packet)
 {
-  auto frame = m_frames.newFrame();
   int res{};
-  if(frame->buf[0])
-    av_buffer_unref(&frame->buf[0]);
 
   while((res = av_read_frame(m_formatContext, &packet)) >= 0)
   {
     if(packet.stream_index == m_avstream->index)
     {
+      auto frame = m_frames.newFrame();
+      if(frame->buf[0])
+        av_buffer_unref(&frame->buf[0]);
       // Mainly for HAP: we feed the raw undecoded codec data directly to the GPU, see HAPDecoder
       load_packet_in_frame(packet, *frame);
 


### PR DESCRIPTION
- **linux: disable glib event dispatcher which just wastes time**
- **js: gpu node: fix invalid call to beginPass**
- **video decoder: move frame acquisition inside scope to reduce unnecessary allocations**
- **execution: move the command execution to the audio thread even when we stop as the QQmlEngine inside js_node really needs to be deleted on the thread it was created in**
