### PR TITLE
feature/new objs 2

### DIFF
--- a/src/plugins/score-lib-process/Control/Layout.hpp
+++ b/src/plugins/score-lib-process/Control/Layout.hpp
@@ -44,28 +44,28 @@ struct SCORE_LIB_PROCESS_EXPORT LayoutBuilderBase
   {
     auto& skin = score::Skin::instance();
     {
-      if constexpr(requires { T::darker; })
-        if(cur == T::darker)
+      if constexpr(requires { T::background_darker; })
+        if(cur == T::background_darker)
           return skin.Background2.darker300;
     }
     {
-      if constexpr(requires { T::dark; })
-        if(cur == T::dark)
+      if constexpr(requires { T::background_dark; })
+        if(cur == T::background_dark)
           return skin.Background2.darker;
     }
     {
-      if constexpr(requires { T::mid; })
-        if(cur == T::mid)
+      if constexpr(requires { T::background_mid; })
+        if(cur == T::background_mid)
           return skin.Background2.main;
     }
     {
-      if constexpr(requires { T::light; })
-        if(cur == T::light)
+      if constexpr(requires { T::background_light; })
+        if(cur == T::background_light)
           return skin.Background2.lighter;
     }
     {
-      if constexpr(requires { T::lighter; })
-        if(cur == T::lighter)
+      if constexpr(requires { T::background_lighter; })
+        if(cur == T::background_lighter)
           return skin.Background2.lighter180;
     }
     return skin.Background2.main;

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -574,7 +574,7 @@ struct TimeChooser
   {
     auto sl = new score::QGraphicsTimeChooser{nullptr};
     initWidgetProperties(inlet, *sl);
-    // bindFloatDomain(slider, inlet, *sl);
+    bindFloatDomain(slider, inlet, sl->knob);
     sl->setValue(ossia::convert<ossia::vec2f>(inlet.value()));
 
     QObject::connect(

--- a/src/plugins/score-lib-process/Process/Dataflow/NodeItem.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/NodeItem.cpp
@@ -170,6 +170,7 @@ void NodeItem::createWithDecorations()
   ossia::qt::run_async(this, [this] {
     resetInlets();
     resetOutlets();
+    updateSize();
   });
   connect(&process, &Process::ProcessModel::controlAdded, this, &NodeItem::resetInlets);
   connect(
@@ -465,12 +466,21 @@ void NodeItem::createContentItem()
 double NodeItem::minimalContentWidth() const noexcept
 {
   if(Q_UNLIKELY(!m_label))
-    return 30.;
+  {
+    if((m_inlets.size() + m_outlets.size()) <= 1)
+      return 10.;
+    else
+      return 20.;
+  }
   else
     return std::max(75.0, TitleWithUiX0 + m_label->boundingRect().width() + 6.);
 }
 double NodeItem::minimalContentHeight() const noexcept
 {
+  if(Q_UNLIKELY(!m_label))
+    if(std::max(m_inlets.size(), m_outlets.size()) <= 1)
+      return 10.;
+
   double h = 22.;
   if(!m_inlets.empty())
     h = std::max(h, m_inlets.back()->y() + 10.);

--- a/src/plugins/score-plugin-avnd/CMakeLists.txt
+++ b/src/plugins/score-plugin-avnd/CMakeLists.txt
@@ -876,16 +876,29 @@ avnd_make_score(
   SOURCES "${AVND_FOLDER}/examples/Advanced/UI/LEDView.hpp"
   TARGET led_view
   MAIN_CLASS LEDView
-  NAMESPACE ao
+  NAMESPACE uo
+)
+
+avnd_make_score(
+  SOURCES "${AVND_FOLDER}/examples/Advanced/UI/PulseView.hpp"
+  TARGET pulse_view
+  MAIN_CLASS PulseView
+  NAMESPACE uo
 )
 
 avnd_make_score(
   SOURCES "${AVND_FOLDER}/examples/Advanced/UI/2DView.hpp"
   TARGET point2d_view
   MAIN_CLASS Point2DView
-  NAMESPACE ao
+  NAMESPACE uo
 )
 
+avnd_make_score(
+  SOURCES "${AVND_FOLDER}/examples/Raw/TimingSplitter.hpp"
+  TARGET timing_splitter
+  MAIN_CLASS TimingSplitter
+  NAMESPACE examples
+)
 avnd_make_score(
   SOURCES "${AVND_FOLDER}/examples/Advanced/Spatialization/DBAP.hpp"
   TARGET avnd_dbap_2d

--- a/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
@@ -282,6 +282,10 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
         {
           auto qitem = new oscr::CustomControl<Item&>{item, *port, this->doc};
           Process::ControlLayout lay{.container = qitem};
+          if(auto* f = portFactory.get(port->concreteKey()))
+          {
+            lay.port_item = f->makePortItem(*port, this->doc, this->layout, &context);
+          }
           setupControl(this->layout, port, lay, item);
           setupItem(item, *qitem);
         }
@@ -299,6 +303,10 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
         {
           auto qitem = new oscr::CustomControl<Item&>{item, *port, this->doc};
           Process::ControlLayout lay{.container = qitem};
+          if(auto* f = portFactory.get(port->concreteKey()))
+          {
+            lay.port_item = f->makePortItem(*port, this->doc, this->layout, &context);
+          }
           setupControl(this->layout, port, lay, item);
           setupItem(item, *qitem);
         }

--- a/src/plugins/score-plugin-avnd/Crousti/MessageBus.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/MessageBus.hpp
@@ -44,8 +44,11 @@ struct MessageBusSender
 {
   std::function<void(QByteArray)>& bus;
 
+  // Case for zero-argument message bus (e.g. just a ping)
+  void operator()() { this->bus(QByteArray{}); }
+
   template <typename T>
-  requires std::is_trivial_v<T>
+    requires std::is_trivial_v<T>
   void operator()(const T& msg)
   {
     // Here we can just do a memcpy
@@ -167,6 +170,9 @@ struct Deserializer
 struct MessageBusReader
 {
   QByteArray& mess;
+
+  // Case for zero-argument message bus (e.g. just a ping)
+  void operator()() { }
 
   template <typename T>
   requires std::is_trivial_v<T>

--- a/src/plugins/score-plugin-fx/Fx/ClassicalBeat.hpp
+++ b/src/plugins/score-plugin-fx/Fx/ClassicalBeat.hpp
@@ -17,6 +17,7 @@ struct Node
   halp_meta(manual_url, "https://ossia.io/score-docs/processes/control-utilities.html#impulse-metronome")
   halp_meta(description, "A simple metronome - outputs a bang on the current tick")
   halp_meta(uuid, "1c185139-04f9-492f-8b4a-000dd4428990")
+  halp_flag(deprecated); // use TimingSplitter instead
 
   struct
   {

--- a/src/plugins/score-plugin-fx/Fx/LFO_v2.hpp
+++ b/src/plugins/score-plugin-fx/Fx/LFO_v2.hpp
@@ -163,7 +163,7 @@ struct Node
     struct
     {
       halp_meta(layout, halp::layouts::vbox)
-      halp_meta(background, halp::colors::mid)
+      halp_meta(background, halp::colors::background_mid)
       struct
       {
         halp_meta(layout, halp::layouts::hbox)
@@ -177,14 +177,14 @@ struct Node
     struct
     {
       halp_meta(layout, halp::layouts::vbox)
-      halp_meta(background, halp::colors::mid)
+      halp_meta(background, halp::colors::background_mid)
       halp::control<&ins::ampl> a;
       halp::control<&ins::offset> o;
     } ampl;
     struct
     {
       halp_meta(layout, halp::layouts::vbox)
-      halp_meta(background, halp::colors::mid)
+      halp_meta(background, halp::colors::background_mid)
       halp::control<&ins::jitter> j;
       halp::control<&ins::phase> p;
     } modulation;

--- a/src/plugins/score-plugin-fx/Fx/Looper.hpp
+++ b/src/plugins/score-plugin-fx/Fx/Looper.hpp
@@ -636,7 +636,7 @@ struct Node
     struct
     {
       halp_meta(layout, halp::layouts::vbox)
-      halp_meta(background, halp::colors::mid)
+      halp_meta(background, halp::colors::background_mid)
       halp::control<&ins::mode> f;
       halp::control<&ins::quantif> q;
       halp::control<&ins::passthrough> p;
@@ -644,7 +644,7 @@ struct Node
     struct
     {
       halp_meta(layout, halp::layouts::vbox)
-      halp_meta(background, halp::colors::mid)
+      halp_meta(background, halp::colors::background_mid)
       halp::control<&ins::postaction> p;
       halp::control<&ins::postaction_bars> b;
     } right;

--- a/src/plugins/score-plugin-fx/Fx/Metro.hpp
+++ b/src/plugins/score-plugin-fx/Fx/Metro.hpp
@@ -71,6 +71,8 @@ struct Node
       // in samples:
       const auto period = get_period(
           inputs.quantify, inputs.dur.value, inputs.frequency, tk.tempo, setup.rate);
+      if(period <= 0)
+        return;
 
       const auto next = next_date(tk.position_in_frames, period);
       if(tk.in_range(next))

--- a/src/plugins/score-plugin-fx/Fx/RateLimiter.hpp
+++ b/src/plugins/score-plugin-fx/Fx/RateLimiter.hpp
@@ -78,7 +78,7 @@ struct Node
   struct ui
   {
     halp_meta(layout, halp::layouts::hbox)
-    halp_meta(background, halp::colors::mid)
+    halp_meta(background, halp::colors::background_mid)
     halp::control<&ins::quantification> q;
     halp::control<&ins::ms> t;
   };

--- a/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
+++ b/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
@@ -639,6 +639,23 @@ static const ossia::string_map<root_fun>& root_parse{[] {
       d.line_size = v.as_string();
   }});
 
+  p.insert({"BACKGROUND_COLOR", [](descriptor& d, const sajson::value& v) {
+    if(v.get_type() == sajson::TYPE_ARRAY && v.get_length() == 4)
+    {
+      if(auto e = v.get_array_element(0);
+         e.get_type() == sajson::TYPE_DOUBLE || e.get_type() == sajson::TYPE_INTEGER)
+        d.background_color[0] = e.get_number_value();
+      if(auto e = v.get_array_element(1);
+         e.get_type() == sajson::TYPE_DOUBLE || e.get_type() == sajson::TYPE_INTEGER)
+        d.background_color[1] = e.get_number_value();
+      if(auto e = v.get_array_element(2);
+         e.get_type() == sajson::TYPE_DOUBLE || e.get_type() == sajson::TYPE_INTEGER)
+        d.background_color[2] = e.get_number_value();
+      if(auto e = v.get_array_element(3);
+         e.get_type() == sajson::TYPE_DOUBLE || e.get_type() == sajson::TYPE_INTEGER)
+        d.background_color[3] = e.get_number_value();
+    }
+  }});
   return p;
 }()};
 

--- a/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.hpp
+++ b/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.hpp
@@ -129,6 +129,7 @@ struct descriptor
   int point_count{};
   std::string primitive_mode;
   std::string line_size;
+  std::array<double, 4> background_color;
 };
 
 class parser

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
@@ -446,6 +446,7 @@ void RenderList::render(QRhiCommandBuffer& commands, bool force)
           updateBatch = nullptr;
 
           QRhiResourceUpdateBatch* res{};
+          // FIXME z-sort
           for(auto [edge, prev_renderer] : prevRenderers)
           {
             prev_renderer->runRenderPass(*this, commands, *edge);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/RenderedISFNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/RenderedISFNode.hpp
@@ -46,7 +46,6 @@ struct AudioTextureUpload
 private:
   std::vector<float> m_scratchpad;
   ossia::fft m_fft;
-  int m_histogramIndex{};
 };
 
 struct RenderedISFNode : score::gfx::NodeRenderer
@@ -179,11 +178,23 @@ struct SimpleRenderedVSANode : score::gfx::NodeRenderer
 private:
   ossia::small_flat_map<const Port*, TextureRenderTarget, 2> m_rts;
 
-  void initPass(const TextureRenderTarget& rt, RenderList& renderer, Edge& edge);
+  void initPass(
+      const TextureRenderTarget& rt, RenderList& renderer, Edge& edge,
+      QRhiResourceUpdateBatch& res);
 
   std::vector<Sampler> allSamplers() const noexcept;
 
-  ossia::small_vector<std::pair<Edge*, Pass>, 2> m_passes;
+  struct PassData
+  {
+    Edge* edge;
+    Pass main_pass;
+    QRhiGraphicsPipeline* background_pipeline{};
+    QRhiShaderResourceBindings* background_srb{};
+    QRhiBuffer* background_ubo{};
+    MeshBuffers background_tri{};
+  };
+
+  ossia::small_vector<PassData, 2> m_passes;
 
   ISFNode& n;
 

--- a/src/plugins/score-plugin-gfx/Gfx/VSA/Process.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/VSA/Process.cpp
@@ -94,12 +94,13 @@ Process::ScriptChangeResult Model::setVertex(QString f)
   m_processedProgram.vertex.clear();
 
   vertexChanged(m_program.vertex);
-  return {};
+  return setProgram(m_program);
 }
 
 Process::ScriptChangeResult Model::setProgram(const ShaderSource& f)
 {
-  setVertex(f.vertex);
+  m_program.fragment.clear();
+  m_processedProgram.fragment.clear();
   if(const auto& [processed, error] = ProgramCache::instance().get(f); bool(processed))
   {
     ossia::flat_map<QString, ossia::value> previous_values;

--- a/src/plugins/score-plugin-scenario/Scenario/Document/ScenarioDocument/ScenarioDocumentPresenter.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/ScenarioDocument/ScenarioDocumentPresenter.cpp
@@ -208,6 +208,7 @@ ScenarioDocumentPresenter::ScenarioDocumentPresenter(
   }
 
   setDisplayedInterval(&model().baseInterval());
+  QTimer::singleShot(0, [this] { view().minimap().zoom(0.0); });
 
   model().cables.mutable_added.connect<&ScenarioDocumentPresenter::on_cableAdded>(*this);
   model().cables.removing.connect<&ScenarioDocumentPresenter::on_cableRemoving>(*this);


### PR DESCRIPTION
- **spline: fix that it could not loop**
- **audio plugins: look for ~/.vst ~/.vst3 etc. on every OS**
- **objects: add two new objects, a powerful value filter, and a live easing function applier**
- **time_chooser: work on respecting the range**
- **nodes: improve default node sizing, allow smaller nodes**
- **avnd: enable message bus to work without any arguments**
- **avnd: make port items for custom controls**
- **metronome: fix a potential division per 0**
- **ui: fix default zoom when switching between nodal and interval without having zoomed once first**
- **value display: add a log mode**
- **ui: update avendish plugins with proper color name**
