### PR TITLE
feature/buffer geometry

### DIFF
--- a/src/plugins/score-plugin-gfx/CMakeLists.txt
+++ b/src/plugins/score-plugin-gfx/CMakeLists.txt
@@ -109,6 +109,11 @@ set(HDRS
     Gfx/Text/Process.hpp
     Gfx/Text/Layer.hpp
 
+    Gfx/BufferGeometry/Metadata.hpp
+    Gfx/BufferGeometry/Process.hpp
+    Gfx/BufferGeometry/Executor.hpp
+
+    Gfx/Graph/BufferGeometryNode.hpp
     Gfx/Graph/CommonUBOs.hpp
     Gfx/Graph/CustomMesh.hpp
     Gfx/Graph/DepthNode.hpp
@@ -220,8 +225,12 @@ set(SRCS
     Gfx/Text/Executor.cpp
     Gfx/Text/Process.cpp
 
+    Gfx/BufferGeometry/Process.cpp
+    Gfx/BufferGeometry/Executor.cpp
+
     Gfx/Graph/decoders/GPUVideoDecoder.cpp
     Gfx/Graph/decoders/HAP.cpp
+    Gfx/Graph/BufferGeometryNode.cpp
     Gfx/Graph/GeometryFilterNode.cpp
     Gfx/Graph/GeometryFilterNodeRenderer.cpp
     Gfx/Graph/RenderedCSFNode.cpp

--- a/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Executor.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Executor.cpp
@@ -1,0 +1,186 @@
+#include "Executor.hpp"
+
+#include <Process/Dataflow/Port.hpp>
+#include <Process/ExecutionContext.hpp>
+
+#include <Gfx/GfxApplicationPlugin.hpp>
+#include <Gfx/GfxContext.hpp>
+#include <Gfx/GfxExecNode.hpp>
+#include <Gfx/Graph/BufferGeometryNode.hpp>
+#include <Gfx/BufferGeometry/Process.hpp>
+#include <Gfx/TexturePort.hpp>
+
+#include <score/document/DocumentContext.hpp>
+
+#include <ossia/dataflow/port.hpp>
+
+namespace Gfx::BufferGeometry
+{
+class buffer_geometry_node final : public gfx_exec_node
+{
+public:
+  buffer_geometry_node(GfxExecutionAction& ctx, const Model& proc)
+      : gfx_exec_node{ctx}
+      , m_process{proc}
+  {
+    auto node = std::make_unique<score::gfx::BufferGeometryNode>();
+    m_bufferGeometryNode = node.get();
+    
+    // Copy configuration from process model
+    node->config = proc.configuration();
+    
+    id = exec_context->ui->register_node(std::move(node));
+  }
+
+  ~buffer_geometry_node()
+  {
+    if(id >= 0)
+      exec_context->ui->unregister_node(id);
+  }
+
+  std::string label() const noexcept override { return "Gfx::buffer_geometry_node"; }
+
+private:
+  const Model& m_process;
+  score::gfx::BufferGeometryNode* m_bufferGeometryNode{};
+};
+
+ProcessExecutorComponent::ProcessExecutorComponent(
+    Gfx::BufferGeometry::Model& element, const Execution::Context& ctx, QObject* parent)
+    : ProcessComponent_T{element, ctx, "gfxBufferGeometryExecutorComponent", parent}
+{
+  auto n = ossia::make_node<buffer_geometry_node>(
+      *ctx.execState, ctx.doc.plugin<DocumentPlugin>().exec, element);
+
+  // Set up texture input connections (up to 4 buffers)
+  for(std::size_t i = 0; i < 4 && i < element.inlets().size(); ++i)
+  {
+    if(auto inlet = qobject_cast<Gfx::TextureInlet*>(element.inlets()[i]))
+    {
+      n->add_texture();
+    }
+  }
+
+  // Set up control inputs for configuration
+  int control_idx = 4; // Start after texture inlets
+
+  // Vertex Count
+  if(auto ctrl = qobject_cast<Process::ControlInlet*>(element.inlets()[control_idx++]))
+  {
+    auto& p = n->add_control();
+    p->value = ctrl->value();
+    QObject::connect(
+        ctrl, &Process::ControlInlet::valueChanged, this,
+        [this, n](const ossia::value& v) {
+      if(auto val = v.target<int>())
+      {
+        this->process().setVertexCount(*val);
+      }
+    });
+  }
+
+  // Position attribute controls (5 controls)
+  auto setupAttributeControls
+      = [&](int& idx, auto locationSetter, auto formatSetter, auto offsetSetter,
+            auto strideSetter, auto bufferSetter) {
+    // Location
+    if(auto ctrl = qobject_cast<Process::ControlInlet*>(element.inlets()[idx++]))
+    {
+      auto& p = n->add_control();
+      p->value = ctrl->value();
+      QObject::connect(
+          ctrl, &Process::ControlInlet::valueChanged, this,
+          [this, locationSetter](const ossia::value& v) {
+        if(auto val = v.target<int>())
+          (this->process().*locationSetter)(*val);
+      });
+    }
+    // Format
+    if(auto ctrl = qobject_cast<Process::ControlInlet*>(element.inlets()[idx++]))
+    {
+      auto& p = n->add_control();
+      p->value = ctrl->value();
+      QObject::connect(
+          ctrl, &Process::ControlInlet::valueChanged, this,
+          [this, formatSetter](const ossia::value& v) {
+        if(auto val = v.target<int>())
+          (this->process().*formatSetter)(*val);
+      });
+    }
+    // Offset
+    if(auto ctrl = qobject_cast<Process::ControlInlet*>(element.inlets()[idx++]))
+    {
+      auto& p = n->add_control();
+      p->value = ctrl->value();
+      QObject::connect(
+          ctrl, &Process::ControlInlet::valueChanged, this,
+          [this, offsetSetter](const ossia::value& v) {
+        if(auto val = v.target<int>())
+          (this->process().*offsetSetter)(*val);
+      });
+    }
+    // Stride
+    if(auto ctrl = qobject_cast<Process::ControlInlet*>(element.inlets()[idx++]))
+    {
+      auto& p = n->add_control();
+      p->value = ctrl->value();
+      QObject::connect(
+          ctrl, &Process::ControlInlet::valueChanged, this,
+          [this, strideSetter](const ossia::value& v) {
+        if(auto val = v.target<int>())
+          (this->process().*strideSetter)(*val);
+      });
+    }
+    // Buffer
+    if(auto ctrl = qobject_cast<Process::ControlInlet*>(element.inlets()[idx++]))
+    {
+      auto& p = n->add_control();
+      p->value = ctrl->value();
+      QObject::connect(
+          ctrl, &Process::ControlInlet::valueChanged, this,
+          [this, bufferSetter](const ossia::value& v) {
+        if(auto val = v.target<int>())
+          (this->process().*bufferSetter)(*val);
+      });
+    }
+  };
+
+  // Position attribute
+  setupAttributeControls(control_idx, &Model::setPositionLocation, &Model::setPositionFormat, 
+                        &Model::setPositionOffset, &Model::setPositionStride, &Model::setPositionBuffer);
+  
+  // Normal attribute  
+  setupAttributeControls(control_idx, &Model::setNormalLocation, &Model::setNormalFormat,
+                        &Model::setNormalOffset, &Model::setNormalStride, &Model::setNormalBuffer);
+  
+  // TexCoord0 attribute
+  setupAttributeControls(control_idx, &Model::setTexcoord0Location, &Model::setTexcoord0Format,
+                        &Model::setTexcoord0Offset, &Model::setTexcoord0Stride, &Model::setTexcoord0Buffer);
+  
+  // Color attribute
+  setupAttributeControls(control_idx, &Model::setColorLocation, &Model::setColorFormat,
+                        &Model::setColorOffset, &Model::setColorStride, &Model::setColorBuffer);
+  
+  // Tangent attribute
+  setupAttributeControls(control_idx, &Model::setTangentLocation, &Model::setTangentFormat,
+                        &Model::setTangentOffset, &Model::setTangentStride, &Model::setTangentBuffer);
+
+  // Add geometry output port to the node
+  n->root_outputs().push_back(new ossia::geometry_outlet);
+
+  this->node = n;
+  m_ossia_process = std::make_shared<ossia::node_process>(n);
+  /*
+  // Connect to configuration changes
+  QObject::connect(
+      &element, &Model::configurationChanged, this, 
+      [n]() {
+        static_cast<buffer_geometry_node*>(n.get())->updateConfiguration();
+      });*/
+}
+
+void ProcessExecutorComponent::cleanup() { }
+
+ProcessExecutorComponent::~ProcessExecutorComponent() { }
+
+}

--- a/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Executor.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Executor.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <Process/Execution/ProcessComponent.hpp>
+
+#include <ossia/dataflow/node_process.hpp>
+
+namespace Gfx::BufferGeometry
+{
+class Model;
+class ProcessExecutorComponent final
+    : public Execution::ProcessComponent_T<Gfx::BufferGeometry::Model, ossia::node_process>
+{
+  COMPONENT_METADATA("f1e2d3c4-b5a6-9788-1234-567890abcdef")
+public:
+  ProcessExecutorComponent(
+      Model& element, const Execution::Context& ctx, QObject* parent);
+
+  void cleanup() override;
+  ~ProcessExecutorComponent();
+};
+
+using ProcessExecutorComponentFactory
+    = Execution::ProcessComponentFactory_T<ProcessExecutorComponent>;
+}

--- a/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Metadata.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Metadata.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <Process/ProcessMetadata.hpp>
+
+namespace Gfx::BufferGeometry
+{
+class Model;
+}
+
+PROCESS_METADATA(
+    , Gfx::BufferGeometry::Model, "61ad3eae-8447-4197-9533-4773da4e9dd2",
+    "buffer-geometry",                                                 // Internal name
+    "Buffer Geometry",                                                 // Pretty name
+    Process::ProcessCategory::Visual,                                  // Category
+    "Visuals/3D",                                                      // Category
+    "Convert buffers to geometry with configurable vertex attributes", // Description
+    "ossia team",                                                      // Author
+    (QStringList{"gfx", "buffer", "geometry", "vertex"}),              // Tags
+    {},                                                                // Inputs
+    {},                                                                // Outputs
+    QUrl(""),
+    Process::ProcessFlags::SupportsAll // Flags
+)

--- a/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Process.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Process.cpp
@@ -1,0 +1,427 @@
+#include "Process.hpp"
+
+#include <Process/Dataflow/Port.hpp>
+#include <Process/Dataflow/WidgetInlets.hpp>
+
+#include <Gfx/TexturePort.hpp>
+
+#include <score/application/ApplicationComponents.hpp>
+
+#include <wobjectimpl.h>
+
+W_OBJECT_IMPL(Gfx::BufferGeometry::Model)
+namespace Gfx::BufferGeometry
+{
+
+Model::Model(const TimeVal& duration, const Id<Process::ProcessModel>& id, QObject* parent)
+    : Process::ProcessModel{duration, id, "gfxProcess", parent}
+{
+  // Create input ports for buffers (up to 4 texture inputs)
+  int inlet_id = 0;
+  for(int i = 0; i < 4; ++i)
+  {
+    auto port = new Gfx::TextureInlet{Id<Process::Port>(inlet_id++), this};
+    port->setName(QString("Buffer %1").arg(i));
+    m_inlets.push_back(port);
+  }
+  
+  // Create control inputs for configuration
+  m_inlets.push_back(
+      new Process::IntSlider{"Vertex Count", Id<Process::Port>(inlet_id++), this});
+  static_cast<Process::IntSlider*>(m_inlets.back())->setDomain(ossia::make_domain(1, 100000));
+  static_cast<Process::IntSlider*>(m_inlets.back())->setValue(m_config.vertex_count);
+
+  // Position attribute configuration
+  m_inlets.push_back(
+      new Process::IntSpinBox{-1, 15, m_config.position.location, "Position Location", Id<Process::Port>(inlet_id++), this});
+  
+  std::vector<std::pair<QString, ossia::value>> format_options = {
+      {"Disabled", -1},
+      {"Float", static_cast<int>(ossia::geometry::attribute::fp1)},
+      {"Vec2", static_cast<int>(ossia::geometry::attribute::fp2)},
+      {"Vec3", static_cast<int>(ossia::geometry::attribute::fp3)},
+      {"Vec4", static_cast<int>(ossia::geometry::attribute::fp4)}
+  };
+  m_inlets.push_back(
+      new Process::ComboBox{format_options, static_cast<int>(ossia::geometry::attribute::fp3), "Position Format", Id<Process::Port>(inlet_id++), this});
+  
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 1000, static_cast<int>(m_config.position.offset), "Position Offset", Id<Process::Port>(inlet_id++), this});
+  
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 100, static_cast<int>(m_config.position.stride), "Position Stride", Id<Process::Port>(inlet_id++), this});
+      
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 3, m_config.position.buffer_index, "Position Buffer", Id<Process::Port>(inlet_id++), this});
+
+  // Normal attribute configuration
+  m_inlets.push_back(
+      new Process::IntSpinBox{-1, 15, m_config.normal.location, "Normal Location", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::ComboBox{format_options, static_cast<int>(ossia::geometry::attribute::fp3), "Normal Format", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 1000, static_cast<int>(m_config.normal.offset), "Normal Offset", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 100, static_cast<int>(m_config.normal.stride), "Normal Stride", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 3, m_config.normal.buffer_index, "Normal Buffer", Id<Process::Port>(inlet_id++), this});
+
+  // Texcoord0 attribute configuration
+  m_inlets.push_back(
+      new Process::IntSpinBox{-1, 15, m_config.texcoord0.location, "TexCoord0 Location", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::ComboBox{format_options, static_cast<int>(ossia::geometry::attribute::fp2), "TexCoord0 Format", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 1000, static_cast<int>(m_config.texcoord0.offset), "TexCoord0 Offset", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 100, static_cast<int>(m_config.texcoord0.stride), "TexCoord0 Stride", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 3, m_config.texcoord0.buffer_index, "TexCoord0 Buffer", Id<Process::Port>(inlet_id++), this});
+
+  // Color attribute configuration
+  m_inlets.push_back(
+      new Process::IntSpinBox{-1, 15, m_config.color.location, "Color Location", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::ComboBox{format_options, static_cast<int>(ossia::geometry::attribute::fp4), "Color Format", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 1000, static_cast<int>(m_config.color.offset), "Color Offset", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 100, static_cast<int>(m_config.color.stride), "Color Stride", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 3, m_config.color.buffer_index, "Color Buffer", Id<Process::Port>(inlet_id++), this});
+
+  // Tangent attribute configuration
+  m_inlets.push_back(
+      new Process::IntSpinBox{-1, 15, m_config.tangent.location, "Tangent Location", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::ComboBox{format_options, static_cast<int>(ossia::geometry::attribute::fp3), "Tangent Format", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 1000, static_cast<int>(m_config.tangent.offset), "Tangent Offset", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 100, static_cast<int>(m_config.tangent.stride), "Tangent Stride", Id<Process::Port>(inlet_id++), this});
+  m_inlets.push_back(
+      new Process::IntSpinBox{0, 3, m_config.tangent.buffer_index, "Tangent Buffer", Id<Process::Port>(inlet_id++), this});
+
+  // Create geometry output port
+  m_outlets.push_back(new Gfx::GeometryOutlet{Id<Process::Port>(inlet_id++), this});
+
+  // Set up default configuration
+  m_config.position.location = 0;
+  m_config.position.format = ossia::geometry::attribute::fp3;
+  m_config.position.stride = 12; // 3 floats
+  
+  m_config.normal.location = 1;
+  m_config.normal.format = ossia::geometry::attribute::fp3;
+  m_config.normal.stride = 12;
+  
+  m_config.texcoord0.location = 2;
+  m_config.texcoord0.format = ossia::geometry::attribute::fp2;
+  m_config.texcoord0.stride = 8; // 2 floats
+  
+  m_config.color.location = 4;
+  m_config.color.format = ossia::geometry::attribute::fp4;
+  m_config.color.stride = 16; // 4 floats
+
+  m_config.vertex_count = 0;
+}
+
+Model::~Model() = default;
+
+void Model::setVertexCount(int count)
+{
+  if(m_config.vertex_count != count)
+  {
+    m_config.vertex_count = count;
+    vertexCountChanged(count);
+    configurationChanged();
+  }
+}
+
+void Model::setPositionLocation(int loc)
+{
+  if(m_config.position.location != loc)
+  {
+    m_config.position.location = loc;
+    positionLocationChanged(loc);
+    configurationChanged();
+  }
+}
+
+void Model::setPositionFormat(int fmt)
+{
+  if(m_config.position.format != fmt)
+  {
+    m_config.position.format = fmt;
+    positionFormatChanged(fmt);
+    configurationChanged();
+  }
+}
+
+void Model::setPositionOffset(int offset)
+{
+  if(m_config.position.offset != static_cast<uint32_t>(offset))
+  {
+    m_config.position.offset = static_cast<uint32_t>(offset);
+    positionOffsetChanged(offset);
+    configurationChanged();
+  }
+}
+
+void Model::setPositionStride(int stride)
+{
+  if(m_config.position.stride != static_cast<uint32_t>(stride))
+  {
+    m_config.position.stride = static_cast<uint32_t>(stride);
+    positionStrideChanged(stride);
+    configurationChanged();
+  }
+}
+
+void Model::setPositionBuffer(int buf)
+{
+  if(m_config.position.buffer_index != buf)
+  {
+    m_config.position.buffer_index = buf;
+    positionBufferChanged(buf);
+    configurationChanged();
+  }
+}
+
+void Model::setNormalLocation(int loc)
+{
+  if(m_config.normal.location != loc)
+  {
+    m_config.normal.location = loc;
+    normalLocationChanged(loc);
+    configurationChanged();
+  }
+}
+
+void Model::setNormalFormat(int fmt)
+{
+  if(m_config.normal.format != fmt)
+  {
+    m_config.normal.format = fmt;
+    normalFormatChanged(fmt);
+    configurationChanged();
+  }
+}
+
+void Model::setNormalOffset(int offset)
+{
+  if(m_config.normal.offset != static_cast<uint32_t>(offset))
+  {
+    m_config.normal.offset = static_cast<uint32_t>(offset);
+    normalOffsetChanged(offset);
+    configurationChanged();
+  }
+}
+
+void Model::setNormalStride(int stride)
+{
+  if(m_config.normal.stride != static_cast<uint32_t>(stride))
+  {
+    m_config.normal.stride = static_cast<uint32_t>(stride);
+    normalStrideChanged(stride);
+    configurationChanged();
+  }
+}
+
+void Model::setNormalBuffer(int buf)
+{
+  if(m_config.normal.buffer_index != buf)
+  {
+    m_config.normal.buffer_index = buf;
+    normalBufferChanged(buf);
+    configurationChanged();
+  }
+}
+
+void Model::setTexcoord0Location(int loc)
+{
+  if(m_config.texcoord0.location != loc)
+  {
+    m_config.texcoord0.location = loc;
+    texcoord0LocationChanged(loc);
+    configurationChanged();
+  }
+}
+
+void Model::setTexcoord0Format(int fmt)
+{
+  if(m_config.texcoord0.format != fmt)
+  {
+    m_config.texcoord0.format = fmt;
+    texcoord0FormatChanged(fmt);
+    configurationChanged();
+  }
+}
+
+void Model::setTexcoord0Offset(int offset)
+{
+  if(m_config.texcoord0.offset != static_cast<uint32_t>(offset))
+  {
+    m_config.texcoord0.offset = static_cast<uint32_t>(offset);
+    texcoord0OffsetChanged(offset);
+    configurationChanged();
+  }
+}
+
+void Model::setTexcoord0Stride(int stride)
+{
+  if(m_config.texcoord0.stride != static_cast<uint32_t>(stride))
+  {
+    m_config.texcoord0.stride = static_cast<uint32_t>(stride);
+    texcoord0StrideChanged(stride);
+    configurationChanged();
+  }
+}
+
+void Model::setTexcoord0Buffer(int buf)
+{
+  if(m_config.texcoord0.buffer_index != buf)
+  {
+    m_config.texcoord0.buffer_index = buf;
+    texcoord0BufferChanged(buf);
+    configurationChanged();
+  }
+}
+
+void Model::setColorLocation(int loc)
+{
+  if(m_config.color.location != loc)
+  {
+    m_config.color.location = loc;
+    colorLocationChanged(loc);
+    configurationChanged();
+  }
+}
+
+void Model::setColorFormat(int fmt)
+{
+  if(m_config.color.format != fmt)
+  {
+    m_config.color.format = fmt;
+    colorFormatChanged(fmt);
+    configurationChanged();
+  }
+}
+
+void Model::setColorOffset(int offset)
+{
+  if(m_config.color.offset != static_cast<uint32_t>(offset))
+  {
+    m_config.color.offset = static_cast<uint32_t>(offset);
+    colorOffsetChanged(offset);
+    configurationChanged();
+  }
+}
+
+void Model::setColorStride(int stride)
+{
+  if(m_config.color.stride != static_cast<uint32_t>(stride))
+  {
+    m_config.color.stride = static_cast<uint32_t>(stride);
+    colorStrideChanged(stride);
+    configurationChanged();
+  }
+}
+
+void Model::setColorBuffer(int buf)
+{
+  if(m_config.color.buffer_index != buf)
+  {
+    m_config.color.buffer_index = buf;
+    colorBufferChanged(buf);
+    configurationChanged();
+  }
+}
+
+void Model::setTangentLocation(int loc)
+{
+  if(m_config.tangent.location != loc)
+  {
+    m_config.tangent.location = loc;
+    tangentLocationChanged(loc);
+    configurationChanged();
+  }
+}
+
+void Model::setTangentFormat(int fmt)
+{
+  if(m_config.tangent.format != fmt)
+  {
+    m_config.tangent.format = fmt;
+    tangentFormatChanged(fmt);
+    configurationChanged();
+  }
+}
+
+void Model::setTangentOffset(int offset)
+{
+  if(m_config.tangent.offset != static_cast<uint32_t>(offset))
+  {
+    m_config.tangent.offset = static_cast<uint32_t>(offset);
+    tangentOffsetChanged(offset);
+    configurationChanged();
+  }
+}
+
+void Model::setTangentStride(int stride)
+{
+  if(m_config.tangent.stride != static_cast<uint32_t>(stride))
+  {
+    m_config.tangent.stride = static_cast<uint32_t>(stride);
+    tangentStrideChanged(stride);
+    configurationChanged();
+  }
+}
+
+void Model::setTangentBuffer(int buf)
+{
+  if(m_config.tangent.buffer_index != buf)
+  {
+    m_config.tangent.buffer_index = buf;
+    tangentBufferChanged(buf);
+    configurationChanged();
+  }
+}
+
+QString Model::prettyName() const noexcept
+{
+  return tr("Buffer Geometry");
+}
+
+}
+
+template <>
+void DataStreamReader::read(const Gfx::BufferGeometry::Model& proc)
+{
+  readPorts(*this, proc.m_inlets, proc.m_outlets);
+
+  insertDelimiter();
+}
+
+template <>
+void DataStreamWriter::write(Gfx::BufferGeometry::Model& proc)
+{
+  writePorts(
+      *this, components.interfaces<Process::PortFactoryList>(), proc.m_inlets,
+      proc.m_outlets, &proc);
+
+  checkDelimiter();
+}
+
+template <>
+void JSONReader::read(const Gfx::BufferGeometry::Model& proc)
+{
+  readPorts(*this, proc.m_inlets, proc.m_outlets);
+}
+
+template <>
+void JSONWriter::write(Gfx::BufferGeometry::Model& proc)
+{
+  writePorts(
+      *this, components.interfaces<Process::PortFactoryList>(), proc.m_inlets,
+      proc.m_outlets, &proc);
+}

--- a/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Process.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/BufferGeometry/Process.hpp
@@ -1,0 +1,159 @@
+#pragma once
+#include <Process/Dataflow/Port.hpp>
+#include <Process/GenericProcessFactory.hpp>
+#include <Process/Process.hpp>
+
+#include <Gfx/CommandFactory.hpp>
+#include <Gfx/Graph/BufferGeometryNode.hpp>
+#include <Gfx/BufferGeometry/Metadata.hpp>
+#include <Gfx/TexturePort.hpp>
+
+#include <score/command/PropertyCommand.hpp>
+
+namespace Gfx::BufferGeometry
+{
+class Model final : public Process::ProcessModel
+{
+  SCORE_SERIALIZE_FRIENDS
+  PROCESS_METADATA_IMPL(Gfx::BufferGeometry::Model)
+  W_OBJECT(Model)
+
+public:
+  constexpr bool hasExternalUI() { return false; }
+  Model(const TimeVal& duration, const Id<Process::ProcessModel>& id, QObject* parent);
+
+  template <typename Impl>
+  Model(Impl& vis, QObject* parent)
+      : Process::ProcessModel{vis, parent}
+  {
+    vis.writeTo(*this);
+  }
+
+  ~Model() override;
+
+  // Configuration access for the UI
+  score::gfx::BufferGeometryNode::Configuration& configuration() noexcept { return m_config; }
+  const score::gfx::BufferGeometryNode::Configuration& configuration() const noexcept { return m_config; }
+  
+  void configurationChanged() W_SIGNAL(configurationChanged);
+
+  // Vertex count property
+  int vertexCount() const noexcept { return m_config.vertex_count; }
+  void setVertexCount(int count);
+  void vertexCountChanged(int count) W_SIGNAL(vertexCountChanged, count);
+  PROPERTY(int, vertexCount READ vertexCount WRITE setVertexCount NOTIFY vertexCountChanged)
+
+  // Position attribute properties
+  int positionLocation() const noexcept { return m_config.position.location; }
+  void setPositionLocation(int loc);
+  void positionLocationChanged(int loc) W_SIGNAL(positionLocationChanged, loc);
+  
+  int positionFormat() const noexcept { return m_config.position.format; }
+  void setPositionFormat(int fmt);
+  void positionFormatChanged(int fmt) W_SIGNAL(positionFormatChanged, fmt);
+  
+  int positionOffset() const noexcept { return static_cast<int>(m_config.position.offset); }
+  void setPositionOffset(int offset);
+  void positionOffsetChanged(int offset) W_SIGNAL(positionOffsetChanged, offset);
+  
+  int positionStride() const noexcept { return static_cast<int>(m_config.position.stride); }
+  void setPositionStride(int stride);
+  void positionStrideChanged(int stride) W_SIGNAL(positionStrideChanged, stride);
+  
+  int positionBuffer() const noexcept { return m_config.position.buffer_index; }
+  void setPositionBuffer(int buf);
+  void positionBufferChanged(int buf) W_SIGNAL(positionBufferChanged, buf);
+
+  // Normal attribute properties  
+  int normalLocation() const noexcept { return m_config.normal.location; }
+  void setNormalLocation(int loc);
+  void normalLocationChanged(int loc) W_SIGNAL(normalLocationChanged, loc);
+  
+  int normalFormat() const noexcept { return m_config.normal.format; }
+  void setNormalFormat(int fmt);
+  void normalFormatChanged(int fmt) W_SIGNAL(normalFormatChanged, fmt);
+  
+  int normalOffset() const noexcept { return static_cast<int>(m_config.normal.offset); }
+  void setNormalOffset(int offset);
+  void normalOffsetChanged(int offset) W_SIGNAL(normalOffsetChanged, offset);
+  
+  int normalStride() const noexcept { return static_cast<int>(m_config.normal.stride); }
+  void setNormalStride(int stride);
+  void normalStrideChanged(int stride) W_SIGNAL(normalStrideChanged, stride);
+  
+  int normalBuffer() const noexcept { return m_config.normal.buffer_index; }
+  void setNormalBuffer(int buf);
+  void normalBufferChanged(int buf) W_SIGNAL(normalBufferChanged, buf);
+
+  // TexCoord0 attribute properties
+  int texcoord0Location() const noexcept { return m_config.texcoord0.location; }
+  void setTexcoord0Location(int loc);
+  void texcoord0LocationChanged(int loc) W_SIGNAL(texcoord0LocationChanged, loc);
+  
+  int texcoord0Format() const noexcept { return m_config.texcoord0.format; }
+  void setTexcoord0Format(int fmt);
+  void texcoord0FormatChanged(int fmt) W_SIGNAL(texcoord0FormatChanged, fmt);
+  
+  int texcoord0Offset() const noexcept { return static_cast<int>(m_config.texcoord0.offset); }
+  void setTexcoord0Offset(int offset);
+  void texcoord0OffsetChanged(int offset) W_SIGNAL(texcoord0OffsetChanged, offset);
+  
+  int texcoord0Stride() const noexcept { return static_cast<int>(m_config.texcoord0.stride); }
+  void setTexcoord0Stride(int stride);
+  void texcoord0StrideChanged(int stride) W_SIGNAL(texcoord0StrideChanged, stride);
+  
+  int texcoord0Buffer() const noexcept { return m_config.texcoord0.buffer_index; }
+  void setTexcoord0Buffer(int buf);
+  void texcoord0BufferChanged(int buf) W_SIGNAL(texcoord0BufferChanged, buf);
+
+  // Color attribute properties
+  int colorLocation() const noexcept { return m_config.color.location; }
+  void setColorLocation(int loc);
+  void colorLocationChanged(int loc) W_SIGNAL(colorLocationChanged, loc);
+  
+  int colorFormat() const noexcept { return m_config.color.format; }
+  void setColorFormat(int fmt);
+  void colorFormatChanged(int fmt) W_SIGNAL(colorFormatChanged, fmt);
+  
+  int colorOffset() const noexcept { return static_cast<int>(m_config.color.offset); }
+  void setColorOffset(int offset);
+  void colorOffsetChanged(int offset) W_SIGNAL(colorOffsetChanged, offset);
+  
+  int colorStride() const noexcept { return static_cast<int>(m_config.color.stride); }
+  void setColorStride(int stride);
+  void colorStrideChanged(int stride) W_SIGNAL(colorStrideChanged, stride);
+  
+  int colorBuffer() const noexcept { return m_config.color.buffer_index; }
+  void setColorBuffer(int buf);
+  void colorBufferChanged(int buf) W_SIGNAL(colorBufferChanged, buf);
+
+  // Tangent attribute properties
+  int tangentLocation() const noexcept { return m_config.tangent.location; }
+  void setTangentLocation(int loc);
+  void tangentLocationChanged(int loc) W_SIGNAL(tangentLocationChanged, loc);
+  
+  int tangentFormat() const noexcept { return m_config.tangent.format; }
+  void setTangentFormat(int fmt);
+  void tangentFormatChanged(int fmt) W_SIGNAL(tangentFormatChanged, fmt);
+  
+  int tangentOffset() const noexcept { return static_cast<int>(m_config.tangent.offset); }
+  void setTangentOffset(int offset);
+  void tangentOffsetChanged(int offset) W_SIGNAL(tangentOffsetChanged, offset);
+  
+  int tangentStride() const noexcept { return static_cast<int>(m_config.tangent.stride); }
+  void setTangentStride(int stride);
+  void tangentStrideChanged(int stride) W_SIGNAL(tangentStrideChanged, stride);
+  
+  int tangentBuffer() const noexcept { return m_config.tangent.buffer_index; }
+  void setTangentBuffer(int buf);
+  void tangentBufferChanged(int buf) W_SIGNAL(tangentBufferChanged, buf);
+
+private:
+  QString prettyName() const noexcept override;
+  
+  score::gfx::BufferGeometryNode::Configuration m_config;
+};
+
+using ProcessFactory = Process::ProcessFactory_T<Gfx::BufferGeometry::Model>;
+
+}

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/BufferGeometryNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/BufferGeometryNode.cpp
@@ -1,0 +1,347 @@
+#include <Gfx/Graph/BufferGeometryNode.hpp>
+#include <Gfx/Graph/NodeRenderer.hpp>
+#include <Gfx/Graph/RenderList.hpp>
+#include <Gfx/Graph/Utils.hpp>
+#include <Gfx/TexturePort.hpp>
+
+#include <score/tools/Debug.hpp>
+
+#include <ossia/detail/small_flat_map.hpp>
+
+#include <set>
+
+namespace score::gfx
+{
+
+/**
+ * @brief Renderer for BufferGeometryNode
+ */
+class BufferGeometryRenderer : public score::gfx::NodeRenderer
+{
+public:
+  explicit BufferGeometryRenderer(const BufferGeometryNode& node) noexcept
+    : NodeRenderer{static_cast<const Node&>(node)}
+    , m_node{node}
+  {
+  }
+
+  TextureRenderTarget renderTargetForInput(const Port& p) override
+  {
+    auto it = m_rts.find(&p);
+    if(it != m_rts.end())
+      return it->second;
+    return {};
+  }
+
+  void init(RenderList& renderer, QRhiResourceUpdateBatch& res) override
+  {
+    // Create render targets for texture inputs
+    // BufferGeometry takes up to 4 texture buffers as input
+    int tex_idx = 0;
+    for(auto in : m_node.input)
+    {
+      if(tex_idx >= 4)
+        break;
+        
+      // Create a storage texture render target for buffer inputs
+      const QSize default_size{1024, 1}; // 1D buffer texture
+      auto rt = score::gfx::createRenderTarget(
+          renderer.state, 
+          QRhiTexture::RGBA32F, 
+          default_size, 
+          renderer.samples(), 
+          false); // No depth buffer needed for compute buffers
+      
+      if(rt.texture)
+      {
+        rt.texture->setName(
+            QByteArray("BufferGeometryNode::input_") + QByteArray::number(tex_idx));
+      }
+      if(rt.renderTarget)
+      {
+        rt.renderTarget->setName(
+            QByteArray("BufferGeometryNode::rt_") + QByteArray::number(tex_idx));
+      }
+      
+      m_rts[in] = std::move(rt);
+      tex_idx++;
+    }
+  }
+
+  void update(RenderList& renderer, QRhiResourceUpdateBatch& res, Edge* edge) override
+  {
+    for(int i = 0; i < 4; i++)
+    {
+      auto port_i = node.input[i]->value;
+      qDebug() << port_i << static_cast<QRhiTexture*>(port_i);
+    }
+    // Update geometry specification if needed
+    if(m_node.m_geometry_dirty)
+    {
+      m_node.updateGeometrySpec();
+    }
+  }
+
+  void release(RenderList&) override
+  {
+    // Release render targets
+    for(auto& [port, rt] : m_rts)
+    {
+      rt.release();
+    }
+    m_rts.clear();
+  }
+
+private:
+  const BufferGeometryNode& m_node;
+  ossia::small_flat_map<const Port*, TextureRenderTarget, 4> m_rts;
+};
+
+BufferGeometryNode::BufferGeometryNode()
+{
+  // Set up default configuration
+  config.position.location = 0;
+  config.position.format = ossia::geometry::attribute::fp3;
+  
+  config.normal.location = 1;
+  config.normal.format = ossia::geometry::attribute::fp3;
+  
+  config.texcoord0.location = 2;
+  config.texcoord0.format = ossia::geometry::attribute::fp2;
+  
+  config.color.location = 4;
+  config.color.format = ossia::geometry::attribute::fp4;
+  
+  // Create default mesh and filter lists
+  m_meshes = std::make_shared<ossia::mesh_list>();
+  m_filters = std::make_shared<ossia::geometry_filter_list>();
+  m_geometry_spec = {m_meshes, m_filters};
+
+  for(int i = 0; i < 4; i++)
+  {
+    input.push_back(new Port{static_cast<Node*>(this), {}, Types::Image, {}});
+  }
+  // vertex count
+  input.push_back(new Port{static_cast<Node*>(this), {}, Types::Int, {}});
+
+  // position
+  // -> location
+  // -> format
+  // -> offset
+  // -> stride
+  // -> buffer
+  for(int i = 0; i < 5 * 5; i++)
+    input.push_back(new Port{static_cast<Node*>(this), {}, Types::Int, {}});
+
+  // Create output port for geometry
+  output.push_back(new Port{static_cast<Node*>(this), {}, Types::Geometry, {}});
+}
+
+BufferGeometryNode::~BufferGeometryNode() = default;
+
+score::gfx::NodeRenderer* BufferGeometryNode::createRenderer(RenderList& r) const noexcept
+{
+  return new BufferGeometryRenderer{*this};
+}
+
+void BufferGeometryNode::process(Message&& msg)
+{
+  // Handle incoming messages to update configuration
+  // For now, geometry updates will be handled via the configuration directly
+  
+  // Mark geometry as dirty when buffers change
+  if(!msg.input.empty())
+  {
+    m_geometry_dirty = true;
+  }
+  
+  // Update output with current geometry spec  
+  if(m_geometry_dirty)
+  {
+    updateGeometrySpec();
+    
+    // Send geometry spec to output
+    if(!output.empty() && output[0]->value)
+    {
+      ossia::geometry_port geom_port;
+      geom_port.geometry = m_geometry_spec;
+      geom_port.flags = ossia::geometry_port::dirty_meshes;
+      
+      // Store in output port value
+      *static_cast<ossia::geometry_port*>(output[0]->value) = geom_port;
+    }
+  }
+}
+
+void BufferGeometryNode::updateGeometrySpec() const
+{
+  if(!m_geometry_dirty)
+    return;
+    
+  // Clear existing meshes
+  m_meshes->meshes.clear();
+  
+  // Create a single geometry from the configuration
+  ossia::geometry geometry;
+  
+  // Set up buffers - reference the input texture buffers
+  geometry.buffers.clear();
+  for(std::size_t i = 0; i < input.size() && i < 8; ++i)
+  {
+    if(input[i]->type == Types::Image && input[i]->value)
+    {
+      // Create buffer with proper initialization
+      geometry.buffers.push_back(
+          ossia::geometry::buffer{.data = ossia::geometry::gpu_buffer{}, .dirty = true});
+    }
+  }
+  
+  // Set up bindings based on unique strides
+  geometry.bindings.clear();
+  std::set<uint32_t> unique_strides;
+  
+  auto add_binding_if_needed = [&](uint32_t stride) -> int {
+    if(stride == 0) return -1;
+    
+    auto it = unique_strides.find(stride);
+    if(it == unique_strides.end())
+    {
+      unique_strides.insert(stride);
+      ossia::geometry::binding binding;
+      binding.stride = stride;
+      binding.classification = ossia::geometry::binding::per_vertex;
+      binding.step_rate = 1;
+      
+      geometry.bindings.push_back(binding);
+      return static_cast<int>(geometry.bindings.size() - 1);
+    }
+    else
+    {
+      return static_cast<int>(std::distance(unique_strides.begin(), it));
+    }
+  };
+  
+  // Set up attributes
+  geometry.attributes.clear();
+  
+  auto add_attribute = [&](const AttributeMapping& mapping, int binding_idx) {
+    if(!mapping.enabled() || binding_idx < 0) return;
+    if(mapping.buffer_index >= static_cast<int>(geometry.buffers.size())) return;
+    
+    ossia::geometry::attribute attr;
+    attr.binding = binding_idx;
+    attr.location = mapping.location;
+    // Cast int to enum properly
+    switch(mapping.format) {
+      case 0: attr.format = ossia::geometry::attribute::fp1; break;
+      case 1: attr.format = ossia::geometry::attribute::fp2; break;
+      case 2: attr.format = ossia::geometry::attribute::fp3; break;
+      case 3: attr.format = ossia::geometry::attribute::fp4; break;
+      case 4: attr.format = ossia::geometry::attribute::unsigned1; break;
+      case 5: attr.format = ossia::geometry::attribute::unsigned2; break;
+      case 6: attr.format = ossia::geometry::attribute::unsigned4; break;
+      default: attr.format = ossia::geometry::attribute::fp3; break;
+    }
+    attr.offset = mapping.offset;
+    
+    geometry.attributes.push_back(attr);
+  };
+  
+  // Add standard attributes
+  int pos_binding = add_binding_if_needed(config.position.stride);
+  int norm_binding = add_binding_if_needed(config.normal.stride);
+  int tex0_binding = add_binding_if_needed(config.texcoord0.stride);
+  int tex1_binding = add_binding_if_needed(config.texcoord1.stride);
+  int color_binding = add_binding_if_needed(config.color.stride);
+  int tangent_binding = add_binding_if_needed(config.tangent.stride);
+  int bitangent_binding = add_binding_if_needed(config.bitangent.stride);
+  
+  add_attribute(config.position, pos_binding);
+  add_attribute(config.normal, norm_binding);
+  add_attribute(config.texcoord0, tex0_binding);
+  add_attribute(config.texcoord1, tex1_binding);
+  add_attribute(config.color, color_binding);
+  add_attribute(config.tangent, tangent_binding);
+  add_attribute(config.bitangent, bitangent_binding);
+  
+  // Add custom attributes
+  for(const auto& custom : config.custom)
+  {
+    int custom_binding = add_binding_if_needed(custom.stride);
+    add_attribute(custom, custom_binding);
+  }
+  
+  // Set up input references
+  geometry.input.clear();
+  for(std::size_t i = 0; i < geometry.buffers.size(); ++i)
+  {
+    struct ossia::geometry::input inp;
+    inp.buffer = static_cast<int>(i);
+    inp.offset = 0;
+    geometry.input.push_back(inp);
+  }
+  
+  // Set geometry properties with proper enum casts
+  geometry.vertices = config.vertex_count;
+  geometry.indices = config.index_buffer.enabled ? config.index_buffer.count : 0;
+  
+  switch(config.topology) {
+    case 0: geometry.topology = ossia::geometry::triangles; break;
+    case 1: geometry.topology = ossia::geometry::triangle_strip; break;
+    case 2: geometry.topology = ossia::geometry::triangle_fan; break;
+    case 3: geometry.topology = ossia::geometry::lines; break;
+    case 4: geometry.topology = ossia::geometry::line_strip; break;
+    case 5: geometry.topology = ossia::geometry::points; break;
+    default: geometry.topology = ossia::geometry::triangles; break;
+  }
+  
+  switch(config.cull_mode) {
+    case 0: geometry.cull_mode = ossia::geometry::none; break;
+    case 1: geometry.cull_mode = ossia::geometry::front; break;
+    case 2: geometry.cull_mode = ossia::geometry::back; break;
+    default: geometry.cull_mode = ossia::geometry::back; break;
+  }
+  
+  switch(config.front_face) {
+    case 0: geometry.front_face = ossia::geometry::counter_clockwise; break;
+    case 1: geometry.front_face = ossia::geometry::clockwise; break;
+    default: geometry.front_face = ossia::geometry::counter_clockwise; break;
+  }
+  
+  // Set up index buffer if enabled
+  if(config.index_buffer.enabled)
+  {
+    geometry.index.buffer = config.index_buffer.buffer_index;
+    geometry.index.offset = config.index_buffer.offset;
+
+    using idx_fmt_t = std::remove_reference_t<decltype(ossia::geometry{}.index.format)>;
+    switch(config.index_buffer.format) {
+      case 0:
+        geometry.index.format = idx_fmt_t::uint16;
+        break;
+      case 1:
+        geometry.index.format = idx_fmt_t::uint32;
+        break;
+      default:
+        geometry.index.format = idx_fmt_t::uint16;
+        break;
+    }
+  }
+  else
+  {
+    geometry.index.buffer = -1;
+  }
+  
+  // Add geometry to mesh list
+  m_meshes->meshes.clear();
+  m_meshes->meshes.push_back(std::move(geometry));
+  m_meshes->dirty_index++;
+  
+  // Update filters list (empty for now)
+  m_filters->filters.clear();
+  m_filters->dirty_index++;
+  
+  m_geometry_dirty = false;
+}
+
+}

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/BufferGeometryNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/BufferGeometryNode.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <Gfx/Graph/Node.hpp>
+#include <ossia/dataflow/geometry_port.hpp>
+
+namespace score::gfx
+{
+
+/**
+ * @brief Configuration for a single vertex attribute mapping
+ */
+struct AttributeMapping
+{
+  int buffer_index{0};      // Which input buffer to read from
+  uint32_t offset{0};       // Byte offset within the buffer
+  uint32_t stride{0};       // Stride between consecutive elements
+  int format{ossia::geometry::attribute::fp3}; // Data format (fp3, fp4, etc.)
+  int location{-1};         // Vertex shader location (-1 = disabled)
+  
+  bool enabled() const noexcept { return location >= 0; }
+};
+
+/**
+ * @brief A node that converts buffer inputs into geometry specifications
+ * 
+ * This node takes multiple texture/buffer inputs and allows the user to specify
+ * how data from these buffers should be interpreted as vertex attributes.
+ * It produces a geometry_spec that references the input buffers with the
+ * specified attribute mappings.
+ */
+struct BufferGeometryNode : NodeModel
+{
+public:
+  explicit BufferGeometryNode();
+  virtual ~BufferGeometryNode();
+
+  score::gfx::NodeRenderer* createRenderer(RenderList& r) const noexcept override;
+
+  /**
+   * @brief Configuration structure for the geometry
+   */
+  struct Configuration
+  {
+    // Standard vertex attributes
+    AttributeMapping position{};    // Usually location 0, fp3 or fp4
+    AttributeMapping normal{};      // Usually location 1, fp3
+    AttributeMapping texcoord0{};   // Usually location 2, fp2
+    AttributeMapping texcoord1{};   // Usually location 3, fp2
+    AttributeMapping color{};       // Usually location 4, fp4
+    AttributeMapping tangent{};     // Usually location 5, fp3 or fp4
+    AttributeMapping bitangent{};   // Usually location 6, fp3
+    
+    // Custom attributes (up to 8 additional)
+    std::array<AttributeMapping, 8> custom{};
+    
+    // Geometry properties
+    int vertex_count{0};            // Number of vertices
+    int topology{ossia::geometry::triangles};
+    int cull_mode{ossia::geometry::back};
+    int front_face{ossia::geometry::counter_clockwise};
+    
+    // Index buffer (optional) 
+    struct {
+      bool enabled{false};
+      int buffer_index{0};
+      uint32_t offset{0};
+      int format{0}; // 0 = uint16, 1 = uint32 (matches ossia::geometry)
+      int count{0};
+    } index_buffer;
+    
+  } config;
+
+  // Cached geometry specification
+  mutable std::shared_ptr<ossia::mesh_list> m_meshes;
+  mutable std::shared_ptr<ossia::geometry_filter_list> m_filters;
+  mutable ossia::geometry_spec m_geometry_spec;
+  mutable bool m_geometry_dirty{true};
+  
+  void updateGeometrySpec() const;
+
+private:
+  void process(Message&& msg) override;
+};
+
+}

--- a/src/plugins/score-plugin-gfx/score_plugin_gfx.cpp
+++ b/src/plugins/score-plugin-gfx/score_plugin_gfx.cpp
@@ -1,6 +1,10 @@
 #include "score_plugin_gfx.hpp"
 
 #include <Dataflow/WidgetInletFactory.hpp>
+#include <Gfx/CSF/Executor.hpp>
+#include <Gfx/CSF/Layer.hpp>
+#include <Gfx/CSF/Library.hpp>
+#include <Gfx/CSF/Process.hpp>
 #include <Gfx/CameraDevice.hpp>
 #include <Gfx/CommandFactory.hpp>
 #include <Gfx/Filter/Executor.hpp>
@@ -22,15 +26,13 @@
 #include <Gfx/SharedOutputSettings.hpp>
 #include <Gfx/Text/Executor.hpp>
 #include <Gfx/Text/Process.hpp>
+#include <Gfx/BufferGeometry/Executor.hpp>
+#include <Gfx/BufferGeometry/Process.hpp>
 #include <Gfx/TexturePort.hpp>
 #include <Gfx/VSA/Executor.hpp>
 #include <Gfx/VSA/Layer.hpp>
 #include <Gfx/VSA/Library.hpp>
 #include <Gfx/VSA/Process.hpp>
-#include <Gfx/CSF/Executor.hpp>
-#include <Gfx/CSF/Layer.hpp>
-#include <Gfx/CSF/Library.hpp>
-#include <Gfx/CSF/Process.hpp>
 #include <Gfx/Video/Executor.hpp>
 #include <Gfx/Video/Inspector.hpp>
 #include <Gfx/Video/Layer.hpp>
@@ -112,6 +114,7 @@ std::vector<score::InterfaceBase*> score_plugin_gfx::factories(
       FW<Process::ProcessModelFactory, Gfx::Filter::ProcessFactory,
          Gfx::GeometryFilter::ProcessFactory, Gfx::Video::ProcessFactory,
          Gfx::Text::ProcessFactory, Gfx::Images::ProcessFactory,
+         Gfx::BufferGeometry::ProcessFactory,
          Gfx::VSA::ProcessFactory, Gfx::CSF::ProcessFactory>,
       FW<Process::LayerFactory, Gfx::Filter::LayerFactory,
          Gfx::GeometryFilter::LayerFactory, Gfx::Video::LayerFactory,
@@ -122,6 +125,7 @@ std::vector<score::InterfaceBase*> score_plugin_gfx::factories(
          Gfx::Video::ProcessExecutorComponentFactory,
          Gfx::Text::ProcessExecutorComponentFactory,
          Gfx::Images::ProcessExecutorComponentFactory,
+         Gfx::BufferGeometry::ProcessExecutorComponentFactory,
          Gfx::VSA::ProcessExecutorComponentFactory,
          Gfx::CSF::ProcessExecutorComponentFactory>,
       FW<Inspector::InspectorWidgetFactory, Gfx::Video::InspectorFactory>,


### PR DESCRIPTION
- **process library: small performance optimization**
- **isf: simplify textures by using textureSize, now supported everywhere it matters**
- **cmake: also allow disabling plugins with SCORE_DISABLE_PLUGINS**
- **isf: deep rework of audio textures**
- **audio textures: small fixes**
- **isf: fix inlet names**
- **isf: introduce a new shader type: compute shader format**
- **core: minor code quality improvements**
- **vsa: fix serialization**
- **dataflow: prevent constant redraw hogging performance due to execution % bar in nodal view**
- **scenario: add new ux features**
- **gpu: allow geometry to hold gpu handles in addition to cpu buffers; add a possibility to specify texture format dynamically**
- **3d: add an array to texture object**
- **gpu: rework renderlist core loop to start enabling non/texture-io objects**
- **ci: missing header**
- **isf, csf, vsa: refactors and bugfixes**
- **renderer: ensure we do not do a resource update batch with nothing**
- **cables: prevent cables going from a slot outside of the nodal of an interval to outside the clipping zone**
- **model displau: compat with older builds**
- **event: take parent speed into account to avoid offset miscalculation in exec_state_facade::timings**
- **dataflow: improvements for rendering of objects ; only show a small dotted line when both ports aren't visible**
- **gpu: fix a resource being released twice in compute renderer**
- **ui: fix drops getting stuck due to a Qt bug**
- **gpu: introduce a buffer-to-geometry object**
