### PR TITLE
xwax: implement xwax for DVS timecode input

### DIFF
--- a/src/plugins/score-plugin-vst/Vst/Widgets.cpp
+++ b/src/plugins/score-plugin-vst/Vst/Widgets.cpp
@@ -39,6 +39,9 @@ GraphicsSlider::GraphicsSlider(AEffect* fx, int num, QGraphicsItem* parent)
 {
   this->fx = fx;
   this->num = num;
+  if(!fx)
+    return;
+
   this->m_value = fx->getParameter(fx, num);
 }
 
@@ -89,6 +92,9 @@ void GraphicsSlider::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
 void GraphicsSlider::paint(
     QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {
+  if(!fx)
+    return;
+
   char str[256]{};
   // Note that effGetParamDisplay will sometimes ignore the m_value argument
   // and just return the value for the actual parameter, which may be different

--- a/src/plugins/score-plugin-vst3/Vst3/Widgets.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Widgets.cpp
@@ -42,7 +42,8 @@ VSTGraphicsSlider::VSTGraphicsSlider(
 {
   this->fx = fx;
   this->num = num;
-  this->m_value = fx->getParamNormalized(num);
+  if(fx)
+    this->m_value = fx->getParamNormalized(num);
 }
 
 void VSTGraphicsSlider::setValue(double v)
@@ -92,6 +93,9 @@ void VSTGraphicsSlider::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
 void VSTGraphicsSlider::paint(
     QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {
+  if(!fx)
+    return;
+
   Steinberg::Vst::String128 str = {};
   m_value = fx->getParamNormalized(num);
   fx->getParamStringByValue(num, m_value, str);


### PR DESCRIPTION
drive-by: fix vsts crashing if reloading on a computer that does not have said vst

fixes: #1895

note: actual commit is there: https://github.com/ossia/score-addon-ltc/commit/1f81bd97e05a2502511d89bff7f0d34ac3a85a59