### PR TITLE
core: add a much more precise timer implementation than Qt timerEvent

### DIFF
--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -34,7 +34,7 @@ CI_PLATFORM="${1:-DEFAULT}"
 if [[ "$CI_PLATFORM" != "WASM" ]];
 then
   clone_addon https://github.com/ossia/score-addon-ltc
-  clone_addon https://github.com/ossia/score-addon-ndi
+#  clone_addon https://github.com/ossia/score-addon-ndi
   clone_addon https://github.com/bltzr/score-avnd-granola
   clone_addon https://github.com/ossia/score-addon-ultraleap
   clone_addon https://github.com/ossia/score-addon-contextfree

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -445,7 +445,12 @@ void Application::init()
 
 #if defined(QT_FEATURE_thread)
 #if QT_FEATURE_thread == 1
+    this->thread()->setPriority(QThread::Priority::TimeCriticalPriority);
     QThreadPool::globalInstance()->setMaxThreadCount(2);
+    QThreadPool::globalInstance()->setThreadPriority(QThread::Priority::HighPriority);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    QThreadPool::globalInstance()->setServiceLevel(QThread::QualityOfService::High);
+#endif
 #endif
 #endif
 

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -230,6 +230,17 @@ Application::Application(int& argc, char** argv)
   }
 
   m_app = createApplication(appSettings, argc, argv);
+
+#if defined(QT_FEATURE_thread)
+#if QT_FEATURE_thread == 1
+  this->thread()->setPriority(QThread::Priority::TimeCriticalPriority);
+  QThreadPool::globalInstance()->setMaxThreadCount(2);
+  QThreadPool::globalInstance()->setThreadPriority(QThread::Priority::HighPriority);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+  QThreadPool::globalInstance()->setServiceLevel(QThread::QualityOfService::High);
+#endif
+#endif
+#endif
 }
 
 Application::Application(

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -408,7 +408,13 @@ struct increase_timer_precision
 
     // Then maybe we can go a bit lower...
     ULONG currentRes{};
-    NtSetTimerResolution(100, TRUE, &currentRes);
+    NtSetTimerResolution(7500, TRUE, &currentRes);
+    if(currentRes <= 8000)
+      NtSetTimerResolution(5000, TRUE, &currentRes);
+    if(currentRes <= 6000)
+      NtSetTimerResolution(2500, TRUE, &currentRes);
+    if(currentRes <= 3000)
+      NtSetTimerResolution(1000, TRUE, &currentRes);
 #endif
   }
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -237,6 +237,7 @@ set(HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/Unused.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/RecursiveWatch.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/ThreadPool.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/Timers.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/Debug.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/Version.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/exceptions/MissingCommand.hpp"
@@ -511,6 +512,7 @@ set(SRCS
 "${CMAKE_CURRENT_SOURCE_DIR}/score/widgets/SpinBoxes.cpp"
 
 "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/ListNetworkAddresses.cpp"
+"${CMAKE_CURRENT_SOURCE_DIR}/score/tools/Timers.cpp"
 
 "${CMAKE_CURRENT_SOURCE_DIR}/core/application/SafeQApplication.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/core/application/ApplicationInterface.cpp"

--- a/src/lib/score/gfx/Vulkan.cpp
+++ b/src/lib/score/gfx/Vulkan.cpp
@@ -5,10 +5,12 @@
 
 #if __has_include(<QtGui/private/qrhi_p.h>)
 #include <QtGui/private/qrhi_p.h>
+#endif
+
+#if __has_include(<rhi/qrhi_platform.h>)
+#include <rhi/qrhi_platform.h>
 #elif __has_include(<private/qrhivulkan_p.h>)
 #include <private/qrhivulkan_p.h>
-#elif __has_include(<rhi/qrhi_platform.h>)
-#include <rhi/qrhi_platform.h>
 #endif
 
 #include <mutex>

--- a/src/lib/score/gfx/Vulkan.cpp
+++ b/src/lib/score/gfx/Vulkan.cpp
@@ -2,6 +2,7 @@
 
 #if defined(QT_FEATURE_vulkan) && QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
 #include <QVulkanInstance>
+#include <QtGui/private/qrhi_p.h>
 
 #include <mutex>
 namespace score::gfx
@@ -27,7 +28,7 @@ QVulkanInstance* staticVulkanInstance(bool create)
 #endif
 
     QByteArrayList exts;
-    exts << "VK_KHR_get_physical_device_properties2";
+    exts << QRhiVulkanInitParams::preferredInstanceExtensions();
 
     if(auto v = instance.supportedApiVersion(); v >= QVersionNumber(1, 1))
     {

--- a/src/lib/score/gfx/Vulkan.cpp
+++ b/src/lib/score/gfx/Vulkan.cpp
@@ -2,7 +2,14 @@
 
 #if defined(QT_FEATURE_vulkan) && QT_CONFIG(vulkan) && __has_include(<vulkan/vulkan.h>)
 #include <QVulkanInstance>
+
+#if __has_include(<QtGui/private/qrhi_p.h>)
 #include <QtGui/private/qrhi_p.h>
+#elif __has_include(<private/qrhivulkan_p.h>)
+#include <private/qrhivulkan_p.h>
+#elif __has_include(<rhi/qrhi_platform.h>)
+#include <rhi/qrhi_platform.h>
+#endif
 
 #include <mutex>
 namespace score::gfx

--- a/src/lib/score/tools/Timers.cpp
+++ b/src/lib/score/tools/Timers.cpp
@@ -108,7 +108,11 @@ public:
     TimerStats stats{};
 #endif
 
+#if defined(_WIN32)
     ossia::windows_timer_sleep sleeper;
+#else
+    ossia::adaptive_sleep sleeper;
+#endif
     while (running.load(std::memory_order_relaxed))
     {
       sleeper.sleep_until(nextTickNs);

--- a/src/lib/score/tools/Timers.cpp
+++ b/src/lib/score/tools/Timers.cpp
@@ -1,0 +1,241 @@
+#include "Timers.hpp"
+#include <QThread>
+#include <QCoreApplication>
+#include <QMutex>
+#include <QDebug>
+#include <cmath>
+#include <ossia/detail/sleep.hpp>
+#include <ossia/detail/thread_priority.hpp>
+
+#include <wobjectimpl.h>
+
+W_OBJECT_IMPL(score::HighResolutionTimer)
+W_OBJECT_IMPL(score::Timers)
+
+namespace score
+{
+
+class HighResolutionTimerPrivate
+{
+public:
+  HighResolutionTimer* q{};
+  QThread thread;
+  std::atomic<bool> running{false};
+  double frequencyHz;
+  uint64_t intervalNs;
+
+  // For jitter calculation
+  double m2 = 0;  // For Welford's online variance
+  double mean = 0;
+
+  HighResolutionTimerPrivate(HighResolutionTimer* parent, double freq)
+      : q(parent)
+      , frequencyHz(freq)
+      , intervalNs(static_cast<uint64_t>(1'000'000'000.0 / freq))
+  {
+    thread.setObjectName(QStringLiteral("ossia-timer"));
+  }
+
+  void timerLoop()
+  {
+    ossia::priority_boost_handle priorityHandle{frequencyHz};
+
+    uint64_t nextTickNs = ossia::now_ns() + intervalNs;
+    uint64_t lastTickNs = ossia::now_ns();
+    uint64_t startTimeNs = lastTickNs;
+
+    struct Stats {
+      double actualFrequencyHz = 0;
+      double jitterUs = 0;
+      double maxLatencyUs = 0;
+      uint64_t tickCount = 0;
+      uint64_t missedTicks = 0;
+    } stats{};
+
+    ossia::adaptive_sleep sleeper;
+    while (running.load(std::memory_order_relaxed))
+    {
+      sleeper.
+          sleep_until(nextTickNs);
+
+      uint64_t actualNs = ossia::now_ns();
+
+#define HRT_STATS 1
+#if defined(HRT_STATS)
+      // Update statistics
+      {
+        stats.tickCount++;
+
+        // Calculate actual interval and jitter using Welford's algorithm
+        double actualIntervalNs = static_cast<double>(actualNs - lastTickNs);
+        double delta = actualIntervalNs - mean;
+        mean += delta / stats.tickCount;
+        double delta2 = actualIntervalNs - mean;
+        m2 += delta * delta2;
+
+        if (stats.tickCount > 1)
+        {
+          const double variance = m2 / (stats.tickCount - 1);
+          stats.jitterUs = std::sqrt(variance) / 1000.0;
+        }
+
+        // Latency
+        int64_t latencyNs = actualNs - nextTickNs;
+        if (latencyNs > 0)
+        {
+          double latencyUs = latencyNs / 1000.0;
+          if (latencyUs > stats.maxLatencyUs)
+            stats.maxLatencyUs = latencyUs;
+        }
+
+        // Actual frequency
+        double elapsedS = (actualNs - startTimeNs) / 1'000'000'000.0;
+        if (elapsedS > 0)
+          stats.actualFrequencyHz = stats.tickCount / elapsedS;
+
+        // Check for missed ticks
+        if (latencyNs > static_cast<int64_t>(intervalNs))
+        {
+          stats.missedTicks += latencyNs / intervalNs;
+        }
+
+        if(stats.tickCount % 10 == 0 && stats.actualFrequencyHz > 90) {
+          qDebug() << " -- actualFrequencyHz:" << stats.actualFrequencyHz
+                   << " ; missed:" << stats.missedTicks
+                   << " ; jitterUs:" << stats.jitterUs
+                   << " ; maxLatencyUs:" << stats.maxLatencyUs
+                   << " ; tickCount:" << stats.tickCount;
+        }
+      }
+#endif
+
+      lastTickNs = actualNs;
+
+      // Emit signal
+      q->timeout(q);
+
+      // Schedule next tick
+      nextTickNs += intervalNs;
+
+      // If we've fallen too far behind, reset
+      if (actualNs > nextTickNs + intervalNs * 3)
+      {
+        nextTickNs = actualNs + intervalNs;
+      }
+    }
+
+  }
+};
+
+HighResolutionTimer::HighResolutionTimer(double frequencyHz, QObject* parent)
+    : QObject(parent)
+    , d(std::make_unique<HighResolutionTimerPrivate>(this, frequencyHz))
+{
+}
+
+HighResolutionTimer::~HighResolutionTimer()
+{
+  stop();
+}
+
+void HighResolutionTimer::start()
+{
+  if (d->running.exchange(true))
+    return;
+
+  QObject::connect(&d->thread, &QThread::started, [this]() {
+    d->timerLoop();
+  });
+
+  d->thread.start(QThread::TimeCriticalPriority);
+  started(this);
+}
+
+void HighResolutionTimer::stop()
+{
+  if (!d->running.exchange(false))
+    return;
+
+  d->thread.quit();
+  d->thread.wait();
+
+  QObject::disconnect(&d->thread, &QThread::started, nullptr, nullptr);
+  stopped(this);
+}
+
+bool HighResolutionTimer::isRunning() const
+{
+  return d->running.load();
+}
+
+double HighResolutionTimer::frequency() const
+{
+  return d->frequencyHz;
+}
+
+Timers& Timers::instance()
+{
+  static Timers s_instance;
+  return s_instance;
+}
+
+Timers::Timers(QObject* parent)
+    : QObject(parent)
+{
+}
+
+Timers::~Timers()
+{
+  std::lock_guard lock{m_mutex};
+  for (auto& [k, entry] : m_timers)
+  {
+    entry.timer->stop();
+  }
+  m_timers.clear();
+}
+
+HighResolutionTimer* Timers::acquireTimer(QObject* user, double frequencyHz)
+{
+  std::lock_guard lock{m_mutex};
+  if (auto it = m_timers.find(frequencyHz); it != m_timers.end())
+  {
+    it->second.users[user]++;
+    return it->second.timer.get();
+  }
+
+  TimerEntry entry;
+  entry.timer = std::make_unique<HighResolutionTimer>(frequencyHz, this);
+  entry.users[user] = 1;
+  entry.timer->start();
+
+  auto* ptr = entry.timer.get();
+  m_timers.emplace(frequencyHz, std::move(entry));
+
+  return ptr;
+}
+
+void Timers::releaseTimer(QObject* user, HighResolutionTimer* timer)
+{
+  if(!timer)
+    return;
+
+  std::lock_guard lock{m_mutex};
+  for (auto it = m_timers.begin(); it != m_timers.end(); ++it)
+  {
+    if (it->second.timer.get() == timer)
+    {
+      if (--it->second.users[user] == 0)
+      {
+        disconnect(it->second.timer.get(), nullptr, user, nullptr);
+        it->second.users.erase(user);
+        if(it->second.users.empty()) {
+          it->second.timer->stop();
+          m_timers.erase(it);
+        }
+      }
+      return;
+    }
+  }
+}
+
+}

--- a/src/lib/score/tools/Timers.hpp
+++ b/src/lib/score/tools/Timers.hpp
@@ -28,7 +28,9 @@ public:
   void started(score::HighResolutionTimer* self) E_SIGNAL(SCORE_LIB_BASE_EXPORT, started, self);
   void stopped(score::HighResolutionTimer* self) E_SIGNAL(SCORE_LIB_BASE_EXPORT, stopped, self);
 
+  void setMaximumAccuracy(bool);
 private:
+  void timerEvent(QTimerEvent *k) override;
   std::unique_ptr<HighResolutionTimerPrivate> d;
 };
 

--- a/src/lib/score/tools/Timers.hpp
+++ b/src/lib/score/tools/Timers.hpp
@@ -1,0 +1,60 @@
+#pragma once
+#include <QObject>
+#include <memory>
+#include <mutex>
+#include <verdigris>
+#include <ossia/detail/small_flat_map.hpp>
+#include <score_lib_base_export.h>
+
+namespace score
+{
+class HighResolutionTimerPrivate;
+
+class SCORE_LIB_BASE_EXPORT HighResolutionTimer : public QObject
+{
+  W_OBJECT(HighResolutionTimer)
+
+public:
+  explicit HighResolutionTimer(double frequencyHz, QObject* parent = nullptr);
+  ~HighResolutionTimer();
+
+  void start();
+  void stop();
+
+  bool isRunning() const;
+  double frequency() const;
+
+  void timeout(score::HighResolutionTimer* self) E_SIGNAL(SCORE_LIB_BASE_EXPORT, timeout, self);
+  void started(score::HighResolutionTimer* self) E_SIGNAL(SCORE_LIB_BASE_EXPORT, started, self);
+  void stopped(score::HighResolutionTimer* self) E_SIGNAL(SCORE_LIB_BASE_EXPORT, stopped, self);
+
+private:
+  std::unique_ptr<HighResolutionTimerPrivate> d;
+};
+
+class SCORE_LIB_BASE_EXPORT Timers : public QObject
+{
+  W_OBJECT(Timers)
+
+public:
+  static Timers& instance();
+
+  explicit Timers(QObject* parent = nullptr);
+  ~Timers() override;
+
+  HighResolutionTimer* acquireTimer(QObject* user, double frequencyHz);
+  void releaseTimer(QObject* user, HighResolutionTimer* timerId);
+
+private:
+  struct TimerEntry
+  {
+    std::unique_ptr<HighResolutionTimer> timer;
+    ossia::small_flat_map<QObject*, int, 8> users;
+  };
+
+  mutable std::mutex m_mutex;
+  ossia::small_flat_map<double, TimerEntry, 16> m_timers; // frequency -> entry
+};
+}
+
+W_REGISTER_ARGTYPE(score::HighResolutionTimer*)

--- a/src/plugins/score-plugin-avnd/Crousti/GpuUtils.cpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuUtils.cpp
@@ -70,9 +70,6 @@ void CustomGpuOutputNodeBase::startRendering() { }
 
 void CustomGpuOutputNodeBase::render()
 {
-  if(m_update)
-    m_update();
-
   auto renderer = m_renderer.lock();
   if(renderer && m_renderState)
   {
@@ -95,12 +92,9 @@ bool CustomGpuOutputNodeBase::canRender() const
 
 void CustomGpuOutputNodeBase::onRendererChange() { }
 
-void CustomGpuOutputNodeBase::createOutput(
-    score::gfx::GraphicsApi graphicsApi, std::function<void()> onReady,
-    std::function<void()> onUpdate, std::function<void()> onResize)
+void CustomGpuOutputNodeBase::createOutput(score::gfx::OutputConfiguration conf)
 {
-  m_update = onUpdate;
-  onReady();
+  conf.onReady();
 }
 
 void CustomGpuOutputNodeBase::destroyOutput() { }

--- a/src/plugins/score-plugin-avnd/Crousti/GpuUtils.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuUtils.hpp
@@ -322,7 +322,6 @@ struct SCORE_PLUGIN_AVND_EXPORT CustomGpuOutputNodeBase
   const score::DocumentContext& m_ctx;
   std::weak_ptr<score::gfx::RenderList> m_renderer{};
   std::shared_ptr<score::gfx::RenderState> m_renderState{};
-  std::function<void()> m_update;
 
   QString vertex, fragment, compute;
   score::gfx::Message last_message;
@@ -338,9 +337,7 @@ struct SCORE_PLUGIN_AVND_EXPORT CustomGpuOutputNodeBase
   bool canRender() const override;
   void onRendererChange() override;
 
-  void createOutput(
-      score::gfx::GraphicsApi graphicsApi, std::function<void()> onReady,
-      std::function<void()> onUpdate, std::function<void()> onResize) override;
+  void createOutput(score::gfx::OutputConfiguration) override;
 
   void destroyOutput() override;
   std::shared_ptr<score::gfx::RenderState> renderState() const override;

--- a/src/plugins/score-plugin-gfx/Gfx/Filter/PreviewWidget.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Filter/PreviewWidget.cpp
@@ -257,7 +257,8 @@ public:
   ShaderPreviewManager()
       : QObject{qApp}
   {
-    m_screen = std::make_unique<score::gfx::ScreenNode>(true);
+    score::gfx::OutputNode::Configuration conf{};
+    m_screen = std::make_unique<score::gfx::ScreenNode>(conf, true);
     m_graph.addNode(m_screen.get());
   }
 
@@ -448,9 +449,9 @@ public:
     }
   }
 
+  std::unique_ptr<score::gfx::ScreenNode> m_screen{};
 private:
   std::unique_ptr<score::gfx::ISFNode> m_isf{};
-  std::unique_ptr<score::gfx::ScreenNode> m_screen{};
   std::vector<std::unique_ptr<score::gfx::Node>> m_textures;
   score::gfx::Graph m_graph{};
   ProcessedProgram m_program;
@@ -520,6 +521,7 @@ void ShaderPreviewWidget::timerEvent(QTimerEvent* event)
   if(g_shaderPreview)
   {
     g_shaderPreview->updateControls();
+    g_shaderPreview->m_screen->render();
   }
 }
 }

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
@@ -11,11 +11,12 @@
 #include <ossia/detail/small_flat_map.hpp>
 #include <ossia/gfx/port_index.hpp>
 #include <ossia/network/value/value.hpp>
-
+#include <score/tools/Timers.hpp>
 #include <concurrentqueue.h>
 #include <score_plugin_gfx_export.h>
 namespace score {
 class HighResolutionTimer;
+class Timers;
 }
 namespace score::gfx
 {
@@ -116,9 +117,11 @@ private:
   score::HighResolutionTimer* m_no_vsync_timer{};
   score::HighResolutionTimer* m_watchdog_timer{};
 
-  ossia::small_flat_map<score::HighResolutionTimer*, score::gfx::OutputNode*, 8> m_manualTimers;
+  ossia::small_flat_map<score::HighResolutionTimer*, ossia::flat_set<score::gfx::OutputNode*>, 8> m_manualTimers;
 
   ossia::object_pool<std::vector<score::gfx::gfx_input>> m_buffers;
+
+  score::Timers m_timers;
 };
 
 }

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
@@ -8,11 +8,15 @@
 #include <ossia/detail/hash_map.hpp>
 #include <ossia/detail/mutex.hpp>
 #include <ossia/detail/variant.hpp>
+#include <ossia/detail/small_flat_map.hpp>
 #include <ossia/gfx/port_index.hpp>
 #include <ossia/network/value/value.hpp>
 
 #include <concurrentqueue.h>
 #include <score_plugin_gfx_export.h>
+namespace score {
+class HighResolutionTimer;
+}
 namespace score::gfx
 {
 struct Graph;
@@ -65,7 +69,9 @@ private:
   void remove_edge(EdgeSpec e);
   void remove_node(std::vector<std::unique_ptr<score::gfx::Node>>& nursery, int32_t id);
 
-  void timerEvent(QTimerEvent*) override;
+  void on_no_vsync_timer(score::HighResolutionTimer* self);
+  void on_watchdog_timer(score::HighResolutionTimer* self);
+  void on_manual_timer(score::HighResolutionTimer* self);
   const score::DocumentContext& m_context;
   std::atomic_int32_t index{1};
   ossia::hash_map<int32_t, NodePtr> nodes;
@@ -107,10 +113,10 @@ private:
   ossia::flat_set<EdgeSpec> preview_edges;
   std::atomic_bool edges_changed{};
 
-  int m_no_vsync_timer{-1};
-  int m_watchdog_timer{-1};
+  score::HighResolutionTimer* m_no_vsync_timer{};
+  score::HighResolutionTimer* m_watchdog_timer{};
 
-  ossia::flat_map<int, score::gfx::OutputNode*> m_manualTimers;
+  ossia::small_flat_map<score::HighResolutionTimer*, score::gfx::OutputNode*, 8> m_manualTimers;
 
   ossia::object_pool<std::vector<score::gfx::gfx_input>> m_buffers;
 };

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/Graph.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/Graph.hpp
@@ -77,14 +77,6 @@ struct SCORE_PLUGIN_GFX_EXPORT Graph
   void relinkGraph();
 
   /**
-   * @brief Set a callback to drive rendering when there is a single output.
-   *
-   * If we render to a single window, we can use the GPU V-Sync mechanism.
-   * Otherwise the implementation will create timers to keep things in sync.
-   */
-  void setVSyncCallback(std::function<void()>);
-
-  /**
    * @brief True if the graph supports being driven by the screen vertical synchronization.
    */
   bool canDoVSync() const noexcept;
@@ -92,6 +84,11 @@ struct SCORE_PLUGIN_GFX_EXPORT Graph
   const std::vector<std::shared_ptr<RenderList>>& renderLists() const noexcept
   {
     return m_renderers;
+  }
+
+  std::span<OutputNode* const> outputs() const noexcept
+  {
+    return m_outputs;
   }
 
 private:
@@ -103,7 +100,6 @@ private:
 
   std::vector<std::shared_ptr<RenderList>> m_renderers;
   std::vector<std::shared_ptr<Window>> m_unused_windows;
-  std::function<void()> m_vsync_callback;
 
   std::vector<score::gfx::Node*> m_nodes;
   std::vector<Edge*> m_edges;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/OutputNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/OutputNode.cpp
@@ -7,7 +7,7 @@ OutputNode::OutputNode() { }
 OutputNode::~OutputNode() { }
 
 void OutputNode::updateGraphicsAPI(GraphicsApi) { }
-
+void OutputNode::setVSyncCallback(std::function<void()>) { }
 OutputNodeRenderer::~OutputNodeRenderer() { }
 
 void OutputNodeRenderer::finishFrame(

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/OutputNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/OutputNode.hpp
@@ -7,6 +7,13 @@
 #include <score_plugin_gfx_export.h>
 namespace score::gfx
 {
+struct OutputConfiguration
+{
+  GraphicsApi graphicsApi{};
+  std::function<void()> onReady;
+  std::function<void()> onResize;
+};
+
 class SCORE_PLUGIN_GFX_EXPORT OutputNodeRenderer : public score::gfx::NodeRenderer
 {
 public:
@@ -36,10 +43,15 @@ public:
   virtual bool canRender() const = 0;
   virtual void onRendererChange() = 0;
 
-  virtual void createOutput(
-      GraphicsApi graphicsApi, std::function<void()> onReady,
-      std::function<void()> onUpdate, std::function<void()> onResize)
-      = 0;
+  /**
+   * @brief Set a callback to drive rendering when there is a single output.
+   *
+   * If we render to a single window, we can use the GPU V-Sync mechanism.
+   * Otherwise the implementation will create timers to keep things in sync.
+   */
+  virtual void setVSyncCallback(std::function<void()>);
+
+  virtual void createOutput(OutputConfiguration conf) = 0;
 
   virtual void updateGraphicsAPI(GraphicsApi);
   virtual void destroyOutput() = 0;
@@ -51,6 +63,7 @@ public:
     // rate (given in milliseconds)
     std::optional<double> manualRenderingRate;
     bool outputNeedsRenderPass{};
+    bool supportsVSync{};
     OutputNode* parent{};
   };
 

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/PreviewNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/PreviewNode.cpp
@@ -64,9 +64,6 @@ void PreviewNode::startRendering() { }
 
 void PreviewNode::render()
 {
-  if(m_update)
-    m_update();
-
   auto renderer = m_renderer.lock();
   if(renderer && m_renderState)
   {
@@ -99,17 +96,14 @@ score::gfx::RenderList* PreviewNode::renderer() const
   return m_renderer.lock().get();
 }
 
-void PreviewNode::createOutput(
-    score::gfx::GraphicsApi graphicsApi, std::function<void()> onReady,
-    std::function<void()> onUpdate, std::function<void()> onResize)
+void PreviewNode::createOutput(score::gfx::OutputConfiguration conf)
 {
   m_renderState = std::make_shared<score::gfx::RenderState>();
-  m_update = onUpdate;
 
   m_renderState = importRenderState(QSize(m_settings.width, m_settings.height), m_rhi);
   m_renderState->renderPassDescriptor = m_renderTarget->renderPassDescriptor();
 
-  onReady();
+  conf.onReady();
 }
 
 void PreviewNode::destroyOutput() { }

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/PreviewNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/PreviewNode.hpp
@@ -22,9 +22,7 @@ public:
   void setRenderer(std::shared_ptr<score::gfx::RenderList> r) override;
   score::gfx::RenderList* renderer() const override;
 
-  void createOutput(
-      score::gfx::GraphicsApi graphicsApi, std::function<void()> onReady,
-      std::function<void()> onUpdate, std::function<void()> onResize) override;
+  void createOutput(score::gfx::OutputConfiguration) override;
   void destroyOutput() override;
 
   std::shared_ptr<score::gfx::RenderState> renderState() const override;
@@ -41,7 +39,6 @@ private:
   std::weak_ptr<score::gfx::RenderList> m_renderer{};
   QRhiRenderTarget* m_renderTarget{};
   QRhiTexture* m_texture{};
-  std::function<void()> m_update;
   std::shared_ptr<score::gfx::RenderState> m_renderState{};
 };
 }

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
@@ -232,6 +232,8 @@ bool ScreenNode::canRender() const
 
 void ScreenNode::startRendering()
 {
+  if(onFps)
+    onFps(0.f);
   if(m_window)
   {
     m_window->onRender = [this](QRhiCommandBuffer& commands) {
@@ -280,6 +282,8 @@ void ScreenNode::stopRendering()
       m_window->state->renderer = {};
     ////window->state->hasSwapChain = false;
   }
+  if(onFps)
+    onFps(0.f);
 }
 
 void ScreenNode::setRenderer(std::shared_ptr<RenderList> r)
@@ -412,6 +416,10 @@ void ScreenNode::createOutput(score::gfx::OutputConfiguration conf)
   QObject::connect(m_window.get(), &Window::keyRelease, [this](int k, const QString& t) {
     if(onKeyRelease)
       onKeyRelease(k, t);
+  });
+  QObject::connect(m_window.get(), &Window::fps, [this](float f) {
+    if(onFps)
+      onFps(f);
   });
   m_window->onUpdate = this->m_vsyncCallback;
   m_window->onWindowReady = [this, graphicsApi=conf.graphicsApi, onReady = std::move(conf.onReady)] {

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
@@ -88,7 +88,6 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
   if(graphicsApi == Vulkan)
   {
     QRhiVulkanInitParams params;
-    params.deviceExtensions = QRhiVulkanInitParams::preferredInstanceExtensions();
 #if defined(_WIN32)
     params.deviceExtensions << VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME
                             << VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME
@@ -321,6 +320,11 @@ void ScreenNode::setTitle(QString title)
   {
     m_window->setTitle(title);
   }
+}
+
+void ScreenNode::setConfiguration(Configuration conf)
+{
+  m_conf = conf;
 }
 
 void ScreenNode::setSize(QSize sz)

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.hpp
@@ -10,7 +10,7 @@ namespace score::gfx
  */
 struct SCORE_PLUGIN_GFX_EXPORT ScreenNode : OutputNode
 {
-  explicit ScreenNode(bool embedded = false, bool startFullScreen = false);
+  explicit ScreenNode(Configuration conf, bool embedded = false, bool startFullScreen = false);
   virtual ~ScreenNode();
 
   void startRendering() override;
@@ -30,11 +30,10 @@ struct SCORE_PLUGIN_GFX_EXPORT ScreenNode : OutputNode
   void setCursor(bool);
   void setTitle(QString);
 
-  void createOutput(
-      GraphicsApi graphicsApi, std::function<void()> onReady,
-      std::function<void()> onUpdate, std::function<void()> onResize) override;
+  void createOutput(score::gfx::OutputConfiguration) override;
   void destroyOutput() override;
   void updateGraphicsAPI(GraphicsApi) override;
+  void setVSyncCallback(std::function<void()>) override;
 
   std::shared_ptr<RenderState> renderState() const override;
   score::gfx::OutputNodeRenderer* createRenderer(RenderList& r) const noexcept override;
@@ -49,6 +48,7 @@ struct SCORE_PLUGIN_GFX_EXPORT ScreenNode : OutputNode
   std::function<void(int, const QString&)> onKeyRelease;
 
 private:
+  Configuration m_conf;
   std::shared_ptr<Window> m_window{};
   QRhiSwapChain* m_swapChain{};
   QRhiRenderBuffer* m_depthStencil{};
@@ -57,6 +57,7 @@ private:
   std::optional<QPoint> m_pos{};
   std::optional<QSize> m_sz{};
   std::optional<QSize> m_renderSz{};
+  std::function<void()> m_vsyncCallback;
 
   bool m_embedded{};
   bool m_fullScreen{};

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.hpp
@@ -47,6 +47,7 @@ struct SCORE_PLUGIN_GFX_EXPORT ScreenNode : OutputNode
   std::function<void(QTabletEvent*)> onTabletMove;
   std::function<void(int, const QString&)> onKey;
   std::function<void(int, const QString&)> onKeyRelease;
+  std::function<void(float)> onFps;
 
 private:
   Configuration m_conf;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.hpp
@@ -29,6 +29,7 @@ struct SCORE_PLUGIN_GFX_EXPORT ScreenNode : OutputNode
   void setFullScreen(bool);
   void setCursor(bool);
   void setTitle(QString);
+  void setConfiguration(Configuration);
 
   void createOutput(score::gfx::OutputConfiguration) override;
   void destroyOutput() override;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/Window.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/Window.cpp
@@ -203,7 +203,11 @@ void Window::render()
 
     state->rhi->endFrame(m_swapChain, {});
   }
-  requestUpdate();
+
+  if(this->onUpdate) {
+    // requestUpdate is only to be used in the vsync case
+    requestUpdate();
+  }
 }
 
 void Window::exposeEvent(QExposeEvent* ev)

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/Window.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/Window.hpp
@@ -2,6 +2,7 @@
 
 #include <Gfx/Graph/RenderState.hpp>
 
+#include <QElapsedTimer>
 #include <QTabletEvent>
 #include <QWindow>
 
@@ -54,10 +55,14 @@ public:
   void key(int key, const QString& t) W_SIGNAL(key, key, t);
   void keyRelease(int key, const QString& t) W_SIGNAL(keyRelease, key, t);
 
+  void fps(float v) W_SIGNAL(fps, v);
+
 private:
   std::shared_ptr<RenderState> state;
   GraphicsApi m_api{};
   QRhiSwapChain* m_swapChain{};
+  QElapsedTimer m_timer;
+  double m_fps{0.};
 
   bool m_closed = false;
   bool m_canRender = false;

--- a/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoderNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoderNode.cpp
@@ -35,8 +35,6 @@ void LibavEncoderNode::render()
 {
   if(!encoder.available())
     return;
-  if(m_update)
-    m_update();
 
   auto renderer = m_renderer.lock();
   if(renderer && m_renderState)
@@ -79,12 +77,9 @@ score::gfx::RenderList* LibavEncoderNode::renderer() const
   return m_renderer.lock().get();
 }
 
-void LibavEncoderNode::createOutput(
-    score::gfx::GraphicsApi graphicsApi, std::function<void()> onReady,
-    std::function<void()> onUpdate, std::function<void()> onResize)
+void LibavEncoderNode::createOutput(score::gfx::OutputConfiguration conf)
 {
   m_renderState = std::make_shared<score::gfx::RenderState>();
-  m_update = onUpdate;
 
   m_renderState->surface = QRhiGles2InitParams::newFallbackSurface();
   QRhiGles2InitParams params;
@@ -108,7 +103,7 @@ void LibavEncoderNode::createOutput(
   m_renderTarget->setRenderPassDescriptor(m_renderState->renderPassDescriptor);
   m_renderTarget->create();
 
-  onReady();
+  conf.onReady();
 }
 
 void LibavEncoderNode::destroyOutput() { }

--- a/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoderNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoderNode.hpp
@@ -17,7 +17,6 @@ struct LibavEncoderNode : score::gfx::OutputNode
   std::weak_ptr<score::gfx::RenderList> m_renderer{};
   QRhiTexture* m_texture{};
   QRhiTextureRenderTarget* m_renderTarget{};
-  std::function<void()> m_update;
   std::shared_ptr<score::gfx::RenderState> m_renderState{};
   bool m_hasSender{};
 
@@ -30,9 +29,7 @@ struct LibavEncoderNode : score::gfx::OutputNode
   void setRenderer(std::shared_ptr<score::gfx::RenderList> r) override;
   score::gfx::RenderList* renderer() const override;
 
-  void createOutput(
-      score::gfx::GraphicsApi graphicsApi, std::function<void()> onReady,
-      std::function<void()> onUpdate, std::function<void()> onResize) override;
+  void createOutput(score::gfx::OutputConfiguration) override;
   void destroyOutput() override;
 
   std::shared_ptr<score::gfx::RenderState> renderState() const override;

--- a/src/plugins/score-plugin-gfx/Gfx/Spout/SpoutOutput.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Spout/SpoutOutput.cpp
@@ -276,9 +276,6 @@ struct SpoutNode final : score::gfx::OutputNode
 
   void render() override
   {
-    if(m_update)
-      m_update();
-
     auto renderer = m_renderer.lock();
     if(renderer && m_renderState)
     {
@@ -534,15 +531,12 @@ struct SpoutNode final : score::gfx::OutputNode
 
   score::gfx::RenderList* renderer() const override { return m_renderer.lock().get(); }
 
-  void createOutput(
-      score::gfx::GraphicsApi graphicsApi, std::function<void()> onReady,
-      std::function<void()> onUpdate, std::function<void()> onResize) override
+  void createOutput(score::gfx::OutputConfiguration conf) override
   {
     m_renderState = std::make_shared<score::gfx::RenderState>();
-    m_update = onUpdate;
 
     // Choose backend based on requested API
-    switch(graphicsApi)
+    switch(conf.graphicsApi)
     {
       case score::gfx::GraphicsApi::D3D11:
         createOutputD3D11();
@@ -583,7 +577,8 @@ struct SpoutNode final : score::gfx::OutputNode
     m_renderTarget->setRenderPassDescriptor(m_renderState->renderPassDescriptor);
     m_renderTarget->create();
 
-    onReady();
+    if(conf.onReady)
+      conf.onReady();
   }
 
   void createOutputOpenGL()
@@ -1044,7 +1039,6 @@ private:
   std::weak_ptr<score::gfx::RenderList> m_renderer{};
   QRhiTexture* m_texture{};
   QRhiTextureRenderTarget* m_renderTarget{};
-  std::function<void()> m_update;
   std::shared_ptr<score::gfx::RenderState> m_renderState{};
 
   // OpenGL backend

--- a/src/plugins/score-plugin-gfx/Gfx/Spout/SpoutOutput.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Spout/SpoutOutput.cpp
@@ -665,7 +665,6 @@ struct SpoutNode final : score::gfx::OutputNode
     params.inst = vkInst;
 
     // Enable required device extensions for external memory
-    params.deviceExtensions = QRhiVulkanInitParams::preferredInstanceExtensions();
     params.deviceExtensions << VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME
                             << VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME
                             << VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME

--- a/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonOutput.mm
+++ b/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonOutput.mm
@@ -112,9 +112,6 @@ struct SyphonNode final : score::gfx::OutputNode
     if(!m_created)
       return;
 
-    if (m_update)
-      m_update();
-
     auto renderer = m_renderer.lock();
     if (renderer && renderer->nodes.size() > 1 && m_renderState)
     {
@@ -178,18 +175,13 @@ struct SyphonNode final : score::gfx::OutputNode
     return m_renderer.lock().get();
   }
 
-  void createOutput(
-        score::gfx::GraphicsApi graphicsApi,
-        std::function<void()> onReady,
-        std::function<void()> onUpdate,
-        std::function<void()> onResize) override
+  void createOutput(score::gfx::OutputConfiguration conf) override
   {
     m_renderState = std::make_shared<score::gfx::RenderState>();
-    m_update = onUpdate;
     m_renderState->renderSize = QSize(m_settings.width, m_settings.height);
     m_renderState->outputSize = m_renderState->renderSize;
 
-    if (graphicsApi == score::gfx::GraphicsApi::Metal)
+    if (conf.graphicsApi == score::gfx::GraphicsApi::Metal)
     {
       // Metal backend
       QRhiMetalInitParams params;
@@ -200,7 +192,7 @@ struct SyphonNode final : score::gfx::OutputNode
     }
     else
     {
-      // OpenGL backend (default)
+      // OpenGL backend
       m_renderState->surface = QRhiGles2InitParams::newFallbackSurface();
       QRhiGles2InitParams params;
       params.format.setMajorVersion(3);
@@ -230,7 +222,7 @@ struct SyphonNode final : score::gfx::OutputNode
     }
 
     createSyphon(*rhi);
-    onReady();
+    conf.onReady();
   }
 
   void destroyOutput() override
@@ -293,7 +285,6 @@ private:
   std::weak_ptr<score::gfx::RenderList> m_renderer{};
   QRhiTexture* m_texture{};
   QRhiTextureRenderTarget* m_renderTarget{};
-  std::function<void()> m_update;
   std::shared_ptr<score::gfx::RenderState> m_renderState{};
 
   // OpenGL Syphon server

--- a/src/plugins/score-plugin-gfx/Gfx/TexturePort.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/TexturePort.cpp
@@ -44,7 +44,9 @@ public:
       , plug{&plug}
   {
     setLayout(new Inspector::VBoxLayout{this});
-    auto window = std::make_unique<score::gfx::ScreenNode>(true);
+
+    score::gfx::OutputNode::Configuration conf{};
+    auto window = std::make_unique<score::gfx::ScreenNode>(conf, true);
     node = window.get();
     screenId = plug.context.register_preview_node(std::move(window));
     if(screenId != -1)
@@ -101,6 +103,7 @@ public:
       container->setMaximumHeight(200);
       this->layout()->addWidget(container);
     }
+    node->render();
   }
 
   ~GraphPreviewWidget()

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
@@ -417,6 +417,13 @@ public:
       });
       m_root.add_child(std::move(fs_node));
     }
+
+    {
+      auto fps_node = std::make_unique<ossia::net::generic_node>("fps", *this, m_root);
+      auto fps_param = fps_node->create_parameter(ossia::val_type::FLOAT);
+      m_screen->onFps = [fps_param](float fps) { fps_param->push_value(fps); };
+      m_root.add_child(std::move(fps_node));
+    }
   }
 
   const gfx_node_base& get_root_node() const override { return m_root; }

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
@@ -9,6 +9,7 @@
 
 #include <core/application/ApplicationSettings.hpp>
 
+#include <Gfx/Settings/Model.hpp>
 #include <ossia/network/base/device.hpp>
 #include <ossia/network/base/protocol.hpp>
 #include <ossia/network/generic/generic_node.hpp>
@@ -31,7 +32,16 @@ namespace Gfx
 static score::gfx::ScreenNode* createScreenNode()
 {
   const auto& settings = score::AppContext().applicationSettings;
-  return new score::gfx::ScreenNode{false, (settings.autoplay || !settings.gui)};
+  const auto& gfx_settings = score::AppContext().settings<Gfx::Settings::Model>();
+
+  score::gfx::OutputNode::Configuration conf;
+  double rate = gfx_settings.getRate();
+  if(rate > 0)
+    conf = { .manualRenderingRate = 1000. / rate, .supportsVSync = true};
+  else
+    conf = { .supportsVSync = true };
+
+  return new score::gfx::ScreenNode{conf, false, (settings.autoplay || !settings.gui)};
 }
 
 class window_device : public ossia::net::device_base

--- a/src/plugins/score-plugin-protocols/Protocols/MCU/MCUProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MCU/MCUProtocolFactory.cpp
@@ -109,7 +109,9 @@ bool MCUProtocolFactory::checkCompatibility(
   if(specif.output_handle.empty())
     return false;
   // FIXME improve when we have multiple devices in one control surface
-  return specif.input_handle[0] != libremidi::port_information{}
-         && specif.output_handle[0] != libremidi::port_information{};
+  return
+      specif.input_handle[0].port != libremidi::port_information{}.port
+         && specif.output_handle[0].port != libremidi::port_information{}.port
+      ;
 }
 }

--- a/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/MIDI/MIDIProtocolFactory.cpp
@@ -236,7 +236,7 @@ bool MIDIInputProtocolFactory::checkCompatibility(
 {
   // FIXME check if we can open the same device multiple times ?
   auto specif = a.deviceSpecificSettings.value<MIDISpecificSettings>();
-  return specif.handle != libremidi::port_information{} || specif.virtualPort;
+  return specif.handle.port != libremidi::port_information{}.port || specif.virtualPort;
 }
 
 QString MIDIOutputProtocolFactory::prettyName() const noexcept
@@ -329,6 +329,6 @@ bool MIDIOutputProtocolFactory::checkCompatibility(
 {
   // FIXME check if we can open the same device multiple times ?
   auto specif = a.deviceSpecificSettings.value<MIDISpecificSettings>();
-  return (specif.handle != libremidi::port_information{}) || specif.virtualPort;
+  return (specif.handle.port != libremidi::port_information{}.port) || specif.virtualPort;
 }
 }


### PR DESCRIPTION
We go from roughly 5 ms of variation to less than 0.5 ms, which gives
much more stable FPS for outputs such as with Spout, NDI, etc.
