### PR TITLE
create-app: add content of score file directory to include assets for windows and macos

### DIFF
--- a/tools/create-app-macos.sh
+++ b/tools/create-app-macos.sh
@@ -162,10 +162,13 @@ for item in "${QML_ITEMS[@]}"; do
     fi
 done
 
-# Copy score file if provided (to Resources, not MacOS)
+# Copy score file and directory content if provided (to Resources, not MacOS)
 if [[ -n "$SCORE_FILE" ]]; then
+    SCORE_DIR="$(dirname "$SCORE_FILE")"
     echo "Adding score file..."
     cp "$SCORE_FILE" "$BUNDLE_RESOURCES/"
+    echo "  Copying directory contents: $(basename "$SCORE_DIR")"
+    cp -r "$SCORE_DIR"/* "$BUNDLE_RESOURCES/" 2>/dev/null || true
 fi
 
 # Rename the original binary

--- a/tools/create-app-windows.sh
+++ b/tools/create-app-windows.sh
@@ -109,10 +109,13 @@ for item in "${QML_ITEMS[@]}"; do
     fi
 done
 
-# Copy score file if provided
+# Copy score file and directory content if provided
 if [[ -n "$SCORE_FILE" ]]; then
+    SCORE_DIR="$(dirname "$SCORE_FILE")"
     echo "Adding score file..."
     cp "$SCORE_FILE" .
+    echo "  Copying directory contents: $(basename "$SCORE_DIR")"
+    cp -r "$SCORE_DIR"/* ./ 2>/dev/null || true
 fi
 
 # Create qrc


### PR DESCRIPTION
Completes https://github.com/ossia/score/pull/1960 to allow adding score assets to custom apps on windows and macos.