### PR TITLE
video: fix IgnoreTempo property regression

### DIFF
--- a/src/plugins/score-plugin-gfx/Gfx/Video/Process.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Video/Process.cpp
@@ -321,6 +321,7 @@ void JSONReader::read(const Gfx::Video::Model& proc)
   obj["Scale"] = (int)proc.m_scaleMode;
   obj["Playback"] = (int)proc.m_playbackMode;
   obj["Tempo"] = proc.m_nativeTempo;
+  obj["IgnoreTempo"] = proc.m_ignoreTempo;
   obj["OutputFormat"] = (int)proc.m_outputFormat;
   obj["Tonemap"] = (int)proc.m_tonemap;
 }


### PR DESCRIPTION
https://github.com/ossia/score/commit/816cb84e2073a3e917288c7e422375b678a4a256 introduced a regression that prevents loading score files that contains a video process from a save made after this commit.

IgnoreTempo property had been inadvertently removed from serialization.