### PR TITLE
UI: Increase hitboxes and interaction areas for core elements

### DIFF
--- a/src/plugins/score-lib-process/Process/Dataflow/CableItem.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/CableItem.cpp
@@ -113,7 +113,7 @@ static const QPainterPathStroker& cableStroker()
     QPen pen;
     pen.setCapStyle(Qt::PenCapStyle::RoundCap);
     pen.setJoinStyle(Qt::PenJoinStyle::RoundJoin);
-    pen.setWidthF(7.);
+    pen.setWidthF(14.);
     return pen;
   }()};
   return cable_stroker;

--- a/src/plugins/score-lib-process/Process/Dataflow/PortItem.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/PortItem.cpp
@@ -568,8 +568,8 @@ void PortItem::setHighlight(bool b)
 
 QRectF PortItem::boundingRect() const
 {
-  constexpr auto max_diam = 13.;
-  return {0., 0., max_diam, max_diam};
+  constexpr auto max_diam = 20.;
+  return {-3.5, -3.5, max_diam, max_diam};
 }
 void PortItem::paint(
     QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)

--- a/src/plugins/score-lib-process/Process/Dataflow/PortItem.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/PortItem.cpp
@@ -644,8 +644,8 @@ void PortItem::setHighlight(bool b)
 
 QRectF PortItem::boundingRect() const
 {
-  constexpr auto max_diam = 13.;
-  return {0., 0., max_diam, max_diam};
+  constexpr auto max_diam = 20.;
+  return {-3.5, -3.5, max_diam, max_diam};
 }
 void PortItem::paint(
     QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Event/ConditionView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Event/ConditionView.cpp
@@ -114,7 +114,7 @@ void ConditionView::setHeight(qreal newH)
   m_Cpath.arcTo(bottomRect, -180., 120.);
 
   QPainterPathStroker stk;
-  stk.setWidth(1.);
+  stk.setWidth(10.);
   m_strokedCpath = stk.createStroke(m_Cpath);
 
   this->update();

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Event/EventView.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Event/EventView.hpp
@@ -45,7 +45,7 @@ public:
 
   const EventPresenter& presenter() const { return m_presenter; }
 
-  QRectF boundingRect() const override { return {-1, 0., 6, m_height}; }
+  QRectF boundingRect() const override { return {-4, 0., 12, m_height}; }
   void setStatus(ExecutionStatus);
 
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalView.cpp
@@ -328,7 +328,7 @@ void IntervalView::dragEnterEvent(QGraphicsSceneDragDropEvent* event)
 
 void IntervalView::dragMoveEvent(QGraphicsSceneDragDropEvent* event)
 {
-  setDropTarget((event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 7.));
+  setDropTarget((event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 12.));
   event->accept();
 }
 
@@ -342,7 +342,7 @@ void IntervalView::dragLeaveEvent(QGraphicsSceneDragDropEvent* event)
 void IntervalView::dropEvent(QGraphicsSceneDragDropEvent* event)
 {
   setDropTarget(false);
-  if(event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 7.)
+  if(event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 12.)
   {
     dropReceived(event->pos(), *event->mimeData());
     update();
@@ -360,9 +360,9 @@ QPainterPath Scenario::IntervalView::shape() const
 {
   qreal x = std::min(0., minWidth());
   QPainterPath p;
-  p.addRect({x, -1., defaultWidth() - x, intervalAndRackHeight()});
+  p.addRect({x, -5., defaultWidth() - x, intervalAndRackHeight() + 10.});
   if(!infinite())
-    p.addRect({x, -1., maxWidth() - x, 5});
+    p.addRect({x, -5., maxWidth() - x, 10.});
 
   return p;
 }
@@ -375,9 +375,9 @@ QPainterPath Scenario::IntervalView::opaqueArea() const
 bool Scenario::IntervalView::contains(const QPointF& pt) const
 {
   qreal x = std::min(0., minWidth());
-  if(!QRectF{x, -1., defaultWidth() - x, intervalAndRackHeight()}.contains(pt))
+  if(!QRectF{x, -5., defaultWidth() - x, intervalAndRackHeight() + 10.}.contains(pt))
     if(!infinite())
-      if(!QRectF{x, -1., maxWidth() - x, 5}.contains(pt))
+      if(!QRectF{x, -5., maxWidth() - x, 10.}.contains(pt))
         return false;
   return true;
 }

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalView.cpp
@@ -329,7 +329,7 @@ void IntervalView::dragEnterEvent(QGraphicsSceneDragDropEvent* event)
 
 void IntervalView::dragMoveEvent(QGraphicsSceneDragDropEvent* event)
 {
-  setDropTarget((event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 7.));
+  setDropTarget((event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 12.));
   event->accept();
 }
 
@@ -343,7 +343,7 @@ void IntervalView::dragLeaveEvent(QGraphicsSceneDragDropEvent* event)
 void IntervalView::dropEvent(QGraphicsSceneDragDropEvent* event)
 {
   setDropTarget(false);
-  if(event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 7.)
+  if(event->pos().x() <= this->m_defaultWidth && event->pos().y() <= 12.)
   {
     dropReceived(event->pos(), *event->mimeData());
     update();
@@ -361,9 +361,9 @@ QPainterPath Scenario::IntervalView::shape() const
 {
   qreal x = std::min(0., minWidth());
   QPainterPath p;
-  p.addRect({x, -1., defaultWidth() - x, intervalAndRackHeight()});
+  p.addRect({x, -5., defaultWidth() - x, intervalAndRackHeight() + 10.});
   if(!infinite())
-    p.addRect({x, -1., maxWidth() - x, 5});
+    p.addRect({x, -5., maxWidth() - x, 10.});
 
   return p;
 }
@@ -376,9 +376,9 @@ QPainterPath Scenario::IntervalView::opaqueArea() const
 bool Scenario::IntervalView::contains(const QPointF& pt) const
 {
   qreal x = std::min(0., minWidth());
-  if(!QRectF{x, -1., defaultWidth() - x, intervalAndRackHeight()}.contains(pt))
+  if(!QRectF{x, -5., defaultWidth() - x, intervalAndRackHeight() + 10.}.contains(pt))
     if(!infinite())
-      if(!QRectF{x, -1., maxWidth() - x, 5}.contains(pt))
+      if(!QRectF{x, -5., maxWidth() - x, 10.}.contains(pt))
         return false;
   return true;
 }

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/SlotHeader.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/SlotHeader.cpp
@@ -100,7 +100,7 @@ void SlotHeader::mousePressEvent(QGraphicsSceneMouseEvent* event)
   m_presenter.selectedSlot(m_slotIndex);
 
   const auto xpos = event->pos().x();
-  if(xpos >= 0 && xpos < 16)
+  if(xpos >= 0 && xpos < 30)
   {
     slot_header_drag.reset(new QDrag(event->widget()));
   }
@@ -159,7 +159,7 @@ void SlotHeader::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
   event->accept();
 
   const auto xpos = event->buttonDownPos(Qt::LeftButton).x();
-  if(xpos >= 0 && xpos < 16 && slot_header_drag)
+  if(xpos >= 0 && xpos < 30 && slot_header_drag)
   {
     auto min_dist = (event->screenPos() - event->buttonDownScreenPos(Qt::LeftButton))
                         .manhattanLength()
@@ -210,7 +210,7 @@ void SlotHeader::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 void SlotHeader::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
   const auto xpos = event->pos().x();
-  if(xpos >= 0 && xpos < 16)
+  if(xpos >= 0 && xpos < 30)
   {
     if(this->cursor().shape() != Qt::CrossCursor)
       setCursor(Qt::CrossCursor);
@@ -225,7 +225,7 @@ void SlotHeader::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 void SlotHeader::hoverMoveEvent(QGraphicsSceneHoverEvent* event)
 {
   const auto xpos = event->pos().x();
-  if(xpos >= 0 && xpos < 16)
+  if(xpos >= 0 && xpos < 30)
   {
     if(this->cursor().shape() != Qt::CrossCursor)
       setCursor(Qt::CrossCursor);
@@ -387,12 +387,12 @@ void SlotDragOverlay::onDrag(QPointF pos)
 
   if(y <= height)
   {
-    m_drawnRect = {0, height - 2.5, rect.width(), 5};
+    m_drawnRect = {0, height - 6.0, rect.width(), 12.0};
     update();
   }
   else if(y > rect.height() - 5.)
   {
-    m_drawnRect = {0, rect.height() - 5., rect.width(), 5};
+    m_drawnRect = {0, rect.height() - 6.0, rect.width(), 12.0};
     update();
   }
   else
@@ -403,13 +403,13 @@ void SlotDragOverlay::onDrag(QPointF pos)
     {
       const auto next_height = itv.getSlotHeight({i, view}) + SlotHeader::headerHeight()
                                + SlotFooter::footerHeight();
-      if(y > height - 2.5 && y < height + 2.5)
+      if(y > height - 6.0 && y < height + 6.0)
       {
-        m_drawnRect = {0, height - 2.5, rect.width(), 5};
+        m_drawnRect = {0, height - 6.0, rect.width(), 12.0};
         update();
         break;
       }
-      else if(y < height + next_height - 2.5)
+      else if(y < height + next_height - 6.0)
       {
         m_drawnRect = {0, height, rect.width(), next_height};
         update();
@@ -419,9 +419,9 @@ void SlotDragOverlay::onDrag(QPointF pos)
       height += next_height;
     }
 
-    if(y > height - 2.5 && y < height + 2.5)
+    if(y > height - 6.0 && y < height + 6.0)
     {
-      m_drawnRect = {0, height - 2.5, rect.width(), 5};
+      m_drawnRect = {0, height - 6.0, rect.width(), 12.0};
       update();
     }
   }
@@ -461,13 +461,13 @@ void SlotDragOverlay::dropEvent(QGraphicsSceneDragDropEvent* event)
 
   if(y <= height)
   {
-    m_drawnRect = {0, height - 2.5, rect.width(), 5};
+    m_drawnRect = {0, height - 6.0, rect.width(), 12.0};
     dropBefore(0);
     update();
   }
   else if(y > rect.height() - 5.)
   {
-    m_drawnRect = {0, rect.height() - 5., rect.width(), 5};
+    m_drawnRect = {0, rect.height() - 6.0, rect.width(), 12.0};
     dropBefore(N);
     update();
   }
@@ -477,14 +477,14 @@ void SlotDragOverlay::dropEvent(QGraphicsSceneDragDropEvent* event)
     {
       const auto next_height = itv.getSlotHeight({i, view}) + SlotHeader::headerHeight()
                                + SlotFooter::footerHeight();
-      if(y > height - 2.5 && y < height + 2.5)
+      if(y > height - 6.0 && y < height + 6.0)
       {
-        m_drawnRect = {0, height - 2.5, rect.width(), 5};
+        m_drawnRect = {0, height - 6.0, rect.width(), 12.0};
         dropBefore(i);
         update();
         return;
       }
-      else if(y < height + next_height - 2.5)
+      else if(y < height + next_height - 6.0)
       {
         m_drawnRect = {0, height, rect.width(), next_height};
         dropIn(i);
@@ -495,9 +495,9 @@ void SlotDragOverlay::dropEvent(QGraphicsSceneDragDropEvent* event)
       height += next_height;
     }
 
-    if(y > height - 2.5 && y < height + 2.5)
+    if(y > height - 6.0 && y < height + 6.0)
     {
-      m_drawnRect = {0, height - 2.5, rect.width(), 5};
+      m_drawnRect = {0, height - 6.0, rect.width(), 12.0};
       dropBefore(N);
       update();
       return;

--- a/src/plugins/score-plugin-scenario/Scenario/Document/State/StateView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/State/StateView.cpp
@@ -114,6 +114,38 @@ QRectF StateView::boundingRect() const
   return {-radius, -radius, 2. * radius, 2. * radius};
 }
 
+QPainterPath StateView::shape() const
+{
+  QPainterPath p;
+  if(m_dilated)
+  {
+    p = smallDilated;
+    if(m_containMessage)
+      p |= fullDilated;
+    if(m_containProcess)
+      p |= fullProcessDilated;
+  }
+  else
+  {
+    p = smallNonDilated;
+    if(m_containMessage)
+      p |= fullNonDilated;
+    if(m_containProcess)
+      p |= fullProcessNonDilated;
+  }
+  return p;
+}
+
+QPainterPath StateView::opaqueArea() const
+{
+  return shape();
+}
+
+bool StateView::contains(const QPointF& point) const
+{
+  return shape().contains(point);
+}
+
 void StateView::paint(
     QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {

--- a/src/plugins/score-plugin-scenario/Scenario/Document/State/StateView.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/State/StateView.hpp
@@ -30,8 +30,8 @@ class SCORE_PLUGIN_SCENARIO_EXPORT StateView final
   W_OBJECT(StateView)
   Q_INTERFACES(QGraphicsItem)
 public:
-  static const constexpr qreal fullRadius = 6.;
-  static const constexpr qreal pointRadius = 3.5;
+  static const constexpr qreal fullRadius = 8.;
+  static const constexpr qreal pointRadius = 5.;
   static const constexpr qreal notDilated = 1.;
   static const constexpr qreal dilated = 1.5;
 

--- a/src/plugins/score-plugin-scenario/Scenario/Document/State/StateView.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/State/StateView.hpp
@@ -5,6 +5,7 @@
 #include <score/model/ColorInterpolator.hpp>
 
 #include <QGraphicsItem>
+#include <QPainterPath>
 #include <QRect>
 
 #include <score_plugin_scenario_export.h>
@@ -44,6 +45,9 @@ public:
   StatePresenter& presenter() const { return m_presenter; }
 
   QRectF boundingRect() const override;
+  QPainterPath shape() const override;
+  QPainterPath opaqueArea() const override;
+  bool contains(const QPointF& point) const override;
 
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
       override;


### PR DESCRIPTION
Closes #1994 

Increased hitboxes and interaction areas for various UI components to improve selection and drag-and-drop usability:
- Cables: Increased stroke width from 7 to 14.
- Intervals: Added a 5-pixel margin and increased drop threshold to 12.
- Conditions: Increased stroke width from 1 to 10.
- Events: Widened bounding box from 6 to 12.
- States: Enlarged visual radii (full: 6->8, point: 3.5->5).
- Ports: Expanded interaction area to 20x20.
- Slot Headers: Widened drag area and increased drop threshold between slots.