### PR TITLE
ui: fix HiDPI rendering issues introduced by the vector-gui commit

### DIFF
--- a/src/lib/score/graphics/TextItem.cpp
+++ b/src/lib/score/graphics/TextItem.cpp
@@ -55,7 +55,7 @@ void SimpleTextItem::paint(
       painter->setPen(m_color->pen1);
     painter->setFont(m_font);
     painter->setBrush(skin.NoBrush);
-    painter->drawText(QPointF{0, (float)m_line.height() - 2.}, m_string);
+    painter->drawText(QPointF{0, (float)m_rect.height() - 2.}, m_string);
   }
   else if(!m_string.isEmpty())
   {

--- a/src/lib/score/widgets/SetIcons.cpp
+++ b/src/lib/score/widgets/SetIcons.cpp
@@ -302,17 +302,20 @@ QCursor get_cursor(QString str, double hotspot_x, double hotspot_y)
     newstr.replace(".png", "@2x.png", Qt::CaseInsensitive);
     if(QFile::exists(newstr))
     {
-      img.setDevicePixelRatio(2.);
-      hotspot_x *= 2.;
-      hotspot_y *= 2.;
       str = newstr;
+      img.load(str);
+      img.setDevicePixelRatio(2.);
     }
     else
     {
       qDebug() << "hidpi pixmap not found: " << newstr;
+      img.load(str);
     }
   }
-  img.load(str);
+  else
+  {
+    img.load(str);
+  }
   cur = QCursor{img, (int)hotspot_x, (int)hotspot_y};
   return cur;
 }

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/Temporal/TemporalIntervalHeader.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/Temporal/TemporalIntervalHeader.cpp
@@ -136,7 +136,7 @@ void TemporalIntervalHeader::paint(
         else
           painter->setPen(QPen(col.getBrush().color()));
       }
-      painter->drawText(QPointF{p.x(), p.y() + m_line.height() - 2.}, text);
+      painter->drawText(QPointF{p.x(), p.y() + m_textRectCache.height() - 2.}, text);
     }
   }
   else if(!m_line.isNull())


### PR DESCRIPTION
Two bugs in the vector_gui rendering path on Retina displays:

1. SimpleTextItem and TemporalIntervalHeader were drawing text using m_line.height() / m_pixmap.height() (physical pixels) as the baseline Y coordinate in logical scene units, causing labels to render below their bounding rect and misaligning hit areas. Fixed by using m_rect.height() / m_textRectCache.height() instead.

2. get_cursor() was setting devicePixelRatio before loading the pixmap (which resets it), and was doubling the hotspot coordinates for @2x cursors. QCursor hotspot is in logical pixels, so doubling it placed the active point at the bottom-right of the cursor image. Fixed by loading before setting dpr, and not doubling the hotspot.