### PR TITLE
Fix knob/slider infinite scroller on multi-screen HiDPI setups

### DIFF
--- a/src/lib/score/graphics/InfiniteScroller.hpp
+++ b/src/lib/score/graphics/InfiniteScroller.hpp
@@ -23,7 +23,10 @@ struct InfiniteScroller
 #if !defined(__EMSCRIPTEN__)
     self.setCursor(QCursor(Qt::BlankCursor));
 #endif
-    currentGeometry = qGuiApp->primaryScreen()->availableGeometry();
+    auto* screen = qGuiApp->screenAt(QCursor::pos());
+    if(!screen)
+      screen = qGuiApp->primaryScreen();
+    currentGeometry = screen->availableGeometry();
   }
 
   static void move_free(QGraphicsSceneMouseEvent* event)
@@ -36,14 +39,15 @@ struct InfiniteScroller
       currentDelta += ratio * delta;
     }
 
-    const double max = currentGeometry.height();
-    if(event->screenPos().y() <= 100)
+    const double top = currentGeometry.top();
+    const double bottom = currentGeometry.bottom();
+    if(event->screenPos().y() <= top + 100)
     {
-      score::setCursorPos(QPointF(event->screenPos().x(), max - 101));
+      score::setCursorPos(QPointF(event->screenPos().x(), bottom - 101));
     }
-    else if(event->screenPos().y() >= (max - 100))
+    else if(event->screenPos().y() >= bottom - 100)
     {
-      score::setCursorPos(QPointF(event->screenPos().x(), 101));
+      score::setCursorPos(QPointF(event->screenPos().x(), top + 101));
     }
   }
 


### PR DESCRIPTION
this one has been bothering me for a while - Claude vibe-coding is dope!

## Summary

- `InfiniteScroller::start()` was hardcoded to `qGuiApp->primaryScreen()->availableGeometry()`, so on any secondary screen the wrap-around thresholds were computed relative to the wrong screen
- When the secondary screen's global Y offset pushed the cursor position above `primaryScreen.height() - 100`, the teleport fired on every mouse move event, blocking the widget from going below its pick-up value
- Fix: use `qGuiApp->screenAt(QCursor::pos())` to detect the actual screen at press time, and account for the screen's `top()` offset in the teleport bounds

## Test plan

- [x] Knob drag works correctly on primary (retina) screen — value goes up and down freely
- [x] Knob drag works correctly on secondary non-HiDPI screen — value goes up and down freely, no longer blocked below pick-up value
- [x] Infinite scroll wrap-around still works when reaching screen top/bottom on both screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)