### PR TITLE
TBD: mapper: keep mapper device readable via Device.read() after device reconnects

### DIFF
--- a/src/plugins/score-plugin-protocols/Protocols/Mapper/MapperDevice.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/Mapper/MapperDevice.cpp
@@ -439,6 +439,9 @@ public:
       ossia::qt::qml_device_cache cache;
       for(auto node : r)
         cache.push_back(&node->get_device());
+      // Always keep the mapper device itself so Device.read() can access its own nodes
+      if(m_device)
+        cache.push_back(m_device);
       ossia::remove_duplicates(cache);
       device_obj->devices = cache;
       m_roots = std::move(r);


### PR DESCRIPTION
This change has been proposed by Claude. Is there a risk that would cause issues, or problems with backwards compatibility?

## Problem

In `mapper_protocol`, the `rootsChanged` handler rebuilds `device_obj->devices` from `m_roots` only:

```cpp
ossia::qt::qml_device_cache cache;
for(auto node : r)
    cache.push_back(&node->get_device());
device_obj->devices = cache;
```

This excludes the mapper device itself from the readable device list. As a result, `Device.read()` calls on mapper-local nodes (e.g. shadow/mirror nodes used for parameter pickup in QML scripts) always return null after the initial device reconnect — even though `setDevice()` adds it on first init.

## Fix

Add the mapper device back to the cache before assigning:

```cpp
if(m_device)
    cache.push_back(m_device);
```

`ossia::remove_duplicates` handles the case where it was already present.

## Use case

A QML Mapper script creates local "shadow" nodes that mirror score parameter values. These are used to implement soft-takeover / parameter pickup: when a hardware control is focused on a track, `Device.read("/shadow/tN/param")` seeds the accumulator from the last known value. Without this fix, those reads always fail after devices reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)