### PR TITLE
sound: add video file support to sound process

### DIFF
--- a/src/plugins/score-plugin-media/Media/AudioDecoder.cpp
+++ b/src/plugins/score-plugin-media/Media/AudioDecoder.cpp
@@ -460,6 +460,7 @@ try
     {
       auto stream = fmt_ctx->streams[i];
       AudioInfo info;
+      info.audioStream = i;
       info.channels = ossia::avstream_get_audio_channels(*stream);
       if(info.channels == 0)
         return {};

--- a/src/plugins/score-plugin-media/Media/AudioDecoder.hpp
+++ b/src/plugins/score-plugin-media/Media/AudioDecoder.hpp
@@ -21,6 +21,7 @@ namespace Media
 {
 struct AudioInfo
 {
+  int32_t audioStream{-1};
   int32_t fileRate{};
   int32_t convertedRate{};
   int64_t channels{};

--- a/src/plugins/score-plugin-media/Media/MediaFileHandle.cpp
+++ b/src/plugins/score-plugin-media/Media/MediaFileHandle.cpp
@@ -54,7 +54,12 @@ static DecodingMethod needsDecoding(const QString& path, int rate)
   }
   else
   {
-    return DecodingMethod::Libav;
+    if(AudioFile::isSupportedVideo(QFile{path}))
+    {
+      return DecodingMethod::LibavStream;
+    }
+    else
+      return DecodingMethod::Libav;
   }
 }
 
@@ -115,9 +120,16 @@ void AudioFile::load(DecodingSetup opt)
       load_sndfile();
       break;
     case DecodingMethod::LibavStream:
-      // FIXME
       if(m_track == -1)
-        m_track = 0;
+      {
+        const auto& info = probe(m_file);
+        if(info && info->audioStream)
+        {
+          m_track = info->audioStream;
+        }
+        else
+          m_track = 0;
+      }
       load_libav_stream();
       break;
     default:
@@ -143,7 +155,15 @@ int64_t AudioFile::decodedSamples() const
 
 bool AudioFile::isSupported(const QFile& file)
 {
-  constexpr auto rex = ".(wav|mp3|m4a|ogg|flac|aif|aiff|w64|ape|wv|wma)";
+  constexpr auto rex = ".(wav|mp3|m4a|ogg|flac|aif|aiff|w64|ape|wv|wma)$";
+  return file.exists()
+         && file.fileName().contains(
+             QRegularExpression(rex, QRegularExpression::CaseInsensitiveOption));
+}
+
+bool AudioFile::isSupportedVideo(const QFile& file)
+{
+  constexpr auto rex = ".(mkv|mov|mp4|h264|avi|hap|mpg|mpeg|imf|mxf|mts|m2ts|mj2|webm|y4m|nut|ts)$";
   return file.exists()
          && file.fileName().contains(
              QRegularExpression(rex, QRegularExpression::CaseInsensitiveOption));

--- a/src/plugins/score-plugin-media/Media/MediaFileHandle.hpp
+++ b/src/plugins/score-plugin-media/Media/MediaFileHandle.hpp
@@ -74,6 +74,7 @@ struct SCORE_PLUGIN_MEDIA_EXPORT AudioFile final : public QObject
 {
 public:
   static bool isSupported(const QFile& f);
+  static bool isSupportedVideo(const QFile& f);
 
   AudioFile();
   ~AudioFile() override;

--- a/src/plugins/score-plugin-media/Media/Sound/Drop/SoundDrop.cpp
+++ b/src/plugins/score-plugin-media/Media/Sound/Drop/SoundDrop.cpp
@@ -22,7 +22,8 @@ DroppedAudioFiles::DroppedAudioFiles(
   for(const auto& url : urls)
   {
     QString filename = url.toLocalFile();
-    if(!AudioFile::isSupported(QFile{filename}))
+    if(!(AudioFile::isSupported(QFile{filename}) 
+      || AudioFile::isSupportedVideo(QFile{filename})))
       continue;
 
     if(auto info_opt = probe(filename))
@@ -50,7 +51,9 @@ QSet<QString> DropHandler::mimeTypes() const noexcept
 
 QSet<QString> DropHandler::fileExtensions() const noexcept
 {
-  return {"wav", "mp3", "m4a", "ogg", "flac", "aif", "aiff", "w64", "ape", "wv", "wma"};
+  return {"wav", "mp3", "m4a", "ogg", "flac", "aif", "aiff", "w64", "ape", "wv", "wma",
+          "mkv", "mov", "mp4", "h264", "avi", "hap",  "mpg", "mpeg",
+          "imf", "mxf", "mts", "m2ts", "mj2", "webm", "y4m", "nut", "ts"};
 }
 
 void DropHandler::dropCustom(


### PR DESCRIPTION
Allow sound process to load video file first audio track at creation using JS (ie. `Score.createProcess(Score.rootInterval(), "Sound file", "video.mp4")`).

Allow loading video file first audio track by drag'n'dropping a video file into an existing sound process.

Fix sound drop regex to match extension as suffix only.