### PR TITLE
main: set QML_XHR_ALLOW_FILE_READ/WRITE by default

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -742,6 +742,10 @@ static void setup_qml()
     qputenv("QV4_JS_MAX_STACK_SIZE", "16777216");
   if(!qEnvironmentVariableIsSet("QV4_GC_MAX_STACK_SIZE"))
     qputenv("QV4_GC_MAX_STACK_SIZE", "16777216");
+  if(!qEnvironmentVariableIsSet("QML_XHR_ALLOW_FILE_READ"))
+    qputenv("QML_XHR_ALLOW_FILE_READ", "1");
+  if(!qEnvironmentVariableIsSet("QML_XHR_ALLOW_FILE_WRITE"))
+    qputenv("QML_XHR_ALLOW_FILE_WRITE", "1");
 }
 
 struct failsafe


### PR DESCRIPTION
## Summary
- Set `QML_XHR_ALLOW_FILE_READ` and `QML_XHR_ALLOW_FILE_WRITE` to `1` by default in `setup_qml()`, so QML's `XMLHttpRequest`-based local file I/O works out of the box without needing the packaging script to export them.
- Each variable is only set when not already present in the environment, matching the `qEnvironmentVariableIsSet` guard pattern used elsewhere in `src/app/main.cpp` (e.g. `QV4_JS_MAX_STACK_SIZE`, `QT_SUBPIXEL_AA_TYPE`, `FREETYPE_PROPERTIES`).

Fixes #2039.

## Test plan
- [ ] Launch score without these env vars set and verify QML `XMLHttpRequest` can read/write local files.
- [ ] Launch score with `QML_XHR_ALLOW_FILE_READ=0` / `QML_XHR_ALLOW_FILE_WRITE=0` and verify the user-supplied values are preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_015e2nDAa5Es8bcHFkHYtR1z)_