### PR TITLE
nodal: persist zoom level when navigating in and out of intervals

### DIFF
--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/FullView/NodalIntervalView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/FullView/NodalIntervalView.cpp
@@ -101,6 +101,12 @@ NodalIntervalView::NodalIntervalView(
       }
     }
   }
+  if(const double savedScale = m_model.nodalScale(); savedScale != 1.0)
+  {
+    m_container->setScale(savedScale);
+    m_zoomLevel = std::log(savedScale) / std::log(g_zoom_base);
+  }
+
   QTimer::singleShot(1, this, &NodalIntervalView::recenterRelativeToView);
 }
 
@@ -157,6 +163,8 @@ void NodalIntervalView::recenter()
   auto delta = ourCenter - childCenter;
 
   m_container->setPos(delta);
+  m_zoomLevel = std::log(z) / std::log(g_zoom_base);
+  const_cast<IntervalModel&>(m_model).setNodalScale(z);
   const_cast<IntervalModel&>(m_model).setNodalOffset(QPointF{});
 }
 
@@ -167,6 +175,7 @@ void NodalIntervalView::rescale()
   auto childRect = enclosingRect();
 
   m_container->setScale(1.0);
+  m_zoomLevel = 0.;
 
   auto childCenter
       = m_container->mapRectToParent(childRect).center() - m_container->pos();
@@ -174,6 +183,7 @@ void NodalIntervalView::rescale()
   auto delta = ourCenter - childCenter;
 
   m_container->setPos(delta + m_model.nodalOffset());
+  const_cast<IntervalModel&>(m_model).setNodalScale(1.0);
 }
 
 NodalIntervalView::~NodalIntervalView()
@@ -361,6 +371,7 @@ void NodalIntervalView::wheelEvent(QGraphicsSceneWheelEvent* event)
 
   QPointF newAnchorPos = m_container->mapToParent(localAnchor);
   m_container->setPos(m_container->pos() + (anchor - newAnchorPos));
+  const_cast<IntervalModel&>(m_model).setNodalScale(newScale);
 
   event->accept();
 }
@@ -393,6 +404,7 @@ void NodalIntervalView::zoomTo(double newZoomLevel)
 
   const QPointF newAnchorPos = m_container->mapToParent(localAnchor);
   m_container->setPos(m_container->pos() + (anchor - newAnchorPos));
+  const_cast<IntervalModel&>(m_model).setNodalScale(newScale);
 }
 
 void NodalIntervalView::on_dropOnNode(const QPointF& pos, const QMimeData& mime)

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/FullView/NodalIntervalView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/FullView/NodalIntervalView.cpp
@@ -41,6 +41,10 @@ W_OBJECT_IMPL(Scenario::NodalContainer)
 namespace Scenario
 {
 constexpr double g_zoom_base = 1.2;
+// g_zoom_base is used as a logarithm base (std::log(g_zoom_base) as a
+// denominator); it must be strictly greater than 1, otherwise the division
+// would yield NaN / a division by zero.
+static_assert(g_zoom_base > 1.0);
 NodalIntervalView::NodalIntervalView(
     NodalIntervalView::ItemsToShow sh, const IntervalModel& model,
     const Process::Context& ctx, QGraphicsItem* parent)


### PR DESCRIPTION
Dome with Claude

IntervalModel already stored m_nodalScale (serialized) but the view never wrote to it. Now wheelEvent, zoomTo, recenter, and rescale all call setNodalScale, and the constructor restores the saved value before the deferred recenterRelativeToView fires.