### PR TITLE
feature/clap-fixes

### DIFF
--- a/src/plugins/score-plugin-clap/Clap/AppleUI/ClapWindow.mm
+++ b/src/plugins/score-plugin-clap/Clap/AppleUI/ClapWindow.mm
@@ -96,7 +96,7 @@ void Window::showEvent(QShowEvent* event)
   else
   {
     // For floating windows on macOS
-    clap_window_t parent_window;
+    clap_window_t parent_window{};
     parent_window.api = CLAP_WINDOW_API_COCOA;
     
     // Get the NSView from the Qt window

--- a/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
@@ -127,6 +127,15 @@ void ApplicationPlugin::rescanPlugins()
 #endif
 
   paths << QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.clap";
+
+  // $CLAP_PATH (per CLAP entry.h), supplementing standard locations.
+  if(qEnvironmentVariableIsSet("CLAP_PATH"))
+  {
+    const auto extra = qEnvironmentVariable("CLAP_PATH")
+                           .split(QDir::listSeparator(), Qt::SkipEmptyParts);
+    paths.append(extra);
+  }
+
   for(auto it = paths.begin(); it != paths.end();)
   {
     auto& path = *it;

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
@@ -12,6 +12,7 @@
 #include <score/serialization/JSONVisitor.hpp>
 #include <score/tools/IdentifierGeneration.hpp>
 
+#include <ossia/dataflow/exec_pool.hpp>
 #include <ossia/detail/json.hpp>
 #include <ossia/detail/thread.hpp>
 #include <ossia/network/domain/domain.hpp>
@@ -39,52 +40,10 @@
 #include <dlfcn.h>
 #endif
 
-#include <boost/asio/post.hpp>
-#include <boost/asio/thread_pool.hpp>
-
-#include <latch>
-#include <thread>
-
 W_OBJECT_IMPL(Clap::Model)
 
 namespace Clap
 {
-
-// Shared fork-join pool for CLAP_EXT_THREAD_POOL.request_exec.
-class ClapThreadPool
-{
-public:
-  static ClapThreadPool& instance()
-  {
-    static ClapThreadPool pool;
-    return pool;
-  }
-
-  bool dispatch(
-      const clap_plugin_t* plugin, const clap_plugin_thread_pool_t* ext,
-      uint32_t num_tasks) noexcept
-  {
-    if(num_tasks == 0)
-      return false;
-    std::latch done(num_tasks);
-    for(uint32_t i = 0; i < num_tasks; ++i)
-    {
-      boost::asio::post(m_pool, [plugin, ext, i, &done] {
-        ext->exec(plugin, i);
-        done.count_down();
-      });
-    }
-    done.wait();
-    return true;
-  }
-
-private:
-  ClapThreadPool()
-      : m_pool{std::max(1u, std::thread::hardware_concurrency() - 1)}
-  {
-  }
-  boost::asio::thread_pool m_pool;
-};
 
 // Some plug-ins (e.g. Octasine) don't zero-init info.name; reject garbage.
 static QString
@@ -603,7 +562,11 @@ static constexpr clap_host_thread_check_t host_thread_check_ext = {
   return ossia::get_current_thread_type() == ossia::thread_type::Ui;
 },
     .is_audio_thread = [](const clap_host_t* host) -> bool {
-  return ossia::get_current_thread_type() == ossia::thread_type::Audio;
+  // The shared task pool pins its workers as AudioTask; they run plug-in
+  // process() / thread-pool exec() under the audio thread's umbrella, so both
+  // count as "the audio thread" for the plug-in (matches ensure_current_thread_kind).
+  const auto t = ossia::get_current_thread_type();
+  return t == ossia::thread_type::Audio || t == ossia::thread_type::AudioTask;
 },
 };
 
@@ -618,7 +581,25 @@ static constexpr clap_host_thread_pool host_thread_pool_ext
       h.plugin->get_extension(h.plugin, CLAP_EXT_THREAD_POOL));
   if(!ext || !ext->exec)
     return false;
-  return ClapThreadPool::instance().dispatch(h.plugin, ext, num_tasks);
+  if(num_tasks == 0)
+    return false;
+
+  // Synchronous fork-join on the shared realtime pool: workers are RT-pinned
+  // AudioTask threads, the calling (audio) thread participates, and nothing is
+  // allocated here. exec() is C ABI but some plug-ins are C++ inside, so guard
+  // against an escaping exception terminating the audio thread.
+  const clap_plugin_t* plugin = h.plugin;
+  ossia::task_pool::instance().fork_n(
+      static_cast<int>(num_tasks), [plugin, ext](int i) noexcept {
+    try
+    {
+      ext->exec(plugin, static_cast<uint32_t>(i));
+    }
+    catch(...)
+    {
+    }
+  });
+  return true;
 }};
 
 static constexpr clap_host_voice_info_t host_voice_info_ext

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
@@ -393,16 +393,15 @@ static constexpr clap_host_params_t host_params_ext
   if(!m.model)
     return;
 
-  auto plugin = m.plugin;
-  auto params
-      = (const clap_plugin_params_t*)plugin->get_extension(plugin, CLAP_EXT_PARAMS);
-  if(!params)
-    return;
-  if(!params->flush)
-    return;
-
-  if(!m.model->executing())
-    m.model->flushFromPluginToHost();
+  // Per CLAP spec, request_flush is [thread-safe, !audio-thread] and the host
+  // must SCHEDULE a call to flush() — not invoke it inline. Plugins sometimes
+  // call request_flush from inside their own state.load() / flush() / GUI
+  // event handler, so calling flushFromPluginToHost synchronously here could
+  // reenter clap_plugin_params.flush().
+  QMetaObject::invokeMethod(m.model, [model = QPointer<Model>{m.model}] {
+    if(model && !model->executing())
+      model->flushFromPluginToHost();
+  }, Qt::QueuedConnection);
 }};
 
 static constexpr clap_host_gui_t host_gui_ext
@@ -1013,17 +1012,19 @@ void Model::loadPlugin()
       if(!plugin)
         return;
       auto params = m_plugin->ext_params;
-      std::size_t control_idx = 0;
+      if(!params || !params->get_value)
+        return;
+
+      // Writable params -> ControlInlets.
+      std::size_t inlet_idx = 0;
       for(auto* inlet : inlets())
       {
         if(auto* control = qobject_cast<Process::ControlInlet*>(inlet))
         {
-          if(control_idx < m_plugin->m_parameters_ins.size())
+          if(inlet_idx < m_plugin->m_parameters_ins.size())
           {
-            const auto& param_info = m_plugin->m_parameters_ins[control_idx];
+            const auto& param_info = m_plugin->m_parameters_ins[inlet_idx];
             double current_value = 0.0;
-
-            // Read current parameter value from plugin
             if(params->get_value(plugin, param_info.id, &current_value))
             {
               currentlyReadingValues = true;
@@ -1031,7 +1032,28 @@ void Model::loadPlugin()
               currentlyReadingValues = false;
             }
           }
-          control_idx++;
+          inlet_idx++;
+        }
+      }
+
+      // Read-only params -> ControlOutlets (Bargraph meters etc.).
+      std::size_t outlet_idx = 0;
+      for(auto* outlet : outlets())
+      {
+        if(auto* control = qobject_cast<Process::ControlOutlet*>(outlet))
+        {
+          if(outlet_idx < m_plugin->m_parameters_outs.size())
+          {
+            const auto& param_info = m_plugin->m_parameters_outs[outlet_idx];
+            double current_value = 0.0;
+            if(params->get_value(plugin, param_info.id, &current_value))
+            {
+              currentlyReadingValues = true;
+              control->setValue(current_value);
+              currentlyReadingValues = false;
+            }
+          }
+          outlet_idx++;
         }
       }
     });
@@ -1045,6 +1067,143 @@ void Model::loadPlugin()
       m_plugin->activated = false;
     }
   }, Qt::QueuedConnection);
+}
+
+// Gesture debounce window: a slider drag is treated as one gesture if changes
+// keep arriving within this window after the last sample.
+static constexpr int CLAP_GESTURE_DEBOUNCE_MS = 200;
+
+namespace
+{
+// Build a clap_input_events_t backed by a std::vector of event pointers.
+struct ParamInputCtx
+{
+  std::vector<const clap_event_header_t*> events;
+};
+inline clap_input_events_t make_input_events(ParamInputCtx& ctx)
+{
+  return {
+      .ctx = &ctx,
+      .size = +[](const clap_input_events* list) -> uint32_t {
+    return static_cast<const ParamInputCtx*>(list->ctx)->events.size();
+  },
+      .get = +[](const clap_input_events* list,
+                 uint32_t index) -> const clap_event_header_t* {
+    auto* c = static_cast<const ParamInputCtx*>(list->ctx);
+    return index < c->events.size() ? c->events[index] : nullptr;
+  }};
+}
+
+inline clap_event_param_value_t
+make_param_value(const clap_param_info_t& info, double value)
+{
+  clap_event_param_value_t ev{};
+  ev.header.size = sizeof(clap_event_param_value_t);
+  ev.header.time = 0;
+  ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+  ev.header.type = CLAP_EVENT_PARAM_VALUE;
+  ev.header.flags = CLAP_EVENT_IS_LIVE;
+  ev.param_id = info.id;
+  ev.cookie = info.cookie;
+  ev.note_id = -1;
+  ev.port_index = -1;
+  ev.channel = -1;
+  ev.key = -1;
+  ev.value = value;
+  return ev;
+}
+
+inline clap_event_param_gesture_t
+make_param_gesture(clap_id pid, uint16_t type)
+{
+  clap_event_param_gesture_t ev{};
+  ev.header.size = sizeof(clap_event_param_gesture_t);
+  ev.header.time = 0;
+  ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+  ev.header.type = type;
+  ev.header.flags = CLAP_EVENT_IS_LIVE;
+  ev.param_id = pid;
+  return ev;
+}
+} // namespace
+
+void Model::sendParamChange(const clap_param_info_t& info, double value)
+{
+  auto plugin = m_plugin->plugin;
+  if(!plugin)
+    return;
+  auto params
+      = (const clap_plugin_params_t*)plugin->get_extension(plugin, CLAP_EXT_PARAMS);
+  if(!params || !params->flush)
+    return;
+
+  // Manage the gesture state for this parameter.
+  auto& gs = gestures[info.id];
+  if(!gs.endTimer)
+  {
+    gs.endTimer = new QTimer{this};
+    gs.endTimer->setSingleShot(true);
+    gs.endTimer->setInterval(CLAP_GESTURE_DEBOUNCE_MS);
+    QObject::connect(gs.endTimer, &QTimer::timeout, this, [this, pid = info.id] {
+      auto it = gestures.find(pid);
+      if(it == gestures.end())
+        return;
+      endGesture(pid, it->second.cookie);
+    });
+  }
+  gs.cookie = info.cookie;
+
+  const bool was_active = gs.active;
+  if(!gs.active)
+    gs.active = true;
+  gs.endTimer->start();
+
+  // Build event stream: optional GESTURE_BEGIN + PARAM_VALUE.
+  clap_event_param_gesture_t begin_ev{};
+  clap_event_param_value_t value_ev = make_param_value(info, value);
+  ParamInputCtx ctx;
+  ctx.events.reserve(2);
+  if(!was_active)
+  {
+    begin_ev = make_param_gesture(info.id, CLAP_EVENT_PARAM_GESTURE_BEGIN);
+    ctx.events.push_back(&begin_ev.header);
+  }
+  ctx.events.push_back(&value_ev.header);
+
+  clap_input_events_t ip = make_input_events(ctx);
+  clap_output_events_t op{
+      .ctx = this,
+      .try_push = [](const struct clap_output_events*,
+                     const clap_event_header_t*) { return false; }};
+  params->flush(plugin, &ip, &op);
+}
+
+void Model::endGesture(clap_id param_id, void* cookie)
+{
+  auto plugin = m_plugin->plugin;
+  if(!plugin)
+    return;
+  auto params
+      = (const clap_plugin_params_t*)plugin->get_extension(plugin, CLAP_EXT_PARAMS);
+  if(!params || !params->flush)
+    return;
+
+  auto it = gestures.find(param_id);
+  if(it != gestures.end())
+    it->second.active = false;
+
+  clap_event_param_gesture_t end_ev = make_param_gesture(
+      param_id, CLAP_EVENT_PARAM_GESTURE_END);
+  end_ev.header.flags = 0;
+
+  ParamInputCtx ctx;
+  ctx.events.push_back(&end_ev.header);
+  clap_input_events_t ip = make_input_events(ctx);
+  clap_output_events_t op{
+      .ctx = this,
+      .try_push = [](const struct clap_output_events*,
+                     const clap_event_header_t*) { return false; }};
+  params->flush(plugin, &ip, &op);
 }
 
 void Model::setupControlInlet(
@@ -1074,46 +1233,13 @@ void Model::setupControlInlet(
       [this, i = index](const ossia::value& v) {
     if(executing())
       return;
+    if(currentlyReadingValues)
+      return;
     SCORE_ASSERT(this->parameterInputs().size() > i);
     auto& param_info = this->parameterInputs()[i];
-    double val = ossia::convert<double>(v);
-
-    auto plugin = m_plugin->plugin;
-    auto params
-        = (const clap_plugin_params_t*)plugin->get_extension(plugin, CLAP_EXT_PARAMS);
-    if(!params)
-      return;
-    clap_event_param_value_t param_event{};
-    param_event.header.size = sizeof(clap_event_param_value_t);
-    param_event.header.time = 0; // Beginning of buffer for now
-    param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-    param_event.header.type = CLAP_EVENT_PARAM_VALUE;
-    param_event.header.flags = CLAP_EVENT_IS_LIVE;
-    param_event.param_id = param_info.id;
-    param_event.cookie = param_info.cookie;
-    param_event.note_id = -1;
-    param_event.port_index = -1;
-    param_event.channel = -1;
-    param_event.key = -1;
-    param_event.value = val;
-    clap_input_events_t ip;
-    ip.ctx = &param_event;
-    ip.get = +[](const struct clap_input_events* list,
-                 uint32_t index) -> const clap_event_header_t* {
-      if(index == 0)
-      {
-        return (const clap_event_header_t*)&list->ctx;
-      }
-      return nullptr;
-    };
-    ip.size = +[](const struct clap_input_events* list) -> uint32_t { return 1; };
-
-    clap_output_events_t op{
-        .ctx = this,
-        .try_push = [](const struct clap_output_events* list,
-                       const clap_event_header_t* event) { return false; }};
-
-    params->flush(plugin, &ip, &op);
+    double val
+        = std::clamp(ossia::convert<double>(v), param_info.min_value, param_info.max_value);
+    sendParamChange(param_info, val);
   });
 }
 
@@ -1649,73 +1775,151 @@ std::vector<Process::Preset> Model::builtinPresets() const noexcept
   return presets;
 }
 
+namespace
+{
+// Find and update the i-th ControlInlet / ControlOutlet on a Model under
+// the currentlyReadingValues guard, so the GUI handler does not echo the
+// value back into a fresh params->flush() call.
+template <typename Port>
+void apply_value_at(Model& self, std::size_t idx, double v)
+{
+  std::size_t found = 0;
+  if constexpr(std::is_same_v<Port, Process::ControlInlet>)
+  {
+    for(auto* inlet : self.inlets())
+    {
+      if(auto* ctl = qobject_cast<Process::ControlInlet*>(inlet))
+      {
+        if(found == idx)
+        {
+          self.currentlyReadingValues = true;
+          ctl->setValue(v);
+          self.currentlyReadingValues = false;
+          return;
+        }
+        ++found;
+      }
+    }
+  }
+  else
+  {
+    for(auto* outlet : self.outlets())
+    {
+      if(auto* ctl = qobject_cast<Process::ControlOutlet*>(outlet))
+      {
+        if(found == idx)
+        {
+          self.currentlyReadingValues = true;
+          ctl->setValue(v);
+          self.currentlyReadingValues = false;
+          return;
+        }
+        ++found;
+      }
+    }
+  }
+}
+} // namespace
+
 void Model::flushFromPluginToHost()
 {
   auto plugin = m_plugin->plugin;
+  if(!plugin)
+    return;
   auto params
       = (const clap_plugin_params_t*)plugin->get_extension(plugin, CLAP_EXT_PARAMS);
-  if(!params)
+  if(!params || !params->flush)
     return;
-
-  std::size_t control_idx = 0;
-  for(auto* inlet : inlets())
-  {
-    if(auto* control = qobject_cast<Process::ControlInlet*>(inlet))
-    {
-      if(control_idx < m_plugin->m_parameters_ins.size())
-      {
-        const auto& param_info = m_plugin->m_parameters_ins[control_idx];
-        double current_value = 0.0;
-
-        // Read current parameter value from plugin
-        // Note how here the plug-in changed its values: we want to save this in the data model.
-        if(params->get_value(plugin, param_info.id, &current_value))
-        {
-          control->setValue(current_value);
-        }
-      }
-      control_idx++;
-    }
-  }
-
   if(this->executing())
     return;
-  /*
-  SCORE_ASSERT(this->parameterInputs().size() > i);
-  auto& param_info = this->parameterInputs()[i];
-  double val = ossia::convert<double>(v);
 
-  clap_event_param_value_t param_event{};
-  param_event.header.size = sizeof(clap_event_param_value_t);
-  param_event.header.time = 0; // Beginning of buffer for now
-  param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-  param_event.header.type = CLAP_EVENT_PARAM_VALUE;
-  param_event.header.flags = 0;
-  param_event.param_id = param_info.id;
-  param_event.cookie = param_info.cookie;
-  param_event.note_id = -1;
-  param_event.port_index = -1;
-  param_event.channel = -1;
-  param_event.key = -1;
-  param_event.value = val;
-*/
-  clap_input_events_t ip;
-  ip.ctx = this;
-  ip.get = +[](const struct clap_input_events* list,
-               uint32_t index) -> const clap_event_header_t* {
-    if(index == 0)
-    {
-      return (const clap_event_header_t*)&list->ctx;
-    }
-    return nullptr;
-  };
-  ip.size = +[](const struct clap_input_events* list) -> uint32_t { return 1; };
+  // The plugin asked the host to flush so it can deliver its accumulated
+  // parameter change events. We have nothing to send it; provide an empty
+  // input list and route its CLAP_EVENT_PARAM_VALUE events to the matching
+  // inlets (writable params) or outlets (read-only params).
+  ParamInputCtx in_ctx; // empty
+  clap_input_events_t ip = make_input_events(in_ctx);
 
   clap_output_events_t op{
       .ctx = this,
       .try_push = [](const struct clap_output_events* list,
-                     const clap_event_header_t* event) { return false; }};
+                     const clap_event_header_t* event) -> bool {
+    auto* self = static_cast<Model*>(list->ctx);
+    if(!event || event->space_id != CLAP_CORE_EVENT_SPACE_ID)
+      return true;
+    if(event->type != CLAP_EVENT_PARAM_VALUE)
+      return true;
+    if(event->size < sizeof(clap_event_param_value_t))
+      return true;
+
+    auto* pv = reinterpret_cast<const clap_event_param_value_t*>(event);
+
+    std::size_t idx = 0;
+    for(auto& info : self->m_plugin->m_parameters_ins)
+    {
+      if(info.id == pv->param_id)
+      {
+        apply_value_at<Process::ControlInlet>(*self, idx, pv->value);
+        return true;
+      }
+      ++idx;
+    }
+    idx = 0;
+    for(auto& info : self->m_plugin->m_parameters_outs)
+    {
+      if(info.id == pv->param_id)
+      {
+        apply_value_at<Process::ControlOutlet>(*self, idx, pv->value);
+        return true;
+      }
+      ++idx;
+    }
+    return true;
+  }};
+
   params->flush(plugin, &ip, &op);
+
+  // Plugins that update internal state silently (without pushing events
+  // through `out`) still expose fresh values via get_value(); poll them so
+  // the GUI mirrors the plugin state, for both writable and read-only params.
+  std::size_t inlet_idx = 0;
+  for(auto* inlet : inlets())
+  {
+    if(auto* control = qobject_cast<Process::ControlInlet*>(inlet))
+    {
+      if(inlet_idx < m_plugin->m_parameters_ins.size())
+      {
+        const auto& param_info = m_plugin->m_parameters_ins[inlet_idx];
+        double current_value = 0.0;
+        if(params->get_value(plugin, param_info.id, &current_value))
+        {
+          currentlyReadingValues = true;
+          control->setValue(current_value);
+          currentlyReadingValues = false;
+        }
+      }
+      inlet_idx++;
+    }
+  }
+  std::size_t outlet_idx = 0;
+  for(auto* outlet : outlets())
+  {
+    if(auto* control = qobject_cast<Process::ControlOutlet*>(outlet))
+    {
+      if(outlet_idx < m_plugin->m_parameters_outs.size())
+      {
+        const auto& param_info = m_plugin->m_parameters_outs[outlet_idx];
+        double current_value = 0.0;
+        if(params->get_value(plugin, param_info.id, &current_value))
+        {
+          currentlyReadingValues = true;
+          control->setValue(current_value);
+          currentlyReadingValues = false;
+        }
+      }
+      outlet_idx++;
+    }
+  }
 }
 }
 

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
@@ -39,10 +39,80 @@
 #include <dlfcn.h>
 #endif
 
+#include <boost/asio/post.hpp>
+#include <boost/asio/thread_pool.hpp>
+
+#include <latch>
+#include <thread>
+
 W_OBJECT_IMPL(Clap::Model)
 
 namespace Clap
 {
+
+// Shared fork-join pool for CLAP_EXT_THREAD_POOL.request_exec.
+class ClapThreadPool
+{
+public:
+  static ClapThreadPool& instance()
+  {
+    static ClapThreadPool pool;
+    return pool;
+  }
+
+  bool dispatch(
+      const clap_plugin_t* plugin, const clap_plugin_thread_pool_t* ext,
+      uint32_t num_tasks) noexcept
+  {
+    if(num_tasks == 0)
+      return false;
+    std::latch done(num_tasks);
+    for(uint32_t i = 0; i < num_tasks; ++i)
+    {
+      boost::asio::post(m_pool, [plugin, ext, i, &done] {
+        ext->exec(plugin, i);
+        done.count_down();
+      });
+    }
+    done.wait();
+    return true;
+  }
+
+private:
+  ClapThreadPool()
+      : m_pool{std::max(1u, std::thread::hardware_concurrency() - 1)}
+  {
+  }
+  boost::asio::thread_pool m_pool;
+};
+
+// Some plug-ins (e.g. Octasine) don't zero-init info.name; reject garbage.
+static QString
+clap_safe_name(const char* raw, const QString& fallback) noexcept
+{
+  if(!raw)
+    return fallback;
+  const auto len = qstrnlen(raw, CLAP_NAME_SIZE);
+  if(len == 0)
+    return fallback;
+  const QString name = QString::fromUtf8(raw, len);
+  if(name.isEmpty())
+    return fallback;
+  qsizetype letters = 0;
+  for(QChar c : name)
+  {
+    if(c == QChar::ReplacementCharacter)
+      return fallback;
+    if(!c.isPrint())
+      return fallback;
+    if(c.isLetter())
+      ++letters;
+  }
+  if(letters < 2 && letters < name.length())
+    return fallback;
+  return name;
+}
+
 // Host GUI callbacks
 extern "C" {
 static void resize_hints_changed(const clap_host_t* host)
@@ -385,8 +455,16 @@ static constexpr clap_host_state_t host_state_ext
 }};
 static constexpr clap_host_params_t host_params_ext
     = {.rescan = [](const clap_host_t* host, clap_param_rescan_flags flags) {
-  // TODO
-  // qDebug(Q_FUNC_INFO);
+  // Spec: [main-thread]. Defer — plug-ins may call from state.load().
+  if(!host || !host->host_data)
+    return;
+  auto& h = *static_cast<Clap::PluginHandle*>(host->host_data);
+  if(!h.model)
+    return;
+  QMetaObject::invokeMethod(h.model, [model = QPointer<Model>{h.model}, flags] {
+    if(model)
+      model->onParamRescan(flags);
+  }, Qt::AutoConnection);
 }, .clear = [](const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags) {
   // TODO
   //  qDebug(Q_FUNC_INFO);
@@ -531,9 +609,16 @@ static constexpr clap_host_thread_check_t host_thread_check_ext = {
 
 static constexpr clap_host_thread_pool host_thread_pool_ext
     = {.request_exec = [](const clap_host_t* host, uint32_t num_tasks) -> bool {
-  //   qDebug(Q_FUNC_INFO);
-  // TODO
-  return false;
+  if(!host || !host->host_data)
+    return false;
+  auto& h = *static_cast<PluginHandle*>(host->host_data);
+  if(!h.plugin)
+    return false;
+  auto ext = static_cast<const clap_plugin_thread_pool_t*>(
+      h.plugin->get_extension(h.plugin, CLAP_EXT_THREAD_POOL));
+  if(!ext || !ext->exec)
+    return false;
+  return ClapThreadPool::instance().dispatch(h.plugin, ext, num_tasks);
 }};
 
 static constexpr clap_host_voice_info_t host_voice_info_ext
@@ -1121,6 +1206,12 @@ void Model::loadPlugin()
       m_plugin->plugin->deactivate(m_plugin->plugin);
       m_plugin->activated = false;
     }
+    // Drain RESCAN_ALL deferred during execution (spec needs deactivate).
+    if(m_pendingRescanFlags != 0)
+    {
+      auto pending = std::exchange(m_pendingRescanFlags, 0u);
+      onParamRescan(pending);
+    }
   }, Qt::QueuedConnection);
 }
 
@@ -1340,14 +1431,16 @@ void Model::createControls(bool loading)
     auto input_count = audio_ports->count(m_plugin->plugin, true);
     for(uint32_t i = 0; i < input_count; ++i)
     {
-      clap_audio_port_info_t info;
+      clap_audio_port_info_t info{};
       if(audio_ports->get(m_plugin->plugin, i, true, &info))
       {
         m_supports64 &= (info.flags & CLAP_AUDIO_PORT_SUPPORTS_64BITS);
 
         if(!loading)
         {
-          auto name = QString::fromUtf8(info.name);
+          QString name = clap_safe_name(
+              info.name, input_count == 1 ? QStringLiteral("Audio In")
+                                          : QStringLiteral("Audio In %1").arg(i + 1));
           if(i == 0 && name.toLower() == "audio input")
             name = "Audio In";
           auto inlet = new Process::AudioInlet(
@@ -1362,14 +1455,16 @@ void Model::createControls(bool loading)
     auto output_count = audio_ports->count(m_plugin->plugin, false);
     for(uint32_t i = 0; i < output_count; ++i)
     {
-      clap_audio_port_info_t info;
+      clap_audio_port_info_t info{};
       if(audio_ports->get(m_plugin->plugin, i, false, &info))
       {
         m_supports64 &= (info.flags & CLAP_AUDIO_PORT_SUPPORTS_64BITS);
 
         if(!loading)
         {
-          auto name = QString::fromUtf8(info.name);
+          QString name = clap_safe_name(
+              info.name, output_count == 1 ? QStringLiteral("Audio Out")
+                                           : QStringLiteral("Audio Out %1").arg(i + 1));
           if(i == 0 && name.toLower() == "audio output")
             name = "Audio Out";
           auto outlet = new Process::AudioOutlet(
@@ -1397,12 +1492,14 @@ void Model::createControls(bool loading)
     uint32_t input_count = note_ports->count(m_plugin->plugin, true);
     for(uint32_t i = 0; i < input_count; ++i)
     {
-      clap_note_port_info_t info;
+      clap_note_port_info_t info{};
       if(note_ports->get(m_plugin->plugin, i, true, &info))
       {
         if(!loading)
         {
-          auto name = QString::fromUtf8(info.name);
+          QString name = clap_safe_name(
+              info.name, input_count == 1 ? QStringLiteral("MIDI In")
+                                          : QStringLiteral("MIDI In %1").arg(i + 1));
           if(i == 0 && name.toLower() == "midi input")
             name = "MIDI In";
           auto inlet = new Process::MidiInlet(
@@ -1417,12 +1514,14 @@ void Model::createControls(bool loading)
     uint32_t output_count = note_ports->count(m_plugin->plugin, false);
     for(uint32_t i = 0; i < output_count; ++i)
     {
-      clap_note_port_info_t info;
+      clap_note_port_info_t info{};
       if(note_ports->get(m_plugin->plugin, i, false, &info))
       {
         if(!loading)
         {
-          auto name = QString::fromUtf8(info.name);
+          QString name = clap_safe_name(
+              info.name, output_count == 1 ? QStringLiteral("MIDI Out")
+                                           : QStringLiteral("MIDI Out %1").arg(i + 1));
           if(i == 0 && name.toLower() == "midi output")
             name = "MIDI Out";
           auto outlet = new Process::MidiOutlet(
@@ -1444,7 +1543,7 @@ void Model::createControls(bool loading)
     uint32_t param_count = params->count(m_plugin->plugin);
     for(uint32_t i = 0; i < param_count; ++i)
     {
-      clap_param_info_t info;
+      clap_param_info_t info{};
       if(params->get_info(m_plugin->plugin, i, &info))
       {
         if(info.flags & CLAP_PARAM_IS_HIDDEN)
@@ -1453,15 +1552,15 @@ void Model::createControls(bool loading)
         {
           if(!loading)
           {
+            const QString param_name = clap_safe_name(
+                info.name, QStringLiteral("Param %1").arg(i + 1));
             Process::ControlInlet* inlet{};
             if(info.flags & CLAP_PARAM_IS_STEPPED)
               inlet = new Process::IntSlider(
-                  QString::fromUtf8(info.name), Id<Process::Port>(getStrongId(m_inlets)),
-                  this);
+                  param_name, Id<Process::Port>(getStrongId(m_inlets)), this);
             else
               inlet = new Process::FloatSlider(
-                  QString::fromUtf8(info.name), Id<Process::Port>(getStrongId(m_inlets)),
-                  this);
+                  param_name, Id<Process::Port>(getStrongId(m_inlets)), this);
 
             setupControlInlet(*params, info, i, inlet);
 
@@ -1482,10 +1581,11 @@ void Model::createControls(bool loading)
         {
           if(!loading)
           {
+            const QString param_name = clap_safe_name(
+                info.name, QStringLiteral("Out %1").arg(i + 1));
             Process::ControlOutlet* port{};
             port = new Process::Bargraph(
-                QString::fromUtf8(info.name), Id<Process::Port>(getStrongId(m_outlets)),
-                this);
+                param_name, Id<Process::Port>(getStrongId(m_outlets)), this);
 
             setupControlOutlet(*params, info, i, port);
 
@@ -1505,6 +1605,12 @@ void Model::createControls(bool loading)
       }
     }
   }
+
+  m_plugin->param_outs_by_id.clear();
+  m_plugin->param_outs_by_id.reserve(m_plugin->m_parameters_outs.size());
+  for(std::size_t i = 0; i < m_plugin->m_parameters_outs.size(); ++i)
+    m_plugin->param_outs_by_id.emplace(
+        m_plugin->m_parameters_outs[i].id, static_cast<std::uint32_t>(i));
 
   inletsChanged();
   outletsChanged();
@@ -1876,10 +1982,180 @@ void apply_value_at(Model& self, std::size_t idx, double v)
 }
 } // namespace
 
+void Model::refreshParamValues()
+{
+  if(!m_plugin || !m_plugin->plugin)
+    return;
+  auto* plugin = m_plugin->plugin;
+  auto params = m_plugin->ext_params;
+  if(!params || !params->get_value)
+    return;
+
+  std::size_t inlet_idx = 0;
+  for(auto* inlet : inlets())
+  {
+    if(auto* control = qobject_cast<Process::ControlInlet*>(inlet))
+    {
+      if(inlet_idx < m_plugin->m_parameters_ins.size())
+      {
+        const auto& info = m_plugin->m_parameters_ins[inlet_idx];
+        double v = 0.0;
+        if(params->get_value(plugin, info.id, &v))
+        {
+          currentlyReadingValues = true;
+          control->setValue(v);
+          currentlyReadingValues = false;
+        }
+      }
+      ++inlet_idx;
+    }
+  }
+
+  std::size_t outlet_idx = 0;
+  for(auto* outlet : outlets())
+  {
+    if(auto* control = qobject_cast<Process::ControlOutlet*>(outlet))
+    {
+      if(outlet_idx < m_plugin->m_parameters_outs.size())
+      {
+        const auto& info = m_plugin->m_parameters_outs[outlet_idx];
+        double v = 0.0;
+        if(params->get_value(plugin, info.id, &v))
+        {
+          currentlyReadingValues = true;
+          control->setValue(v);
+          currentlyReadingValues = false;
+        }
+      }
+      ++outlet_idx;
+    }
+  }
+}
+
+bool Model::refreshParamInfoIfStable()
+{
+  if(!m_plugin || !m_plugin->plugin)
+    return true;
+  auto* plugin = m_plugin->plugin;
+  auto params = m_plugin->ext_params;
+  if(!params || !params->count || !params->get_info)
+    return true;
+
+  const uint32_t new_count = params->count(plugin);
+  const std::size_t old_count
+      = m_plugin->m_parameters_ins.size() + m_plugin->m_parameters_outs.size();
+  if(new_count != old_count)
+    return false;
+
+  std::size_t in_idx = 0, out_idx = 0;
+  for(uint32_t i = 0; i < new_count; ++i)
+  {
+    clap_param_info_t info{};
+    if(!params->get_info(plugin, i, &info))
+      return false;
+    if(info.flags & CLAP_PARAM_IS_HIDDEN)
+      continue;
+    if(!(info.flags & CLAP_PARAM_IS_READONLY))
+    {
+      if(in_idx >= m_plugin->m_parameters_ins.size())
+        return false;
+      if(m_plugin->m_parameters_ins[in_idx].id != info.id)
+        return false;
+      m_plugin->m_parameters_ins[in_idx] = info;
+      ++in_idx;
+    }
+    else
+    {
+      if(out_idx >= m_plugin->m_parameters_outs.size())
+        return false;
+      if(m_plugin->m_parameters_outs[out_idx].id != info.id)
+        return false;
+      m_plugin->m_parameters_outs[out_idx] = info;
+      ++out_idx;
+    }
+  }
+  if(in_idx != m_plugin->m_parameters_ins.size()
+     || out_idx != m_plugin->m_parameters_outs.size())
+    return false;
+
+  // Don't re-invoke setupControlInlet: it would duplicate valueChanged connections.
+  std::size_t inlet_idx = 0, outlet_idx = 0;
+  for(auto* inlet : inlets())
+  {
+    if(auto* ctl = qobject_cast<Process::ControlInlet*>(inlet))
+    {
+      if(inlet_idx < m_plugin->m_parameters_ins.size())
+      {
+        const auto& info = m_plugin->m_parameters_ins[inlet_idx];
+        ctl->setName(clap_safe_name(
+            info.name, QStringLiteral("Param %1").arg(inlet_idx + 1)));
+        ctl->setDomain(ossia::make_domain(info.min_value, info.max_value));
+      }
+      ++inlet_idx;
+    }
+  }
+  for(auto* outlet : outlets())
+  {
+    if(auto* ctl = qobject_cast<Process::ControlOutlet*>(outlet))
+    {
+      if(outlet_idx < m_plugin->m_parameters_outs.size())
+      {
+        const auto& info = m_plugin->m_parameters_outs[outlet_idx];
+        ctl->setName(clap_safe_name(
+            info.name, QStringLiteral("Out %1").arg(outlet_idx + 1)));
+        ctl->setDomain(ossia::make_domain(info.min_value, info.max_value));
+      }
+      ++outlet_idx;
+    }
+  }
+  return true;
+}
+
+void Model::onParamRescan(clap_param_rescan_flags flags)
+{
+  if(!m_plugin || !m_plugin->plugin)
+    return;
+
+  // RESCAN_ALL needs deactivation; defer if executing.
+  if((flags & CLAP_PARAM_RESCAN_ALL) && executing())
+  {
+    m_pendingRescanFlags |= flags;
+    return;
+  }
+
+  // RESCAN_TEXT: nothing cached, display strings fetched on demand.
+  (void)CLAP_PARAM_RESCAN_TEXT;
+
+  if(flags & CLAP_PARAM_RESCAN_INFO)
+  {
+    if(!refreshParamInfoIfStable())
+      flags |= CLAP_PARAM_RESCAN_ALL;
+  }
+
+  if(flags & CLAP_PARAM_RESCAN_ALL)
+  {
+    if(refreshParamInfoIfStable())
+    {
+      refreshParamValues();
+      return;
+    }
+    // FIXME score does not rebuild inlets dynamically (see VST2/VST3 backends).
+    qWarning() << "CLAP: parameter layout changed at runtime for"
+               << m_pluginId
+               << "— score doesn't yet rebuild inlets dynamically. "
+                  "Remove and re-add the plug-in to pick up the new "
+                  "parameter set.";
+    restartPlugin();
+    return;
+  }
+
+  if(flags & CLAP_PARAM_RESCAN_VALUES)
+    refreshParamValues();
+}
+
 void Model::markStateDirty()
 {
-  // Plug-ins spam this — Vital, Surge XT etc. fire it on every parameter
-  // tweak from their own UI. Snapshot at most once per ~400 ms.
+  // Plug-ins (Vital, Surge XT) fire this on every UI tweak; debounce.
   constexpr int kStateDirtyDebounceMs = 400;
 
   if(!m_stateDirtyTimer)
@@ -1910,10 +2186,6 @@ void Model::flushFromPluginToHost()
   if(this->executing())
     return;
 
-  // The plugin asked the host to flush so it can deliver its accumulated
-  // parameter change events. We have nothing to send it; provide an empty
-  // input list and route its CLAP_EVENT_PARAM_VALUE events to the matching
-  // inlets (writable params) or outlets (read-only params).
   ParamInputCtx in_ctx; // empty
   clap_input_events_t ip = make_input_events(in_ctx);
 

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
@@ -945,6 +945,20 @@ void PluginHandle::load(Model& context, QByteArray path, QByteArray id)
 {
   this->model = &context;
 
+  // Helper to roll back partial-load state. CLAP entry init/deinit is
+  // refcounted (see clap/entry.h): we must NOT call deinit unless init
+  // returned true, otherwise we corrupt the refcount and eventually crash
+  // other plug-ins that share the .clap bundle. Same idea for
+  // dlclose(library) — only meaningful if dlopen succeeded.
+  auto rollback = [this](bool entry_inited) {
+    if(!entry_inited)
+      entry = nullptr;
+    if(!library)
+      return;
+    // If we never reached entry->init() successfully, don't deinit; just
+    // release the library handle so ~PluginHandle doesn't redo it.
+  };
+
   // Load the library
 #if defined(_WIN32)
   library = LoadLibraryA(path.data());
@@ -958,8 +972,21 @@ void PluginHandle::load(Model& context, QByteArray path, QByteArray id)
   entry = (const clap_plugin_entry_t*)dlsym(library, "clap_entry");
 #endif
 
-  if(!entry || !entry->init(path.data()))
+  if(!entry)
+  {
+    // No clap_entry symbol — drop the library handle and bail.
+    rollback(false);
     return;
+  }
+
+  if(!entry->init(path.data()))
+  {
+    // init() failed: entry pointer is valid but the DSO is uninitialized,
+    // so we must NOT call entry->deinit() later. Forget the entry pointer
+    // so ~PluginHandle's `if(entry) entry->deinit();` is skipped.
+    rollback(false);
+    return;
+  }
 
   factory = (const clap_plugin_factory_t*)entry->get_factory(CLAP_PLUGIN_FACTORY_ID);
   if(!factory)

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
@@ -372,13 +372,16 @@ static constexpr clap_host_posix_fd_support_t host_posix_fd_ext = {
     .register_fd = register_fd, .modify_fd = modify_fd, .unregister_fd = unregister_fd};
 
 static constexpr clap_host_state_t host_state_ext
-    = {.mark_dirty = [](const clap_host_t*) {
-  // qDebug(Q_FUNC_INFO);
-  // TODO
-
-  // FIXME likely we want to accumulate and serialize the state of the plugin
-  // so that we can restore in case of a crash.
-  // But plug-ins may spam things so we need some debounce.
+    = {.mark_dirty = [](const clap_host_t* host) {
+  // [main-thread] per CLAP spec. The plug-in says its state changed
+  // (typically because the user manipulated its own UI). Forward to the
+  // model, which debounces and snapshots. Plug-ins are known to spam
+  // this — Vital fires it multiple times per knob movement — so the
+  // debounce is mandatory.
+  auto& m = *static_cast<Clap::PluginHandle*>(host->host_data);
+  if(!m.model)
+    return;
+  m.model->markStateDirty();
 }};
 static constexpr clap_host_params_t host_params_ext
     = {.rescan = [](const clap_host_t* host, clap_param_rescan_flags flags) {
@@ -1872,6 +1875,28 @@ void apply_value_at(Model& self, std::size_t idx, double v)
   }
 }
 } // namespace
+
+void Model::markStateDirty()
+{
+  // Plug-ins spam this — Vital, Surge XT etc. fire it on every parameter
+  // tweak from their own UI. Snapshot at most once per ~400 ms.
+  constexpr int kStateDirtyDebounceMs = 400;
+
+  if(!m_stateDirtyTimer)
+  {
+    m_stateDirtyTimer = new QTimer(this);
+    m_stateDirtyTimer->setSingleShot(true);
+    m_stateDirtyTimer->setInterval(kStateDirtyDebounceMs);
+    connect(m_stateDirtyTimer, &QTimer::timeout, this, [this] {
+      if(!m_plugin || !m_plugin->plugin)
+        return;
+      QByteArray blob = Clap::readCLAPState(*m_plugin->plugin);
+      if(!blob.isEmpty())
+        stateSnapshotChanged(blob);
+    });
+  }
+  m_stateDirtyTimer->start();
+}
 
 void Model::flushFromPluginToHost()
 {

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
@@ -411,10 +411,14 @@ static constexpr clap_host_gui_t host_gui_ext
        .request_hide = request_hide,
        .closed = closed};
 
+// [main-thread] — plug-in queries the enclosing track's name/colour. We
+// look up the closest parent interval and report its metadata. This is
+// what AIDA-X et al. show in the title bar.
 static constexpr clap_host_track_info_t host_track_info_ext
     = {.get = [](const clap_host_t* host, clap_track_info_t* info) -> bool {
   auto& m = *static_cast<Clap::PluginHandle*>(host->host_data);
-  return false;
+  if(!m.model || !info)
+    return false;
   auto* parent = Scenario::closestParentInterval(m.model);
   if(!parent)
     return false;
@@ -749,10 +753,6 @@ PluginHandle::PluginHandle()
       return &host_context_menu_ext;
     if(strcmp(extension_id, "clap.context-menu.draft/0") == 0)
       return &host_context_menu_ext;
-    if(strcmp(extension_id, CLAP_EXT_PRESET_LOAD) == 0)
-      return &host_preset_load_ext;
-    if(strcmp(extension_id, "clap.preset-load.draft/2") == 0)
-      return &host_preset_load_ext;
     return nullptr;
   };
   host.request_restart = [](const clap_host* host) {

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.cpp
@@ -756,15 +756,40 @@ PluginHandle::PluginHandle()
     return nullptr;
   };
   host.request_restart = [](const clap_host* host) {
+    // Per clap/host.h: deactivate then reactivate the plug-in. This is
+    // [thread-safe] but the actual deactivate/activate must run on the
+    // main thread. We refuse to do the cycle while score is executing —
+    // a live audio thread is using the plug-in in CLAP-active state, and
+    // tearing it down underneath would race with process(). The plug-in
+    // sees the request as deferred (per spec it may be delayed by the
+    // host), and will get the restart on the next stop transition.
     auto& m = *static_cast<Clap::PluginHandle*>(host->host_data);
     if(!m.model)
       return;
-    QMetaObject::invokeMethod(m.model, [handle = std::weak_ptr{m.model->handle()}] {
-      if(auto h = handle.lock())
+    QMetaObject::invokeMethod(m.model, [model = QPointer<Model>{m.model}] {
+      if(!model)
+        return;
+      if(model->executing())
+        return;
+      auto h = model->handle();
+      if(!h || !h->plugin)
+        return;
+
+      const auto plug = h->plugin;
+      if(h->activated)
       {
-        // FIXME implement restart
-        auto plug = h->plugin;
-        plug->on_main_thread(plug);
+        plug->deactivate(plug);
+        h->activated = false;
+      }
+      // Re-activate with the rate/buffer the executor was last using.
+      // We don't have an audio context outside of execution, so fall
+      // back to the standard 44.1k / 1024 frames if nothing else is
+      // known (matches DPF's d_nextSampleRate fallback).
+      const double sr = 44100.0;
+      const uint32_t bs = 1024;
+      if(plug->activate(plug, sr, 1, bs))
+      {
+        h->activated = true;
       }
     }, Qt::QueuedConnection);
   };

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.hpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.hpp
@@ -9,6 +9,7 @@
 #include <score/serialization/DataStreamVisitor.hpp>
 #include <score/serialization/JSONVisitor.hpp>
 
+#include <ossia/detail/flat_map.hpp>
 #include <ossia/detail/hash_map.hpp>
 
 #include <QSocketNotifier>
@@ -53,7 +54,7 @@ struct PluginHandle
   const clap_plugin_t* plugin{};
   const clap_plugin_descriptor_t* desc{};
 
-  clap_host_t host;
+  clap_host_t host{};
 
   // Common plugin extensions
   const clap_plugin_params_t* ext_params{};
@@ -66,6 +67,8 @@ struct PluginHandle
   std::vector<clap_audio_port_info_t> m_audio_outs;
   std::vector<clap_note_port_info_t> m_midi_ins;
   std::vector<clap_note_port_info_t> m_midi_outs;
+
+  ossia::flat_map<clap_id, std::uint32_t> param_outs_by_id;
 
   QPointer<Model> model;
 
@@ -157,8 +160,6 @@ public:
 
   bool currentlyReadingValues{};
 
-  // Per-parameter gesture state for debounced
-  // CLAP_EVENT_PARAM_GESTURE_BEGIN / _END wrapping around live GUI changes.
   struct GestureState
   {
     QTimer* endTimer{};
@@ -167,19 +168,19 @@ public:
   };
   ossia::hash_map<clap_id, GestureState> gestures;
 
-  // CLAP host.state.mark_dirty bridge: the plug-in calls it when its
-  // internal state has drifted from the last value the host saw (e.g.
-  // user manipulated the plug-in's own UI). We debounce because some
-  // plug-ins call mark_dirty several times per second, then snapshot
-  // the state once and emit stateSnapshotChanged so the document layer
-  // (or any future crash-recovery system) can react.
   void markStateDirty();
   void stateSnapshotChanged(const QByteArray& blob)
       W_SIGNAL(stateSnapshotChanged, blob);
 
+  void onParamRescan(clap_param_rescan_flags flags);
+
 private:
   void loadPlugin();
   void createControls(bool loading);
+
+  void refreshParamValues();
+  // Returns false on structural mismatch — caller should treat as RESCAN_ALL.
+  bool refreshParamInfoIfStable();
   void setupControlInlet(
       const clap_plugin_params_t&, const clap_param_info_t& info, int index,
       Process::ControlInlet* ctl);
@@ -190,8 +191,6 @@ private:
   void sendParamChange(const clap_param_info_t& info, double value);
   void endGesture(clap_id param_id, void* cookie);
 
-  // Debounce timer for markStateDirty(); created lazily on first
-  // mark_dirty call and parented to *this for automatic Qt cleanup.
   QTimer* m_stateDirtyTimer{};
 
   QString m_pluginPath;
@@ -201,6 +200,8 @@ private:
   QByteArray m_loadedState;
 
   bool m_supports64{};
+
+  clap_param_rescan_flags m_pendingRescanFlags{};
 };
 }
 

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.hpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.hpp
@@ -167,6 +167,16 @@ public:
   };
   ossia::hash_map<clap_id, GestureState> gestures;
 
+  // CLAP host.state.mark_dirty bridge: the plug-in calls it when its
+  // internal state has drifted from the last value the host saw (e.g.
+  // user manipulated the plug-in's own UI). We debounce because some
+  // plug-ins call mark_dirty several times per second, then snapshot
+  // the state once and emit stateSnapshotChanged so the document layer
+  // (or any future crash-recovery system) can react.
+  void markStateDirty();
+  void stateSnapshotChanged(const QByteArray& blob)
+      W_SIGNAL(stateSnapshotChanged, blob);
+
 private:
   void loadPlugin();
   void createControls(bool loading);
@@ -179,6 +189,10 @@ private:
 
   void sendParamChange(const clap_param_info_t& info, double value);
   void endGesture(clap_id param_id, void* cookie);
+
+  // Debounce timer for markStateDirty(); created lazily on first
+  // mark_dirty call and parented to *this for automatic Qt cleanup.
+  QTimer* m_stateDirtyTimer{};
 
   QString m_pluginPath;
   QString m_pluginId;

--- a/src/plugins/score-plugin-clap/Clap/EffectModel.hpp
+++ b/src/plugins/score-plugin-clap/Clap/EffectModel.hpp
@@ -157,6 +157,16 @@ public:
 
   bool currentlyReadingValues{};
 
+  // Per-parameter gesture state for debounced
+  // CLAP_EVENT_PARAM_GESTURE_BEGIN / _END wrapping around live GUI changes.
+  struct GestureState
+  {
+    QTimer* endTimer{};
+    bool active{};
+    void* cookie{};
+  };
+  ossia::hash_map<clap_id, GestureState> gestures;
+
 private:
   void loadPlugin();
   void createControls(bool loading);
@@ -166,6 +176,9 @@ private:
   void setupControlOutlet(
       const clap_plugin_params_t&, const clap_param_info_t& info, int index,
       Process::ControlOutlet* ctl);
+
+  void sendParamChange(const clap_param_info_t& info, double value);
+  void endGesture(clap_id param_id, void* cookie);
 
   QString m_pluginPath;
   QString m_pluginId;

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -285,78 +285,63 @@ public:
 
   void init_parameter_values(const clap_plugin_t* plugin)
   {
-    if(!plugin)
+    if(!plugin || m_param_ins.empty())
       return;
 
-    int param_i = 0;
-    // Get parameter extension to set initial values
-    for(const auto& param_info : m_param_ins)
+    // Push initial parameter values via clap.params.flush, not process().
+    // process() requires the plugin's declared audio port layout (a plugin may
+    // assert on it, e.g. Floe), and the spec reserves process() for actual
+    // audio rendering; flush() exists precisely to set parameters with no
+    // audio. We're on the audio thread, active and not concurrently
+    // processing, which is a legal context for flush.
+    auto params = static_cast<const clap_plugin_params_t*>(
+        plugin->get_extension(plugin, CLAP_EXT_PARAMS));
+    if(!params || !params->flush)
+      return;
+
+    event_storage in;
+    in.param_events.reserve(m_param_ins.size());
+    in.all_events.reserve(m_param_ins.size());
+    for(std::size_t i = 0; i < m_param_ins.size(); ++i)
     {
-      // Create parameter value event with default value
-      clap_event_param_value_t param_event{};
-      param_event.header.size = sizeof(clap_event_param_value_t);
-      param_event.header.time = 0;
-      param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-      param_event.header.type = CLAP_EVENT_PARAM_VALUE;
-      param_event.header.flags = 0;
-      param_event.param_id = param_info.id;
-      param_event.cookie = param_info.cookie;
-      param_event.note_id = -1;
-      param_event.port_index = -1;
-      param_event.channel = -1;
-      param_event.key = -1;
-      auto& v = parameter_ins[param_i]->data.get_data();
-      if(!v.empty())
-        param_event.value = ossia::convert<float>(v.back().value);
-      else
-        param_event.value = param_info.default_value;
-      param_i++;
-
-      // Create temporary input events structure to send the parameter
-      event_storage temp_events;
-      temp_events.param_events.push_back(param_event);
-      temp_events.all_events.push_back(
-          reinterpret_cast<clap_event_header_t*>(&temp_events.param_events.back()));
-
-      // Create input events interface
-      clap_input_events evs{
-          .ctx = &temp_events,
-          .size = +[](const clap_input_events* list) -> uint32_t {
-        auto* storage = static_cast<event_storage*>(list->ctx);
-        return storage->all_events.size();
-      },
-          .get = +[](const clap_input_events* list,
-                     uint32_t index) -> const clap_event_header_t* {
-        auto* storage = static_cast<event_storage*>(list->ctx);
-        if(index < storage->all_events.size())
-          return storage->all_events[index];
-        return nullptr;
-      }};
-
-      // Create dummy output events
-      event_storage temp_output;
-      clap_output_events_t o_evs{
-          .ctx = &temp_output,
-          .try_push = [](const struct clap_output_events* list,
-                         const clap_event_header_t* event) -> bool {
-        return false; // Ignore output events during initialization
-      }};
-
-      // Create minimal process structure just for parameter setting
-      clap_process_t process{};
-      process.frames_count = 0;
-      process.audio_inputs = nullptr;
-      process.audio_outputs = nullptr;
-      process.audio_inputs_count = 0;
-      process.audio_outputs_count = 0;
-      process.steady_time = -1;
-      process.in_events = &evs;
-      process.out_events = &o_evs;
-      process.transport = nullptr;
-
-      // Send the parameter to the plugin
-      plugin->process(plugin, &process);
+      const auto& param_info = m_param_ins[i];
+      clap_event_param_value_t ev{};
+      ev.header.size = sizeof(clap_event_param_value_t);
+      ev.header.time = 0;
+      ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+      ev.header.type = CLAP_EVENT_PARAM_VALUE;
+      ev.header.flags = 0;
+      ev.param_id = param_info.id;
+      ev.cookie = param_info.cookie;
+      ev.note_id = -1;
+      ev.port_index = -1;
+      ev.channel = -1;
+      ev.key = -1;
+      const auto& v = parameter_ins[i]->data.get_data();
+      ev.value = v.empty() ? param_info.default_value
+                           : ossia::convert<float>(v.back().value);
+      in.param_events.push_back(ev);
     }
+    for(auto& ev : in.param_events)
+      in.all_events.push_back(reinterpret_cast<clap_event_header_t*>(&ev));
+
+    clap_input_events evs{
+        .ctx = &in,
+        .size = +[](const clap_input_events* list) -> uint32_t {
+      return static_cast<event_storage*>(list->ctx)->all_events.size();
+    },
+        .get = +[](const clap_input_events* list,
+                   uint32_t index) -> const clap_event_header_t* {
+      auto* storage = static_cast<event_storage*>(list->ctx);
+      return index < storage->all_events.size() ? storage->all_events[index]
+                                                : nullptr;
+    }};
+    clap_output_events_t o_evs{
+        .ctx = nullptr,
+        .try_push = [](const struct clap_output_events*,
+                       const clap_event_header_t*) -> bool { return false; }};
+
+    params->flush(plugin, &evs, &o_evs);
   }
 
   [[nodiscard]]

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -7,14 +7,17 @@
 #include <ossia/dataflow/execution_state.hpp>
 #include <ossia/dataflow/graph_node.hpp>
 #include <ossia/dataflow/port.hpp>
+#include <ossia/detail/lockfree_queue.hpp>
 
 #include <QCoreApplication>
 #include <QDebug>
 #include <QThread>
 #include <QTimer>
 
+#include <clap/ext/state.h>
 #include <libremidi/detail/conversion.hpp>
 
+#include <atomic>
 #include <ranges>
 
 #if defined(_WIN32)
@@ -25,6 +28,72 @@
 
 namespace Clap
 {
+namespace
+{
+// Snapshot a plug-in's state via clap.state (returns empty if the plug-in
+// doesn't implement the extension). [main-thread]
+inline QByteArray snapshot_clap_state(const clap_plugin_t* plugin)
+{
+  QByteArray out;
+  if(!plugin)
+    return out;
+  auto state = static_cast<const clap_plugin_state_t*>(
+      plugin->get_extension(plugin, CLAP_EXT_STATE));
+  if(!state || !state->save)
+    return out;
+
+  clap_ostream_t stream{};
+  stream.ctx = &out;
+  stream.write
+      = [](const clap_ostream_t* s, const void* buf, uint64_t sz) -> int64_t {
+    auto* b = static_cast<QByteArray*>(s->ctx);
+    const auto old = b->size();
+    b->resize(old + sz);
+    std::memcpy(b->data() + old, buf, sz);
+    return static_cast<int64_t>(sz);
+  };
+
+  if(!state->save(plugin, &stream))
+    out.clear();
+  return out;
+}
+
+// Apply a previously-captured snapshot to a fresh plug-in instance.
+// [main-thread]
+inline void apply_clap_state(const clap_plugin_t* plugin, const QByteArray& blob)
+{
+  if(!plugin || blob.isEmpty())
+    return;
+  auto state = static_cast<const clap_plugin_state_t*>(
+      plugin->get_extension(plugin, CLAP_EXT_STATE));
+  if(!state || !state->load)
+    return;
+
+  struct read_ctx
+  {
+    const char* data;
+    qsizetype size;
+    qsizetype pos;
+  } ctx{blob.constData(), blob.size(), 0};
+
+  clap_istream_t stream{};
+  stream.ctx = &ctx;
+  stream.read
+      = [](const clap_istream_t* s, void* buf, uint64_t sz) -> int64_t {
+    auto* c = static_cast<read_ctx*>(s->ctx);
+    const auto remaining = c->size - c->pos;
+    if(remaining <= 0)
+      return 0;
+    const auto to_read = std::min<int64_t>(sz, remaining);
+    std::memcpy(buf, c->data + c->pos, to_read);
+    c->pos += to_read;
+    return to_read;
+  };
+
+  state->load(plugin, &stream);
+}
+}
+
 static auto dummy_audio_buffer() noexcept
 {
   clap_audio_buffer_t buffer{};
@@ -124,8 +193,6 @@ public:
   { //FIXME
     return "clap";
   }
-
-  virtual void reset_execution() = 0;
 
   [[nodiscard]] bool activate_plugin(
       const clap_plugin_t* plugin, double sample_rate, uint32_t max_buffer_size)
@@ -472,6 +539,28 @@ public:
     });
   }
 
+  // Forward any CLAP_EVENT_PARAM_VALUE events the plugin emitted during
+  // process() to the matching `parameter_outs` value_outlet so downstream
+  // ossia nodes (and the GUI bargraphs) see live values.
+  void dispatch_param_outputs()
+  {
+    if(m_output_events.param_events.empty() || m_param_outs.empty())
+      return;
+
+    for(const auto& ev : m_output_events.param_events)
+    {
+      for(std::size_t i = 0; i < m_param_outs.size(); ++i)
+      {
+        if(m_param_outs[i].id == ev.param_id && i < parameter_outs.size())
+        {
+          parameter_outs[i]->data.write_value(
+              ossia::value{ev.value}, static_cast<int64_t>(ev.header.time));
+          break;
+        }
+      }
+    }
+  }
+
   ossia::small_vector<ossia::audio_inlet*, 2> audio_ins;
   ossia::small_vector<ossia::audio_outlet*, 2> audio_outs;
   ossia::small_vector<ossia::midi_inlet*, 2> midi_ins;
@@ -513,17 +602,8 @@ public:
   ~clap_node()
   {
     // We do not deactivate in the audio thread where the dtor of clap_node runs
-    // but later in the main thread
-  }
-
-  void reset_execution() override
-  {
-    // FIXME wrong thread
-    if(m_activated)
-    {
-      (void)deactivate_plugin(m_instance.plugin);
-      m_activated = false;
-    }
+    // but later in the main thread (driven by Model::resetExecution / ~Model
+    // through the synced handle.activated flag set in the constructor).
   }
 
   void do_process(
@@ -555,20 +635,38 @@ public:
         .try_push = [](const struct clap_output_events* list,
                        const clap_event_header_t* event) -> bool {
       auto* storage = static_cast<event_storage*>(list->ctx);
-      if(event->type == CLAP_EVENT_MIDI && event->size == sizeof(clap_event_midi_t))
+      if(!event || event->space_id != CLAP_CORE_EVENT_SPACE_ID)
+        return false;
+      switch(event->type)
       {
-        storage->midi_events.push_back(
-            *reinterpret_cast<const clap_event_midi_t*>(event));
-        return true;
+        case CLAP_EVENT_MIDI:
+          if(event->size >= sizeof(clap_event_midi_t))
+          {
+            storage->midi_events.push_back(
+                *reinterpret_cast<const clap_event_midi_t*>(event));
+            return true;
+          }
+          return false;
+        case CLAP_EVENT_PARAM_VALUE:
+          if(event->size >= sizeof(clap_event_param_value_t))
+          {
+            storage->param_events.push_back(
+                *reinterpret_cast<const clap_event_param_value_t*>(event));
+            return true;
+          }
+          return false;
+        default:
+          // FIXME notes, note-end, etc.
+          return false;
       }
-      // FIXME else if note...
-      return false;
     }};
 
     process.in_events = &evs;
     process.out_events = &o_evs;
 
     m_instance.plugin->process(m_instance.plugin, &process);
+
+    dispatch_param_outputs();
 
     // Process MIDI output
     std::size_t midi_port_index = 0;
@@ -739,22 +837,17 @@ public:
       audio_out_idx++;
     }
 
-    // Process audio through CLAP plugin
+    // Ensure we have exactly the number of buffers the plugin expects
+    // *before* taking .data() pointers below.
+    while(input_buffers.size() < m_expected_audio_inputs.size())
+      input_buffers.push_back(dummy_audio_buffer());
+    while(output_buffers.size() < m_expected_audio_outputs.size())
+      output_buffers.push_back(dummy_audio_buffer());
+
     clap_process_t process{};
     process.frames_count = samples;
     process.audio_inputs = input_buffers.data();
     process.audio_outputs = output_buffers.data();
-    // Ensure we have exactly the number of buffers the plugin expects
-    while(input_buffers.size() < m_expected_audio_inputs.size())
-    {
-      input_buffers.push_back(dummy_audio_buffer());
-    }
-
-    while(output_buffers.size() < m_expected_audio_outputs.size())
-    {
-      output_buffers.push_back(dummy_audio_buffer());
-    }
-
     process.audio_inputs_count = m_expected_audio_inputs.size();
     process.audio_outputs_count = m_expected_audio_outputs.size();
     do_process(process, m_input_events, m_output_events);
@@ -767,10 +860,14 @@ public:
       {
         auto& channels = audio_out->data.get();
         const auto& storage = output_channel_storage[audio_out_idx];
+        const uint32_t plugin_channels
+            = m_expected_audio_outputs[audio_out_idx].channel_count;
 
-        if(audio_out_idx == 0 && needs_stereo_main_out)
+        if(audio_out_idx == 0 && needs_stereo_main_out && plugin_channels == 1)
         {
-          // Basic mono instrument case (e.g. Nekobi)
+          // Basic mono instrument case (e.g. Nekobi): duplicate L → R only
+          // when the plugin's main out is actually mono. For ≥2-channel
+          // outs the second channel holds valid audio.
           const float* src = storage.data();
           double* dst_l = channels[0].data() + offset;
           double* dst_r = channels[1].data() + offset;
@@ -782,15 +879,14 @@ public:
         }
         else
         {
-          for(uint32_t c = 0;
-              c < std::min((uint32_t)channels.size(), (uint32_t)storage.size()); ++c)
+          const uint32_t channel_max
+              = std::min<uint32_t>(channels.size(), plugin_channels);
+          for(uint32_t c = 0; c < channel_max; ++c)
           {
             const float* src = storage.data() + c * samples;
             double* dst = channels[c].data() + offset;
             for(uint32_t s = 0; s < samples; ++s)
-            {
               dst[s] = static_cast<double>(src[s]);
-            }
           }
         }
       }
@@ -849,8 +945,8 @@ public:
       auto& channels = audio_in->data.get();
       if(!channels.empty())
       {
-        buffer.channel_count = std::min((uint32_t)channels.size(), 2u);
-
+        // Pass exactly what the plugin expects. The previous code clamped
+        // this to 2 channels, dropping surround / multi-channel inputs.
         auto& ptrs = input_channel_ptrs.emplace_back();
         ptrs.resize(buffer.channel_count);
 
@@ -859,8 +955,7 @@ public:
           if(c < channels.size())
           {
             auto& channel = channels[c];
-            //SCORE_SOFT_ASSERT(channel.size() >= e.bufferSize());
-            channel.resize(std::max((int)channel.size(), (int)e.bufferSize()));
+            channel.resize(std::max<std::size_t>(channel.size(), e.bufferSize()));
             ptrs[c] = const_cast<double*>(channels[c].data() + offset);
           }
           else
@@ -910,23 +1005,28 @@ public:
       audio_out_idx++;
     }
 
+    // Pad both buffer lists *before* taking .data() pointers so we don't
+    // hand the plugin a stale pointer after a reallocation, and so the two
+    // counts actually match what the plugin is told below.
+    while(this->input_buffers.size() < m_expected_audio_inputs.size())
+      this->input_buffers.push_back(dummy_audio_buffer());
+    while(this->output_buffers.size() < m_expected_audio_outputs.size())
+      this->output_buffers.push_back(dummy_audio_buffer());
+
     clap_process_t process{};
     process.frames_count = samples;
     process.audio_inputs = this->input_buffers.data();
     process.audio_outputs = this->output_buffers.data();
-    while(this->input_buffers.size() < m_expected_audio_inputs.size())
-      this->input_buffers.push_back(dummy_audio_buffer());
-
-    while(this->output_buffers.size() < m_expected_audio_outputs.size())
-      this->input_buffers.push_back(dummy_audio_buffer());
-
     process.audio_inputs_count = m_expected_audio_inputs.size();
     process.audio_outputs_count = m_expected_audio_outputs.size();
     do_process(process, m_input_events, m_output_events);
 
-    if(needs_stereo_main_out)
+    // Basic mono instrument case (e.g. Nekobi): only duplicate if the plug-in
+    // really has a mono main out. For ≥2-channel outputs the right channel is
+    // valid and must not be clobbered.
+    if(needs_stereo_main_out && !m_expected_audio_outputs.empty()
+       && m_expected_audio_outputs[0].channel_count == 1)
     {
-      // Basic mono instrument case (e.g. Nekobi)
       auto& l = audio_outs[0]->data.channel(0);
       auto& r = audio_outs[0]->data.channel(1);
       r.assign(l.begin(), l.end());
@@ -938,27 +1038,65 @@ public:
 class clap_node_mono : public clap_node_base
 {
 public:
+  // Declared early so member function signatures (make_poly_instance) and the
+  // m_incoming queue declared further down can refer to it.
+  struct poly_plugin
+  {
+    const clap_plugin_t* plugin{};
+    bool activated{};
+    bool processing{};
+    operator const clap_plugin_t*() const noexcept { return plugin; }
+  };
+
   clap_node_mono(
       const Clap::Model& proc, Clap::PluginHandle& handle, int sampleRate, int bs)
       : clap_node_base{proc}
       , m_instance{handle}
       , m_plugin_id{proc.pluginId().toUtf8()}
   {
-    m_poly.reserve(8);
+    // Pre-reserve enough capacity that the dynamic grower (which feeds
+    // m_poly from the audio thread via drain_incoming → push_back) never
+    // triggers a reallocation in normal use. 256 * sizeof(poly_plugin)
+    // ≈ 4 kB up front, and covers up to 256 channels of polyphony without
+    // any audio-thread malloc; beyond that vector will still grow, just
+    // with a non-RT-friendly reallocation cost each doubling.
+    m_poly.reserve(256);
     m_poly.push_back({handle.plugin, false});
     if(handle.activated)
       (void)deactivate_plugin(handle.plugin);
     m_poly.back().activated = activate_plugin(m_instance.plugin, sampleRate, bs);
+    // Mirror the activation state on the shared handle so that
+    // Clap::Model::~Model / resetExecution can drive the deactivate of
+    // m_poly[0] from the main thread, symmetrically with clap_node.
+    handle.activated = m_poly.back().activated;
 
-    for(int i = 0; i < 7; i++)
+    // The constructor runs on the main thread, so create_plugin/init are
+    // spec-correct here. If any of the extra instances fail to construct we
+    // tear down the ones we already built so we never leak plugin handles.
+    try
     {
-      add_poly_instance(sampleRate, bs);
+      for(int i = 0; i < 7; i++)
+        add_poly_instance(sampleRate, bs);
+    }
+    catch(...)
+    {
+      destroy_extra_instances();
+      throw;
     }
   }
 
   void add_poly_instance(int sampleRate, int bs)
   {
-    poly_plugin p{nullptr, false};
+    m_poly.push_back(make_poly_instance(sampleRate, bs, /*state*/ {}));
+  }
+
+  // [main-thread] Build a fresh, init'd, activated polyphonic instance.
+  // Optionally clones state into it via clap.state (so AIDA-X & friends
+  // keep their loaded model / preset on each instance).
+  // Throws std::runtime_error on create_plugin / init failure.
+  poly_plugin make_poly_instance(int sampleRate, int bs, const QByteArray& state)
+  {
+    poly_plugin p{nullptr, false, false};
     p.plugin = m_instance.factory->create_plugin(
         m_instance.factory, &m_instance.host, m_plugin_id.data());
     if(!p.plugin)
@@ -969,49 +1107,102 @@ public:
       p.plugin->destroy(p.plugin);
       throw std::runtime_error("Could not init plug-in instance");
     }
+    // Apply the snapshot *before* activate, matching how Model::loadPlugin
+    // restores state for the primary instance.
+    apply_clap_state(p.plugin, state);
     p.activated = activate_plugin(p.plugin, sampleRate, bs);
-    m_poly.push_back(p);
+    return p;
+  }
+
+  // [audio-thread] Drain any new instances that the main-thread grower
+  // has handed us through m_incoming.
+  void drain_incoming() noexcept
+  {
+    poly_plugin p;
+    while(m_incoming.try_dequeue(p))
+      m_poly.push_back(p);
+  }
+
+  // [audio-thread] Tell the grower we need at least `n` total instances.
+  // Monotonically-increasing: a brief drop to a smaller channel count
+  // does not cause us to shrink the pool.
+  void request_pool_size(std::size_t n) noexcept
+  {
+    auto prev = m_requested_pool.load(std::memory_order_relaxed);
+    while(n > prev
+          && !m_requested_pool.compare_exchange_weak(
+              prev, n, std::memory_order_release, std::memory_order_relaxed))
+      ;
+  }
+
+  // Tear down extra polyphonic instances (skipping m_poly[0], which is
+  // owned by the Clap::Model). Used by the constructor's catch and by the
+  // destructor's queued main-thread cleanup.
+  void destroy_extra_instances() noexcept
+  {
+    for(std::size_t i = 1; i < m_poly.size(); ++i)
+    {
+      auto& p = m_poly[i];
+      if(!p.plugin)
+        continue;
+      if(p.processing)
+      {
+        p.plugin->stop_processing(p.plugin);
+        p.processing = false;
+      }
+      if(p.activated)
+      {
+        p.plugin->deactivate(p.plugin);
+        p.activated = false;
+      }
+      p.plugin->destroy(p.plugin);
+      p.plugin = nullptr;
+    }
   }
 
   ~clap_node_mono()
   {
-    for(int i = 0; i < m_poly.size(); i++)
+    // Stop any instance that was still processing. ~clap_node_mono runs on
+    // the audio thread, so stop_processing is allowed here (it is the only
+    // CLAP entry point we may call from there). Deactivation and destruction
+    // of the extra instances is deferred to the main thread below.
+    for(std::size_t i = 0; i < m_poly.size(); ++i)
     {
       if(m_poly[i].processing)
       {
-        stop_plugin(m_poly[i].plugin);
+        m_poly[i].plugin->stop_processing(m_poly[i].plugin);
         m_poly[i].processing = false;
       }
     }
 
-    // FIXME not RT-friendly
-    QMetaObject::invokeMethod(
-        QCoreApplication::instance(), [poly = std::move(m_poly)]() {
-      for(int i = 1; i < poly.size(); i++)
-      {
-        auto& p = poly[i];
-        if(p.plugin)
-        {
-          if(p.activated)
-            p.plugin->deactivate(p.plugin);
-
-          p.plugin->destroy(p.plugin);
-        }
-      }
-    });
-  }
-
-  void reset_execution() override
-  {
-    // FIXME
-    for(int i = 0; i < m_poly.size(); i++)
+    // Drain any instances the grower had pushed but the audio thread did
+    // not consume yet. They are already created/init'd/activated, so we
+    // must deactivate + destroy them on the main thread alongside m_poly.
+    std::vector<poly_plugin> pending;
     {
-      if(m_poly[i].activated)
-      {
-        (void)deactivate_plugin(m_poly[i].plugin);
-        m_poly[i].activated = false;
-      }
+      poly_plugin tmp{};
+      while(m_incoming.try_dequeue(tmp))
+        pending.push_back(tmp);
     }
+
+    // m_poly[0] is the Clap::Model's shared handle: Model::~Model and the
+    // resetExecution handler take care of deactivating it on the main
+    // thread (and they will, because the ctor synced handle.activated).
+    QMetaObject::invokeMethod(
+        QCoreApplication::instance(),
+        [poly = std::move(m_poly), pending = std::move(pending)]() mutable {
+      auto destroy = [](const poly_plugin& p) {
+        if(!p.plugin)
+          return;
+        if(p.activated)
+          p.plugin->deactivate(p.plugin);
+        p.plugin->destroy(p.plugin);
+      };
+      for(std::size_t i = 1; i < poly.size(); ++i)
+        destroy(poly[i]);
+      for(auto& p : pending)
+        destroy(p);
+    });
   }
 
   void do_process(
@@ -1040,7 +1231,19 @@ public:
     clap_output_events_t o_evs{
         .ctx = &output_storage,
         .try_push = [](const struct clap_output_events* list,
-                       const clap_event_header_t* event) -> bool { return false; }};
+                       const clap_event_header_t* event) -> bool {
+      auto* storage = static_cast<event_storage*>(list->ctx);
+      if(!event || event->space_id != CLAP_CORE_EVENT_SPACE_ID)
+        return false;
+      if(event->type == CLAP_EVENT_PARAM_VALUE
+         && event->size >= sizeof(clap_event_param_value_t))
+      {
+        storage->param_events.push_back(
+            *reinterpret_cast<const clap_event_param_value_t*>(event));
+        return true;
+      }
+      return false;
+    }};
 
     process.in_events = &evs;
     process.out_events = &o_evs;
@@ -1102,16 +1305,19 @@ public:
   }
 
   PluginHandle& m_instance;
-  struct poly_plugin
-  {
-    const clap_plugin_t* plugin{};
-    bool activated{};
-    bool processing{};
-    operator const clap_plugin_t*() const noexcept { return plugin; }
-  };
-
   std::vector<poly_plugin> m_poly;
   std::string m_plugin_id;
+
+  // Lock-free channel for the main-thread grower (Executor::grow_pool_tick)
+  // to hand fully-constructed instances to the audio thread. Single
+  // producer (the QTimer slot) / single consumer (run()), but mpmc is fine
+  // and what the rest of the codebase uses.
+  ossia::mpmc_queue<poly_plugin> m_incoming;
+
+  // Highest poly count the audio thread has ever needed for this node.
+  // The main-thread grower reads this and creates additional instances
+  // until the queue + m_poly reach this size.
+  std::atomic<std::size_t> m_requested_pool{0};
 };
 
 class clap_node_mono_32 final : public clap_node_mono
@@ -1148,19 +1354,25 @@ public:
     const auto audio_in = audio_ins[0];
     const auto audio_out = audio_outs[0];
     auto& in_channels = audio_in->data.get();
-    auto& out_channels = audio_out->data.get();
-    const auto poly_channels = audio_in->data.channels();
-    if(poly_channels == 0)
+    const auto upstream_channels = audio_in->data.channels();
+    if(upstream_channels == 0)
       return;
-    // FIXME should be in main thread
-    while(m_poly.size() < poly_channels)
-      add_poly_instance(e.sampleRate(), e.bufferSize());
+    // Pick up any newly-created polyphonic instances handed to us by the
+    // Executor's main-thread grower, then announce our current need so it
+    // can keep growing the pool. The audio thread never creates plug-ins
+    // itself (CLAP requires create_plugin/init on the main thread).
+    drain_incoming();
+    request_pool_size(upstream_channels);
+    const std::size_t poly_channels
+        = std::min<std::size_t>(upstream_channels, m_poly.size());
     // FIXME constant mode of audio inputs
     if(std::all_of(
            audio_in->data.begin(), audio_in->data.end(),
            [](const auto& channel) { return channel.size() == 0; }))
       return;
     audio_out->data.set_channels(poly_channels);
+    auto& out_channels = audio_out->data.get();
+    const uint32_t buffer_size = e.bufferSize();
     clap_audio_buffer_t in_buffer = dummy_audio_buffer();
     clap_audio_buffer_t out_buffer = dummy_audio_buffer();
     in_buffer.channel_count = 1;
@@ -1168,8 +1380,8 @@ public:
     out_buffer.channel_count = 1;
     out_buffer.data32 = outs_pointer;
 
-    int current_channel = 0;
-    for(auto& channel : in_channels)
+    for(std::size_t current_channel = 0; current_channel < poly_channels;
+        ++current_channel)
     {
       // 0. Activate plug-in if necessary
       auto& cur = m_poly[current_channel];
@@ -1183,10 +1395,12 @@ public:
           return;
       }
 
-      // 1. Copy input
+      auto& channel = in_channels[current_channel];
+
+      // 1. Copy input (extend the upstream buffer to the full block size in
+      //    case the producer wrote fewer frames than the engine block).
       {
-        //SCORE_SOFT_ASSERT(channel.size() >= e.bufferSize());
-        channel.resize(std::max((int)channel.size(), (int)e.bufferSize()));
+        channel.resize(std::max<std::size_t>(channel.size(), buffer_size));
         SCORE_ASSERT(input_channel_storage.size() >= samples);
         const double* src = channel.data() + offset;
         float* dst = input_channel_storage.data();
@@ -1206,17 +1420,20 @@ public:
       process.audio_outputs_count = 1;
       do_process(cur, process, m_input_events, m_output_events, current_channel);
 
-      // 4. Copy double back to matching output channel
+      // 4. Copy float back to matching output channel. Resize to the full
+      //    block size first — writing samples frames starting at `offset`
+      //    would otherwise overflow when `offset > 0`.
       {
+        auto& out_channel = out_channels[current_channel];
+        out_channel.resize(std::max<std::size_t>(out_channel.size(), buffer_size));
         const float* src = output_channel_storage.data();
-        out_channels[current_channel].resize(samples);
-        double* dst = out_channels[current_channel].data() + offset;
+        double* dst = out_channel.data() + offset;
         for(uint32_t s = 0; s < samples; ++s)
           dst[s] = static_cast<double>(src[s]);
       }
-
-      current_channel++;
     }
+
+    dispatch_param_outputs();
   }
 };
 
@@ -1235,7 +1452,6 @@ public:
 
     m_current_transport = make_transport(t, e);
 
-    // Clear previous data
     prepare_input_events(samples);
 
     double* ins_pointer[1]{};
@@ -1244,23 +1460,33 @@ public:
     // Setup audio input buffers
     const auto audio_in = audio_ins[0];
     const auto audio_out = audio_outs[0];
-    const auto poly_channels = audio_in->data.channels();
-    if(poly_channels == 0)
+    const auto upstream_channels = audio_in->data.channels();
+    if(upstream_channels == 0)
       return;
-    // FIXME should be in main thread
-    while(m_poly.size() < poly_channels)
-      add_poly_instance(e.sampleRate(), e.bufferSize());
+    // See clap_node_mono_32::run — never create_plugin/init from here;
+    // ask the main-thread grower to do it and use whatever it's handed us
+    // so far.
+    drain_incoming();
+    request_pool_size(upstream_channels);
+    const std::size_t poly_channels
+        = std::min<std::size_t>(upstream_channels, m_poly.size());
     // FIXME constant mode of audio inputs
     if(std::all_of(
            audio_in->data.begin(), audio_in->data.end(),
            [](const auto& channel) { return channel.size() == 0; }))
       return;
+    const uint32_t buffer_size = e.bufferSize();
     for(auto& channel : audio_in->data.get())
     {
-      //SCORE_SOFT_ASSERT(channel.size() >= e.bufferSize());
-      channel.resize(std::max((int)channel.size(), (int)e.bufferSize()));
+      channel.resize(std::max<std::size_t>(channel.size(), buffer_size));
     }
     audio_out->data.set_channels(poly_channels);
+    auto& out_channels = audio_out->data.get();
+    for(std::size_t c = 0; c < poly_channels; ++c)
+    {
+      out_channels[c].resize(
+          std::max<std::size_t>(out_channels[c].size(), buffer_size));
+    }
     clap_audio_buffer_t in_buffer = dummy_audio_buffer();
     clap_audio_buffer_t out_buffer = dummy_audio_buffer();
     in_buffer.channel_count = 1;
@@ -1269,9 +1495,8 @@ public:
     out_buffer.data64 = outs_pointer;
 
     auto& in_channels = audio_in->data.get();
-    auto& out_channels = audio_out->data.get();
-    int current_channel = 0;
-    for(auto& channel : in_channels)
+    for(std::size_t current_channel = 0; current_channel < poly_channels;
+        ++current_channel)
     {
       // 0. Activate plug-in if necessary
       auto& cur = m_poly[current_channel];
@@ -1285,13 +1510,15 @@ public:
           return;
       }
 
-      // 1. Clear output
-      auto in_chan = channel.data();
-      ins_pointer[0] = const_cast<double*>(in_chan);
-      out_channels[current_channel].resize(samples);
-      auto out_chan = out_channels[current_channel].data();
+      // 1. Point the plugin at the right slice of the buffer.
+      //    The previous code passed channel.data()/out_channel.data() with
+      //    no `offset`, which made the plugin process frames 0..samples
+      //    regardless of where the current tick actually started.
+      ins_pointer[0] = const_cast<double*>(in_channels[current_channel].data())
+                       + offset;
+      auto* out_chan = out_channels[current_channel].data() + offset;
       outs_pointer[0] = out_chan;
-      std::fill_n(out_chan, samples, 0);
+      std::fill_n(out_chan, samples, 0.0);
 
       // 2. Process this channel
       clap_process_t process{};
@@ -1301,9 +1528,9 @@ public:
       process.audio_inputs_count = 1;
       process.audio_outputs_count = 1;
       do_process(cur, process, m_input_events, m_output_events, current_channel);
-
-      current_channel++;
     }
+
+    dispatch_param_outputs();
   }
 };
 
@@ -1332,12 +1559,18 @@ struct clap_mono_process final : public ossia::node_process
   {
     auto* clap = static_cast<clap_node_mono*>(this->node.get());
 
+    // Stop each polyphonic instance individually. The old version always
+    // stopped m_instance.plugin (m_poly[0]) once per processing entry,
+    // leaving instances 1..N in {active, processing} on shutdown, which
+    // violates the CLAP state machine.
     for(auto& plug : clap->m_poly)
-      if(plug.processing)
+    {
+      if(plug.processing && plug.plugin)
       {
-        clap->stop_plugin(clap->m_instance.plugin);
+        plug.plugin->stop_processing(plug.plugin);
         plug.processing = false;
       }
+    }
   }
   void pause() override { }
   void resume() override { }
@@ -1380,6 +1613,21 @@ Executor::Executor(Clap::Model& proc, const Execution::Context& ctx, QObject* pa
       this->node = node;
       m_ossia_process = std::make_shared<clap_mono_process>(node);
     }
+
+    // Drive the polyphonic-pool grower on the main thread. The mono node
+    // pre-allocates 8 instances in its constructor; if the upstream channel
+    // count exceeds that the audio thread bumps m_requested_pool and this
+    // timer creates more on the main thread (CLAP requires create_plugin /
+    // init / activate / state.load to all run there).
+    constexpr std::size_t kInitialPoly = 8;
+    m_pool_sample_rate = e.sampleRate;
+    m_pool_buffer_size = e.bufferSize;
+    m_pool_pushed = kInitialPoly;
+    m_pool_max_requested = kInitialPoly;
+    m_grow_timer = new QTimer(this);
+    m_grow_timer->setInterval(50);
+    connect(m_grow_timer, &QTimer::timeout, this, [this] { grow_pool_tick(); });
+    m_grow_timer->start();
   }
   else
   {
@@ -1430,6 +1678,67 @@ Executor::Executor(Clap::Model& proc, const Execution::Context& ctx, QObject* pa
         });
       });
       control_idx++;
+    }
+  }
+}
+
+void Executor::grow_pool_tick()
+{
+  auto mono = std::dynamic_pointer_cast<clap_node_mono>(this->node);
+  if(!mono)
+    return;
+
+  // Promote brief spikes into the long-term high-water mark so we don't
+  // miss a 2 → 512 → 2 transient.
+  const auto requested
+      = mono->m_requested_pool.load(std::memory_order_acquire);
+  if(requested > m_pool_max_requested)
+    m_pool_max_requested = requested;
+
+  if(m_pool_pushed >= m_pool_max_requested)
+    return;
+
+  // Snapshot the primary plug-in's state once per growth burst so newly
+  // created instances inherit loaded models / presets (AIDA-X et al.).
+  // Re-captured on each call to track ongoing edits while we're growing.
+  auto handle = this->process().handle();
+  if(!handle || !handle->plugin)
+    return;
+  const QByteArray state = snapshot_clap_state(handle->plugin);
+
+  // Create at most a few per tick — each new instance can be expensive
+  // (AIDA-X loads a neural model on state.load) and we don't want to
+  // stall the UI thread. The 50 ms tick + batch of 4 gives ~80
+  // instances/sec, fast enough to grow 8 → 512 in ~6 s while remaining
+  // responsive.
+  constexpr std::size_t kBatch = 4;
+  const std::size_t to_add
+      = std::min(kBatch, m_pool_max_requested - m_pool_pushed);
+  for(std::size_t i = 0; i < to_add; ++i)
+  {
+    try
+    {
+      auto p
+          = mono->make_poly_instance(m_pool_sample_rate, m_pool_buffer_size, state);
+      if(!mono->m_incoming.enqueue(p))
+      {
+        // Queue's heap alloc failed: roll back this instance and stop
+        // growing for this tick — we'll try again on the next one.
+        if(p.activated && p.plugin)
+          p.plugin->deactivate(p.plugin);
+        if(p.plugin)
+          p.plugin->destroy(p.plugin);
+        qWarning() << "CLAP: poly queue enqueue failed; will retry";
+        break;
+      }
+      ++m_pool_pushed;
+    }
+    catch(const std::exception& ex)
+    {
+      qWarning() << "CLAP: failed to grow polyphonic pool:" << ex.what();
+      // Give up trying to reach the current target; future requests
+      // larger than what we've already pushed will retry naturally.
+      break;
     }
   }
 }

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -111,6 +111,12 @@ struct event_storage
   std::vector<clap_event_midi2_t> midi2_events;
   std::vector<clap_event_note_t> note_events;
   std::vector<clap_event_param_value_t> param_events;
+  // Sysex events captured from plug-in output. The CLAP spec says
+  // clap_event_midi_sysex_t.buffer is only valid for the duration of
+  // try_push, so we copy each payload into sysex_data and rewrite the
+  // event to point at our copy.
+  std::vector<clap_event_midi_sysex_t> sysex_events;
+  std::vector<std::vector<uint8_t>> sysex_data;
   std::vector<clap_event_header_t*> all_events;
 
   void clear()
@@ -119,6 +125,8 @@ struct event_storage
     midi2_events.clear();
     note_events.clear();
     param_events.clear();
+    sysex_events.clear();
+    sysex_data.clear();
     all_events.clear();
   }
 };
@@ -688,8 +696,49 @@ public:
             return true;
           }
           return false;
+        case CLAP_EVENT_NOTE_ON:
+        case CLAP_EVENT_NOTE_OFF:
+        case CLAP_EVENT_NOTE_END:
+        case CLAP_EVENT_NOTE_CHOKE:
+          // Plug-in voice events: useful both as plain MIDI fanout to a
+          // downstream MidiOutlet (we convert later) and, for NOTE_END
+          // specifically, so polyphonic hosts can release a voice slot.
+          if(event->size >= sizeof(clap_event_note_t))
+          {
+            storage->note_events.push_back(
+                *reinterpret_cast<const clap_event_note_t*>(event));
+            return true;
+          }
+          return false;
+        case CLAP_EVENT_MIDI2:
+          // MIDI 2.0 / UMP packets — forward 1:1 to libremidi::ump in
+          // the post-process step below.
+          if(event->size >= sizeof(clap_event_midi2_t))
+          {
+            storage->midi2_events.push_back(
+                *reinterpret_cast<const clap_event_midi2_t*>(event));
+            return true;
+          }
+          return false;
+        case CLAP_EVENT_MIDI_SYSEX:
+          // The buffer pointer is only valid for the duration of this
+          // try_push call (clap/events.h), so copy the bytes into our
+          // own storage and rewrite the event to point there.
+          if(event->size >= sizeof(clap_event_midi_sysex_t))
+          {
+            auto* sx
+                = reinterpret_cast<const clap_event_midi_sysex_t*>(event);
+            if(sx->size == 0 || sx->buffer == nullptr)
+              return false;
+            storage->sysex_data.emplace_back(
+                sx->buffer, sx->buffer + sx->size);
+            clap_event_midi_sysex_t copy = *sx;
+            copy.buffer = storage->sysex_data.back().data();
+            storage->sysex_events.push_back(copy);
+            return true;
+          }
+          return false;
         default:
-          // FIXME notes, note-end, etc.
           return false;
       }
     }};
@@ -702,6 +751,14 @@ public:
     dispatch_param_outputs();
 
     // Process MIDI output
+    forward_midi_outputs();
+  }
+
+  // Fan plug-in MIDI / note / sysex output events out to score's MIDI
+  // outlets, converting to UMP packets. Shared between clap_node and
+  // clap_node_mono so they don't drift.
+  void forward_midi_outputs()
+  {
     std::size_t midi_port_index = 0;
     for(std::size_t i = 0; i < m_outlets.size(); ++i)
     {
@@ -710,18 +767,102 @@ public:
         auto& port_messages = midi_out->messages;
         port_messages.clear();
 
+        // CLAP_EVENT_MIDI: MIDI 1.0 → UMP via cmidi2.
         for(const auto& midi_event : m_output_events.midi_events)
         {
-          if(midi_event.port_index == midi_port_index)
+          if(midi_event.port_index != midi_port_index)
+            continue;
+          libremidi::ump msg;
+          if(cmidi2_midi1_channel_voice_to_midi2(midi_event.data, 3, msg.data))
           {
-            libremidi::ump msg;
-            if(cmidi2_midi1_channel_voice_to_midi2(midi_event.data, 3, msg.data))
-            {
-              msg.timestamp = midi_event.header.time;
-              port_messages.push_back(msg);
-            }
+            msg.timestamp = midi_event.header.time;
+            port_messages.push_back(msg);
           }
         }
+
+        // CLAP_EVENT_NOTE_*: synthesize a MIDI 1.0 message and convert.
+        // NOTE_END / NOTE_CHOKE have no direct MIDI equivalent — both
+        // mean "this voice is over", so emit NOTE_OFF (velocity 0) so a
+        // downstream MIDI device sees the voice released.
+        for(const auto& ne : m_output_events.note_events)
+        {
+          if(ne.port_index != midi_port_index)
+            continue;
+          const uint8_t ch = static_cast<uint8_t>(ne.channel & 0x0F);
+          const uint8_t key = static_cast<uint8_t>(std::clamp<int>(ne.key, 0, 127));
+          uint8_t bytes[3]{};
+          switch(ne.header.type)
+          {
+            case CLAP_EVENT_NOTE_ON: {
+              const uint8_t vel = static_cast<uint8_t>(std::clamp(
+                  static_cast<int>(ne.velocity * 127.0 + 0.5), 0, 127));
+              bytes[0] = 0x90 | ch;
+              bytes[1] = key;
+              bytes[2] = vel;
+              break;
+            }
+            case CLAP_EVENT_NOTE_OFF: {
+              const uint8_t vel = static_cast<uint8_t>(std::clamp(
+                  static_cast<int>(ne.velocity * 127.0 + 0.5), 0, 127));
+              bytes[0] = 0x80 | ch;
+              bytes[1] = key;
+              bytes[2] = vel;
+              break;
+            }
+            case CLAP_EVENT_NOTE_END:
+            case CLAP_EVENT_NOTE_CHOKE:
+              bytes[0] = 0x80 | ch;
+              bytes[1] = key;
+              bytes[2] = 0;
+              break;
+            default:
+              continue;
+          }
+          libremidi::ump msg;
+          if(cmidi2_midi1_channel_voice_to_midi2(bytes, 3, msg.data))
+          {
+            msg.timestamp = ne.header.time;
+            port_messages.push_back(msg);
+          }
+        }
+
+        // CLAP_EVENT_MIDI2: already UMP-shaped — copy verbatim.
+        for(const auto& m2 : m_output_events.midi2_events)
+        {
+          if(m2.port_index != midi_port_index)
+            continue;
+          libremidi::ump msg;
+          std::memcpy(msg.data, m2.data, sizeof(m2.data));
+          msg.timestamp = m2.header.time;
+          port_messages.push_back(msg);
+        }
+
+        // CLAP_EVENT_MIDI_SYSEX: encode the captured byte buffer into
+        // one or more UMP sysex7 packets (6 data bytes per packet).
+        for(const auto& sx : m_output_events.sysex_events)
+        {
+          if(sx.port_index != midi_port_index)
+            continue;
+          if(sx.size == 0 || sx.buffer == nullptr)
+            continue;
+          const std::size_t num_packets
+              = cmidi2_ump_sysex_get_num_packets(sx.size, 6);
+          for(std::size_t pkt = 0; pkt < num_packets; ++pkt)
+          {
+            libremidi::ump msg{};
+            uint64_t r1 = 0, r2 = 0;
+            cmidi2_ump_sysex_get_packet_of(
+                &r1, &r2, /*group*/ 0, sx.size, sx.buffer,
+                static_cast<int32_t>(pkt), CMIDI2_MESSAGE_TYPE_SYSEX7, 6,
+                /*hasStreamId*/ false, /*streamId*/ 0);
+            // sysex7 packets are 64-bit; libremidi::ump.data[0..1] holds it.
+            msg.data[0] = static_cast<uint32_t>(r1 >> 32);
+            msg.data[1] = static_cast<uint32_t>(r1 & 0xFFFFFFFFu);
+            msg.timestamp = sx.header.time;
+            port_messages.push_back(msg);
+          }
+        }
+
         midi_port_index++;
       }
     }

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -603,6 +603,14 @@ public:
   const std::vector<clap_note_port_info_t>& m_midi_outs;
   double m_sample_rate{44100.0};
   uint32_t m_buffer_size{512};
+
+  // Last clap_process_status returned by the plugin. CLAP_PROCESS_SLEEP
+  // tells us "no more processing needed until next event or audio input
+  // variation" — we use this to skip plugin->process on instruments that
+  // are idle (audio_ins empty + no events). For effects (audio_ins
+  // non-empty) we always process: detecting "audio input variation"
+  // accurately would require a per-frame scan we don't want to pay for.
+  clap_process_status m_last_status{CLAP_PROCESS_CONTINUE};
 };
 
 // Normal implementation
@@ -689,7 +697,7 @@ public:
     process.in_events = &evs;
     process.out_events = &o_evs;
 
-    m_instance.plugin->process(m_instance.plugin, &process);
+    m_last_status = m_instance.plugin->process(m_instance.plugin, &process);
 
     dispatch_param_outputs();
 
@@ -770,6 +778,37 @@ public:
     output_channel_ptrs.clear();
 
     prepare_input_events(samples);
+
+    // Honour CLAP_PROCESS_SLEEP: the plug-in told us it needs no further
+    // work until an event arrives or audio input varies. We trust the
+    // event check; for audio-input variation we conservatively bail only
+    // on instruments (no audio input ports) — for effects, scanning every
+    // input frame for non-zero content would cost more than just running
+    // the plug-in's process() and is exactly what plug-ins themselves do.
+    if(m_last_status == CLAP_PROCESS_SLEEP && audio_ins.empty()
+       && m_input_events.all_events.empty())
+    {
+      // Stay asleep — emit silence on the audio outputs so downstream
+      // sees a clean signal instead of stale data from the last block.
+      std::size_t out_idx = 0;
+      for(ossia::audio_outlet* audio_out : audio_outs)
+      {
+        if(out_idx >= m_expected_audio_outputs.size())
+          break;
+        const auto& info = m_expected_audio_outputs[out_idx];
+        audio_out->data.set_channels(info.channel_count);
+        for(auto& ch : audio_out->data.get())
+        {
+          ch.resize(std::max<std::size_t>(ch.size(), e.bufferSize()));
+          std::fill_n(ch.data() + offset, samples, 0.0);
+        }
+        out_idx++;
+      }
+      // Also clear any midi outlets so we don't repeat last block's MIDI.
+      for(ossia::midi_outlet* midi_out : midi_outs)
+        midi_out->data.messages.clear();
+      return;
+    }
 
     // Setup audio input buffers
     // We must create exactly the number of buffers the plugin expects
@@ -957,6 +996,29 @@ public:
 
     // Process parameter changes
     prepare_input_events(samples);
+
+    // Honour CLAP_PROCESS_SLEEP — see clap_node_32::run for rationale.
+    if(m_last_status == CLAP_PROCESS_SLEEP && audio_ins.empty()
+       && m_input_events.all_events.empty())
+    {
+      std::size_t out_idx = 0;
+      for(ossia::audio_outlet* audio_out : audio_outs)
+      {
+        if(out_idx >= m_expected_audio_outputs.size())
+          break;
+        const auto& info = m_expected_audio_outputs[out_idx];
+        audio_out->data.set_channels(info.channel_count);
+        for(auto& ch : audio_out->data.get())
+        {
+          ch.resize(std::max<std::size_t>(ch.size(), e.bufferSize()));
+          std::fill_n(ch.data() + offset, samples, 0.0);
+        }
+        out_idx++;
+      }
+      for(ossia::midi_outlet* midi_out : midi_outs)
+        midi_out->data.messages.clear();
+      return;
+    }
 
     // Setup audio input buffers
     std::size_t audio_in_idx = 0;
@@ -1273,7 +1335,12 @@ public:
     process.in_events = &evs;
     process.out_events = &o_evs;
 
-    plug->process(plug, &process);
+    // We track m_last_status mainly for diagnostics in the mono path. We
+    // don't act on CLAP_PROCESS_SLEEP for monophonic-faked plugins because
+    // each m_poly[i] has independent processing state and a per-channel
+    // skip would require per-channel status tracking + audio-input
+    // variation detection per channel — more bookkeeping than it's worth.
+    m_last_status = plug->process(plug, &process);
 
     // In poly mode, we have to save the parameter changes from the first node and replicate
     // it to the other nodes to handle the case where the user moves something in the UI.

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -350,7 +350,11 @@ public:
   }
   void process_controls(uint32_t samples)
   {
-    // Process control inlets and create parameter events
+    // Process control inlets and create parameter events. Each ossia
+    // timed_value carries its own frame offset within the block, so emit
+    // one CLAP_EVENT_PARAM_VALUE per timestamp instead of collapsing them
+    // all to frame 0 — that lets sample-accurate automation (LFO, curve,
+    // MIDI mapping) drive plug-in smoothers correctly.
     std::size_t param_idx = 0;
 
     for(std::size_t i = 0; i < m_inlets.size(); ++i)
@@ -361,29 +365,41 @@ public:
         if(!data.empty() && param_idx < m_param_ins.size())
         {
           auto& param_info = m_param_ins[param_idx];
-          double value = ossia::convert<double>(data.back().value);
+          for(const auto& tv : data)
+          {
+            double value = std::clamp(
+                ossia::convert<double>(tv.value), param_info.min_value,
+                param_info.max_value);
 
-          // Clamp value to parameter range
-          value = std::clamp(value, param_info.min_value, param_info.max_value);
+            // Map ossia's signed frame offset onto CLAP's unsigned uint32
+            // time field. Negative timestamps (carry-over from the previous
+            // block) clamp to 0; out-of-block timestamps clamp to samples-1
+            // so the plug-in still sees the change within the current block.
+            const int64_t t = tv.timestamp;
+            const uint32_t time
+                = t <= 0 ? 0u
+                         : static_cast<uint32_t>(
+                               std::min<int64_t>(t, samples > 0 ? samples - 1 : 0));
 
-          clap_event_param_value_t param_event{};
-          param_event.header.size = sizeof(clap_event_param_value_t);
-          param_event.header.time = 0; // Beginning of buffer for now
-          param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-          param_event.header.type = CLAP_EVENT_PARAM_VALUE;
-          param_event.header.flags = CLAP_EVENT_IS_LIVE;
-          param_event.param_id = param_info.id;
-          param_event.cookie = param_info.cookie;
-          param_event.note_id = -1;
-          param_event.port_index = -1;
-          param_event.channel = -1;
-          param_event.key = -1;
-          param_event.value = value;
+            clap_event_param_value_t param_event{};
+            param_event.header.size = sizeof(clap_event_param_value_t);
+            param_event.header.time = time;
+            param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            param_event.header.type = CLAP_EVENT_PARAM_VALUE;
+            param_event.header.flags = CLAP_EVENT_IS_LIVE;
+            param_event.param_id = param_info.id;
+            param_event.cookie = param_info.cookie;
+            param_event.note_id = -1;
+            param_event.port_index = -1;
+            param_event.channel = -1;
+            param_event.key = -1;
+            param_event.value = value;
 
-          m_input_events.param_events.push_back(param_event);
-          m_input_events.all_events.push_back(
-              reinterpret_cast<clap_event_header_t*>(
-                  &m_input_events.param_events.back()));
+            m_input_events.param_events.push_back(param_event);
+            m_input_events.all_events.push_back(
+                reinterpret_cast<clap_event_header_t*>(
+                    &m_input_events.param_events.back()));
+          }
         }
         param_idx++;
       }

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -7,7 +7,9 @@
 #include <ossia/dataflow/execution_state.hpp>
 #include <ossia/dataflow/graph_node.hpp>
 #include <ossia/dataflow/port.hpp>
+#include <ossia/detail/hash_map.hpp>
 #include <ossia/detail/lockfree_queue.hpp>
+#include <ossia/detail/nullable_variant.hpp>
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -92,6 +94,47 @@ inline void apply_clap_state(const clap_plugin_t* plugin, const QByteArray& blob
 
   state->load(plugin, &stream);
 }
+
+// Per-voice slice; mirrors LV2's voice_control_value in score-plugin-lv2/LV2/Node.hpp.
+inline std::optional<double>
+voice_control_value(const ossia::value& val, std::size_t voice_idx) noexcept
+{
+  return ossia::apply_nonnull(
+      [voice_idx](const auto& v) -> std::optional<double> {
+    using T = std::decay_t<decltype(v)>;
+    if constexpr(std::is_same_v<T, std::vector<ossia::value>>)
+    {
+      if(v.empty())
+        return std::nullopt;
+      const auto& elem = (voice_idx < v.size()) ? v[voice_idx] : v.back();
+      return ossia::convert<double>(elem);
+    }
+    else if constexpr(std::is_same_v<T, ossia::vec2f>)
+      return v[std::min<std::size_t>(voice_idx, 1)];
+    else if constexpr(std::is_same_v<T, ossia::vec3f>)
+      return v[std::min<std::size_t>(voice_idx, 2)];
+    else if constexpr(std::is_same_v<T, ossia::vec4f>)
+      return v[std::min<std::size_t>(voice_idx, 3)];
+    else if constexpr(
+        std::is_same_v<T, float> || std::is_same_v<T, double>
+        || std::is_same_v<T, int> || std::is_same_v<T, bool>)
+      return double(v);
+    else
+      return std::nullopt;
+  },
+      val.v);
+}
+
+inline bool is_vector_value(const ossia::value& val) noexcept
+{
+  return ossia::apply_nonnull([](const auto& v) noexcept -> bool {
+    using T = std::decay_t<decltype(v)>;
+    return std::is_same_v<T, std::vector<ossia::value>>
+           || std::is_same_v<T, ossia::vec2f>
+           || std::is_same_v<T, ossia::vec3f>
+           || std::is_same_v<T, ossia::vec4f>;
+  }, val.v);
+}
 }
 
 static auto dummy_audio_buffer() noexcept
@@ -141,6 +184,7 @@ public:
       , m_param_outs{handle->m_parameters_outs}
       , m_midi_ins{handle->m_midi_ins}
       , m_midi_outs{handle->m_midi_outs}
+      , m_param_out_index{handle->param_outs_by_id}
   {
     set_not_fp_safe();
     midi_ins.reserve(m_midi_ins.size());
@@ -372,53 +416,49 @@ public:
     // one CLAP_EVENT_PARAM_VALUE per timestamp instead of collapsing them
     // all to frame 0 — that lets sample-accurate automation (LFO, curve,
     // MIDI mapping) drive plug-in smoothers correctly.
-    std::size_t param_idx = 0;
-
-    for(std::size_t i = 0; i < m_inlets.size(); ++i)
+    for(std::size_t i = 0; i < parameter_ins.size(); ++i)
     {
-      if(auto ctrl_in = m_inlets[i]->target<ossia::value_port>())
+      const auto& data = parameter_ins[i]->data.get_data();
+      if(data.empty())
+        continue;
+      const auto& param_info = m_param_ins[i];
+      for(const auto& tv : data)
       {
-        const auto& data = ctrl_in->get_data();
-        if(!data.empty() && param_idx < m_param_ins.size())
-        {
-          auto& param_info = m_param_ins[param_idx];
-          for(const auto& tv : data)
-          {
-            double value = std::clamp(
-                ossia::convert<double>(tv.value), param_info.min_value,
-                param_info.max_value);
+        // Vector values are addressed per-voice by prepare_voice_overrides.
+        if(is_vector_value(tv.value))
+          continue;
+        double value = std::clamp(
+            ossia::convert<double>(tv.value), param_info.min_value,
+            param_info.max_value);
 
-            // Map ossia's signed frame offset onto CLAP's unsigned uint32
-            // time field. Negative timestamps (carry-over from the previous
-            // block) clamp to 0; out-of-block timestamps clamp to samples-1
-            // so the plug-in still sees the change within the current block.
-            const int64_t t = tv.timestamp;
-            const uint32_t time
-                = t <= 0 ? 0u
-                         : static_cast<uint32_t>(
-                               std::min<int64_t>(t, samples > 0 ? samples - 1 : 0));
+        // Map ossia's signed frame offset onto CLAP's unsigned uint32
+        // time field. Negative timestamps (carry-over from the previous
+        // block) clamp to 0; out-of-block timestamps clamp to samples-1
+        // so the plug-in still sees the change within the current block.
+        const int64_t t = tv.timestamp;
+        const uint32_t time
+            = t <= 0 ? 0u
+                     : static_cast<uint32_t>(
+                           std::min<int64_t>(t, samples > 0 ? samples - 1 : 0));
 
-            clap_event_param_value_t param_event{};
-            param_event.header.size = sizeof(clap_event_param_value_t);
-            param_event.header.time = time;
-            param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-            param_event.header.type = CLAP_EVENT_PARAM_VALUE;
-            param_event.header.flags = CLAP_EVENT_IS_LIVE;
-            param_event.param_id = param_info.id;
-            param_event.cookie = param_info.cookie;
-            param_event.note_id = -1;
-            param_event.port_index = -1;
-            param_event.channel = -1;
-            param_event.key = -1;
-            param_event.value = value;
+        clap_event_param_value_t param_event{};
+        param_event.header.size = sizeof(clap_event_param_value_t);
+        param_event.header.time = time;
+        param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+        param_event.header.type = CLAP_EVENT_PARAM_VALUE;
+        param_event.header.flags = CLAP_EVENT_IS_LIVE;
+        param_event.param_id = param_info.id;
+        param_event.cookie = param_info.cookie;
+        param_event.note_id = -1;
+        param_event.port_index = -1;
+        param_event.channel = -1;
+        param_event.key = -1;
+        param_event.value = value;
 
-            m_input_events.param_events.push_back(param_event);
-            m_input_events.all_events.push_back(
-                reinterpret_cast<clap_event_header_t*>(
-                    &m_input_events.param_events.back()));
-          }
-        }
-        param_idx++;
+        m_input_events.param_events.push_back(param_event);
+        m_input_events.all_events.push_back(
+            reinterpret_cast<clap_event_header_t*>(
+                &m_input_events.param_events.back()));
       }
     }
   }
@@ -560,6 +600,9 @@ public:
                     .size()); // Important to reserve one additional buffer of parameters for the mono case
     m_input_events.all_events.reserve((param_event_count + midi_event_count + 1) * 1.1);
 
+    if(m_pending_all_notes_off.exchange(false, std::memory_order_acq_rel))
+      inject_all_notes_off();
+
     // Process parameter changes
     process_controls(samples);
     process_midi();
@@ -572,25 +615,68 @@ public:
     });
   }
 
+  // NOTE_CHOKE wildcard + CC#120/123 on all 16 channels covers every dialect.
+  void inject_all_notes_off()
+  {
+    {
+      clap_event_note_t ev{};
+      ev.header.size = sizeof(clap_event_note_t);
+      ev.header.time = 0;
+      ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+      ev.header.type = CLAP_EVENT_NOTE_CHOKE;
+      ev.header.flags = 0;
+      ev.note_id = -1;
+      ev.port_index = -1;
+      ev.channel = -1;
+      ev.key = -1;
+      ev.velocity = 0.0;
+      m_input_events.note_events.push_back(ev);
+      m_input_events.all_events.push_back(
+          reinterpret_cast<clap_event_header_t*>(&m_input_events.note_events.back()));
+    }
+    for(uint8_t ch = 0; ch < 16; ++ch)
+    {
+      for(uint8_t cc : {uint8_t(120), uint8_t(123)})
+      {
+        clap_event_midi_t ev{};
+        ev.header.size = sizeof(clap_event_midi_t);
+        ev.header.time = 0;
+        ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+        ev.header.type = CLAP_EVENT_MIDI;
+        ev.header.flags = 0;
+        ev.port_index = 0;
+        ev.data[0] = uint8_t(0xB0 | ch);
+        ev.data[1] = cc;
+        ev.data[2] = 0;
+        m_input_events.midi_events.push_back(ev);
+        m_input_events.all_events.push_back(
+            reinterpret_cast<clap_event_header_t*>(&m_input_events.midi_events.back()));
+      }
+    }
+  }
+
+  void all_notes_off() noexcept override
+  {
+    m_pending_all_notes_off.store(true, std::memory_order_release);
+  }
+
   // Forward any CLAP_EVENT_PARAM_VALUE events the plugin emitted during
   // process() to the matching `parameter_outs` value_outlet so downstream
   // ossia nodes (and the GUI bargraphs) see live values.
   void dispatch_param_outputs()
   {
-    if(m_output_events.param_events.empty() || m_param_outs.empty())
+    if(m_output_events.param_events.empty())
       return;
 
     for(const auto& ev : m_output_events.param_events)
     {
-      for(std::size_t i = 0; i < m_param_outs.size(); ++i)
-      {
-        if(m_param_outs[i].id == ev.param_id && i < parameter_outs.size())
-        {
-          parameter_outs[i]->data.write_value(
-              ossia::value{ev.value}, static_cast<int64_t>(ev.header.time));
-          break;
-        }
-      }
+      auto it = m_param_out_index.find(ev.param_id);
+      if(it == m_param_out_index.end())
+        continue;
+      const auto idx = it->second;
+      if(idx < parameter_outs.size())
+        parameter_outs[idx]->data.write_value(
+            ossia::value{ev.value}, static_cast<int64_t>(ev.header.time));
     }
   }
 
@@ -600,7 +686,7 @@ public:
   ossia::small_vector<ossia::midi_outlet*, 2> midi_outs;
   std::vector<ossia::value_inlet*> parameter_ins;
   std::vector<ossia::value_outlet*> parameter_outs;
-  clap_event_transport_t m_current_transport;
+  clap_event_transport_t m_current_transport{};
 
   event_storage m_input_events;
   event_storage m_output_events;
@@ -609,6 +695,7 @@ public:
   const std::vector<clap_param_info_t>& m_param_outs;
   const std::vector<clap_note_port_info_t>& m_midi_ins;
   const std::vector<clap_note_port_info_t>& m_midi_outs;
+  const ossia::flat_map<clap_id, std::uint32_t>& m_param_out_index;
   double m_sample_rate{44100.0};
   uint32_t m_buffer_size{512};
 
@@ -619,6 +706,8 @@ public:
   // non-empty) we always process: detecting "audio input variation"
   // accurately would require a per-frame scan we don't want to pay for.
   clap_process_status m_last_status{CLAP_PROCESS_CONTINUE};
+
+  std::atomic<bool> m_pending_all_notes_off{false};
 };
 
 // Normal implementation
@@ -1342,14 +1431,8 @@ public:
     return p;
   }
 
-  // [audio-thread] Drain any new instances that the main-thread grower
-  // has handed us through m_incoming.
-  void drain_incoming() noexcept
-  {
-    poly_plugin p;
-    while(m_incoming.try_dequeue(p))
-      m_poly.push_back(p);
-  }
+  // [audio-thread] Called by grow_pool_tick via in_exec.
+  void append_poly(poly_plugin p) noexcept { m_poly.push_back(p); }
 
   // [audio-thread] Tell the grower we need at least `n` total instances.
   // Monotonically-increasing: a brief drop to a smaller channel count
@@ -1403,22 +1486,11 @@ public:
       }
     }
 
-    // Drain any instances the grower had pushed but the audio thread did
-    // not consume yet. They are already created/init'd/activated, so we
-    // must deactivate + destroy them on the main thread alongside m_poly.
-    std::vector<poly_plugin> pending;
-    {
-      poly_plugin tmp{};
-      while(m_incoming.try_dequeue(tmp))
-        pending.push_back(tmp);
-    }
-
-    // m_poly[0] is the Clap::Model's shared handle: Model::~Model and the
-    // resetExecution handler take care of deactivating it on the main
-    // thread (and they will, because the ctor synced handle.activated).
+    // m_poly[0] is the Model's shared handle; deactivated by Model::~Model.
+    // Orphaned grower output is cleaned up via grow_pool_tick's weak_ptr.
     QMetaObject::invokeMethod(
         QCoreApplication::instance(),
-        [poly = std::move(m_poly), pending = std::move(pending)]() mutable {
+        [poly = std::move(m_poly)]() mutable {
       auto destroy = [](const poly_plugin& p) {
         if(!p.plugin)
           return;
@@ -1428,8 +1500,6 @@ public:
       };
       for(std::size_t i = 1; i < poly.size(); ++i)
         destroy(poly[i]);
-      for(auto& p : pending)
-        destroy(p);
     });
   }
 
@@ -1482,75 +1552,161 @@ public:
     // skip would require per-channel status tracking + audio-input
     // variation detection per channel — more bookkeeping than it's worth.
     m_last_status = plug->process(plug, &process);
+    (void)current_channel;
+  }
 
-    // In poly mode, we have to save the parameter changes from the first node and replicate
-    // it to the other nodes to handle the case where the user moves something in the UI.
+  // Snapshot voice-0 params into voices 1+ so UI edits propagate (CLAP UI binds to voice 0).
+  void replicate_voice0_state(
+      const clap_plugin_t* plug, event_storage& input_storage) noexcept
+  {
     auto params = this->handle->ext_params;
-    if(params && current_channel == 0)
-    {
-      const int orig = input_storage.param_events.size();
-      int cur = input_storage.param_events.size();
-      const int param_count = params->count(plug);
-      if(param_count > 0)
-      {
-        input_storage.param_events.resize(
-            input_storage.param_events.size() + param_count);
-        clap_event_param_value_t* cur_p = &input_storage.param_events[cur];
-        for(auto& p : m_param_ins)
-        {
-          double current_value;
-          // Read current parameter value from plugin
-          if(params->get_value(plug, p.id, &current_value))
-          {
-            clap_event_param_value_t& param_event = *cur_p;
-            param_event.header.size = sizeof(clap_event_param_value_t);
-            param_event.header.time = 0; // Beginning of buffer for now
-            param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-            param_event.header.type = CLAP_EVENT_PARAM_VALUE;
-            param_event.header.flags = CLAP_EVENT_IS_LIVE;
-            param_event.param_id = p.id;
-            param_event.cookie = p.cookie;
-            param_event.note_id = -1;
-            param_event.port_index = -1;
-            param_event.channel = -1;
-            param_event.key = -1;
-            param_event.value = current_value;
-            ++cur;
-            ++cur_p;
-          }
-        }
+    if(!params)
+      return;
+    const int param_count = params->count(plug);
+    if(param_count <= 0)
+      return;
 
-        if(cur > orig)
+    const int orig = input_storage.param_events.size();
+    int cur = orig;
+    input_storage.param_events.resize(orig + param_count);
+    clap_event_param_value_t* cur_p = &input_storage.param_events[cur];
+    for(auto& p : m_param_ins)
+    {
+      // Per-voice slice would be clobbered by voice-0's value here.
+      if(m_overridden_params.contains(p.id))
+        continue;
+      double current_value;
+      if(params->get_value(plug, p.id, &current_value))
+      {
+        clap_event_param_value_t& param_event = *cur_p;
+        param_event.header.size = sizeof(clap_event_param_value_t);
+        param_event.header.time = 0;
+        param_event.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+        param_event.header.type = CLAP_EVENT_PARAM_VALUE;
+        param_event.header.flags = CLAP_EVENT_IS_LIVE;
+        param_event.param_id = p.id;
+        param_event.cookie = p.cookie;
+        param_event.note_id = -1;
+        param_event.port_index = -1;
+        param_event.channel = -1;
+        param_event.key = -1;
+        param_event.value = current_value;
+        ++cur;
+        ++cur_p;
+      }
+    }
+
+    if(cur > orig)
+    {
+      auto it = std::upper_bound(
+          input_storage.all_events.begin(), input_storage.all_events.end(), 0,
+          [](auto& t1, auto& ev2) { return t1 < ev2->time; });
+      const auto r = std::span<clap_event_param_value_t>(
+                         input_storage.param_events.data() + orig,
+                         input_storage.param_events.data() + cur)
+                     | std::views::transform([](clap_event_param_value_t& elem) {
+        return &elem.header;
+      });
+      input_storage.all_events.insert(it, std::begin(r), std::end(r));
+    }
+  }
+
+  // Must run after prepare_input_events and before the per-voice loop.
+  void prepare_voice_overrides(uint32_t samples) noexcept
+  {
+    m_voice_overrides.resize(m_poly.size());
+    for(auto& vec : m_voice_overrides)
+      vec.clear();
+    m_overridden_params.clear();
+
+    for(std::size_t i = 0; i < parameter_ins.size(); ++i)
+    {
+      const auto& data = parameter_ins[i]->data.get_data();
+      if(data.empty())
+        continue;
+      const auto& param_info = m_param_ins[i];
+      for(const auto& tv : data)
+      {
+        if(!is_vector_value(tv.value))
+          continue;
+        m_overridden_params.insert(param_info.id);
+        const int64_t t = tv.timestamp;
+        const uint32_t time
+            = t <= 0
+                  ? 0u
+                  : static_cast<uint32_t>(
+                        std::min<int64_t>(t, samples > 0 ? samples - 1 : 0));
+        for(std::size_t v = 0; v < m_poly.size(); ++v)
         {
-          auto it = std::upper_bound(
-              input_storage.all_events.begin(), input_storage.all_events.end(), 0,
-              [](auto& t1, auto& ev2) { return t1 < ev2->time; });
-          const auto r = std::span<clap_event_param_value_t>(
-                             input_storage.param_events.data() + orig,
-                             input_storage.param_events.data() + cur)
-                         | std::views::transform([](clap_event_param_value_t& elem) {
-            return &elem.header;
-          });
-          input_storage.all_events.insert(it, std::begin(r), std::end(r));
+          auto sliced = voice_control_value(tv.value, v);
+          if(!sliced)
+            continue;
+          const double value = std::clamp(
+              *sliced, param_info.min_value, param_info.max_value);
+          clap_event_param_value_t ev{};
+          ev.header.size = sizeof(clap_event_param_value_t);
+          ev.header.time = time;
+          ev.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+          ev.header.type = CLAP_EVENT_PARAM_VALUE;
+          ev.header.flags = CLAP_EVENT_IS_LIVE;
+          ev.param_id = param_info.id;
+          ev.cookie = param_info.cookie;
+          ev.note_id = -1;
+          ev.port_index = -1;
+          ev.channel = -1;
+          ev.key = -1;
+          ev.value = value;
+          m_voice_overrides[v].push_back(ev);
         }
       }
     }
+  }
+
+  // Compose shared base + this voice's overrides into one sorted event stream.
+  void build_voice_input(event_storage& dst, std::size_t voice_idx)
+  {
+    dst.midi_events = m_input_events.midi_events;
+    dst.midi2_events = m_input_events.midi2_events;
+    dst.note_events = m_input_events.note_events;
+    dst.param_events = m_input_events.param_events;
+    dst.sysex_events = m_input_events.sysex_events;
+    dst.sysex_data = m_input_events.sysex_data;
+    const auto& overrides = m_voice_overrides[voice_idx];
+    dst.param_events.insert(
+        dst.param_events.end(), overrides.begin(), overrides.end());
+
+    dst.all_events.clear();
+    dst.all_events.reserve(
+        dst.midi_events.size() + dst.midi2_events.size() + dst.note_events.size()
+        + dst.param_events.size() + dst.sysex_events.size());
+    for(auto& ev : dst.midi_events)
+      dst.all_events.push_back(reinterpret_cast<clap_event_header_t*>(&ev));
+    for(auto& ev : dst.midi2_events)
+      dst.all_events.push_back(reinterpret_cast<clap_event_header_t*>(&ev));
+    for(auto& ev : dst.note_events)
+      dst.all_events.push_back(reinterpret_cast<clap_event_header_t*>(&ev));
+    for(auto& ev : dst.param_events)
+      dst.all_events.push_back(reinterpret_cast<clap_event_header_t*>(&ev));
+    for(auto& ev : dst.sysex_events)
+      dst.all_events.push_back(reinterpret_cast<clap_event_header_t*>(&ev));
+    std::sort(
+        dst.all_events.begin(), dst.all_events.end(),
+        [](const clap_event_header_t* a, const clap_event_header_t* b) {
+      return a->time < b->time;
+    });
   }
 
   PluginHandle& m_instance;
   std::vector<poly_plugin> m_poly;
   std::string m_plugin_id;
 
-  // Lock-free channel for the main-thread grower (Executor::grow_pool_tick)
-  // to hand fully-constructed instances to the audio thread. Single
-  // producer (the QTimer slot) / single consumer (run()), but mpmc is fine
-  // and what the rest of the codebase uses.
-  ossia::mpmc_queue<poly_plugin> m_incoming;
-
-  // Highest poly count the audio thread has ever needed for this node.
-  // The main-thread grower reads this and creates additional instances
-  // until the queue + m_poly reach this size.
   std::atomic<std::size_t> m_requested_pool{0};
+
+  std::vector<std::vector<clap_event_param_value_t>> m_voice_overrides;
+
+  ossia::hash_set<clap_id> m_overridden_params;
+
+  event_storage m_voice_input;
 };
 
 class clap_node_mono_32 final : public clap_node_mono
@@ -1579,6 +1735,7 @@ public:
     output_channel_storage.resize(samples);
 
     prepare_input_events(samples);
+    prepare_voice_overrides(samples);
 
     float* ins_pointer[1]{input_channel_storage.data()};
     float* outs_pointer[1]{output_channel_storage.data()};
@@ -1590,11 +1747,6 @@ public:
     const auto upstream_channels = audio_in->data.channels();
     if(upstream_channels == 0)
       return;
-    // Pick up any newly-created polyphonic instances handed to us by the
-    // Executor's main-thread grower, then announce our current need so it
-    // can keep growing the pool. The audio thread never creates plug-ins
-    // itself (CLAP requires create_plugin/init on the main thread).
-    drain_incoming();
     request_pool_size(upstream_channels);
     const std::size_t poly_channels
         = std::min<std::size_t>(upstream_channels, m_poly.size());
@@ -1651,7 +1803,10 @@ public:
       process.audio_outputs = &out_buffer;
       process.audio_inputs_count = 1;
       process.audio_outputs_count = 1;
-      do_process(cur, process, m_input_events, m_output_events, current_channel);
+      build_voice_input(m_voice_input, current_channel);
+      do_process(cur, process, m_voice_input, m_output_events, current_channel);
+      if(current_channel == 0)
+        replicate_voice0_state(cur, m_input_events);
 
       // 4. Copy float back to matching output channel. Resize to the full
       //    block size first — writing samples frames starting at `offset`
@@ -1686,6 +1841,7 @@ public:
     m_current_transport = make_transport(t, e);
 
     prepare_input_events(samples);
+    prepare_voice_overrides(samples);
 
     double* ins_pointer[1]{};
     double* outs_pointer[1]{};
@@ -1696,10 +1852,6 @@ public:
     const auto upstream_channels = audio_in->data.channels();
     if(upstream_channels == 0)
       return;
-    // See clap_node_mono_32::run — never create_plugin/init from here;
-    // ask the main-thread grower to do it and use whatever it's handed us
-    // so far.
-    drain_incoming();
     request_pool_size(upstream_channels);
     const std::size_t poly_channels
         = std::min<std::size_t>(upstream_channels, m_poly.size());
@@ -1760,7 +1912,10 @@ public:
       process.audio_outputs = &out_buffer;
       process.audio_inputs_count = 1;
       process.audio_outputs_count = 1;
-      do_process(cur, process, m_input_events, m_output_events, current_channel);
+      build_voice_input(m_voice_input, current_channel);
+      do_process(cur, process, m_voice_input, m_output_events, current_channel);
+      if(current_channel == 0)
+        replicate_voice0_state(cur, m_input_events);
     }
 
     dispatch_param_outputs();
@@ -1931,46 +2086,45 @@ void Executor::grow_pool_tick()
   if(m_pool_pushed >= m_pool_max_requested)
     return;
 
-  // Snapshot the primary plug-in's state once per growth burst so newly
-  // created instances inherit loaded models / presets (AIDA-X et al.).
-  // Re-captured on each call to track ongoing edits while we're growing.
+  // Snapshot primary's state so new instances inherit loaded models/presets.
   auto handle = this->process().handle();
   if(!handle || !handle->plugin)
     return;
   const QByteArray state = snapshot_clap_state(handle->plugin);
 
-  // Create at most a few per tick — each new instance can be expensive
-  // (AIDA-X loads a neural model on state.load) and we don't want to
-  // stall the UI thread. The 50 ms tick + batch of 4 gives ~80
-  // instances/sec, fast enough to grow 8 → 512 in ~6 s while remaining
-  // responsive.
+  // Few per tick: each instance can be expensive (e.g. AIDA-X neural model load).
   constexpr std::size_t kBatch = 4;
   const std::size_t to_add
       = std::min(kBatch, m_pool_max_requested - m_pool_pushed);
+  auto weak_node = std::weak_ptr{this->node};
   for(std::size_t i = 0; i < to_add; ++i)
   {
     try
     {
       auto p
           = mono->make_poly_instance(m_pool_sample_rate, m_pool_buffer_size, state);
-      if(!mono->m_incoming.enqueue(p))
-      {
-        // Queue's heap alloc failed: roll back this instance and stop
-        // growing for this tick — we'll try again on the next one.
-        if(p.activated && p.plugin)
-          p.plugin->deactivate(p.plugin);
-        if(p.plugin)
-          p.plugin->destroy(p.plugin);
-        qWarning() << "CLAP: poly queue enqueue failed; will retry";
-        break;
-      }
+      // Orphaned if the node dies before in_exec fires; post destroy to main thread.
+      in_exec([weak_node, p]() mutable {
+        if(auto n = weak_node.lock())
+        {
+          static_cast<clap_node_mono*>(n.get())->append_poly(p);
+        }
+        else
+        {
+          QMetaObject::invokeMethod(QCoreApplication::instance(), [p] {
+            if(!p.plugin)
+              return;
+            if(p.activated)
+              p.plugin->deactivate(p.plugin);
+            p.plugin->destroy(p.plugin);
+          });
+        }
+      });
       ++m_pool_pushed;
     }
     catch(const std::exception& ex)
     {
       qWarning() << "CLAP: failed to grow polyphonic pool:" << ex.what();
-      // Give up trying to reach the current target; future requests
-      // larger than what we've already pushed will retry naturally.
       break;
     }
   }

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -212,6 +212,15 @@ public:
 
   [[nodiscard]] bool start_plugin(const clap_plugin_t* plugin)
   {
+    // CLAP spec (plugin.h): reset() "clears all buffers, performs a full
+    // reset of the processing state (filters, oscillators, envelopes,
+    // lfo, ...) and kills all voices" and is the right call when
+    // clap_process.steady_time may jump backward — exactly what happens
+    // when score (re)starts a transport that has been idle. It's a cheap
+    // mandatory entry point, and gets rid of residual reverb tails /
+    // filter ringing between plays.
+    plugin->reset(plugin);
+
     if(plugin->start_processing(plugin))
     {
       init_parameter_values(plugin);

--- a/src/plugins/score-plugin-clap/Clap/Executor.hpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.hpp
@@ -8,7 +8,11 @@
 #include <Clap/EffectModel.hpp>
 #include <clap/all.h>
 
+#include <QByteArray>
+
 #include <verdigris>
+
+class QTimer;
 
 namespace Clap
 {
@@ -26,6 +30,17 @@ public:
 private:
   template <typename Node_T>
   void setupNode(Node_T& node);
+
+  // Monophonic polyphonic-pool growth (see clap_node_mono in Executor.cpp).
+  // Audio thread sets m_requested_pool on the node; this timer (main thread)
+  // notices, creates plug-in instances in small batches, clones state, and
+  // pushes them through the SPSC queue. Monotonic — we never shrink.
+  void grow_pool_tick();
+  QTimer* m_grow_timer{};
+  std::size_t m_pool_pushed{0};
+  std::size_t m_pool_max_requested{0};
+  double m_pool_sample_rate{0.0};
+  int m_pool_buffer_size{0};
 };
 using ExecutorFactory = Execution::ProcessComponentFactory_T<Executor>;
 }

--- a/src/plugins/score-plugin-clap/Clap/Library.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Library.cpp
@@ -50,27 +50,13 @@ void LibraryHandler::setup(
 
   reset_plugs();
 
+  // Async rescan: addToLibrary doesn't emit per-row signals, so reset whole subtree.
   con(plug, &Clap::ApplicationPlugin::pluginsChanged, this,
-      [&plug, &model, node, &parent, reset_plugs] {
-    if(parent.childCount() > 0)
-    {
-      model.beginRemoveRows(node, 0, parent.childCount() - 1);
-      parent.resize(0);
-      model.endRemoveRows();
-    }
-
-    int k = 0;
-    for(const auto& clap : plug.plugins())
-    {
-      if(clap.valid)
-        k++;
-    }
-    if(k > 0)
-    {
-      model.beginInsertRows(node, 0, k - 1);
-      reset_plugs();
-      model.endInsertRows();
-    }
+      [&model, &parent, reset_plugs] {
+    model.beginResetModel();
+    parent.resize(0);
+    reset_plugs();
+    model.endResetModel();
   });
 }
 

--- a/src/plugins/score-plugin-clap/Clap/Window.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Window.cpp
@@ -195,7 +195,7 @@ void Window::showEvent(QShowEvent* event)
     if(m_gui_ext->set_transient)
     {
       // FIXME should be the main window WId instead?
-      clap_window_t parent_window;
+      clap_window_t parent_window{};
       parent_window.api = m_gui_api.c_str();
 #if defined(__APPLE__)
       parent_window.cocoa = reinterpret_cast<clap_nsview>(windowHandle()->winId());

--- a/src/plugins/score-plugin-library/Library/ProcessTreeView.cpp
+++ b/src/plugins/score-plugin-library/Library/ProcessTreeView.cpp
@@ -32,7 +32,9 @@ void ProcessTreeView::selectionChanged(
 
   if(!sel.isEmpty())
   {
-    selected(*dataFromViewIndex(sel.indexes().front()));
+    // guard against transient null internalPointer from async scan rebuild
+    if(auto* data = dataFromViewIndex(sel.indexes().front()))
+      selected(*data);
   }
   else if(desel.size() > 0)
   {

--- a/src/plugins/score-plugin-library/Library/ProcessesItemModel.hpp
+++ b/src/plugins/score-plugin-library/Library/ProcessesItemModel.hpp
@@ -49,6 +49,10 @@ public:
   using QAbstractItemModel::beginRemoveRows;
   using QAbstractItemModel::endRemoveRows;
 
+  // async scanners (LV2, CLAP) rebuild whole subtrees on descriptorsChanged
+  using QAbstractItemModel::beginResetModel;
+  using QAbstractItemModel::endResetModel;
+
   ProcessesItemModel(const score::GUIApplicationContext& ctx, QObject* parent);
 
   void rescan();


### PR DESCRIPTION
- **library: guard ProcessTreeView against async scan rebuilds**
- **clap: fix parameter editing and monophonic execution**
- **clap: don't call entry->deinit() when init() failed**
- **clap: implement request_restart properly**
- **clap: clean up host extension table**
- **clap: emit one event per timed_value in process_controls**
- **clap: reset() plug-in before start_processing**
- **clap: honour CLAP_PROCESS_SLEEP on instrument paths**
- **clap: implement host.state.mark_dirty with debounced snapshot**
- **clap: forward note/midi2/sysex output events to MIDI outlets**
- **clap: thread pool, vector controls, port-name sanitiser, env path**
