### PR TITLE
ci: verify against avendish addon-cmake PR (#97)

### DIFF
--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -4,7 +4,7 @@
 # the new addon CMake doesn't break score or its avnd addons. Revert once it is merged.
 (
   cd 3rdparty/avendish
-  git fetch origin addon-cmake-score-ci
+  git fetch origin addon-cmake-score-ci-main
   git checkout FETCH_HEAD
   git submodule update --init --recursive || true
 )

--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# TEMPORARY: build against the Avendish "addon-cmake" PR (celtera/avendish#97) to verify
+# the new addon CMake doesn't break score or its avnd addons. Revert once it is merged.
+(
+  cd 3rdparty/avendish
+  git fetch origin addon-cmake
+  git checkout FETCH_HEAD
+  git submodule update --init --recursive || true
+)
+
 (
 cd src/addons
 

--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -4,7 +4,7 @@
 # the new addon CMake doesn't break score or its avnd addons. Revert once it is merged.
 (
   cd 3rdparty/avendish
-  git fetch origin addon-cmake
+  git fetch origin addon-cmake-score-ci
   git checkout FETCH_HEAD
   git submodule update --init --recursive || true
 )


### PR DESCRIPTION
Temporary CI change to verify [celtera/avendish#97](https://github.com/celtera/avendish/pull/97) (host-aware `find_package(Avendish)` + `AvendishAddon` dispatcher, godot include fix) does not break score or its avnd-based add-ons.

`ci/common.deps.sh` checks out the `addon-cmake` branch in `3rdparty/avendish` before building, so the full matrix (score + all bundled addons) compiles against the PR.

Revert once #97 is merged.