### PR TITLE
sdk: match clang builtin headers to the compiler in use on macOS

### DIFF
--- a/ci/create-sdk-mac.sh
+++ b/ci/create-sdk-mac.sh
@@ -26,10 +26,11 @@ export XCODE_TOOLCHAIN=$XCODE/Toolchains/XcodeDefault.xctoolchain
 rsync -ar "$XCODE_MACOS_SDK/usr/include/" "$INCLUDE/"
 rsync -ar "$XCODE_MACOS_SDK/usr/include/c++" "$INCLUDE/"
 
-# Copy clang lib headers
-export LLVM_VER=$(ls $OSSIA_SDK/llvm-libs/lib/clang | sort -r | head -1)
+# Copy clang lib headers from the Xcode toolchain: macOS consumers build with
+# AppleClang, whose builtins differ from the LLVM the ossia-sdk ships
+export LLVM_VER=$(ls $XCODE_TOOLCHAIN/usr/lib/clang | sort -r | head -1)
 mkdir -p "$LIB/clang/$LLVM_VER"
-rsync -ar "$OSSIA_SDK/llvm-libs/lib/clang/$LLVM_VER/include" "$LIB/clang/$LLVM_VER/"
+rsync -ar "$XCODE_TOOLCHAIN/usr/lib/clang/$LLVM_VER/include" "$LIB/clang/$LLVM_VER/"
 
 # Copy Qt frameworks
 QT_FRAMEWORKS=$(find "$OSSIA_SDK/qt6-static/lib" -name '*.framework' | grep -E --only-matching 'Qt[a-zA-Z0-9_]+') 

--- a/cmake/ScoreExternalAddon.sdk.cmake
+++ b/cmake/ScoreExternalAddon.sdk.cmake
@@ -10,10 +10,20 @@ set(CMAKE_MODULE_PATH
 # Useful variables
 set(SCORE_AVND_SOURCE_DIR "${SCORE_SDK}/lib/cmake/score")
 
-# Find the clang version
-file(GLOB CLANG_RESOURCE_DIR "${SCORE_SDK}/lib/clang/*")
-list(GET CLANG_RESOURCE_DIR 0 CLANG_RESOURCE_DIR)
-string(STRIP "${CLANG_RESOURCE_DIR}" CLANG_RESOURCE_DIR)
+# Use the resource dir of the compiler actually in use, so that the builtin headers
+# always match it (e.g. AppleClang vs the LLVM the SDK was built with); fall back to
+# the headers shipped in the SDK.
+execute_process(
+  COMMAND "${CMAKE_CXX_COMPILER}" -print-resource-dir
+  OUTPUT_VARIABLE CLANG_RESOURCE_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
+)
+if(NOT CLANG_RESOURCE_DIR OR NOT EXISTS "${CLANG_RESOURCE_DIR}")
+  file(GLOB CLANG_RESOURCE_DIR "${SCORE_SDK}/lib/clang/*")
+  list(GET CLANG_RESOURCE_DIR 0 CLANG_RESOURCE_DIR)
+  string(STRIP "${CLANG_RESOURCE_DIR}" CLANG_RESOURCE_DIR)
+endif()
 
 # Find the Qt version
 file(GLOB QTCORE_FILES LIST_DIRECTORIES true "${SCORE_SDK}/include/qt/QtCore/*")


### PR DESCRIPTION
SDK builds of external addons fail on macOS with `arm_vector_types.h: unknown type name '__mfp8'`: the score SDK ships the ossia-sdk LLVM's clang resource headers (currently 21), but macOS consumers compile with AppleClang (older LLVM baseline), and `ScoreExternalAddon.sdk.cmake` forces that resource dir via `-nostdinc`/`-resource-dir`. On Linux/Windows the headers match because `build-addon` compiles with the ossia-sdk's own clang.

- `ScoreExternalAddon.sdk.cmake`: query the actual compiler with `-print-resource-dir` so the builtin headers always match it; fall back to the SDK-shipped headers.
- `ci/create-sdk-mac.sh`: package the Xcode toolchain's clang headers instead of the ossia-sdk LLVM ones, so the SDK fallback is also consistent with AppleClang.

Fixes the `SDK macOS` jobs across all score-addon repos.