### PR TITLE
jit: resolve addon prototypes from a relocatable SDK

### DIFF
--- a/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
+++ b/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
@@ -152,6 +152,14 @@ inline located_sdk locateSDKWithFallback()
   else
     ret.sdk_kind = located_sdk::platform;
 
+  // An explicitly-provided or relocatable SDK (SCORE_JIT_SDK, an AppImage / .app
+  // bundle) can live outside /usr; trust it as official when it actually ships the
+  // deployed score files the addon compiler needs, otherwise prototype and include
+  // resolution wrongly falls back to the build-time source tree (absent at runtime).
+  if(ret.sdk_kind == located_sdk::platform
+     && QDir(QString::fromStdString(ret.path)).exists("lib/cmake/score/prototype.cpp.in"))
+    ret.sdk_kind = located_sdk::official;
+
   {
     QDir dir(QString::fromStdString(ret.path));
     if(!dir.exists())


### PR DESCRIPTION
## Problem

JIT add-on compilation fails with **"Add-on has no cpp files"** whenever score runs from a relocatable build (AppImage / `.app` / `.exe`) or with `SCORE_JIT_SDK` pointing outside `/usr`. Reproduces on Linux/macOS/Windows in the `celtera/avendish-*-processor-template` `score / jit … continuous` CI jobs:

```
Registering JIT addon "./addon"
Found avnd finalize? true
QIODevice::read (QFile, "/score/src/plugins/score-plugin-avnd//prototype.cpp.in"): device not open
QIODevice::read (QFile, ".../plugin_prototype.cpp.in"): device not open
Add-on has no cpp files
```

## Root cause

`locateSDKWithFallback()` (`JitPlatform.hpp`) tags an SDK as `official` only if its path starts with `/usr` or `/Applications`. The CI sets `SCORE_JIT_SDK=…/sdk/usr` (a checkout-relative path), so it is tagged `platform`. Both prototype loading (`MetadataGenerator.hpp:257`) and include setup (`JitPlatform.hpp:797`) are gated on `sdk_kind == official && deploying`, so both fall back to `SCORE_ROOT_SOURCE_DIR` — the compile-time source path, which doesn't exist at runtime. The SDK *does* ship the prototypes (`score-plugin-avnd/CMakeLists.txt` installs them to `lib/cmake/score/`); only the classification was wrong.

## Fix

Promote a `platform` SDK to `official` when it actually contains `lib/cmake/score/prototype.cpp.in`. This fixes both gated sites at once and does not affect genuine dev builds (their located path won't contain that file).