### PR TITLE
jit: apply the COFF responsibility setup to the JITLink object layer

### DIFF
--- a/src/plugins/score-plugin-jit/JitCpp/Compiler/Compiler.cpp
+++ b/src/plugins/score-plugin-jit/JitCpp/Compiler/Compiler.cpp
@@ -223,6 +223,19 @@ static std::unique_ptr<llvm::orc::LLJIT> jitBuilder(JitCompiler& self)
     auto ObjLinkingLayer
         = std::make_unique<llvm::orc::ObjectLinkingLayer>(ES, *self.m_memmgr);
 
+    // COFF needs the same responsibility setup LLJIT applies to its own COFF
+    // object layer; a hand-built ObjectLinkingLayer omits it, so JIT-linking COFF
+    // objects fails with "Could not find symbol at given index, did you add it to
+    // JITSymbolTable?" on symbols the layer never claimed.
+#if LLVM_VERSION_MAJOR >= 21
+    const llvm::Triple& TT = ES.getTargetTriple();
+#endif
+    if(TT.isOSBinFormatCOFF())
+    {
+      ObjLinkingLayer->setOverrideObjectFlagsWithResponsibilityFlags(true);
+      ObjLinkingLayer->setAutoClaimResponsibilityForObjectSymbols(true);
+    }
+
     ObjLinkingLayer->addPlugin(std::make_shared<RuntimeInterposePlugin>(self.m_mangler));
     ObjLinkingLayer->addPlugin(std::make_shared<EagerLinkingPlugin>(ES));
 


### PR DESCRIPTION
Supersedes the earlier RuntimeDyld-revert approach (which didn't work). Keeps JITLink on Windows and instead completes its COFF setup.

## Root cause
score overrides `LLJITBuilder::setObjectLinkingLayerCreator` and hand-builds an `orc::ObjectLinkingLayer`. LLJIT's own object layer applies two COFF-specific settings that the hand-built one skips:
```cpp
if (TT.isOSBinFormatCOFF()) {
  Layer->setOverrideObjectFlagsWithResponsibilityFlags(true);
  Layer->setAutoClaimResponsibilityForObjectSymbols(true);
}
```
Without `setAutoClaimResponsibilityForObjectSymbols`, COFF objects fail to JIT-link with:
```
could not compile plug-in: Could not find symbol at given index, did you add it to JITSymbolTable? index: 9, section: 45
JITLink failed for main
```
— which is exactly the "symbol never claimed" condition those flags fix. (Note LLVM defaults COFF to RTDyld; if we keep JITLink on COFF we must replicate its COFF layer setup.)

## Fix
Apply both settings on the JITLink `ObjectLinkingLayer` when the target is COFF. ELF/MachO are unchanged.

⚠️ Not compile/run-tested locally (needs a Windows + LLVM-21 build) — please verify on the Windows JIT CI.