### PR TITLE
jit: add the SDK's bundled platform include paths to the addon compiler

### DIFF
--- a/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
+++ b/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
@@ -676,6 +676,22 @@ static inline void populateIncludeDirs(std::vector<std::string>& args)
   args.push_back(sdk + "/include/c++/v1");
 #endif
 
+  // libc++'s per-target __config_site lives at include/<triple>/c++/v1 (multiarch
+  // layout) and is #include'd by the main libc++ headers, so that dir must also be
+  // on the search path.
+  {
+    const QDir incdir(qsdk + "/include");
+    for(const auto& d : incdir.entryList(QDir::Dirs | QDir::NoDotAndDotDot))
+    {
+      if(QFileInfo::exists(qsdk + "/include/" + d + "/c++/v1/__config_site"))
+      {
+        args.push_back("-internal-isystem");
+        args.push_back(sdk + "/include/" + d.toStdString() + "/c++/v1");
+        break;
+      }
+    }
+  }
+
 #elif defined(_GLIBCXX_RELEASE)
   // Try to locate the correct libstdc++ folder
   // TODO these are only heuristics. how to make them better ?
@@ -727,6 +743,15 @@ static inline void populateIncludeDirs(std::vector<std::string>& args)
   args.push_back(sdk + "/lib/clang/" + llvm_lib_version + "/include");
   args.push_back("-internal-externc-isystem");
   args.push_back(sdk + "/include");
+#endif
+
+#if defined(__APPLE__)
+  // macOS framework headers are bundled flat in the SDK under include/macos-sdks
+  // (e.g. macos-sdks/ApplicationServices/ApplicationServices.h). In -cc1 mode no
+  // default framework path is added, so addons that transitively include a system
+  // framework (e.g. ApplicationServices via score/tools/Cursor.hpp) need this.
+  if(QFileInfo{qsdk + "/include/macos-sdks"}.isDir())
+    args.push_back("-isystem" + sdk + "/include/macos-sdks");
 #endif
 
   // -resource-dir


### PR DESCRIPTION
## Problem

The JIT compiler is invoked in `-cc1` mode (`populateIncludeDirs`), where clang adds **no default search paths**. Two directories the SDK already ships were not passed, so addon compilation failed once it got past the prototype stage (#2084):

- **macOS:** `score/tools/Cursor.hpp:5: 'ApplicationServices/ApplicationServices.h' file not found`
- **Linux:** `c++/v1/__config:13: '__config_site' file not found`

In both cases the headers are present in the SDK — just not on the search path.

## Fix

- **macOS:** the framework headers are bundled flat under `usr/include/macos-sdks/` (e.g. `macos-sdks/ApplicationServices/ApplicationServices.h`). Add `-isystem <sdk>/include/macos-sdks`.
- **Linux:** libc++'s per-target `__config_site` lives at `include/<triple>/c++/v1/__config_site` (multiarch layout). Discover that triple dir and add it as `-internal-isystem`.

Both come straight from the SDK; no host-toolchain dependency. Verified the paths against `sdk-darwin-aarch64.zip` and `sdk-linux-x86_64.zip` from the continuous release.