### PR TITLE
jit: accept Apple's CF_ENUM idiom on macOS (-Wno-elaborated-enum-base)

### DIFF
--- a/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
+++ b/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
@@ -257,6 +257,16 @@ populateCompileOptions(std::vector<std::string>& args, CompilerOptions opts)
 
 #if defined(__APPLE__)
   args.push_back("-fmax-type-align=16");
+
+  // Apple's CoreFoundation CF_ENUM / CF_OPTIONS macros expand (when the fixed
+  // underlying type is available, as in C++) to a non-defining fixed-underlying-
+  // type enum embedded in a typedef, e.g. `typedef enum E : long E; enum E : long
+  // {...};`. That form is only valid in Objective-C(++) where objc_fixed_enum is
+  // a feature; in plain C++23 clang rejects it as -Welaborated-enum-base. The JIT
+  // compiles the addon as C++ but pulls these headers in transitively (Qt, ossia),
+  // so accept the Apple idiom as the extension it is. clang still assigns the enum
+  // its correct fixed-type values.
+  args.push_back("-Wno-elaborated-enum-base");
 #endif
   args.push_back("-mrelocation-model");
   args.push_back("pic");


### PR DESCRIPTION
## Problem

The macOS `JIT … continuous` job (e.g. in the avendish audio-processor-template CI) fails at the JIT compile step with **144 identical errors**, all:

```
CFAvailability.h:142: non-defining declaration of enumeration with a fixed
underlying type is only permitted as a standalone declaration [-Welaborated-enum-base]
```
followed by `JITLink failed for main`.

This is the residual macOS failure exposed once #2086 made the `macos-sdks` headers reachable — the include path is now correct, but the headers themselves don't compile under the JIT clang.

## Cause

The JIT compiles the addon as plain C++23 (`-x c++`) and pulls in CoreFoundation transitively (Qt, ossia). Apple's `CF_ENUM` / `CF_OPTIONS` macros, when a fixed underlying type is available — which is true in C++ because `__has_extension(cxx_strong_enums)` — expand to a non-defining fixed-underlying-type enum embedded in a typedef:

```c
typedef enum E : long E; enum E : long { ... };
```

That form is only valid in **Objective-C(++)**, where `objc_fixed_enum` is a language feature. Upstream clang in plain C++ mode rejects it as a hard `-Welaborated-enum-base` error.

## Fix

Add `-Wno-elaborated-enum-base` to the JIT cc1 options on Apple only. clang then accepts the idiom as the extension it is, and still assigns the enums their correct fixed-type values.

Verified with clang-20: `-x c++` rejects the construct, `-x objective-c++` and `-x c++ -Wno-elaborated-enum-base` both accept it and produce correct enum values. The diagnostic is the sole error class across all 144 failures, so this clears the whole set.

Considered `-x objective-c++` (the most faithful fix) but it changes the whole TU's language; `-Wno-elaborated-enum-base` is surgical and keeps C++ mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)