### PR TITLE
library: make support-package native libraries loadable on Linux/macOS

### DIFF
--- a/src/plugins/score-plugin-library/Library/LibrarySettings.cpp
+++ b/src/plugins/score-plugin-library/Library/LibrarySettings.cpp
@@ -21,6 +21,8 @@
 
 #ifdef Q_OS_WIN
 #include <windows.h>
+#else
+#include <dlfcn.h>
 #endif
 W_OBJECT_IMPL(Library::Settings::View)
 W_OBJECT_IMPL(Library::Settings::Model)
@@ -46,12 +48,16 @@ static void initUserLibrary(const QDir& userlib)
   userlib.mkpath("./cues");
 }
 
-static void addSupportDllDirectories(const QDir& supportDir)
+// Make the native libraries shipped by "support" packages (in {RootPath}/support)
+// loadable by addons that dlopen / LoadLibrary them by bare name.
+static void addSupportLibraries(const QDir& supportDir)
 {
-#ifdef Q_OS_WIN
   if(!supportDir.exists())
     return;
 
+#ifdef Q_OS_WIN
+  // On Windows we can extend the DLL search path: register every directory that
+  // contains a .dll, so a later LoadLibrary("foo.dll") from an addon resolves.
   QSet<QString> added;
 
   QDirIterator it(
@@ -67,6 +73,47 @@ static void addSupportDllDirectories(const QDir& supportDir)
     added.insert(dir);
 
     AddDllDirectory(reinterpret_cast<PCWSTR>(dir.utf16()));
+  }
+#else
+  // On Linux/macOS there is no runtime equivalent of AddDllDirectory: the dynamic
+  // loader snapshots LD_LIBRARY_PATH / DYLD_* at process start, so changing them
+  // here would not affect later dlopen() calls. Instead, eagerly dlopen every
+  // support library with RTLD_GLOBAL: a subsequent bare-name dlopen() from an addon
+  // then resolves to the already-loaded object (the loader matches it by soname /
+  // install name). We iterate to a fixpoint so that inter-dependent support
+  // libraries load regardless of their on-disk order (each successful load makes its
+  // symbols / NEEDED entries available to the others). Libraries that never load
+  // (e.g. a missing external dependency) are simply skipped — the addon relying on
+  // them just stays unavailable, exactly as before.
+#if defined(Q_OS_MACOS)
+  const QStringList patterns{"*.dylib"};
+#else
+  const QStringList patterns{"*.so", "*.so.*"};
+#endif
+
+  QStringList pending;
+  for(QDirIterator it(
+          supportDir.absolutePath(), patterns, QDir::Files,
+          QDirIterator::Subdirectories);
+      it.hasNext();)
+    pending.push_back(it.next());
+
+  bool progress = true;
+  while(progress && !pending.empty())
+  {
+    progress = false;
+    for(auto it = pending.begin(); it != pending.end();)
+    {
+      if(dlopen(it->toUtf8().constData(), RTLD_LAZY | RTLD_GLOBAL))
+      {
+        it = pending.erase(it);
+        progress = true;
+      }
+      else
+      {
+        ++it;
+      }
+    }
   }
 #endif
 }
@@ -96,7 +143,7 @@ Model::Model(
   }
   initUserLibrary(getUserLibraryPath());
 
-  addSupportDllDirectories(getSupportPath());
+  addSupportLibraries(getSupportPath());
 }
 
 QString Model::getPackagesPath() const noexcept


### PR DESCRIPTION
## Problem

`Library::Settings` registers the native libraries shipped by `support`-kind packages (extracted to `{RootPath}/support`) so addons can `dlopen`/`LoadLibrary` them **by bare name**. But `addSupportDllDirectories` was **Windows-only** (`AddDllDirectory` per directory containing a `.dll`). On Linux/macOS there was no equivalent, so a native library delivered by a `support` package could not be resolved by a bare-name `dlopen()` from an addon.

## Approach

Generalize `addSupportDllDirectories` → `addSupportLibraries`:

- **Windows** — unchanged (`AddDllDirectory`).
- **Linux/macOS** — `LD_LIBRARY_PATH` / `DYLD_*` are snapshotted by the dynamic loader at process start, so mutating them here would not affect later `dlopen()` calls. Instead, eagerly `dlopen` every support library with `RTLD_GLOBAL`; a subsequent bare-name `dlopen()` from an addon then resolves to the already-loaded object (matched by soname / install name). The loads run to a **fixpoint** so inter-dependent support libraries load regardless of on-disk order; libraries with unmet external dependencies are skipped (no behavior change for them).

This is fully generic: any current or future native-library `support` package becomes loadable without per-addon code.

## Notes

- Timing matches the Windows path (once, at `Library::Settings::Model` construction / startup), so a freshly-installed `support` package is picked up on the next launch.
- No effect when the Library subsystem is disabled (`SCORE_DISABLE_LIBRARY=1`) — custom apps that bundle libraries next to the binary are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)