### PR TITLE
gfx: set Text process help URL

### DIFF
--- a/src/plugins/score-plugin-gfx/Gfx/Text/Metadata.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Text/Metadata.hpp
@@ -17,6 +17,6 @@ PROCESS_METADATA(
     (QStringList{"gfx", "text"}),     // Tags
     {},                               // Inputs
     {},                               // Outputs
-    QUrl(""),
+    QUrl("https://ossia.io/score-docs/processes/text.html"),
     Process::ProcessFlags::SupportsAll | Process::ProcessFlags::ControlSurface // Flags
 )


### PR DESCRIPTION
The Text process had an empty manual_url, so pressing F1 opened nothing. Point it to the existing reference page.