### PR TITLE
gfx/js: per-preset F1 help URLs for ISF shaders and JS scripts

### DIFF
--- a/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
+++ b/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
@@ -1132,6 +1132,10 @@ static const ossia::string_map<root_fun>& root_parse{[] {
     if(v.get_type() == sajson::TYPE_STRING)
       d.credits = v.as_string();
   }});
+  p.insert({"DOCUMENTATION", [](descriptor& d, const sajson::value& v) {
+    if(v.get_type() == sajson::TYPE_STRING)
+      d.documentation = v.as_string();
+  }});
   p.insert({"CATEGORIES", [](descriptor& d, const sajson::value& v) {
     if(v.get_type() == sajson::TYPE_ARRAY)
     {
@@ -2912,6 +2916,12 @@ std::string parser::write_isf() const
   if(!m_desc.credits.empty())
   {
     oss << "  \"CREDIT\": \"" << escape_json(m_desc.credits) << "\",\n";
+  }
+
+  // Add documentation URL if present
+  if(!m_desc.documentation.empty())
+  {
+    oss << "  \"DOCUMENTATION\": \"" << escape_json(m_desc.documentation) << "\",\n";
   }
 
   // Add categories if present

--- a/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.hpp
+++ b/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.hpp
@@ -332,6 +332,7 @@ struct descriptor
   } mode{ISF};
   std::string description;
   std::string credits;
+  std::string documentation;
   std::vector<std::string> categories;
   std::vector<input> inputs;
   std::vector<output_declaration> outputs; // Parsed from OUTPUTS array; empty = single color output

--- a/src/plugins/score-plugin-gfx/Gfx/ISFProcess.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/ISFProcess.hpp
@@ -42,6 +42,8 @@ struct ISFHelpers
         base.author = QString::fromStdString(desc.credits);
       if(!desc.description.empty())
         base.description = QString::fromStdString(desc.description);
+      if(!desc.documentation.empty())
+        base.documentationLink = QUrl(QString::fromStdString(desc.documentation));
       for(auto& cat : desc.categories)
         base.tags.push_back(QString::fromStdString(cat));
     }

--- a/src/plugins/score-plugin-js/JS/JSProcessFactory.hpp
+++ b/src/plugins/score-plugin-js/JS/JSProcessFactory.hpp
@@ -16,7 +16,40 @@ struct LanguageSpec
   static constexpr const char* language = "JS";
 };
 
-using ProcessFactory = Process::ProcessFactory_T<JS::ProcessModel>;
+// Scan the first lines of a QML script for a `// @documentation <url>`
+// comment so a preset can point F1 to its own help page.
+inline QUrl documentationUrlFromScript(const QString& script) noexcept
+{
+  static const QString tag = QStringLiteral("// @documentation");
+  int line = 0;
+  for(const QString& raw : script.split('\n'))
+  {
+    if(++line > 20)
+      break;
+    const QString trimmed = raw.trimmed();
+    if(trimmed.startsWith(tag))
+    {
+      const QString url = trimmed.mid(tag.size()).trimmed();
+      if(!url.isEmpty())
+        return QUrl(url);
+    }
+  }
+  return {};
+}
+
+class ProcessFactory final : public Process::ProcessFactory_T<JS::ProcessModel>
+{
+public:
+  using Process::ProcessFactory_T<JS::ProcessModel>::descriptor;
+  Process::Descriptor descriptor(const Process::ProcessModel& m) const noexcept override
+  {
+    auto desc = Metadata<Process::Descriptor_k, JS::ProcessModel>::get();
+    const auto& js = safe_cast<const JS::ProcessModel&>(m);
+    if(auto url = documentationUrlFromScript(js.executionScript()); !url.isEmpty())
+      desc.documentationLink = url;
+    return desc;
+  }
+};
 struct LayerFactory : Process::EffectLayerFactory_Base
 {
   using Model_T = JS::ProcessModel;


### PR DESCRIPTION
ISF (libisf): parse an optional "DOCUMENTATION" key from the ISF JSON header into descriptor::documentation, serialize it back, and set it as the process documentationLink in descriptorFromISFFile. Lets a shader preset point F1 at its own page instead of the generic ISF site.

JS (score-plugin-js): add a ProcessFactory that overrides descriptor(const ProcessModel&) to scan the QML's first lines for a `// @documentation <url>` comment and use it as the documentationLink.

With these, score-user-library presets can route F1 to their own score-docs pages. Verified compiling (libisf + gfx + js TUs); the rest of the tree has unrelated pre-existing build breakage in this checkout.