### PR TITLE
ci: bump ossia SDK sdk36 -> sdk37 (Windows JIT COFF fix + orc_rt)

### DIFF
--- a/ci/appimage.deps.sh
+++ b/ci/appimage.deps.sh
@@ -9,7 +9,7 @@ else
   export CPU_ARCH_SUFFIX="-x86_64"
 fi
 
-wget -nv "https://github.com/ossia/sdk/releases/download/sdk36/sdk-linux${CPU_ARCH_SUFFIX}.tar.xz"
+wget -nv "https://github.com/ossia/sdk/releases/download/sdk37/sdk-linux${CPU_ARCH_SUFFIX}.tar.xz"
 tar xaf sdk-linux${CPU_ARCH_SUFFIX}.tar.xz
 rm -rf  sdk-linux${CPU_ARCH_SUFFIX}.tar.xz
 

--- a/ci/osx.package.deps.sh
+++ b/ci/osx.package.deps.sh
@@ -33,7 +33,7 @@ brew install gnu-tar ninja xz
 wget -nv "https://github.com/jcelerier/cninja/releases/download/v3.7.9/cninja-v3.7.9-macOS-$MACOS_ARCH.tar.gz" -O cninja.tgz &
 
 SDK_ARCHIVE=sdk-macOS-$MACOS_ARCH.tar.xz
-wget -nv https://github.com/ossia/sdk/releases/download/sdk36/$SDK_ARCHIVE -O "$SDK_ARCHIVE"
+wget -nv https://github.com/ossia/sdk/releases/download/sdk37/$SDK_ARCHIVE -O "$SDK_ARCHIVE"
 
 sudo mkdir -p "/opt/ossia-sdk-$MACOS_ARCH/"
 sudo chown -R "$(whoami)" /opt

--- a/ci/win32.deps.sh
+++ b/ci/win32.deps.sh
@@ -8,7 +8,7 @@ choco install -y nsis
 set -x
 mkdir /c/ossia-sdk-x86_64
 cd /c/ossia-sdk-x86_64
-curl -L https://github.com/ossia/sdk/releases/download/sdk36/sdk-mingw-x86_64.7z --output sdk-mingw-x86_64.7z
+curl -L https://github.com/ossia/sdk/releases/download/sdk37/sdk-mingw-x86_64.7z --output sdk-mingw-x86_64.7z
 7z x sdk-mingw-x86_64.7z
 rm sdk-mingw-x86_64.7z
 ls

--- a/tools/fetch-sdk.sh
+++ b/tools/fetch-sdk.sh
@@ -3,7 +3,7 @@
 if [[ $# > 0 ]]; then
   export SDK_VERSION=$1
 else
-  export SDK_VERSION=sdk36
+  export SDK_VERSION=sdk37
 fi
 
 echo "Running on OSTYPE: '$OSTYPE'"


### PR DESCRIPTION
Bumps the pinned ossia SDK `sdk36 → sdk37` in the deps scripts (win32 / macOS / AppImage + `tools/fetch-sdk.sh`). The other `sdkNN` pins (icu/msvc/wasm components) are untouched.

**sdk37** is the SDK rebuilt on **LLVM 22.1.8** with:
- the JITLink **COFF leaderless-COMDAT fix** (ossia/sdk#9) — links the `.xdata`/`.pdata` SEH unwind sections every throwing C++ add-on emits, fixing the Windows JIT `Could not find symbol at given index, index: 9`;
- compiler-rt **orc_rt** (ossia/sdk#7).

Asset names/layout are identical to sdk36, so this is a pure version bump (verified `…/sdk37/sdk-mingw-x86_64.7z` → HTTP 200).

Once merged + the Windows build republishes, the audio-template `JIT Windows continuous` should get past linking. (Runtime exception unwinding via orc_rt is the follow-up — draft #2092.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)