### PR TITLE
Various execution engine fixes

### DIFF
--- a/src/lib/core/presenter/DocumentManager.cpp
+++ b/src/lib/core/presenter/DocumentManager.cpp
@@ -158,6 +158,17 @@ DocumentManager::~DocumentManager()
   // ApplicationPlugin.
   for(auto document : m_documents)
   {
+    // Reverse creation order, to match ~DocumentModel (e.g. the execution
+    // plugin must be torn down before the device explorer plugin).
+    auto& plugs = document->model().pluginModels();
+    for(auto it = plugs.rbegin(); it != plugs.rend(); ++it)
+    {
+      (*it)->on_documentClosing();
+    }
+  }
+
+  for(auto document : m_documents)
+  {
     document->deleteLater();
   }
 

--- a/src/lib/score/gfx/Vulkan.cpp
+++ b/src/lib/score/gfx/Vulkan.cpp
@@ -60,6 +60,8 @@ QVulkanInstance* staticVulkanInstance(bool create)
     if(!instance.create())
     {
       g_staticVulkanInstanceInvalid = true;
+      delete g_staticVulkanInstance;
+      g_staticVulkanInstance = nullptr;
     }
   });
 

--- a/src/lib/score/model/path/ObjectPath.cpp
+++ b/src/lib/score/model/path/ObjectPath.cpp
@@ -147,6 +147,30 @@ QString ObjectPath::toString() const noexcept
   return s;
 }
 
+ObjectPath ObjectPath::fromString(const QString& str) noexcept
+{
+  std::vector<ObjectIdentifier> v;
+  for(const auto& seg : QStringView{str}.split(QLatin1Char('/'), Qt::SkipEmptyParts))
+  {
+    const auto dot = seg.lastIndexOf(QLatin1Char('.'));
+    if(dot <= 0)
+      return {};
+    bool ok{};
+    const int32_t id = seg.mid(dot + 1).toInt(&ok);
+    if(!ok)
+      return {};
+    v.emplace_back(seg.left(dot).toString(), id);
+  }
+  return ObjectPath{std::move(v)};
+}
+
+QObject* ObjectPath::findObject(const score::DocumentContext& ctx) const noexcept
+{
+  if(m_objectIdentifiers.empty())
+    return nullptr;
+  return find_impl_unsafe(ctx);
+}
+
 QObject* ObjectPath::find_impl(const score::DocumentContext& ctx) const
 {
   using namespace score;

--- a/src/lib/score/model/path/ObjectPath.hpp
+++ b/src/lib/score/model/path/ObjectPath.hpp
@@ -59,6 +59,8 @@ public:
   ObjectPath() noexcept { }
   ~ObjectPath() noexcept = default;
   QString toString() const noexcept;
+  static ObjectPath fromString(const QString& str) noexcept;
+  QObject* findObject(const score::DocumentContext& ctx) const noexcept;
 
   explicit ObjectPath(std::vector<ObjectIdentifier> vec) noexcept
       : m_objectIdentifiers{std::move(vec)}

--- a/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
@@ -38,6 +38,12 @@
 namespace oscr
 {
 
+// The condition under which a process needs the port-callback storage (a
+// model-side Info instance). The storage member and its init guard below must
+// both use it — keep them in sync.
+template <typename Info>
+concept needs_ports_callback_storage = has_dynamic_ports<Info>;
+
 template <typename Info>
 struct MessageBusWrapperToUi
 {
@@ -92,7 +98,8 @@ public:
   oscr::dynamic_ports_storage<Info> dynamic_ports;
 
   [[no_unique_address]]
-  ossia::type_if<Info, oscr::has_dynamic_ports<Info>> object_storage_for_ports_callbacks;
+  ossia::type_if<Info, oscr::needs_ports_callback_storage<Info>>
+      object_storage_for_ports_callbacks;
 
   ProcessModel(
       const TimeVal& duration, const Id<Process::ProcessModel>& id,
@@ -202,9 +209,7 @@ private:
 
   void init_controller_ports()
   {
-    if constexpr(
-        avnd::dynamic_ports_input_introspection<Info>::size > 0
-        || avnd::dynamic_ports_output_introspection<Info>::size > 0)
+    if constexpr(oscr::needs_ports_callback_storage<Info>)
     {
       avnd::control_input_introspection<Info>::for_all_n2(
           avnd::get_inputs<Info>((Info&)this->object_storage_for_ports_callbacks),

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/DocumentPlugin/DeviceDocumentPlugin.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/DocumentPlugin/DeviceDocumentPlugin.cpp
@@ -59,6 +59,14 @@ DeviceDocumentPlugin::DeviceDocumentPlugin(
   m_explorer = new DeviceExplorerModel{*this, this};
 }
 
+void DeviceDocumentPlugin::on_documentClosing()
+{
+  for(auto dev : this->m_list.devices())
+  {
+    dev->disconnect();
+  }
+}
+
 DeviceDocumentPlugin::~DeviceDocumentPlugin()
 {
   for(auto dev : this->m_list.devices())

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp
@@ -49,6 +49,8 @@ public:
 
   void init();
 
+  void on_documentClosing() override;
+
   Device::Node& rootNode() { return m_rootNode; }
   const Device::Node& rootNode() const { return m_rootNode; }
 

--- a/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
@@ -35,8 +35,10 @@ extern "C" {
 #include <Gfx/GStreamer/GStreamerLoader.hpp>
 #include <Video/GStreamerCompatibility.hpp>
 
+#include <ossia/detail/parse_strict.hpp>
+
 #include <climits>
-#include <regex>
+#include <ctre.hpp>
 #include <thread>
 
 namespace Gfx::GStreamer
@@ -72,6 +74,11 @@ struct gstreamer_pipeline
 
     // Ring buffer per channel, written by GStreamer thread, read by audio engine
     static constexpr std::size_t ring_size = 65536;
+
+    // Max block the audio thread may resize the output storage to; the
+    // parameter reserves this up front so the per-tick resize never reallocates
+    // (a realloc would free a buffer the audio thread is reading through).
+    static constexpr std::size_t max_block = 1 << 15;
     std::vector<std::vector<float>> ring; // [channel][ring_size]
     std::atomic<std::size_t> write_pos{0};
     std::atomic<std::size_t> read_pos{0};
@@ -100,11 +107,38 @@ struct gstreamer_pipeline
       write_pos.store(wp + num_samples, std::memory_order_release);
     }
 
+    // Points at the parameter's audio spans so read_into_output can re-point
+    // them after a resize. A raw pointer (not a std::function) so that clearing
+    // or using it during teardown can never throw on the audio thread.
+    ossia::small_vector<std::span<float>, 8>* output_spans{};
+
     // Called by audio engine (indirectly): copy from ring into output spans
     void read_into_output(int block_size)
     {
       if(!output_data)
         return;
+
+      // The engine tick size can differ from the configured buffer size
+      // (e.g. PipeWire dynamic quantum); the storage follows it, but never
+      // beyond the capacity reserved at construction (so no reallocation).
+      if(block_size > (int)max_block)
+        block_size = max_block;
+      bool resized = false;
+      for(auto& v : *output_data)
+      {
+        if(std::ssize(v) != block_size)
+        {
+          v.resize(block_size);
+          resized = true;
+        }
+      }
+      if(resized && output_spans && output_data)
+      {
+        const std::size_t n = std::min(output_spans->size(), output_data->size());
+        for(std::size_t i = 0; i < n; i++)
+          (*output_spans)[i] = (*output_data)[i];
+      }
+
       auto rp = read_pos.load(std::memory_order_relaxed);
       auto wp = write_pos.load(std::memory_order_acquire);
 
@@ -237,12 +271,15 @@ struct gstreamer_pipeline
           }
           else
           {
-            // Caps not yet negotiated; default to video
-            info.is_video = true;
-            info.width = 640;
-            info.height = 480;
-            info.pixfmt = AV_PIX_FMT_RGBA;
-            video_count++;
+            // Caps not yet negotiated (e.g. live sources: v4l2src, webrtcsrc,
+            // audiotestsrc is-live=true don't preroll in PAUSED).
+            // Fall back to classifying from the pipeline description: the
+            // nearest audio/video token before this appsink wins.
+            classify_from_pipeline_string(pipeline_string, sink_name, info);
+            if(info.is_video)
+              video_count++;
+            else
+              audio_count++;
           }
           gst.object_unref(pad);
         }
@@ -347,17 +384,16 @@ struct gstreamer_pipeline
   }
 
 private:
+  static constexpr auto appsink_name_rexp
+      = ctll::fixed_string{R"(appsink\b[^!]*?\bname\s*=\s*([A-Za-z0-9_]+))"};
+  static constexpr auto elem_name_rexp
+      = ctll::fixed_string{R"(\bname\s*=\s*([A-Za-z0-9_]+))"};
+
   static std::vector<std::string> find_appsink_names(const std::string& pipeline)
   {
     std::vector<std::string> names;
-    // Match "appsink" optionally followed by properties including name=<identifier>
-    std::regex re(R"(appsink\b[^!]*?\bname\s*=\s*(\w+))");
-    auto begin = std::sregex_iterator(pipeline.begin(), pipeline.end(), re);
-    auto end = std::sregex_iterator();
-    for(auto it = begin; it != end; ++it)
-    {
-      names.push_back((*it)[1].str());
-    }
+    for(auto m : ctre::search_all<appsink_name_rexp>(pipeline))
+      names.push_back(m.get<1>().to_string());
     return names;
   }
 
@@ -366,14 +402,87 @@ private:
   static std::vector<std::string> find_all_named_elements(const std::string& pipeline)
   {
     std::vector<std::string> names;
-    std::regex re(R"(\bname\s*=\s*(\w+))");
-    auto begin = std::sregex_iterator(pipeline.begin(), pipeline.end(), re);
-    auto end = std::sregex_iterator();
-    for(auto it = begin; it != end; ++it)
-    {
-      names.push_back((*it)[1].str());
-    }
+    for(auto m : ctre::search_all<elem_name_rexp>(pipeline))
+      names.push_back(m.get<1>().to_string());
     return names;
+  }
+
+  static constexpr auto channels_rexp
+      = ctll::fixed_string{R"(channels=(?:\(int\))?\s*([0-9]+))"};
+  static constexpr auto rate_rexp
+      = ctll::fixed_string{R"(rate=(?:\(int\))?\s*([0-9]+))"};
+  static constexpr auto width_rexp
+      = ctll::fixed_string{R"(width=(?:\(int\))?\s*([0-9]+))"};
+  static constexpr auto height_rexp
+      = ctll::fixed_string{R"(height=(?:\(int\))?\s*([0-9]+))"};
+  static constexpr auto format_rexp
+      = ctll::fixed_string{R"(format=(?:\(string\))?\s*([A-Za-z0-9]+))"};
+
+  template <ctll::fixed_string Rexp>
+  static int last_int_of(std::string_view str, int fallback)
+  {
+    int ret = fallback;
+    for(auto m : ctre::search_all<Rexp>(str))
+      if(auto v = ossia::parse_strict<int>(m.template get<1>().to_view()))
+        ret = *v;
+    return ret;
+  }
+
+  // Guess an appsink's media type from the pipeline string when caps are
+  // not negotiated yet: look for the last audio/video-ish token occurring
+  // before "appsink ... name=<sink_name>".
+  static void classify_from_pipeline_string(
+      const std::string& pipeline, const std::string& sink_name, AppsinkInfo& info)
+  {
+    std::size_t sink_pos = std::string::npos;
+    for(auto m : ctre::search_all<appsink_name_rexp>(pipeline))
+    {
+      if(m.get<1>().to_view() == sink_name)
+      {
+        sink_pos = std::distance(pipeline.begin(), m.get<0>().begin());
+        break;
+      }
+    }
+    const std::string_view before
+        = std::string_view{pipeline}.substr(0, sink_pos);
+
+    static constexpr std::string_view audio_tokens[]
+        = {"audio/x-raw", "audioconvert", "audioresample", "audiotestsrc"};
+    static constexpr std::string_view video_tokens[]
+        = {"video/x-raw", "videoconvert", "videoscale", "videotestsrc", "videorate"};
+
+    std::size_t last_audio = std::string::npos, last_video = std::string::npos;
+    for(auto tok : audio_tokens)
+      if(auto p = before.rfind(tok); p != std::string::npos)
+        last_audio = (last_audio == std::string::npos) ? p : std::max(last_audio, p);
+    for(auto tok : video_tokens)
+      if(auto p = before.rfind(tok); p != std::string::npos)
+        last_video = (last_video == std::string::npos) ? p : std::max(last_video, p);
+
+    const bool is_audio = last_audio != std::string::npos
+                          && (last_video == std::string::npos || last_audio > last_video);
+    if(is_audio)
+    {
+      info.is_video = false;
+      info.channels = last_int_of<channels_rexp>(before, 2);
+      info.rate = last_int_of<rate_rexp>(before, 48000);
+    }
+    else
+    {
+      info.is_video = true;
+      info.width = last_int_of<width_rexp>(before, 640);
+      info.height = last_int_of<height_rexp>(before, 480);
+      info.pixfmt = AV_PIX_FMT_RGBA;
+      std::string format;
+      for(auto m : ctre::search_all<format_rexp>(before))
+        format = m.get<1>().to_string();
+      if(!format.empty())
+      {
+        auto& map = ::Video::gstreamerToLibav();
+        if(auto it = map.find(format); it != map.end())
+          info.pixfmt = it->second;
+      }
+    }
   }
 
   static void parse_video_caps(
@@ -601,18 +710,29 @@ public:
       , m_audio_data(num_channels)
       , m_block_size{bs}
   {
-    // Set up owned buffers and point audio spans to them permanently
+    // Set up owned buffers and point audio spans to them permanently.
+    // Reserve a generous capacity up front so the per-tick resize() in
+    // read_into_output (block size follows the engine quantum) never
+    // reallocates — a realloc here would free a buffer the audio thread may
+    // still be reading through the spans, causing a double free.
     audio.resize(num_channels);
     for(int i = 0; i < num_channels; i++)
     {
+      m_audio_data[i].reserve(gstreamer_pipeline::AudioBuffer::max_block);
       m_audio_data[i].resize(bs, 0.f);
       audio[i] = m_audio_data[i];
     }
-    // Give the AudioBuffer a pointer so read_into_output can fill our buffers
+    // Give the AudioBuffer pointers so read_into_output can fill our buffers
+    // and re-point our spans after a resize.
     m_buffer.output_data = &m_audio_data;
+    m_buffer.output_spans = &audio;
   }
 
-  virtual ~gstreamer_audio_parameter() { m_buffer.output_data = nullptr; }
+  virtual ~gstreamer_audio_parameter()
+  {
+    m_buffer.output_data = nullptr;
+    m_buffer.output_spans = nullptr;
+  }
 
   // clone_value() (not virtual) reads from audio spans.
   // We use push_value(audio_port) as a hook — it's called by the audio engine
@@ -633,8 +753,10 @@ public:
 
   void refresh_from_ring()
   {
-    m_buffer.read_into_output(m_block_size);
-    // Re-point spans (in case vectors reallocated, though they shouldn't)
+    // Follow whatever block size the engine last requested in pre_tick
+    const int bs
+        = m_audio_data.empty() ? m_block_size : (int)m_audio_data[0].size();
+    m_buffer.read_into_output(bs);
     for(std::size_t i = 0; i < m_audio_data.size(); i++)
       audio[i] = m_audio_data[i];
   }

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
@@ -1303,7 +1303,38 @@ void RenderList::render(QRhiCommandBuffer& commands, bool force)
       // For each edge incoming to each image input ports of this node,
       // we render the edge source's content.
       if(input->edges.empty())
+      {
+        // An image input with no incoming edge must still have its render
+        // target cleared each frame; otherwise removing a cable while both
+        // endpoints stay alive leaves the last frame stuck in the consumer
+        // (e.g. a mixer keeps compositing a source that was disconnected).
+        if(input->type == Types::Image
+           && (input->flags & Flag::GrabsFromSource) != Flag::GrabsFromSource)
+        {
+          auto rendered = node->renderedNodes.find(this);
+          SCORE_ASSERT(rendered != node->renderedNodes.end());
+          NodeRenderer* renderer = rendered->second;
+
+          auto rt = renderer->renderTargetForInput(*input);
+          if(!rt)
+            rt = renderTargetForInputPort(*input);
+          if(rt)
+          {
+            QColor bg = (it + 1 == this->nodes.rend() ? Qt::black : Qt::transparent);
+            commands.beginPass(rt.renderTarget, bg, {1.0f, 0}, updateBatch);
+            updateBatch = nullptr;
+            commands.endPass(updateBatch);
+            updateBatch = nullptr;
+
+            if(node != &output)
+            {
+              updateBatch = state.rhi->nextResourceUpdateBatch();
+              SCORE_ASSERT(updateBatch);
+            }
+          }
+        }
         continue;
+      }
 
       if(input->type == Types::Image)
       {

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
@@ -238,9 +238,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     params.format.setSamples(state.samples);
     state.version = caps.qShaderVersion;
     state.rhi = QRhi::create(QRhi::OpenGLES2, &params, flags);
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 
@@ -331,9 +334,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     if(!state.rhi)
       state.rhi = QRhi::create(QRhi::Vulkan, &params, flags);
 
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 
@@ -351,9 +357,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     // }
     state.version = Gfx::Settings::shaderVersionForAPI(D3D11);
     state.rhi = QRhi::create(QRhi::D3D11, &params, flags);
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
   else if(graphicsApi == D3D12)
@@ -369,9 +378,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     // }
     state.version = Gfx::Settings::shaderVersionForAPI(D3D12);
     state.rhi = QRhi::create(QRhi::D3D12, &params, flags);
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 #endif
@@ -382,9 +394,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     QRhiMetalInitParams params;
     state.version = Gfx::Settings::shaderVersionForAPI(Metal);
     state.rhi = QRhi::create(QRhi::Metal, &params, flags);
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 

--- a/src/plugins/score-plugin-gfx/Gfx/InvertYRenderer.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/InvertYRenderer.cpp
@@ -108,6 +108,11 @@ void InvertYRenderer::finishFrame(
 {
   cb.beginPass(m_renderTarget.renderTarget, Qt::black, {0.0f, 0}, res);
   res = nullptr;
+  // m_p.pipeline is null when buildPipeline's QRhiGraphicsPipeline::create()
+  // failed (transient during graph rebuild). setGraphicsPipeline asserts on a
+  // null pipeline (Q_ASSERT) and dereferences it in release builds, so skip
+  // the draw — the target is still cleared and read back (as black).
+  if(m_p.pipeline)
   {
     const auto sz = renderer.state.renderSize;
     cb.setGraphicsPipeline(m_p.pipeline);
@@ -195,6 +200,9 @@ void ScaledRenderer::finishFrame(score::gfx::RenderList &renderer, QRhiCommandBu
 {
   cb.beginPass(m_renderTarget.renderTarget, Qt::black, {0.0f, 0}, res);
   res = nullptr;
+  // See InvertYRenderer::finishFrame: skip the draw if the pipeline failed to
+  // build (null), rather than asserting/dereferencing in setGraphicsPipeline.
+  if(m_p.pipeline)
   {
     const auto sz = renderer.state.outputSize;
 

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.cpp
@@ -1,3 +1,4 @@
+#include <score/model/path/ObjectPath.hpp>
 #include <JS/Qml/EditContext.hpp>
 
 #include <score/application/GUIApplicationContext.hpp>
@@ -9,6 +10,7 @@
 
 #include <core/command/CommandStack.hpp>
 #include <core/document/Document.hpp>
+#include <core/document/DocumentModel.hpp>
 #include <core/presenter/DocumentManager.hpp>
 
 #include <QFile>
@@ -79,6 +81,31 @@ QObject* EditJsContext::findByLabel(QString p)
     }
   }
   return nullptr;
+}
+
+QString EditJsContext::path(QObject* obj)
+{
+  auto doc = ctx();
+  if(!doc || !obj)
+    return {};
+  try
+  {
+    auto full = ObjectPath::pathBetweenObjects(&doc->document.model(), obj);
+    auto& v = full.vec();
+    return ObjectPath{{v.begin() + 1, v.end()}}.toString();
+  }
+  catch(...)
+  {
+    return {};
+  }
+}
+
+QObject* EditJsContext::findByPath(QString path)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  return ObjectPath::fromString(path).findObject(*doc);
 }
 
 void EditJsContext::load(QString doc)

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
@@ -142,6 +142,12 @@ public:
   void setIntervalSpeed(QObject* object, double);
   W_SLOT(setIntervalSpeed)
 
+  void setAutoTrigger(QObject* timeSync, bool);
+  W_SLOT(setAutoTrigger)
+
+  void setProcessLoop(QObject* process, bool);
+  W_SLOT(setProcessLoop)
+
   QObject* port(QObject* obj, QString name);
   W_SLOT(port)
 
@@ -161,6 +167,9 @@ public:
   W_SLOT(createCable, (QObject*, QObject*))
   QObject* createCable(QObject* outlet, QObject* inlet, Process::CableType type);
   W_SLOT(createCable, (QObject*, QObject*, Process::CableType))
+
+  QObject* cable(QObject* outlet, QObject* inlet);
+  W_SLOT(cable)
 
   void setAddress(QObject* obj, QString addr);
   W_SLOT(setAddress)
@@ -284,6 +293,10 @@ public:
 
   QObject* findByLabel(QString p);
   W_SLOT(findByLabel)
+  QString path(QObject* obj);
+  W_SLOT(path)
+  QObject* findByPath(QString path);
+  W_SLOT(findByPath)
 
   QObject* document();
   W_SLOT(document)

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.port.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.port.cpp
@@ -128,6 +128,29 @@ EditJsContext::createCable(QObject* outlet, QObject* inlet, Process::CableType t
   return &c;
 }
 
+// Find the cable currently connecting a given outlet to a given inlet, or null.
+// Derives connection state from the live graph (cables are unnamed and their
+// ids are reused, so they cannot be tracked reliably by name or path).
+QObject* EditJsContext::cable(QObject* outlet, QObject* inlet)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  auto src = qobject_cast<Process::Outlet*>(outlet);
+  auto sink = qobject_cast<Process::Inlet*>(inlet);
+  if(!src || !sink)
+    return nullptr;
+
+  auto& root = score::IDocument::get<Scenario::ScenarioDocumentModel>(doc->document);
+  auto& ctx = doc->document.context();
+  for(auto& c : root.cables)
+  {
+    if(c.source().try_find(ctx) == src && c.sink().try_find(ctx) == sink)
+      return &c;
+  }
+  return nullptr;
+}
+
 void EditJsContext::setAddress(QObject* obj, QString addr)
 {
   auto doc = ctx();

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
@@ -1,5 +1,8 @@
+#include <Process/Commands/Properties.hpp>
+#include <Process/Dataflow/Cable.hpp>
 #include <Process/Preset.hpp>
 #include <Process/ProcessList.hpp>
+#include <Scenario/Commands/TimeSync/SetAutoTrigger.hpp>
 
 #include <Scenario/Commands/CommandAPI.hpp>
 #include <Scenario/Commands/Metadata/ChangeElementName.hpp>
@@ -485,6 +488,15 @@ void EditJsContext::remove(QObject* obj)
     if(auto itv = qobject_cast<Scenario::IntervalModel*>(proc->parent()))
       m->removeProcess(*itv, proc->id());
   }
+  else if(auto cable = qobject_cast<Process::Cable*>(obj))
+  {
+    // Cables live in the document-level cable map, not in a scenario process,
+    // so the generic parent-based removal below never matches them.
+    auto& root
+        = score::IDocument::get<Scenario::ScenarioDocumentModel>(doc->document);
+    auto [m, _] = macro(*doc);
+    m->removeCable(root, *cable);
+  }
   else if(auto p = obj->parent())
   {
     if(auto scenar = qobject_cast<Scenario::ProcessModel*>(p))
@@ -634,5 +646,33 @@ void EditJsContext::setIntervalSpeed(QObject* object, double s)
     return;
 
   i->duration.setSpeed(s);
+}
+
+void EditJsContext::setAutoTrigger(QObject* object, bool b)
+{
+  auto doc = ctx();
+  if(!doc)
+    return;
+
+  auto ts = qobject_cast<Scenario::TimeSyncModel*>(object);
+  if(!ts)
+    return;
+
+  auto [m, _] = macro(*doc);
+  m->setProperty<Scenario::TimeSyncModel::p_autotrigger>(*ts, b);
+}
+
+void EditJsContext::setProcessLoop(QObject* object, bool b)
+{
+  auto doc = ctx();
+  if(!doc)
+    return;
+
+  auto proc = qobject_cast<Process::ProcessModel*>(object);
+  if(!proc)
+    return;
+
+  auto [m, _] = macro(*doc);
+  m->setProperty<Process::ProcessModel::p_loops>(*proc, b);
 }
 }

--- a/src/plugins/score-plugin-remotecontrol/RemoteControl/Websockets/DocumentPlugin.cpp
+++ b/src/plugins/score-plugin-remotecontrol/RemoteControl/Websockets/DocumentPlugin.cpp
@@ -131,36 +131,6 @@ void DocumentPlugin::cleanup()
   m_root = nullptr;
 }
 
-ObjectPath fromString(const QString& str)
-{
-  auto res = str.split("/");
-  if(res.empty())
-    return {};
-  if(res[0].isEmpty())
-    res.pop_front();
-  if(res.empty())
-    return {};
-
-  ObjectIdentifierVector i;
-  for(const QString& is : res)
-  {
-    int idx = is.lastIndexOf('.');
-    if(idx == -1)
-      return {};
-    auto name = is.mid(0, idx);
-    auto index = is.mid(idx + 1);
-
-    bool ok = false;
-    int num = index.toInt(&ok);
-    if(!ok)
-      return {};
-
-    i.emplace_back(name, num);
-  }
-
-  return ObjectPath{std::move(i)};
-}
-
 template <typename T>
 static Path<T> readPathFromValue(const rapidjson::Value& val)
 {
@@ -168,7 +138,7 @@ static Path<T> readPathFromValue(const rapidjson::Value& val)
   {
     auto str = QString::fromUtf8(val.GetString(), val.GetStringLength());
 
-    auto path = fromString(str);
+    auto path = ObjectPath::fromString(str);
     if(path.vec().empty())
       return {};
 

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalExecution.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalExecution.cpp
@@ -572,6 +572,16 @@ IntervalComponentBase::make(ProcessComponentFactory& fac, Process::ProcessModel&
       if(auto& onode = plug->node)
         ctx.setup.register_node(proc, onode);
 
+      // Processes added during execution must be flagged like the others.
+      // Guard on !proc.executing() so a graph rebuild during playback (which
+      // re-runs make() for already-running processes) doesn't re-emit
+      // startExecution.
+      if(interval().executing() && !proc.executing())
+      {
+        proc.setExecuting(true);
+        proc.startExecution();
+      }
+
       // Selection
       QObject::connect(
           &proc.selection, &Selectable::changed, plug.get(),


### PR DESCRIPTION
- **core: add ObjectPath::fromString / findObject, reuse in remote control**
- **js: add Score.cable, path/findByPath, cable removal, setAutoTrigger/setProcessLoop**
- **gfx: clear image inputs with no incoming edge each frame**
- **gfx: don't return a half-initialized render state when QRhi::create fails**
- **gfx: fall back to a null RHI in output nodes when there is no GPU**
- **core: disconnect devices before tearing down documents**
- **gfx: release the static Vulkan instance when creation fails**
- **gstreamer: classify appsinks from the pipeline string, follow the engine quantum**
- **scenario: start processes added while the interval is already executing**
- **exec: set buffer size before begin_tick**
