### PR TITLE
scenario load: preserve control values across a port-set change

### DIFF
--- a/src/plugins/score-plugin-scenario/Dataflow/Commands/CableHelpers.cpp
+++ b/src/plugins/score-plugin-scenario/Dataflow/Commands/CableHelpers.cpp
@@ -361,7 +361,13 @@ void reloadPortsInNewProcess(
 
     if(new_p->type() == old_p.type && new_p->name() == old_p.name)
     {
-      new_p->loadData(old_p.data);
+      // Preserve values across a port-set change (e.g. an updated add-on that
+      // gained a port): without DontReloadValue, loadData drops the value and
+      // an existing scenario reloads the process with all defaults. Same fix as
+      // 6fed47b19 ("presets: fix that values sometimes did not reload"), applied
+      // to the scenario-load migration path. Guarded by the type()/name() match
+      // above, so a value is only ever restored into an identical port.
+      new_p->loadData(old_p.data, Process::PortLoadDataFlags::DontReloadValue);
     }
   }
 
@@ -372,7 +378,7 @@ void reloadPortsInNewProcess(
 
     if(new_p->type() == old_p.type && new_p->name() == old_p.name)
     {
-      new_p->loadData(old_p.data);
+      new_p->loadData(old_p.data, Process::PortLoadDataFlags::DontReloadValue);
     }
   }
 }

--- a/src/plugins/score-plugin-scenario/Dataflow/Commands/CableHelpers.cpp
+++ b/src/plugins/score-plugin-scenario/Dataflow/Commands/CableHelpers.cpp
@@ -361,12 +361,7 @@ void reloadPortsInNewProcess(
 
     if(new_p->type() == old_p.type && new_p->name() == old_p.name)
     {
-      // Preserve values across a port-set change (e.g. an updated add-on that
-      // gained a port): without DontReloadValue, loadData drops the value and
-      // an existing scenario reloads the process with all defaults. Same fix as
-      // 6fed47b19 ("presets: fix that values sometimes did not reload"), applied
-      // to the scenario-load migration path. Guarded by the type()/name() match
-      // above, so a value is only ever restored into an identical port.
+      // Keep the saved value across a port-set change; only restored into a type/name-identical port.
       new_p->loadData(old_p.data, Process::PortLoadDataFlags::DontReloadValue);
     }
   }


### PR DESCRIPTION
### Problem

When an avnd process's port count changes — e.g. an add-on gains a new port in an update — opening a scenario **saved with the older version** reloads that process with **every value reset to default** (soundfile path blank, all controls back to their init values). This breaks backward-compat for any existing document once an object grows a port.

### Cause

The count mismatch makes `ProcessModel::check_all_ports()` recreate the ports (with default values) and migrate the saved data through the 3-arg `Dataflow::reloadPortsInNewProcess()`. That path called `loadData(old_p.data)` **without** `DontReloadValue`, and `ControlInlet::loadData` drops the value unless that flag is set — so the recreated ports keep their defaults.

### Fix

Pass `Process::PortLoadDataFlags::DontReloadValue` in that migration, exactly as `LoadPresetCommand` already does. It's guarded by the existing `type()==type() && name()==name()` match, so a value is only ever restored into an identical port.

This is the same fix as 6fed47b19 (*"presets: fix that values sometimes did not reload"*), applied to the **scenario-load** migration path rather than the preset path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvD2PFHZtW6pfsh3gGhayg