### PR TITLE
Scenario: fix Scale-mode tooltip modifier (Ctrl/Cmd, was Alt)

### DIFF
--- a/src/plugins/score-plugin-scenario/Scenario/Application/Menus/ToolMenuActions.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Application/Menus/ToolMenuActions.cpp
@@ -130,7 +130,11 @@ ToolMenuActions::ToolMenuActions(ScenarioApplicationPlugin* parent)
   m_scaleAction = makeToolbarAction(tr("Scale"), this, ExpandMode::Scale, {});
   m_scaleAction->setCheckable(true);
   m_scaleAction->setChecked(false);
-  score::setHelp(m_scaleAction, tr("Scale mode (Alt)"));
+#if defined(Q_OS_MACOS)
+  score::setHelp(m_scaleAction, tr("Scale mode (Cmd)"));
+#else
+  score::setHelp(m_scaleAction, tr("Scale mode (Ctrl)"));
+#endif
 
   connect(m_scaleAction, &QAction::toggled, this, [this](bool b) {
     if(b)


### PR DESCRIPTION
The Scale edition mode is toggled by holding **Ctrl** — `ToolMenuActions::keyPressed` maps `Qt::Key_Control` to the scale action (and `Qt::Key_Shift` to Lock, whose tooltip is already correct). The scale action's help text advertised "Alt", which does nothing.

This shows the correct modifier, contextually per OS: **Cmd** on macOS (where Qt maps `Key_Control` to the ⌘ key) and **Ctrl** elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ya5qsdZbjVtA697QUhJFz