### PR TITLE
avnd ui: resolve file-path templates before syncing them to custom items

### DIFF
--- a/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
@@ -7,11 +7,14 @@
 #include <Crousti/Painter.hpp>
 #include <Crousti/ProcessModel.hpp>
 
+#include <Process/Dataflow/WidgetInlets.hpp>
+
 #include <score/graphics/layouts/GraphicsBoxLayout.hpp>
 #include <score/graphics/layouts/GraphicsGridLayout.hpp>
 #include <score/graphics/layouts/GraphicsSplitLayout.hpp>
 #include <score/graphics/layouts/GraphicsTabLayout.hpp>
 #include <score/graphics/widgets/QGraphicsLineEdit.hpp>
+#include <score/tools/File.hpp>
 
 #include <avnd/common/aggregates.hpp>
 #include <avnd/concepts/layout.hpp>
@@ -140,6 +143,22 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       const Process::ControlLayout& lay, Item& item)
       = delete; // TODO
 
+  // File paths are stored in the document as templates (<PROJECT>:...,
+  // <LIBRARY>:..., or document-relative); resolve them so the ui items
+  // always receive a usable absolute path, like the score-side file
+  // widgets do.
+  static ossia::value resolveFilePath(
+      const ossia::value& v, Process::ControlInlet* inl,
+      const score::DocumentContext& ctx) noexcept
+  {
+    if(qobject_cast<Process::FileChooserBase*>(inl)
+       || qobject_cast<Process::FolderChooser*>(inl))
+      if(auto str = v.target<std::string>(); str && !str->empty())
+        return score::locateFilePath(QString::fromStdString(*str), ctx)
+            .toStdString();
+    return v;
+  }
+
   template <typename Item>
   void setupControl(
       QGraphicsItem* parent, Process::ControlInlet* inl,
@@ -149,14 +168,16 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
     {
       using avnd_port_type = pmf_member_type_t<decltype(item.model)>;
       avnd_port_type p;
-      oscr::from_ossia_value(p, inl->value(), item.value);
+      oscr::from_ossia_value(p, resolveFilePath(inl->value(), inl, doc), item.value);
       if constexpr(requires { rootUi->on_control_update(); })
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [rui = rootUi, layout = this->layout, &item](const ossia::value& v) {
+            [rui = rootUi, layout = this->layout, &item, inl,
+             &ctx = static_cast<const score::DocumentContext&>(this->doc)](
+                const ossia::value& v) {
           avnd_port_type p;
-          oscr::from_ossia_value(p, v, item.value);
+          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
 
           rui->on_control_update();
           layout->update();
@@ -166,9 +187,11 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [layout = this->layout, &item](const ossia::value& v) {
+            [layout = this->layout, &item, inl,
+             &ctx = static_cast<const score::DocumentContext&>(this->doc)](
+                const ossia::value& v) {
           avnd_port_type p;
-          oscr::from_ossia_value(p, v, item.value);
+          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
           layout->update();
         });
       }

--- a/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
@@ -7,8 +7,6 @@
 #include <Crousti/Painter.hpp>
 #include <Crousti/ProcessModel.hpp>
 
-#include <Process/Dataflow/WidgetInlets.hpp>
-
 #include <score/graphics/layouts/GraphicsBoxLayout.hpp>
 #include <score/graphics/layouts/GraphicsGridLayout.hpp>
 #include <score/graphics/layouts/GraphicsSplitLayout.hpp>
@@ -17,9 +15,10 @@
 #include <score/tools/File.hpp>
 
 #include <avnd/common/aggregates.hpp>
+#include <avnd/concepts/file_port.hpp>
 #include <avnd/concepts/layout.hpp>
-
-#include <avnd/common/aggregates.hpp>
+#include <avnd/concepts/midifile.hpp>
+#include <avnd/concepts/soundfile.hpp>
 
 namespace oscr
 {
@@ -127,6 +126,41 @@ struct pmf_member_type<V T::*>
 template <typename T>
 using pmf_member_type_t = typename pmf_member_type<T>::type;
 
+template <typename T>
+struct SetGUIValue
+{
+  const score::DocumentContext& ctx;
+  void operator()(const ossia::value& v, auto& dst) const
+  {
+    T p;
+    oscr::from_ossia_value(p, v, dst);
+  }
+};
+
+// File & folder ports: paths are stored in the document as templates
+// (<PROJECT>:..., <LIBRARY>:..., or document-relative); resolve them so the
+// ui items always receive a usable absolute path.
+template <typename T>
+  requires(
+      avnd::soundfile_port<T> || avnd::midifile_port<T> || avnd::file_port<T>
+      || requires { T::widget::folder; })
+struct SetGUIValue<T>
+{
+  const score::DocumentContext& ctx;
+  void operator()(const ossia::value& v, auto& dst) const
+  {
+    T p;
+    if(auto str = v.target<std::string>(); str && !str->empty())
+      oscr::from_ossia_value(
+          p,
+          ossia::value{
+              score::locateFilePath(QString::fromStdString(*str), ctx).toStdString()},
+          dst);
+    else
+      oscr::from_ossia_value(p, v, dst);
+  }
+};
+
 template <typename Info>
 struct LayoutBuilder final : Process::LayoutBuilderBase
 {
@@ -143,22 +177,6 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       const Process::ControlLayout& lay, Item& item)
       = delete; // TODO
 
-  // File paths are stored in the document as templates (<PROJECT>:...,
-  // <LIBRARY>:..., or document-relative); resolve them so the ui items
-  // always receive a usable absolute path, like the score-side file
-  // widgets do.
-  static ossia::value resolveFilePath(
-      const ossia::value& v, Process::ControlInlet* inl,
-      const score::DocumentContext& ctx) noexcept
-  {
-    if(qobject_cast<Process::FileChooserBase*>(inl)
-       || qobject_cast<Process::FolderChooser*>(inl))
-      if(auto str = v.target<std::string>(); str && !str->empty())
-        return score::locateFilePath(QString::fromStdString(*str), ctx)
-            .toStdString();
-    return v;
-  }
-
   template <typename Item>
   void setupControl(
       QGraphicsItem* parent, Process::ControlInlet* inl,
@@ -167,17 +185,15 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
     if constexpr(requires { sizeof(Item::value); })
     {
       using avnd_port_type = pmf_member_type_t<decltype(item.model)>;
-      avnd_port_type p;
-      oscr::from_ossia_value(p, resolveFilePath(inl->value(), inl, doc), item.value);
+      SetGUIValue<avnd_port_type>{doc}(inl->value(), item.value);
       if constexpr(requires { rootUi->on_control_update(); })
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [rui = rootUi, layout = this->layout, &item, inl,
+            [rui = rootUi, layout = this->layout, &item,
              &ctx = static_cast<const score::DocumentContext&>(this->doc)](
                 const ossia::value& v) {
-          avnd_port_type p;
-          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
+          SetGUIValue<avnd_port_type>{ctx}(v, item.value);
 
           rui->on_control_update();
           layout->update();
@@ -187,11 +203,10 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [layout = this->layout, &item, inl,
+            [layout = this->layout, &item,
              &ctx = static_cast<const score::DocumentContext&>(this->doc)](
                 const ossia::value& v) {
-          avnd_port_type p;
-          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
+          SetGUIValue<avnd_port_type>{ctx}(v, item.value);
           layout->update();
         });
       }


### PR DESCRIPTION
### Problem

File-chooser port values are stored in the document as path templates (`<PROJECT>:...`, `<LIBRARY>:...`, or document-relative). Score's own file widgets resolve them through `score::locateFilePath`, but the avnd layout builder pushed the **raw template string** into custom UI items' `value`.

So an add-on widget bound to a soundfile/file/folder port received a path it cannot use — e.g. a waveform widget that decodes the file to display it in edit mode could never find `<PROJECT>:samples/foo.wav`. Values worked during execution only because the engine resolves paths on its own side, which made panels that depend on the path (waveform displays, folder pickers) appear empty until playback started.

### Fix

Resolve through `score::locateFilePath` in `LayoutBuilder::setupControl`, both for the initial sync and in the `valueChanged` connections, whenever the inlet is a `Process::FileChooserBase` or `Process::FolderChooser` and the value is a non-empty string. Other value types and non-file ports are untouched.

Verified with an avnd add-on (Granola) whose custom waveform widget decodes the Sound port's file: with this change the widget receives `/abs/path/samples/foo.wav` at document load and can display the waveform in edit mode, matching the behavior of score's built-in file widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvD2PFHZtW6pfsh3gGhayg