### PR TITLE
jit: Windows CRT-correctness for JIT'd add-ons + teardown heap-corruption fixes

### DIFF
--- a/ci/create-sdk-mingw.sh
+++ b/ci/create-sdk-mingw.sh
@@ -45,5 +45,17 @@ for CLANGROOT in "$OSSIA_SDK/llvm-libs/lib/clang" "$OSSIA_SDK/llvm/lib/clang"; d
   done < <(find "$CLANGROOT" -name 'libclang_rt.builtins*.a')
 done
 
+# Ship mingw-w64's CRT-support archives too (the driver's implicit -lmingwex /
+# -lucrt): libmingwex has the C99-name math functions (hypotf, ...) that the UCRT
+# only exports under their underscore names; libucrt's alias objects have the
+# POSIX old names (fileno) and renamed imports (__msvcrt_assert).
+# locateMingwRuntimeLib() finds them at <sdk>/lib/.
+for CRTLIB in libmingwex.a libucrt.a; do
+  SRC="$OSSIA_SDK/llvm/x86_64-w64-mingw32/lib/$CRTLIB"
+  [[ -f "$SRC" ]] || continue
+  cp -f "$SRC" "$LIB/$CRTLIB"
+  echo "shipped crt-support: lib/$CRTLIB"
+done
+
 source $SCRIPTDIR/cleanup-sdk-common.sh
 

--- a/src/plugins/score-plugin-jit/JitCpp/Compiler/Compiler.cpp
+++ b/src/plugins/score-plugin-jit/JitCpp/Compiler/Compiler.cpp
@@ -11,9 +11,14 @@
 #if defined(_WIN32) && !defined(_MSC_VER) && LLVM_VERSION_MAJOR >= 22
 #include <JitCpp/Compiler/MinGWCOFFPlatform.hpp>
 
+#include <llvm/ExecutionEngine/Orc/COFF.h>
 #include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
 #include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
 #include <llvm/ExecutionEngine/Orc/MemoryMapper.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <malloc.h>
 #endif
 
 #if LLVM_VERSION_MAJOR >= 22
@@ -278,6 +283,38 @@ static std::unique_ptr<llvm::orc::LLJIT> jitBuilder(JitCompiler& self)
       auto& PlatformJD = ES.createBareJITDylib("<Platform>");
       PlatformJD.addToLinkOrder(*ProcessSymbolsJD);
 
+      // Pin the C allocator family to the exact functions score itself uses.
+      // Third-party DLLs (e.g. JACK) pull the legacy msvcrt.dll into the
+      // process, and it exports malloc/free too -- operating on a *different*
+      // CRT heap. The process-symbols search is module-order dependent, so
+      // JIT'd code could bind malloc to one CRT while the host frees with the
+      // other; buffers do cross the JIT boundary (e.g. orc_rt's
+      // WrapperFunctionResult error payloads, freed by the host in
+      // runDeallocActions at teardown) and a mismatch corrupts the heap
+      // (flaky 0xC0000374 at exit). Definitions beat the JD's process
+      // generator, so every JIT resolution sees exactly these addresses.
+      {
+        llvm::orc::SymbolMap m;
+        auto pin = [&](const char* n, auto* f) {
+          m[ES.intern(n)]
+              = {llvm::orc::ExecutorAddr::fromPtr(reinterpret_cast<void*>(f)),
+                 llvm::JITSymbolFlags::Exported | llvm::JITSymbolFlags::Callable};
+        };
+        pin("malloc", &std::malloc);
+        pin("free", &std::free);
+        pin("calloc", &std::calloc);
+        pin("realloc", &std::realloc);
+        pin("_msize", &_msize);
+        pin("_strdup", &_strdup);
+        pin("_wcsdup", &_wcsdup);
+        pin("_aligned_malloc", &_aligned_malloc);
+        pin("_aligned_realloc", &_aligned_realloc);
+        pin("_aligned_free", &_aligned_free);
+        if(auto Err
+           = ProcessSymbolsJD->define(llvm::orc::absoluteSymbols(std::move(m))))
+          llvm::consumeError(std::move(Err));
+      }
+
       // Provide compiler-rt's builtins in the add-on's link order (the driver
       // links these via -rtlib=compiler-rt; the bare -cc1 JIT compile does not, so
       // helpers it emits -- e.g. __udivti3, 128-bit division used by fmt -- are
@@ -290,6 +327,72 @@ static std::unique_ptr<llvm::orc::LLJIT> jitBuilder(JitCompiler& self)
           PlatformJD.addGenerator(std::move(*G));
         else
           llvm::consumeError(G.takeError());
+      }
+
+      // Same for mingw-w64's libmingwex (the driver's implicit -lmingwex): the
+      // C99-name math functions (hypotf, ...) the UCRT only exports under their
+      // underscore names live there; its members call back into the host's
+      // ucrtbase/kernel32 which resolve from the process as usual.
+      if(std::string mingwex = Jit::locateMingwexRuntime(); !mingwex.empty())
+      {
+        if(auto G = llvm::orc::StaticLibraryDefinitionGenerator::Load(
+               *OLL, mingwex.c_str()))
+          PlatformJD.addGenerator(std::move(*G));
+        else
+          llvm::consumeError(G.takeError());
+      }
+
+      // And the UCRT import library (the driver's implicit -lucrt), in two
+      // slices:
+      //  - Its weak-external aliases (the POSIX old names: fileno -> _fileno)
+      //    via COFFImportLibWeakAliasGenerator, which binds them to the same
+      //    UCRT exports an AOT link would. (JITLink's COFF backend cannot load
+      //    the alias objects themselves.) Added first so alias names never
+      //    reach the static generator below.
+      //  - Its real object members (e.g. __ms_fwprintf) via a
+      //    StaticLibraryDefinitionGenerator; COFFImportFileScanner excludes the
+      //    short import members, so __imp_* still resolves through the
+      //    DLLImport generator against the already-loaded ucrtbase.
+      if(std::string ucrt = Jit::locateUcrtImportLib(); !ucrt.empty())
+      {
+        if(auto G = Jit::COFFImportLibWeakAliasGenerator::Load(ucrt.c_str()))
+          PlatformJD.addGenerator(std::move(*G));
+        else
+          llvm::consumeError(G.takeError());
+
+        std::set<std::string> dylibs; // api-set DLLs; already loaded in-process
+        if(auto G = llvm::orc::StaticLibraryDefinitionGenerator::Load(
+               *OLL, ucrt.c_str(), llvm::orc::COFFImportFileScanner(dylibs)))
+          PlatformJD.addGenerator(std::move(*G));
+        else
+          llvm::consumeError(G.takeError());
+      }
+
+      // libmingwex's _assert / iswctype wrappers call the CRT through *renamed*
+      // imports (__imp___msvcrt_assert -> ucrt's _assert) that exist only inside
+      // the import lib, so neither the process generator nor the DLLImport
+      // generator can resolve them. Provide the import GOT slots directly:
+      // host-allocated pointers filled with the ucrt export addresses -- exactly
+      // the indirection an AOT link produces, so JIT'd code goes through the
+      // same mingwex wrapper -> ucrt path as code linked by the driver.
+      {
+        auto& ES = J.getExecutionSession();
+        // (import slot storage, __imp_ name, ucrt export it renames)
+        static void* Slots[2];
+        static constexpr std::pair<const char*, const char*> Renames[] = {
+            {"__imp___msvcrt_assert", "_assert"},
+            {"__imp___msvcrt_iswctype", "iswctype"},
+        };
+        llvm::orc::SymbolMap m;
+        for(int i = 0; i < 2; i++)
+          if((Slots[i] = llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(
+                  Renames[i].second)))
+            m[ES.intern(Renames[i].first)]
+                = {llvm::orc::ExecutorAddr::fromPtr(&Slots[i]),
+                   llvm::JITSymbolFlags::Exported};
+        if(!m.empty())
+          if(auto Err = PlatformJD.define(llvm::orc::absoluteSymbols(std::move(m))))
+            llvm::consumeError(std::move(Err));
       }
 
       auto P = Jit::MinGWCOFFPlatform::Create(

--- a/src/plugins/score-plugin-jit/JitCpp/Compiler/MinGWCOFFPlatform.cpp
+++ b/src/plugins/score-plugin-jit/JitCpp/Compiler/MinGWCOFFPlatform.cpp
@@ -9,28 +9,14 @@
 #include <llvm/ExecutionEngine/Orc/LookupAndRecordAddrs.h>
 #include <llvm/ExecutionEngine/Orc/ObjectFileInterface.h>
 #include <llvm/ExecutionEngine/Orc/Shared/ObjectFormats.h>
+#include <llvm/Object/Archive.h>
 #include <llvm/Object/COFF.h>
+#include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/FormatVariadic.h>
 
 using namespace llvm;
 using namespace llvm::orc;
 using namespace llvm::orc::shared;
-
-// x64 SEH function-table registration (from ntdll/kernel32; score links them).
-// Declared locally to avoid pulling <windows.h> into an LLVM translation unit.
-extern "C"
-{
-struct JIT_RUNTIME_FUNCTION
-{
-  uint32_t BeginAddress;
-  uint32_t EndAddress;
-  uint32_t UnwindData;
-};
-__declspec(dllimport) unsigned char __stdcall RtlAddFunctionTable(
-    JIT_RUNTIME_FUNCTION* FunctionTable, uint32_t EntryCount, uint64_t BaseAddress);
-__declspec(dllimport) unsigned char __stdcall RtlDeleteFunctionTable(
-    JIT_RUNTIME_FUNCTION* FunctionTable);
-}
 
 namespace llvm
 {
@@ -702,11 +688,105 @@ Error MinGWCOFFPlatform::initializeJITDylib(JITDylib& JD)
   return runJDInitializers(JD);
 }
 
-MinGWCOFFPlatform::~MinGWCOFFPlatform()
+Expected<std::unique_ptr<COFFImportLibWeakAliasGenerator>>
+COFFImportLibWeakAliasGenerator::Load(const char* ImportLibPath)
 {
-  std::lock_guard<std::mutex> Lock(PlatformMutex);
-  for(void* Table : RegisteredEHTables)
-    RtlDeleteFunctionTable(static_cast<JIT_RUNTIME_FUNCTION*>(Table));
+  auto Buf = MemoryBuffer::getFile(ImportLibPath);
+  if(!Buf)
+    return createFileError(ImportLibPath, Buf.getError());
+
+  auto A = object::Archive::create((*Buf)->getMemBufferRef());
+  if(!A)
+    return A.takeError();
+
+  StringMap<std::string> WeakToAlt;
+  Error Err = Error::success();
+  for(auto& Child : (*A)->children(Err))
+  {
+    auto Bin = Child.getAsBinary();
+    if(!Bin)
+    {
+      // Short import members and non-objects are irrelevant here.
+      consumeError(Bin.takeError());
+      continue;
+    }
+    auto* Obj = dyn_cast<object::COFFObjectFile>(Bin->get());
+    if(!Obj)
+      continue;
+
+    for(uint32_t I = 0, E = Obj->getNumberOfSymbols(); I < E; ++I)
+    {
+      auto Sym = Obj->getSymbol(I);
+      if(!Sym)
+      {
+        consumeError(Sym.takeError());
+        continue;
+      }
+      uint32_t NumAux = Sym->getNumberOfAuxSymbols();
+      if(Sym->getStorageClass() == COFF::IMAGE_SYM_CLASS_WEAK_EXTERNAL
+         && NumAux >= 1)
+      {
+        ArrayRef<uint8_t> Aux = Obj->getSymbolAuxData(*Sym);
+        if(Aux.size() >= sizeof(object::coff_aux_weak_external))
+        {
+          const auto* WE
+              = reinterpret_cast<const object::coff_aux_weak_external*>(Aux.data());
+          auto Alt = Obj->getSymbol(WE->TagIndex);
+          auto WeakName = Obj->getSymbolName(*Sym);
+          if(Alt && WeakName)
+          {
+            if(auto AltName = Obj->getSymbolName(*Alt))
+              WeakToAlt[*WeakName] = AltName->str();
+            else
+              consumeError(AltName.takeError());
+          }
+          else
+          {
+            if(!Alt)
+              consumeError(Alt.takeError());
+            if(!WeakName)
+              consumeError(WeakName.takeError());
+          }
+        }
+      }
+      I += NumAux;
+    }
+  }
+  if(Err)
+    return std::move(Err);
+
+  return std::unique_ptr<COFFImportLibWeakAliasGenerator>(
+      new COFFImportLibWeakAliasGenerator(std::move(WeakToAlt)));
+}
+
+Error COFFImportLibWeakAliasGenerator::tryToGenerate(
+    LookupState& LS, LookupKind K, JITDylib& JD, JITDylibLookupFlags JDLookupFlags,
+    const SymbolLookupSet& Symbols)
+{
+  // Define matches as ORC aliases of their alternative name (fileno -> _fileno),
+  // NOT as absolute addresses: the alternative then resolves through the JD's
+  // usual machinery -- in practice the DLLImport generator, which builds a
+  // near jump stub to the far UCRT export. mingw archive members are compiled
+  // small-code-model and call these with REL32, so they need that near stub
+  // (an absolute far address would fail the PCRel32 fixup), and it is exactly
+  // the thunk an AOT link's alias would land on.
+  auto& ES = JD.getExecutionSession();
+  SymbolAliasMap Aliases;
+  for(auto& KV : Symbols)
+  {
+    StringRef Name = *KV.first;
+    auto It = WeakToAlt.find(Name);
+    if(It == WeakToAlt.end())
+      continue;
+    Aliases[KV.first]
+        = {ES.intern(It->second),
+           JITSymbolFlags::Exported | JITSymbolFlags::Callable};
+  }
+
+  if(Aliases.empty())
+    return Error::success();
+
+  return JD.define(symbolAliases(std::move(Aliases)));
 }
 
 Error MinGWCOFFPlatform::bootstrapCOFFRuntime(JITDylib& PlatformJD)
@@ -855,32 +935,19 @@ Error MinGWCOFFPlatform::MinGWCOFFPlatformPlugin::registerObjectPlatformSections
   COFFObjectSectionsMap ObjSecs;
   auto HeaderAddr = CP.JITDylibToHeaderAddr[&JD];
   assert(HeaderAddr && "Must be registered jitdylib");
-  jitlink::Section* PData = nullptr;
   for(auto& S : G.sections())
   {
     jitlink::SectionRange Range(S);
     if(Range.getSize())
       ObjSecs.push_back(std::make_pair(S.getName().str(), Range.getRange()));
-    if(S.getName() == ".pdata" && Range.getSize())
-      PData = &S;
   }
 
-  // Register the object's .pdata with the OS x64 unwinder so exceptions thrown in
-  // JIT'd code unwind. The .pdata holds RUNTIME_FUNCTION entries with RVAs from
-  // __ImageBase (== HeaderAddr, the slab base). In-process JIT, so call directly
-  // here (post-fixup: addresses and RVAs are final). The matching
-  // RtlDeleteFunctionTable happens in ~MinGWCOFFPlatform.
-  if(PData)
-  {
-    jitlink::SectionRange Range(*PData);
-    auto* Table = Range.getRange().Start.toPtr<JIT_RUNTIME_FUNCTION*>();
-    auto Count = static_cast<uint32_t>(Range.getSize() / sizeof(JIT_RUNTIME_FUNCTION));
-    if(Count && RtlAddFunctionTable(Table, Count, HeaderAddr.getValue()))
-    {
-      std::lock_guard<std::mutex> Lock(CP.PlatformMutex);
-      CP.RegisteredEHTables.push_back(Table);
-    }
-  }
+  // NB: the object's SEH unwind tables (.pdata) are registered with the OS x64
+  // unwinder by orc_rt itself -- the register_object_sections alloc action below
+  // calls RtlAddFunctionTable in the executor, and the dealloc action
+  // RtlDeleteFunctionTable. Do NOT also register them here: the double
+  // RtlDeleteFunctionTable at teardown corrupts ntdll's dynamic-function-table
+  // bookkeeping on the process heap (flaky 0xC0000374 at exit).
 
   G.allocActions().push_back(
       {cantFail(WrapperFunctionCall::Create<SPSCOFFRegisterObjectSectionsArgs>(

--- a/src/plugins/score-plugin-jit/JitCpp/Compiler/MinGWCOFFPlatform.hpp
+++ b/src/plugins/score-plugin-jit/JitCpp/Compiler/MinGWCOFFPlatform.hpp
@@ -30,6 +30,7 @@
 #if LLVM_VERSION_MAJOR >= 22
 
 #include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
 #include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
@@ -39,6 +40,7 @@
 #include <llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h>
 
 #include <atomic>
+#include <deque>
 #include <list>
 #include <map>
 #include <memory>
@@ -235,15 +237,39 @@ private:
   // add-ons), so we never run them twice.
   std::set<llvm::orc::JITDylib*> InitializedJDs;
 
-  // .pdata function tables registered with the OS x64 unwinder
-  // (RtlAddFunctionTable), so exceptions thrown in JIT'd code unwind. Deleted at
-  // teardown.
-  std::vector<void*> RegisteredEHTables;
-
   std::mutex PlatformMutex;
+};
 
+/// Serves the *weak-external aliases* of a mingw-w64 import library (the POSIX
+/// old names: fileno -> _fileno, and dllimport variants: __imp_fileno ->
+/// __imp__fileno) as ORC symbol aliases of their alternative name.
+///
+/// A driver link gets these from small alias objects inside libucrt.a, but
+/// JITLink's COFF backend rejects them ("Weak external symbol with external
+/// symbol as alternative not supported"), so a StaticLibraryDefinitionGenerator
+/// over the import lib cannot load them. This generator parses the weak-external
+/// records out of those objects itself -- data-driven from the toolchain's own
+/// import lib, so the alias set always matches what the driver would produce --
+/// and the aliased name then resolves through the JD's normal machinery (near
+/// DLLImport stub to the UCRT export), same as an AOT link's alias thunk.
+class COFFImportLibWeakAliasGenerator : public llvm::orc::DefinitionGenerator
+{
 public:
-  ~MinGWCOFFPlatform();
+  static llvm::Expected<std::unique_ptr<COFFImportLibWeakAliasGenerator>>
+  Load(const char* ImportLibPath);
+
+  llvm::Error tryToGenerate(
+      llvm::orc::LookupState& LS, llvm::orc::LookupKind K, llvm::orc::JITDylib& JD,
+      llvm::orc::JITDylibLookupFlags JDLookupFlags,
+      const llvm::orc::SymbolLookupSet& Symbols) override;
+
+private:
+  explicit COFFImportLibWeakAliasGenerator(llvm::StringMap<std::string> WeakToAlt)
+      : WeakToAlt(std::move(WeakToAlt))
+  {
+  }
+
+  llvm::StringMap<std::string> WeakToAlt; // weak name -> alternative name
 };
 
 /// LLJIT PlatformSupport that runs add-on static initializers via the platform's

--- a/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
+++ b/src/plugins/score-plugin-jit/JitCpp/JitPlatform.hpp
@@ -261,6 +261,49 @@ static inline std::string locateBuiltinsRuntime()
   return fallback.toStdString();
 }
 
+// Locates a mingw-w64 CRT-support archive (libmingwex.a, libucrt.a, ...) that
+// the driver links implicitly into every mingw executable but the JIT's bare
+// -cc1 compile does not. libmingwex supplies the C99-name math functions the
+// UCRT only exports under their underscore names (e.g. hypotf wraps _hypot)
+// plus routines the CRT lacks entirely; libucrt's alias objects supply the
+// POSIX old names (fileno -> _fileno) and renamed imports (__msvcrt_assert).
+static inline std::string locateMingwRuntimeLib(const char* env, const char* name)
+{
+  if(QString p = qgetenv(env); !p.isEmpty())
+    return p.toStdString();
+
+  auto sdk = locateSDKWithFallback();
+  if(sdk.path.empty())
+    return {};
+
+  const QString base = QString::fromStdString(sdk.path);
+  const QString parent = QFileInfo(base).absolutePath();
+  const QStringList roots{base,           parent,
+                          parent + "/llvm", parent + "/llvm-libs",
+                          base + "/llvm",   base + "/llvm-libs"};
+  const QString lib = QString::fromUtf8(name);
+  for(const QString& root : roots)
+  {
+    // Shipped runtime SDK layout (create-sdk-mingw.sh) and toolchain layout.
+    for(const QString& p :
+        {QString(root + "/lib/" + lib),
+         QString(root + "/x86_64-w64-mingw32/lib/" + lib)})
+      if(QFile::exists(p))
+        return p.toStdString();
+  }
+  return {};
+}
+
+static inline std::string locateMingwexRuntime()
+{
+  return locateMingwRuntimeLib("SCORE_JIT_MINGWEX", "libmingwex.a");
+}
+
+static inline std::string locateUcrtImportLib()
+{
+  return locateMingwRuntimeLib("SCORE_JIT_UCRT", "libucrt.a");
+}
+
 static inline void
 populateCompileOptions(std::vector<std::string>& args, CompilerOptions opts)
 {


### PR DESCRIPTION
Two bodies of work for the Windows COFF JIT, both validated on the 28-addon compile matrix.

## CRT/math symbol support

JIT'd add-ons referenced CRT symbols the bare `-cc1` compile + ORC link could not resolve (first seen as `Symbols not found: [ hypotf ]` in GBAP). The driver links `-lmingwex`/`-lucrt` implicitly; this replicates that **exactly** — every resolution was verified against an AOT linker map + import table so JIT'd code binds to the same implementation a driver-linked binary would (mingwex wrapper where AOT has one, UCRT import where AOT imports):

- **libmingwex.a** as a `StaticLibraryDefinitionGenerator` on the platform JITDylib: the C99-name math functions the UCRT only exports under underscore names (`hypotf` wraps `_hypot`, …).
- **libucrt.a** in two slices: a new `COFFImportLibWeakAliasGenerator` parses the import lib's weak-external records (the POSIX old names: `fileno` → `_fileno`) — JITLink's COFF backend rejects the alias objects themselves — and defines matches as ORC symbol **aliases**, resolving through the DLLImport near-stub exactly like an AOT alias thunk (absolute far addresses would break REL32 calls from small-code-model archive members); plus its real object members (`__ms_fwprintf`).
- The two renamed imports (`__imp___msvcrt_assert` / `__imp___msvcrt_iswctype`, which exist only inside the import lib) are provided as host GOT slots pointing at the ucrt exports they alias.
- `create-sdk-mingw.sh` ships both archives in the runtime SDK; `SCORE_JIT_MINGWEX` / `SCORE_JIT_UCRT` env overrides.

## Teardown heap corruption (flaky `0xC0000374` at `--compile-addon` exit)

Root-caused with cdb (`_NO_DEBUG_HEAP=1`; the debug heap masks it completely). Two independent fixes:

1. **Remove the double `.pdata` registration**: orc_rt's COFF platform already calls `RtlAddFunctionTable`/`RtlDeleteFunctionTable` through the `register_object_sections` alloc/dealloc actions; the extra direct registration meant a double `RtlDeleteFunctionTable` at teardown, corrupting ntdll's dynamic-function-table bookkeeping on the process heap. JIT'd SEH exceptions keep working through orc_rt's registration alone (jit-min c05/c12 pass).
2. **Pin the C allocator family in the process-symbols JITDylib** to the exact functions the host uses: third-party DLLs (e.g. JACK's `libjack64.dll`) pull the legacy `msvcrt.dll` into the process, and it also exports `malloc`/`free` operating on a *different* CRT heap. The module-order-dependent process search could bind JIT'd code to one CRT while the host frees with the other — captured twice at the same site: orc_rt `WrapperFunctionResult` error payloads freed in `runDeallocActions` at `~LLJIT`. msvcrt.dll stays loadable; it is just never used for JIT resolution.

## Validation

- `tests/jit-min`: 13/13 (incl. both exception cases)
- 28-addon compile matrix: 9 SUCCESS / 19 addon-side compile-fails, **0 crashes / 0 hangs** (previously ~5/28 flaky exit-127s)
- 30/30 clean soak runs in the previously worst-case configuration (failsafe mode, which used to fail ~1 in 8)

Known follow-ups (not in this PR): the `failsafe.bit` cascade (`--no-gui`/`--compile-addon` runs should not persist failsafe mode), and optionally replacing the ambient all-modules process search with an explicit ordered module whitelist via `setProcessSymbolsJITDylibSetup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHGzakV7gzAU6CYeyNgw3y