### PR TITLE
fix: static factory-list caches UAF across app instances (17 sites)

### DIFF
--- a/src/plugins/score-lib-process/Process/Dataflow/MinMaxFloatPort.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/MinMaxFloatPort.cpp
@@ -95,7 +95,7 @@ template <>
 SCORE_LIB_PROCESS_EXPORT void
 DataStreamWriter::write(Process::MinMaxFloatOutlet& p)
 {
-  static auto& il = components.interfaces<Process::PortFactoryList>();
+  auto& il = components.interfaces<Process::PortFactoryList>();
 
   p.minInlet.reset((Process::FloatSlider*)deserialize_interface(il, *this, &p));
   p.maxInlet.reset((Process::FloatSlider*)deserialize_interface(il, *this, &p));
@@ -114,7 +114,7 @@ template <>
 SCORE_LIB_PROCESS_EXPORT void
 JSONWriter::write(Process::MinMaxFloatOutlet& p)
 {
-  static auto& il = components.interfaces<Process::PortFactoryList>();
+  auto& il = components.interfaces<Process::PortFactoryList>();
 
   {
     JSONWriter writer{obj["MinInlet"]};

--- a/src/plugins/score-lib-process/Process/Dataflow/Port.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/Port.cpp
@@ -1037,28 +1037,28 @@ PortFactoryList::~PortFactoryList() { }
 
 std::unique_ptr<Inlet> load_inlet(DataStreamWriter& wr, QObject* parent)
 {
-  static auto& il = score::AppComponents().interfaces<Process::PortFactoryList>();
+  auto& il = wr.components.interfaces<Process::PortFactoryList>();
   return std::unique_ptr<Process::Inlet>(
       (Process::Inlet*)deserialize_interface(il, wr, parent));
 }
 
 std::unique_ptr<Inlet> load_inlet(JSONWriter& wr, QObject* parent)
 {
-  static auto& il = score::AppComponents().interfaces<Process::PortFactoryList>();
+  auto& il = wr.components.interfaces<Process::PortFactoryList>();
   return std::unique_ptr<Process::Inlet>(
       (Process::Inlet*)deserialize_interface(il, wr, parent));
 }
 
 std::unique_ptr<Outlet> load_outlet(DataStreamWriter& wr, QObject* parent)
 {
-  static auto& il = score::AppComponents().interfaces<Process::PortFactoryList>();
+  auto& il = wr.components.interfaces<Process::PortFactoryList>();
   return std::unique_ptr<Process::Outlet>(
       (Process::Outlet*)deserialize_interface(il, wr, parent));
 }
 
 std::unique_ptr<Outlet> load_outlet(JSONWriter& wr, QObject* parent)
 {
-  static auto& il = score::AppComponents().interfaces<Process::PortFactoryList>();
+  auto& il = wr.components.interfaces<Process::PortFactoryList>();
   return std::unique_ptr<Process::Outlet>(
       (Process::Outlet*)deserialize_interface(il, wr, parent));
 }

--- a/src/plugins/score-plugin-controlsurface/ControlSurface/Commands.hpp
+++ b/src/plugins/score-plugin-controlsurface/ControlSurface/Commands.hpp
@@ -78,7 +78,7 @@ public:
   {
     auto& proc = m_model.find(ctx);
 
-    static auto& cl = ctx.app.components.interfaces<Process::PortFactoryList>();
+    auto& cl = ctx.app.components.interfaces<Process::PortFactoryList>();
     Process::Port* ctl = deserialize_interface(cl, DataStreamWriter{m_data}, &proc);
 
     proc.setupControl(safe_cast<Process::ControlInlet*>(ctl), m_addr);

--- a/src/plugins/score-plugin-nodal/Nodal/Commands.cpp
+++ b/src/plugins/score-plugin-nodal/Nodal/Commands.cpp
@@ -135,7 +135,7 @@ void ReplaceAllNodes::redo(const score::DocumentContext& ctx) const
   // Add new nodes
   auto doc = readJson(m_new_block);
 
-  static auto& pl = ctx.app.interfaces<Process::ProcessFactoryList>();
+  auto& pl = ctx.app.interfaces<Process::ProcessFactoryList>();
   JSONWriter wr{doc};
   for(const auto& json_vref : wr.obj["Nodes"].toArray())
   {

--- a/src/plugins/score-plugin-nodal/Nodal/Process.cpp
+++ b/src/plugins/score-plugin-nodal/Nodal/Process.cpp
@@ -166,7 +166,7 @@ void DataStreamWriter::write(Nodal::Model& process)
   process.outlet = Process::load_audio_outlet(*this, &process);
 
   // Nodes
-  static auto& pl = components.interfaces<Process::ProcessFactoryList>();
+  auto& pl = components.interfaces<Process::ProcessFactoryList>();
   int32_t process_count = 0;
   m_stream >> process_count;
   for(; process_count-- > 0;)
@@ -204,7 +204,7 @@ void JSONWriter::write(Nodal::Model& proc)
     proc.outlet = Process::load_audio_outlet(writer, &proc);
   }
 
-  static auto& pl = components.interfaces<Process::ProcessFactoryList>();
+  auto& pl = components.interfaces<Process::ProcessFactoryList>();
   const auto& nodes = obj["Nodes"].toArray();
   for(const auto& json_vref : nodes)
   {

--- a/src/plugins/score-plugin-scenario/Scenario/Commands/Scenario/Displacement/MoveEventMeta.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Commands/Scenario/Displacement/MoveEventMeta.cpp
@@ -92,8 +92,8 @@ void MoveEventMeta::update(
   }
   else
   {
-    static const auto& appctx = score::AppContext();
-    static const auto& mevlist = appctx.interfaces<MoveEventList>();
+    const auto& appctx = score::AppContext();
+    const auto& mevlist = appctx.interfaces<MoveEventList>();
     m_moveEventImplementation
         = mevlist.get(appctx, MoveEventFactoryInterface::Strategy::MOVE)
               .make(scenar, eventId, newDate, mode, lock);
@@ -113,8 +113,8 @@ void MoveEventMeta::update(
   }
   else
   {
-    static const auto& appctx = score::AppContext();
-    static const auto& mevlist = appctx.interfaces<MoveEventList>();
+    const auto& appctx = score::AppContext();
+    const auto& mevlist = appctx.interfaces<MoveEventList>();
     m_moveEventImplementation
         = mevlist.get(appctx, MoveEventFactoryInterface::Strategy::MOVE)
               .make(scenar, eventId, newDate, mode, lock);

--- a/src/plugins/score-plugin-scenario/Scenario/Commands/Scenario/ScenarioPaste.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Commands/Scenario/ScenarioPaste.hpp
@@ -176,7 +176,7 @@ struct ProcessesBeingCopied
     // have a parent because it tries to access the event in the scenario if it
     // has one) We deserialize everything
     {
-      static auto& pl = ctx.app.interfaces<Process::ProcessFactoryList>();
+      auto& pl = ctx.app.interfaces<Process::ProcessFactoryList>();
       const auto& json_arr = sourceProcesses;
       processes.reserve(json_arr.Size());
       for(const auto& element : json_arr)

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModelSerialization.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModelSerialization.cpp
@@ -186,7 +186,7 @@ DataStreamWriter::write(Scenario::IntervalModel& interval)
   int32_t process_count;
   m_stream >> process_count;
 
-  static auto& pl = components.interfaces<Process::ProcessFactoryList>();
+  auto& pl = components.interfaces<Process::ProcessFactoryList>();
   for(; process_count-- > 0;)
   {
     auto proc = deserialize_interface(pl, *this, interval.context(), &interval);
@@ -315,7 +315,7 @@ SCORE_PLUGIN_SCENARIO_EXPORT void JSONWriter::write(Scenario::IntervalModel& int
         "Audio Out", Id<Process::Port>(0), &interval);
   }
 
-  static auto& pl = components.interfaces<Process::ProcessFactoryList>();
+  auto& pl = components.interfaces<Process::ProcessFactoryList>();
 
   const auto& process_array = obj[strings.Processes].toArray();
   for(const auto& json_vref : process_array)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -3,3 +3,16 @@
 score_add_test(test_unit_address
   SOURCES AddressParseTest.cpp
   PLUGINS score_lib_state)
+
+# --- regression: per-app interface-list lookup in port deserialization -----
+# Boots two headless apps in one process and round-trips ControlInlet /
+# ControlOutlet through Process::load_inlet / load_outlet in each: a stale
+# function-local static cache of the first app's PortFactoryList would be a
+# heap-use-after-free in the second round. Needs the full app (APP) so the
+# dynamic plugins that register the port factories (score_plugin_dataflow)
+# are loaded from <build>/plugins.
+score_add_test(test_unit_port_factory_reuse
+  SOURCES PortFactoryListReuseTest.cpp
+  APP
+  PLUGINS score_lib_process)
+

--- a/tests/unit/PortFactoryListReuseTest.cpp
+++ b/tests/unit/PortFactoryListReuseTest.cpp
@@ -1,0 +1,104 @@
+// Regression test: per-app interface-list lookup in port deserialization.
+//
+// Process::load_inlet / load_outlet (and a dozen similar deserialization
+// sites) used to cache the application's PortFactoryList in a function-local
+// `static`:
+//
+//   static auto& il = score::AppComponents().interfaces<Process::PortFactoryList>();
+//
+// The `static` froze the FIRST application's factory list. When a second
+// score application was booted in the same process — exactly what the test
+// fixtures do when several run_in_app tests share one binary — the first
+// app's ApplicationComponents had been destroyed, and the second app's
+// deserialization iterated the freed list: heap-use-after-free.
+//
+// This test boots two MinimalApplications sequentially and round-trips a
+// ControlInlet / ControlOutlet through Process::load_inlet / load_outlet in
+// each. Under ASAN it crashes in the second round without the fix (the fix
+// looks the list up per-call through the serializer's `components` member).
+
+#include <Process/Dataflow/Port.hpp>
+#include <Process/Dataflow/PortSerialization.hpp>
+
+#include <score/serialization/DataStreamVisitor.hpp>
+#include <score/serialization/JSONVisitor.hpp>
+#include <score/serialization/VisitorCommon.hpp>
+
+#include <score_test/App.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+// Serialize + deserialize ports so that all four load_inlet/load_outlet
+// overloads (JSON + DataStream) run against the current app's factory list.
+void roundtrip_ports_in_fresh_app()
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    Process::ControlInlet inlet{"Ctl In", Id<Process::Port>{1234}, nullptr};
+    inlet.setValue(2.5f);
+
+    Process::ControlOutlet outlet{"Ctl Out", Id<Process::Port>{5678}, nullptr};
+    outlet.setValue(0.75f);
+
+    // JSON round-trip
+    {
+      auto json = toValue(score::marshall<JSONObject>((Process::Inlet&)inlet));
+      JSONObject::Deserializer writer{json};
+      auto in = Process::load_inlet(writer, nullptr);
+      REQUIRE(in);
+      auto ctl = dynamic_cast<Process::ControlInlet*>(in.get());
+      REQUIRE(ctl);
+      CHECK(ctl->id() == inlet.id());
+      CHECK(ctl->value() == inlet.value());
+    }
+    {
+      auto json = toValue(score::marshall<JSONObject>((Process::Outlet&)outlet));
+      JSONObject::Deserializer writer{json};
+      auto out = Process::load_outlet(writer, nullptr);
+      REQUIRE(out);
+      auto ctl = dynamic_cast<Process::ControlOutlet*>(out.get());
+      REQUIRE(ctl);
+      CHECK(ctl->id() == outlet.id());
+      CHECK(ctl->value() == outlet.value());
+    }
+
+    // DataStream round-trip
+    {
+      auto data = score::marshall<DataStream>((Process::Inlet&)inlet);
+      DataStream::Deserializer writer{data};
+      auto in = Process::load_inlet(writer, nullptr);
+      REQUIRE(in);
+      auto ctl = dynamic_cast<Process::ControlInlet*>(in.get());
+      REQUIRE(ctl);
+      CHECK(ctl->id() == inlet.id());
+      CHECK(ctl->value() == inlet.value());
+    }
+    {
+      auto data = score::marshall<DataStream>((Process::Outlet&)outlet);
+      DataStream::Deserializer writer{data};
+      auto out = Process::load_outlet(writer, nullptr);
+      REQUIRE(out);
+      auto ctl = dynamic_cast<Process::ControlOutlet*>(out.get());
+      REQUIRE(ctl);
+      CHECK(ctl->id() == outlet.id());
+      CHECK(ctl->value() == outlet.value());
+    }
+  });
+}
+}
+
+TEST_CASE(
+    "Port deserialization uses the current app's factory list, not a stale "
+    "static cache",
+    "[unit][regression][serialization][ports]")
+{
+  // First app: primes what used to be the function-local static caches.
+  roundtrip_ports_in_fresh_app();
+
+  // Second app in the same process: before the fix, load_inlet/load_outlet
+  // iterated the torn-down first app's PortFactoryList (heap-use-after-free).
+  roundtrip_ports_in_fresh_app();
+
+  SUCCEED("two apps deserialized ports in one process");
+}


### PR DESCRIPTION
Several deserialization + command sites cache an application-owned interface list in a **function-local `static`**:
```cpp
static auto& il = score::AppComponents().interfaces<Process::PortFactoryList>();
```
The `static` freezes the **first** app's list. Once that app is torn down (its `ApplicationComponents` freed), a **second** app booting in the same process deserializes through the freed list → **heap-use-after-free** (ASAN-confirmed). One-app-per-process is the production invariant, so it's **latent in production**, but it's a real bug and it blocks any test binary that boots two apps and deserializes ports/processes.

## Fix
Drop the `static` at all **17 sites** and look the list up per-call via the context **already in scope** — the visitor's `components` member / `ctx.app` / a fresh `score::AppContext()` — matching the codebase's dominant convention (e.g. `DefaultEffectItem.cpp:118`). Same object, resolved per call; the lookup is one small hash-find and `deserialize_interface` already does per-port lookups, so the cost is noise.

Sites: `Port.cpp` ×4, `MinMaxFloatPort.cpp` ×2, `ControlSurface/Commands.hpp`, `Nodal/Commands.cpp` + `Process.cpp` ×2, `ScenarioPaste.hpp`, `IntervalModelSerialization.cpp` ×2, `MoveEventMeta.cpp` ×4 (that one also cached a dangling `static AppContext&`). Each edit only removes the storage duration — behavior is unchanged.

## Regression test
`test_unit_port_factory_reuse` boots two headless apps sequentially and round-trips a `ControlInlet`/`ControlOutlet` through `load_inlet`/`load_outlet` (JSON + DataStream) in each. It **UAF-crashes at baseline and passes with the fix** (verified both directions by reinstating a single `static`). The full non-GUI suite stays green (the only non-passes are pre-existing and unrelated — proven by rebuilding at baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)