### PR TITLE
wasm: defer first engine start + fix ffmpeg SDK path

### DIFF
--- a/src/plugins/score-plugin-audio/Audio/AudioApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-audio/Audio/AudioApplicationPlugin.cpp
@@ -23,6 +23,7 @@
 #include <ossia/audio/audio_engine.hpp>
 #include <ossia/audio/audio_protocol.hpp>
 
+#include <QTimer>
 #include <QToolBar>
 
 SCORE_DECLARE_ACTION(RestartAudio, "Restart Audio", Common, QKeySequence::UnknownKey)
@@ -160,7 +161,12 @@ try
   if(!init)
   {
     init = true;
-    start_engine();
+    // The miniaudio WebAudio backend blocks (emscripten_sleep / ASYNCIFY) while
+    // waiting for the AudioWorklet to come up. Running that synchronously while
+    // nested deep inside document loading (loadFile -> on_documentChanged)
+    // deadlocks the async worklet init. Defer the first engine start to the
+    // event loop so it runs at a clean stack depth.
+    QTimer::singleShot(0, this, [this] { start_engine(); });
   }
 #else
   stop_engine();

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -163,13 +163,13 @@ if(EMSCRIPTEN)
   target_include_directories(${PROJECT_NAME} PUBLIC ${OSSIA_SDK}/ffmpeg/include)
   target_link_libraries(${PROJECT_NAME} PUBLIC
     -Wl,--start-group
-    /opt/ossia-sdk-wasm/ffmpeg/lib/libavcodec.a
-    /opt/ossia-sdk-wasm/ffmpeg/lib/libavdevice.a
-    /opt/ossia-sdk-wasm/ffmpeg/lib/libavfilter.a
-    /opt/ossia-sdk-wasm/ffmpeg/lib/libavformat.a
-    /opt/ossia-sdk-wasm/ffmpeg/lib/libavutil.a
-    /opt/ossia-sdk-wasm/ffmpeg/lib/libswscale.a
-    /opt/ossia-sdk-wasm/ffmpeg/lib/libswresample.a
+    ${OSSIA_SDK}/ffmpeg/lib/libavcodec.a
+    ${OSSIA_SDK}/ffmpeg/lib/libavdevice.a
+    ${OSSIA_SDK}/ffmpeg/lib/libavfilter.a
+    ${OSSIA_SDK}/ffmpeg/lib/libavformat.a
+    ${OSSIA_SDK}/ffmpeg/lib/libavutil.a
+    ${OSSIA_SDK}/ffmpeg/lib/libswscale.a
+    ${OSSIA_SDK}/ffmpeg/lib/libswresample.a
     -Wl,--end-group
   )
 elseif(TARGET avcodec)


### PR DESCRIPTION
Two small WASM build/runtime fixes.

**audio: defer the first wasm engine start out of document loading**
On WASM the miniaudio WebAudio backend blocks (`emscripten_sleep` / ASYNCIFY) while waiting for the AudioWorklet. Starting it synchronously from `restart_engine()` while nested inside document loading (`loadFile` → `on_documentChanged`) deadlocks the async worklet init, so loading a document would hang. Deferring the first `start_engine()` via `QTimer::singleShot(0, …)` runs it at a clean stack depth and the document loads/plays normally.

**media: use `OSSIA_SDK` for the wasm ffmpeg lib paths**
The include dir already used `${OSSIA_SDK}/ffmpeg`, but the static libs were hardcoded to `/opt/ossia-sdk-wasm`, breaking builds against an SDK placed anywhere else. Point them at `${OSSIA_SDK}` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)