### PR TITLE
core: don't re-enter document teardown on a second exit request

### DIFF
--- a/src/lib/core/application/ApplicationInterface.cpp
+++ b/src/lib/core/application/ApplicationInterface.cpp
@@ -247,8 +247,10 @@ void GUIApplicationInterface::registerPlugin(Plugin_QtInterface& p)
 
 void GUIApplicationInterface::requestExit()
 {
-  auto pres = qApp->findChild<score::Presenter*>();
-  pres->exit();
+  // The presenter is gone in headless setups and during late teardown;
+  // exit requests arriving then have nothing left to close.
+  if(auto pres = qApp->findChild<score::Presenter*>())
+    pres->exit();
 }
 
 void GUIApplicationInterface::forceExit()

--- a/src/lib/core/presenter/Presenter.cpp
+++ b/src/lib/core/presenter/Presenter.cpp
@@ -71,7 +71,17 @@ Presenter::~Presenter() { }
 
 bool Presenter::exit()
 {
-  return m_docManager.closeAllDocuments(m_context);
+  // Closing documents pumps the event loop (execution stop, deferred
+  // deletions); a second exit request arriving meanwhile — e.g. the OSC
+  // /exit callback firing again, or a queued quit timer — would re-enter
+  // closeAllDocuments and tear down half-destroyed documents.
+  if(m_exiting)
+    return false;
+  m_exiting = true;
+  const bool closed = m_docManager.closeAllDocuments(m_context);
+  if(!closed)
+    m_exiting = false; // the user cancelled a save prompt; the session continues
+  return closed;
 }
 
 View* Presenter::view() const

--- a/src/lib/core/presenter/Presenter.hpp
+++ b/src/lib/core/presenter/Presenter.hpp
@@ -65,6 +65,7 @@ public:
   void optimize();
 
 private:
+  bool m_exiting{};
   void setupMenus();
   View* m_view{};
   Settings& m_settings;

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -80,6 +80,12 @@ score_add_test(test_regression_presenter_drain
   SOURCES RegressionPresenterDrainTest.cpp
   APP)
 
+# A second exit request during or after shutdown is a no-op
+# (re-entering closeAllDocuments aborted the process).
+score_add_test(test_regression_double_exit
+  SOURCES RegressionDoubleExitTest.cpp
+  APP)
+
 # A throwing dropCustom handler is contained by the
 # noexcept getCustomDrops API.
 score_add_test(test_regression_throwing_drop_handler

--- a/tests/integration/RegressionDoubleExitTest.cpp
+++ b/tests/integration/RegressionDoubleExitTest.cpp
@@ -1,0 +1,51 @@
+// Regression test for the re-entrant exit abort: Presenter::exit() pumps the
+// event loop while closing documents (execution stop, deferred deletions), so
+// a second exit request arriving meanwhile — an OSC /exit callback firing
+// again, or an already-queued quit timer — re-entered closeAllDocuments and
+// tore down half-destroyed documents, aborting the process.
+//
+// Presenter::exit() now latches: the first call closes the documents, any
+// further call while exiting (or after a completed exit) is a no-op returning
+// false. A cancelled close (user said no to a save prompt) resets the latch so
+// the session can exit later. GUIApplicationInterface::requestExit() also
+// tolerates the presenter being gone.
+
+#include <score_test/App.hpp>
+
+#include <core/application/MinimalApplication.hpp>
+#include <core/presenter/Presenter.hpp>
+
+#include <QApplication>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE(
+    "A second exit request during or after shutdown is a no-op",
+    "[integration][regression][teardown]")
+{
+  score::test::prepare_test_environment(/*headless=*/true);
+  QLocale::setDefault(QLocale::C);
+  std::setlocale(LC_ALL, "C");
+
+  static int argc = 1;
+  static char arg0[] = "score-test";
+  static char* argv[] = {arg0, nullptr};
+  score::MinimalGUIApplication app{argc, argv, /*show=*/false};
+  QApplication::processEvents();
+
+  auto* pres = qApp->findChild<score::Presenter*>();
+  REQUIRE(pres);
+
+  // First request closes every document and reports success.
+  CHECK(pres->exit() == true);
+
+  // Any further request is latched out instead of re-entering the close.
+  CHECK(pres->exit() == false);
+  CHECK(pres->exit() == false);
+
+  // The full request path stays safe too (this is what the OSC /exit
+  // callback and the quit timer end up calling).
+  app.requestExit();
+  app.forceExit();
+  QApplication::processEvents();
+}


### PR DESCRIPTION
Presenter::exit() pumps the event loop while closing documents (execution stop, deferred deletions). A second exit request arriving meanwhile — the OSC /exit callback firing again, or an already-queued quit timer — re-entered closeAllDocuments and tore down half-destroyed documents, aborting the process at shutdown. This was the recurring exit=134 in headless OSC-driven runs.

- Presenter::exit() latches: first call closes the documents; further calls while exiting (or after a completed exit) are no-ops returning false. A cancelled close (save prompt declined) resets the latch so the session can still exit later.
- GUIApplicationInterface::requestExit() tolerates the presenter being gone (headless setups, late teardown).
- Regression test: test_regression_double_exit (fails at baseline — a second exit() re-runs the close and returns true; with the latch it returns false and nothing is re-entered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZgzE8JjWvHDtaVUhxpLE