### PR TITLE
ci: pin continuous release target_commitish to the build commit

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false

--- a/.github/workflows/debian-builds.yaml
+++ b/.github/workflows/debian-builds.yaml
@@ -72,6 +72,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         name: "Continuous"
         tag_name: "continuous"
+        target_commitish: ${{ github.sha }}
         body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
         append_body: false
         generate_release_notes: false

--- a/.github/workflows/mac-builds.yaml
+++ b/.github/workflows/mac-builds.yaml
@@ -68,6 +68,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false
@@ -204,6 +205,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false

--- a/.github/workflows/ubuntu-builds.yaml
+++ b/.github/workflows/ubuntu-builds.yaml
@@ -77,6 +77,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -78,6 +78,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false

--- a/.github/workflows/win-builds.yaml
+++ b/.github/workflows/win-builds.yaml
@@ -60,6 +60,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false
@@ -124,6 +125,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false
@@ -206,6 +208,7 @@ jobs:
         with:
           name: "Continuous"
           tag_name: "continuous"
+          target_commitish: ${{ github.sha }}
           body: "Continuous (development) build of ossia score, automatically rebuilt from the latest commit on master. For stable versions, see the tagged releases."
           append_body: false
           generate_release_notes: false


### PR DESCRIPTION
## Problem

Every continuous-upload job on `master` has failed since **2026-07-15** at the `softprops/action-gh-release@v3` step:

```
Found release Continuous (with id=44130693)
⚠️ Unexpected error fetching GitHub release for tag refs/heads/master:
   HttpError: Resource not accessible by integration - .../releases#update-a-release
```

Last successful asset upload: `2026-07-15T05:04Z`. All platforms affected (Tarball, AppImage, WASM, Flatpak, Windows, macOS, Ubuntu, Debian).

## Root cause

The `Continuous` steps never passed `target_commitish`. When updating an existing release, the action falls back to the value already stored on it:

```ts
// src/github.ts
if (config.input_target_commitish && config.input_target_commitish !== existingRelease.target_commitish) {
  target_commitish = config.input_target_commitish;
} else {
  target_commitish = existingRelease.target_commitish;   // <-- replayed every run
}
```

That stored value is **`262531f1` — "[ci] Try to switch continuous build to GH actions", from 2024-08-24**. It is neither the current `master` head nor the commit the `continuous` tag points at.

`GITHUB_TOKEN` can only write a release targeting the **head** commit. Targeting an arbitrary commit additionally requires the `workflows` permission, which `GITHUB_TOKEN` structurally cannot hold ([community discussion #121022](https://github.com/orgs/community/discussions/121022); same root cause as [cli/cli#9514](https://github.com/cli/cli/issues/9514)). Hence a 403 despite `Contents: write`.

### Ruled out

- **Not a permissions misconfiguration.** The `GITHUB_TOKEN Permissions` block is byte-identical between the last green run and a failing one, and both show `Contents: write`. Repo default is `write`. The `rickstaa/action-create-tag` step in the same job (which force-pushes a tag, requiring contents:write) succeeds.
- **Not immutable releases or rulesets.** Release is `immutable: false`, `draft: false`; the only ruleset targets branches, not tags.
- **Not an action regression.** v3.0.2 was already in use for the green runs on 07-13 and 07-14. Updating to the action's `master` would **not** help: the only commit touching `src/github.ts` since v3.0.2 is #822 "safely classify GitHub API errors", 143 lines of pure error-classification refactoring that changes zero `target_commitish` lines and explicitly keeps "endpoint precedence unchanged".

## Fix

Pass the build commit explicitly, at all 11 `Continuous` sites across 8 workflows:

```yaml
  tag_name: "continuous"
+ target_commitish: ${{ github.sha }}
```

A one-off API repair of the release would not be durable — without this input the action reads the stored value back each run and breaks again once `master` advances past it.

The tag-triggered `Release` steps are deliberately untouched; they already target the tagged commit.

## Verification

- All 14 workflow files parse as YAML.
- All 11 insertions are under `if: github.ref == 'refs/heads/master'`.
- All 11 tag-triggered `Release` steps confirmed unchanged.

## Caveat

The mechanism above is well documented, but I could find **no** corroboration for why it began failing on 07-15 after ~2 years of the same stale value succeeding — no GitHub changelog entry, no upstream issue. Best explanation is server-side tightening, but that is inference. This change is correct regardless; if the real trigger is something else, it may not be sufficient. The Tarball job is the fastest signal after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nnv1a8Kf38wfMqnVfS3J1k
