### PR TITLE
tests: make the test suite work on macOS and Windows

### DIFF
--- a/cmake/ScoreFunctions.cmake
+++ b/cmake/ScoreFunctions.cmake
@@ -95,6 +95,12 @@ function(score_write_static_plugins_header)
 
   string(APPEND SCORE_PLUGINS_FILE_DATA "#include <score/plugins/PluginInstances.hpp>\n")
   string(APPEND SCORE_PLUGINS_FILE_DATA "void score_init_static_plugins() {\n")
+  # Idempotent: the static plug-in set is process-global, but the function is
+  # called from every application instance (score::MinimalApplication is
+  # constructed more than once in the test suite). Without this guard each call
+  # push_back()s the same plug-ins again, so every factory / action condition
+  # gets registered twice and the second application aborts.
+  string(APPEND SCORE_PLUGINS_FILE_DATA "  if(!score::staticPlugins().empty()) return\;\n")
 
   foreach(plugin ${SCORE_PLUGINS_LIST})
     string(APPEND SCORE_PLUGINS_FILE_DATA "#if __has_include(<${plugin}.hpp>)\n{ static ${plugin} p\; score::staticPlugins().push_back(&p)\; }\n#endif\n")

--- a/cmake/ScoreFunctions.cmake
+++ b/cmake/ScoreFunctions.cmake
@@ -95,11 +95,6 @@ function(score_write_static_plugins_header)
 
   string(APPEND SCORE_PLUGINS_FILE_DATA "#include <score/plugins/PluginInstances.hpp>\n")
   string(APPEND SCORE_PLUGINS_FILE_DATA "void score_init_static_plugins() {\n")
-  # Idempotent: the static plug-in set is process-global, but the function is
-  # called from every application instance (score::MinimalApplication is
-  # constructed more than once in the test suite). Without this guard each call
-  # push_back()s the same plug-ins again, so every factory / action condition
-  # gets registered twice and the second application aborts.
   string(APPEND SCORE_PLUGINS_FILE_DATA "  if(!score::staticPlugins().empty()) return\;\n")
 
   foreach(plugin ${SCORE_PLUGINS_LIST})

--- a/cmake/ScoreTests.cmake
+++ b/cmake/ScoreTests.cmake
@@ -73,18 +73,6 @@ function(score_add_test NAME)
       ${QT_PREFIX}::Network
       ${QT_PREFIX}::Xml)
 
-    # Static-plugin builds (macOS SDK, deployment) have no runtime plugin
-    # discovery from <build>/plugins: MinimalApplication registers score
-    # plugins through score_init_static_plugins(), whose __has_include checks
-    # only see the plugins linked into the executable. Link the full plugin
-    # set, exactly like the main app does (src/app/CMakeLists.txt), so that
-    # APP/GUI tests observe the same factory lists as with dynamic plugins.
-    # No-op for dynamic-plugin (Linux dev) builds.
-    #
-    # score_plugin_jit is excluded: it embeds a prebuilt (uninstrumented) LLVM
-    # whose static initializers trip ASan container-overflow false positives at
-    # process start (llvm::DebugCounter growing an annotated std::vector), and
-    # it makes every test link enormous.
     if(SCORE_STATIC_PLUGINS)
       set(_test_plugins "${SCORE_PLUGINS_LIST}")
       list(REMOVE_ITEM _test_plugins score_plugin_jit)
@@ -94,9 +82,6 @@ function(score_add_test NAME)
 
   setup_score_common_exe_features(${NAME})
 
-  # Static-Qt builds (SDK/deployment) have no runtime QPA plugin discovery:
-  # every executable must link the platform integration plugins itself, like
-  # the main app does. No-op with a dynamic Qt (link_if_exists).
   if(ARG_GUI)
     enable_minimal_qt_plugins(${NAME} 1)
   else()
@@ -114,10 +99,6 @@ function(score_add_test NAME)
       WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   endif()
 
-  # SCORE_DISABLE_AUDIOPLUGINS: without it the app scans the developer machine's
-  # real VST/CLAP/AU library, spawning a puppet process per plug-in. That is
-  # invisible on CI (no plug-ins installed) but makes every app test take
-  # minutes — or time out — on a workstation.
   if(ARG_APP)
     # Headless: force the offscreen platform.
     set_tests_properties(${NAME} PROPERTIES

--- a/cmake/ScoreTests.cmake
+++ b/cmake/ScoreTests.cmake
@@ -72,9 +72,37 @@ function(score_add_test NAME)
       ${QT_PREFIX}::Widgets
       ${QT_PREFIX}::Network
       ${QT_PREFIX}::Xml)
+
+    # Static-plugin builds (macOS SDK, deployment) have no runtime plugin
+    # discovery from <build>/plugins: MinimalApplication registers score
+    # plugins through score_init_static_plugins(), whose __has_include checks
+    # only see the plugins linked into the executable. Link the full plugin
+    # set, exactly like the main app does (src/app/CMakeLists.txt), so that
+    # APP/GUI tests observe the same factory lists as with dynamic plugins.
+    # No-op for dynamic-plugin (Linux dev) builds.
+    #
+    # score_plugin_jit is excluded: it embeds a prebuilt (uninstrumented) LLVM
+    # whose static initializers trip ASan container-overflow false positives at
+    # process start (llvm::DebugCounter growing an annotated std::vector), and
+    # it makes every test link enormous.
+    if(SCORE_STATIC_PLUGINS)
+      set(_test_plugins "${SCORE_PLUGINS_LIST}")
+      list(REMOVE_ITEM _test_plugins score_plugin_jit)
+      target_link_libraries(${NAME} PRIVATE ${_test_plugins})
+    endif()
   endif()
 
   setup_score_common_exe_features(${NAME})
+
+  # Static-Qt builds (SDK/deployment) have no runtime QPA plugin discovery:
+  # every executable must link the platform integration plugins itself, like
+  # the main app does. No-op with a dynamic Qt (link_if_exists).
+  if(ARG_GUI)
+    enable_minimal_qt_plugins(${NAME} 1)
+  else()
+    enable_minimal_qt_plugins(${NAME} 0)
+  endif()
+
   set_target_properties(${NAME} PROPERTIES FOLDER "Tests")
 
   add_test(NAME ${NAME} COMMAND ${NAME})
@@ -86,15 +114,19 @@ function(score_add_test NAME)
       WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   endif()
 
+  # SCORE_DISABLE_AUDIOPLUGINS: without it the app scans the developer machine's
+  # real VST/CLAP/AU library, spawning a puppet process per plug-in. That is
+  # invisible on CI (no plug-ins installed) but makes every app test take
+  # minutes — or time out — on a workstation.
   if(ARG_APP)
     # Headless: force the offscreen platform.
     set_tests_properties(${NAME} PROPERTIES
-      ENVIRONMENT "QT_QPA_PLATFORM=offscreen;SCORE_AUDIO_BACKEND=dummy")
+      ENVIRONMENT "QT_QPA_PLATFORM=offscreen;SCORE_AUDIO_BACKEND=dummy;SCORE_DISABLE_AUDIOPLUGINS=1")
   elseif(ARG_GUI)
     # GUI tests need a real display (X11 locally, Xvfb in CI): do NOT force
     # offscreen. Labelled "gui" so CI can gate them behind a display.
     set_tests_properties(${NAME} PROPERTIES
-      ENVIRONMENT "SCORE_AUDIO_BACKEND=dummy"
+      ENVIRONMENT "SCORE_AUDIO_BACKEND=dummy;SCORE_DISABLE_AUDIOPLUGINS=1"
       LABELS "gui")
   endif()
 endfunction()

--- a/src/lib/core/application/MinimalApplication.hpp
+++ b/src/lib/core/application/MinimalApplication.hpp
@@ -22,13 +22,6 @@ class MinimalApplication final
     , public score::GUIApplicationInterface
 {
 public:
-  // QApplication takes argc by reference and edits argc/argv in place (it
-  // strips the arguments it recognizes), so the default arguments cannot be
-  // shared: a second MinimalApplication in the same process would be handed
-  // the leftovers of the first — argc == 0 in practice, which breaks
-  // QCommandLineParser and anything else reading the command line.
-  // Hand out a fresh, intentionally leaked set per instance instead: it must
-  // outlive its QApplication, which keeps the reference for its whole life.
   struct DefaultArgs
   {
     int argc = 1;

--- a/src/lib/core/application/MinimalApplication.hpp
+++ b/src/lib/core/application/MinimalApplication.hpp
@@ -22,14 +22,26 @@ class MinimalApplication final
     , public score::GUIApplicationInterface
 {
 public:
-  // Static so they are alive before construction (the delegating constructor
-  // below reads them) and outlive the QApplication, which keeps a reference to
-  // argc for its whole lifetime.
-  static inline int default_argc = 1;
-  static inline const char* default_argv[2] = {"score", nullptr};
+  // QApplication takes argc by reference and edits argc/argv in place (it
+  // strips the arguments it recognizes), so the default arguments cannot be
+  // shared: a second MinimalApplication in the same process would be handed
+  // the leftovers of the first — argc == 0 in practice, which breaks
+  // QCommandLineParser and anything else reading the command line.
+  // Hand out a fresh, intentionally leaked set per instance instead: it must
+  // outlive its QApplication, which keeps the reference for its whole life.
+  struct DefaultArgs
+  {
+    int argc = 1;
+    const char* argv[2] = {"score", nullptr};
+  };
 
   MinimalApplication()
-      : MinimalApplication{default_argc, (char**)default_argv}
+      : MinimalApplication{*new DefaultArgs{}}
+  {
+  }
+
+  explicit MinimalApplication(DefaultArgs& args)
+      : MinimalApplication{args.argc, (char**)args.argv}
   {
   }
 

--- a/src/lib/core/view/Window.cpp
+++ b/src/lib/core/view/Window.cpp
@@ -452,6 +452,13 @@ void View::resizeEvent(QResizeEvent* e)
 bool score::View::event(QEvent* event)
 {
   auto display = [this](QString tip) {
+    // m_status is only created once the first panel delegate is registered
+    // (see View::setupPanel). Headless / minimal application setups - e.g. the
+    // test harnesses - never register any panel, so it stays null while status
+    // tips can still be emitted by menus and actions.
+    if(!m_status)
+      return;
+
     auto idx = tip.indexOf(QChar('\n'));
     if(idx != -1)
     {

--- a/src/lib/core/view/Window.cpp
+++ b/src/lib/core/view/Window.cpp
@@ -452,10 +452,6 @@ void View::resizeEvent(QResizeEvent* e)
 bool score::View::event(QEvent* event)
 {
   auto display = [this](QString tip) {
-    // m_status is only created once the first panel delegate is registered
-    // (see View::setupPanel). Headless / minimal application setups - e.g. the
-    // test harnesses - never register any panel, so it stays null while status
-    // tips can still be emitted by menus and actions.
     if(!m_status)
       return;
 

--- a/src/plugins/score-lib-device/Tests/CMakeLists.txt
+++ b/src/plugins/score-lib-device/Tests/CMakeLists.txt
@@ -1,6 +1,13 @@
 # Device node serialization test. Boots a MinimalApplication (via Utils.hpp),
 # so it needs the APP mode (offscreen + runtime plugin discovery).
+#
+# score_plugin_deviceexplorer is linked explicitly: JSONReader::read(DeviceSettings)
+# aborts without the Device::ProtocolFactoryList interface list it registers.
+# With dynamic plugins (Linux) the plugin is discovered at runtime from
+# <build>/plugins, but in static-plugin builds (macOS SDK)
+# score_init_static_plugins() only registers plugins whose headers are visible
+# to the test target, i.e. linked ones.
 score_add_test(test_device_serialization
   SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/SerializationTest.cpp"
   APP
-  PLUGINS score_lib_device score_lib_state)
+  PLUGINS score_lib_device score_lib_state score_plugin_deviceexplorer)

--- a/src/plugins/score-lib-device/Tests/CMakeLists.txt
+++ b/src/plugins/score-lib-device/Tests/CMakeLists.txt
@@ -1,12 +1,5 @@
 # Device node serialization test. Boots a MinimalApplication (via Utils.hpp),
 # so it needs the APP mode (offscreen + runtime plugin discovery).
-#
-# score_plugin_deviceexplorer is linked explicitly: JSONReader::read(DeviceSettings)
-# aborts without the Device::ProtocolFactoryList interface list it registers.
-# With dynamic plugins (Linux) the plugin is discovered at runtime from
-# <build>/plugins, but in static-plugin builds (macOS SDK)
-# score_init_static_plugins() only registers plugins whose headers are visible
-# to the test target, i.e. linked ones.
 score_add_test(test_device_serialization
   SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/SerializationTest.cpp"
   APP

--- a/src/plugins/score-lib-device/Tests/Utils.hpp
+++ b/src/plugins/score-lib-device/Tests/Utils.hpp
@@ -12,10 +12,31 @@
 #include <QMetaType>
 #include <QObject>
 
-static auto init = [] {
-  // Qt6: QDataStream stream operators and comparators for registered metatypes
-  // are picked up automatically (qRegisterMetaTypeStreamOperators /
-  // QMetaType::registerComparators were removed).
-  static score::MinimalApplication app;
-  return 0;
-}();
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+
+// Qt6: QDataStream stream operators and comparators for registered metatypes
+// are picked up automatically (qRegisterMetaTypeStreamOperators /
+// QMetaType::registerComparators were removed).
+//
+// The app used to be created in a file-scope static initializer. With a static
+// Qt (macOS SDK build), the QPA plugins are registered by static initializers
+// in Qt-generated Q_IMPORT_PLUGIN translation units, and the relative order is
+// link-line dependent: constructing the Q(Gui)Application before they ran
+// aborts with "Could not find the Qt platform plugin". Create the app at
+// test-run start instead, once all static initialization is done.
+namespace
+{
+struct ScoreTestApplicationStarter final : Catch::EventListenerBase
+{
+  using Catch::EventListenerBase::EventListenerBase;
+  void testRunStarting(const Catch::TestRunInfo&) override
+  {
+    // Pure model/serialization tests: no display needed, keep them hermetic.
+    if(!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
+      qputenv("QT_QPA_PLATFORM", "offscreen");
+    static score::MinimalApplication app;
+  }
+};
+}
+CATCH_REGISTER_LISTENER(ScoreTestApplicationStarter)

--- a/src/plugins/score-lib-device/Tests/Utils.hpp
+++ b/src/plugins/score-lib-device/Tests/Utils.hpp
@@ -18,13 +18,6 @@
 // Qt6: QDataStream stream operators and comparators for registered metatypes
 // are picked up automatically (qRegisterMetaTypeStreamOperators /
 // QMetaType::registerComparators were removed).
-//
-// The app used to be created in a file-scope static initializer. With a static
-// Qt (macOS SDK build), the QPA plugins are registered by static initializers
-// in Qt-generated Q_IMPORT_PLUGIN translation units, and the relative order is
-// link-line dependent: constructing the Q(Gui)Application before they ran
-// aborts with "Could not find the Qt platform plugin". Create the app at
-// test-run start instead, once all static initialization is done.
 namespace
 {
 struct ScoreTestApplicationStarter final : Catch::EventListenerBase
@@ -32,7 +25,6 @@ struct ScoreTestApplicationStarter final : Catch::EventListenerBase
   using Catch::EventListenerBase::EventListenerBase;
   void testRunStarting(const Catch::TestRunInfo&) override
   {
-    // Pure model/serialization tests: no display needed, keep them hermetic.
     if(!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
       qputenv("QT_QPA_PLATFORM", "offscreen");
     static score::MinimalApplication app;

--- a/src/plugins/score-lib-state/Tests/Utils.hpp
+++ b/src/plugins/score-lib-state/Tests/Utils.hpp
@@ -12,7 +12,27 @@
 #include <QMetaType>
 #include <QObject>
 
-static auto init = [] {
-  static score::MinimalApplication app;
-  return 0;
-}();
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+
+// The app used to be created in a file-scope static initializer. With a static
+// Qt (macOS SDK build), the QPA plugins are registered by static initializers
+// in Qt-generated Q_IMPORT_PLUGIN translation units, and the relative order is
+// link-line dependent: constructing the Q(Gui)Application before they ran
+// aborts with "Could not find the Qt platform plugin". Create the app at
+// test-run start instead, once all static initialization is done.
+namespace
+{
+struct ScoreTestApplicationStarter final : Catch::EventListenerBase
+{
+  using Catch::EventListenerBase::EventListenerBase;
+  void testRunStarting(const Catch::TestRunInfo&) override
+  {
+    // Pure model/serialization tests: no display needed, keep them hermetic.
+    if(!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
+      qputenv("QT_QPA_PLATFORM", "offscreen");
+    static score::MinimalApplication app;
+  }
+};
+}
+CATCH_REGISTER_LISTENER(ScoreTestApplicationStarter)

--- a/src/plugins/score-lib-state/Tests/Utils.hpp
+++ b/src/plugins/score-lib-state/Tests/Utils.hpp
@@ -15,12 +15,6 @@
 #include <catch2/reporters/catch_reporter_event_listener.hpp>
 #include <catch2/reporters/catch_reporter_registrars.hpp>
 
-// The app used to be created in a file-scope static initializer. With a static
-// Qt (macOS SDK build), the QPA plugins are registered by static initializers
-// in Qt-generated Q_IMPORT_PLUGIN translation units, and the relative order is
-// link-line dependent: constructing the Q(Gui)Application before they ran
-// aborts with "Could not find the Qt platform plugin". Create the app at
-// test-run start instead, once all static initialization is done.
 namespace
 {
 struct ScoreTestApplicationStarter final : Catch::EventListenerBase
@@ -28,7 +22,6 @@ struct ScoreTestApplicationStarter final : Catch::EventListenerBase
   using Catch::EventListenerBase::EventListenerBase;
   void testRunStarting(const Catch::TestRunInfo&) override
   {
-    // Pure model/serialization tests: no display needed, keep them hermetic.
     if(!qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
       qputenv("QT_QPA_PLATFORM", "offscreen");
     static score::MinimalApplication app;

--- a/tests/integration/RegressionMinimalAppTwiceTest.cpp
+++ b/tests/integration/RegressionMinimalAppTwiceTest.cpp
@@ -32,14 +32,16 @@ TEST_CASE(
   {
     INFO("iteration " << i);
     {
-      // The default constructor is the fixed code path: it reads the
-      // (now static) default argc/argv.
+      // The default constructor is the fixed code path: each instance gets
+      // its own argc/argv, so the previous QApplication cannot have eaten
+      // them (it edits argc/argv in place).
       score::MinimalApplication app;
 
       REQUIRE(qApp != nullptr);
-      // QApplication keeps a reference to argc: it must still read 1.
-      CHECK(score::MinimalApplication::default_argc == 1);
+      // The second application must see a full command line, not the
+      // leftovers of the first one.
       CHECK(QCoreApplication::arguments().size() == 1);
+      CHECK(!QCoreApplication::arguments().front().isEmpty());
 
       QApplication::processEvents();
       QApplication::processEvents();
@@ -47,10 +49,8 @@ TEST_CASE(
       score::test::close_all_documents(app.context());
       QApplication::processEvents();
     }
-    // After destruction the static storage must be intact for the next round.
+    // The application must be fully torn down before the next round.
     REQUIRE(qApp == nullptr);
-    CHECK(score::MinimalApplication::default_argc == 1);
-    CHECK(score::MinimalApplication::default_argv[0] != nullptr);
   }
 
   SUCCEED("two full MinimalApplication lifecycles completed");

--- a/tests/integration/RegressionMinimalAppTwiceTest.cpp
+++ b/tests/integration/RegressionMinimalAppTwiceTest.cpp
@@ -32,14 +32,9 @@ TEST_CASE(
   {
     INFO("iteration " << i);
     {
-      // The default constructor is the fixed code path: each instance gets
-      // its own argc/argv, so the previous QApplication cannot have eaten
-      // them (it edits argc/argv in place).
       score::MinimalApplication app;
 
       REQUIRE(qApp != nullptr);
-      // The second application must see a full command line, not the
-      // leftovers of the first one.
       CHECK(QCoreApplication::arguments().size() == 1);
       CHECK(!QCoreApplication::arguments().front().isEmpty());
 
@@ -49,7 +44,6 @@ TEST_CASE(
       score::test::close_all_documents(app.context());
       QApplication::processEvents();
     }
-    // The application must be fully torn down before the next round.
     REQUIRE(qApp == nullptr);
   }
 

--- a/tests/nodes/Devices.cpp
+++ b/tests/nodes/Devices.cpp
@@ -37,6 +37,19 @@
 
 #include <csetjmp>
 #include <csignal>
+
+// Windows has no sigsetjmp/siglongjmp, no SIGBUS/SIGTRAP/SIGALRM and no
+// alarm(): fall back to plain setjmp/longjmp, drop the missing signals from
+// the guarded set and make the watchdog a no-op. The guard still catches
+// SIGSEGV/SIGABRT/SIGFPE/SIGILL, which is what these sweeps rely on.
+#if defined(_WIN32)
+#include <csetjmp>
+using sigjmp_buf = std::jmp_buf;
+#define sigsetjmp(buf, save) setjmp(buf)
+#define siglongjmp(buf, val) longjmp(buf, val)
+static inline unsigned int alarm(unsigned int) noexcept { return 0; }
+#endif
+
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -70,7 +83,11 @@ extern "C" void dev_crash_handler(int sig)
   std::raise(sig);
 }
 
-constexpr int g_guarded_signals[] = {SIGSEGV, SIGABRT, SIGFPE, SIGBUS, SIGILL, SIGTRAP};
+constexpr int g_guarded_signals[] = {SIGSEGV, SIGABRT, SIGFPE, SIGILL
+#if !defined(_WIN32)
+                                     , SIGBUS, SIGTRAP
+#endif
+};
 void install_crash_handlers()
 {
   for(int s : g_guarded_signals)

--- a/tests/nodes/Devices.cpp
+++ b/tests/nodes/Devices.cpp
@@ -38,10 +38,7 @@
 #include <csetjmp>
 #include <csignal>
 
-// Windows has no sigsetjmp/siglongjmp, no SIGBUS/SIGTRAP/SIGALRM and no
-// alarm(): fall back to plain setjmp/longjmp, drop the missing signals from
-// the guarded set and make the watchdog a no-op. The guard still catches
-// SIGSEGV/SIGABRT/SIGFPE/SIGILL, which is what these sweeps rely on.
+// Windows shim: no sigsetjmp/siglongjmp, SIGBUS/SIGTRAP/SIGALRM or alarm().
 #if defined(_WIN32)
 #include <csetjmp>
 using sigjmp_buf = std::jmp_buf;

--- a/tests/nodes/Processes.cpp
+++ b/tests/nodes/Processes.cpp
@@ -64,18 +64,13 @@
 #include <csetjmp>
 #include <csignal>
 
-// Windows has no sigsetjmp/siglongjmp, no SIGBUS/SIGTRAP/SIGALRM and no
-// alarm(): fall back to plain setjmp/longjmp, drop the missing signals from
-// the guarded set and make the watchdog a no-op. The guard still catches
-// SIGSEGV/SIGABRT/SIGFPE/SIGILL, which is what these sweeps rely on.
+// Windows shim: no sigsetjmp/siglongjmp, SIGBUS/SIGTRAP/SIGALRM or alarm().
 #if defined(_WIN32)
 #include <csetjmp>
 using sigjmp_buf = std::jmp_buf;
 #define sigsetjmp(buf, save) setjmp(buf)
 #define siglongjmp(buf, val) longjmp(buf, val)
 static inline unsigned int alarm(unsigned int) noexcept { return 0; }
-// No alarm() on Windows, so the watchdog never fires: use an impossible
-// value so the timeout branch stays compilable but unreachable.
 #define SIGALRM (-1)
 #endif
 

--- a/tests/nodes/Processes.cpp
+++ b/tests/nodes/Processes.cpp
@@ -63,6 +63,22 @@
 
 #include <csetjmp>
 #include <csignal>
+
+// Windows has no sigsetjmp/siglongjmp, no SIGBUS/SIGTRAP/SIGALRM and no
+// alarm(): fall back to plain setjmp/longjmp, drop the missing signals from
+// the guarded set and make the watchdog a no-op. The guard still catches
+// SIGSEGV/SIGABRT/SIGFPE/SIGILL, which is what these sweeps rely on.
+#if defined(_WIN32)
+#include <csetjmp>
+using sigjmp_buf = std::jmp_buf;
+#define sigsetjmp(buf, save) setjmp(buf)
+#define siglongjmp(buf, val) longjmp(buf, val)
+static inline unsigned int alarm(unsigned int) noexcept { return 0; }
+// No alarm() on Windows, so the watchdog never fires: use an impossible
+// value so the timeout branch stays compilable but unreachable.
+#define SIGALRM (-1)
+#endif
+
 #include <cstdlib>
 #include <set>
 #include <string>
@@ -108,7 +124,11 @@ extern "C" void sweep_crash_handler(int sig)
 }
 
 constexpr int g_guarded_signals[]
-    = {SIGSEGV, SIGABRT, SIGFPE, SIGBUS, SIGILL, SIGTRAP, SIGALRM};
+    = {SIGSEGV, SIGABRT, SIGFPE, SIGILL
+#if !defined(_WIN32)
+       , SIGBUS, SIGTRAP, SIGALRM
+#endif
+};
 
 void install_crash_handlers()
 {


### PR DESCRIPTION
The SCORE_TESTING suite had only ever been built and run on Linux with dynamic plugins. Running it on the macOS SDK build and on Windows/MSYS2 (both static-plugin, static-Qt) surfaced several genuine bugs. All fixes verified on Linux (no regression), macOS (arm64, SDK static Qt, ASAN+UBSan) and Windows (clang64, static).

**`score_init_static_plugins()` was not idempotent** — the headline bug. It is generated as `{ static X p; score::staticPlugins().push_back(&p); }` per plug-in: the object is `static`, but the `push_back` runs on *every* call, and it is called from every application instance. A second `score::MinimalApplication` in one process therefore registered every plug-in twice, so every factory and action condition was registered twice and the second application aborted in `ActionManager::onFocusChange` (`SCORE_ASSERT(m_focusConditions.find(key) == end())`). This is exactly what `test_regression_minimal_app_twice` was written to catch — it could not fail on Linux because dynamic-plugin builds skip that path entirely. Verified: that test went from abort (exit 3 / SIGTRAP) to green on Windows.

**`MinimalApplication` default arguments were a shared static**, but `QApplication` takes `argc` by reference and edits `argc`/`argv` in place, so the second application got the leftovers of the first (`argc == 0`). Each instance now gets its own block.

**Static-Qt builds have no runtime QPA plugin discovery** — every executable must import the platform plugins itself, as the main app does; otherwise every test dies with *"Could not find the Qt platform plugin"*. Static-plugin builds likewise need the plug-in set linked in.

**The app scanned the machine's real VST/CLAP/AU library** during tests, spawning a puppet process per plug-in. Invisible on CI (no plug-ins installed), but minutes per test — or a timeout — on a workstation: 300 s vs 1 s for one test. Now `SCORE_DISABLE_AUDIOPLUGINS=1` in the ctest environment.

**score-lib-state / score-lib-device tests built their QApplication in a file-scope static initializer**, which with a static Qt runs *before* the `Q_IMPORT_PLUGIN` registrars. Constructed at test-run start instead.

**`tests/nodes` used POSIX-only APIs** (`sigsetjmp`/`siglongjmp`, `alarm()`, `SIGBUS`/`SIGTRAP`/`SIGALRM`) so the suite did not compile on Windows at all — 31 errors. Portable shim with a reduced signal set there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZgzE8JjWvHDtaVUhxpLE