### PR TITLE
cmake: fill the gaps external addons hit in SDK mode

### DIFF
--- a/cmake/ScoreExternalAddon.cmake
+++ b/cmake/ScoreExternalAddon.cmake
@@ -34,6 +34,12 @@ set(SCORE_VERSION_MINOR 0)
 set(SCORE_VERSION_PATCH 0)
 set(SCORE_VERSION "${SCORE_VERSION_MAJOR}.${SCORE_VERSION_MINOR}.${SCORE_VERSION_PATCH}")
 
+# Addons written against the in-tree build use ${QT_VERSION} in their
+# find_package calls; it is set by score's top-level CMakeLists, which an
+# external addon never sees. Without it those calls degenerate into a bare
+# find_package(REQUIRED ...) and fail. Keep in sync with CMakeLists.txt.
+set(QT_VERSION Qt6 6.2)
+
 set(SCORE_DYNAMIC_PLUGINS 1)
 
 # Official Mac / Win / Linux releases are built against KFR

--- a/cmake/ScoreExternalAddon.sdk.cmake
+++ b/cmake/ScoreExternalAddon.sdk.cmake
@@ -213,3 +213,107 @@ function(setup_score_plugin PluginName)
     )
   endif()
 endfunction()
+
+# The helpers below live in ScoreFunctions.cmake / ScoreTargetSetup.cmake for
+# in-tree builds. Those cannot simply be included here: ScoreFunctions includes
+# ScoreTargetSetup, which in turn includes six modules (Sanitize, UseGold,
+# LinkerWarnings, DebugMode, ScoreStaticQt, GenerateStaticExport) that are not
+# shipped in the SDK. Addons call them unconditionally, so mirror the
+# self-contained ones here, as is already done for score_common_setup above.
+
+function(score_write_file FileName Content)
+  if(EXISTS "${FileName}")
+    file(READ "${FileName}" EXISTING_CONTENT)
+    string(REGEX REPLACE ";" "\\\\;" EXISTING_CONTENT "${EXISTING_CONTENT}")
+    if(NOT "${Content}" STREQUAL "${EXISTING_CONTENT}")
+      file(WRITE "${FileName}" ${Content})
+    endif()
+  else()
+    file(WRITE "${FileName}" ${Content})
+  endif()
+endfunction()
+
+function(score_generate_command_list_file TheTarget Headers)
+    # Initialize our lists
+    set(commandNameList)
+    set(commandFileList)
+
+    # First look for the SCORE_COMMAND_DECL(...) ones
+    foreach(sourceFile ${Headers})
+        file(READ "${sourceFile}" fileContent)
+        string(REGEX MATCHALL "SCORE_COMMAND_DECL\\([A-Za-z_0-9\,\:<>\r\n\t ]*\\(\\)[A-Za-z_0-9\,\"'\:<>\+\r\n\t ]*\\)"
+               defaultCommands "${fileContent}")
+
+        foreach(fileLine ${defaultCommands})
+            string(REPLACE "\n" "" fileLine "${fileLine}")
+            string(REPLACE "\r" "" fileLine "${fileLine}")
+            string(STRIP ${fileLine} strippedLine)
+
+            string(REPLACE "," ";" lineAsList ${strippedLine})
+            list(GET lineAsList 1 commandName)
+            string(STRIP ${commandName} strippedCommandName)
+            list(APPEND commandNameList "${strippedCommandName}")
+        endforeach()
+
+        # If there are matching strings, we add the file to our include list
+        list(LENGTH defaultCommands matchingLines)
+        if(${matchingLines} GREATER 0)
+            list(APPEND commandFileList "${sourceFile}")
+        endif()
+
+        # Then look for the SCORE_COMMAND_DECL_T(...) ones
+        string(REGEX MATCHALL "SCORE_COMMAND_DECL_T\\([A-Za-z_0-9\,\:<>\+\r\n\t ]*\\)"
+               templateCommands "${fileContent}")
+        foreach(fileLine ${templateCommands})
+            string(REPLACE "\n" "" fileLine "${fileLine}")
+            string(REPLACE "\r" "" fileLine "${fileLine}")
+            string(STRIP ${fileLine} strippedLine)
+
+            string(REPLACE "SCORE_COMMAND_DECL_T(" "" filtered1 ${strippedLine})
+            string(REPLACE ")" "" commandName ${filtered1})
+            string(STRIP ${commandName} strippedCommandName)
+
+            list(APPEND commandNameList "${strippedCommandName}")
+        endforeach()
+
+        list(LENGTH templateCommands matchingLines)
+        if(${matchingLines} GREATER 0)
+            list(APPEND commandFileList "${sourceFile}")
+        endif()
+
+    endforeach()
+
+    # Generate a file with the list of includes
+    set(finalCommandFileList)
+    foreach(sourceFile ${commandFileList})
+        string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" strippedSourceFile ${sourceFile})
+        set(finalCommandFileList "${finalCommandFileList}#include <${strippedSourceFile}>\n")
+    endforeach()
+
+    score_write_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/${TheTarget}_commands_files.hpp"
+        "${finalCommandFileList}"
+        )
+
+    # Generate a file with the list of types
+    string(REPLACE ";" ", \n" commaSeparatedCommandList "${commandNameList}")
+    score_write_file(
+         "${CMAKE_CURRENT_BINARY_DIR}/${TheTarget}_commands.hpp"
+         "${commaSeparatedCommandList}"
+        )
+
+endfunction()
+
+function(score_optimize_in_debug_mode Target)
+  if(NOT MSVC)
+    if(NOT CMAKE_CROSSCOMPILING)
+      if(CMAKE_BUILD_TYPE MATCHES ".*Debug.*")
+        get_target_property(_has_custom_pch ${Target} SCORE_CUSTOM_PCH)
+        if(NOT ${_has_custom_pch})
+          set_target_properties(${Target} PROPERTIES SCORE_CUSTOM_PCH 1)
+          target_compile_options(${Target} PRIVATE -Ofast -march=native)
+        endif()
+      endif()
+    endif()
+  endif()
+endfunction()


### PR DESCRIPTION
Three things addons call unconditionally are unavailable when building against the SDK rather than the score tree. Each of them fails at configure time, so they mask everything downstream.

### `QT_VERSION`

Set by score's top-level `CMakeLists.txt:91`, which an external addon never sees. Addons written against the in-tree build do `find_package(${QT_VERSION} REQUIRED COMPONENTS Core Widgets ...)`, which degenerates into a bare `find_package(REQUIRED ...)`. Now set in `ScoreExternalAddon.cmake` next to `SCORE_VERSION`.

### `score_optimize_in_debug_mode`

Missing from `ScoreExternalAddon.sdk.cmake`, so any addon calling it dies with `Unknown CMake command "score_optimize_in_debug_mode"`. GBAP hits this on all six of its SDK legs.

### `score_generate_command_list_file`

Likewise missing, along with `score_write_file` which it calls. `iscore-addon-network` and `score-addon-deuterium` both use it.

---

These helpers live in `ScoreFunctions.cmake` / `ScoreTargetSetup.cmake` for in-tree builds, and it would obviously be nicer to include those than to mirror them. That does not work from SDK mode: `ScoreFunctions.cmake` opens with `include(ScoreTargetSetup)`, and `ScoreTargetSetup.cmake` includes six modules — `Sanitize`, `UseGold`, `LinkerWarnings`, `DebugMode`, `ScoreStaticQt`, `GenerateStaticExport` — that `ScoreDeployment.cmake` does not install into `lib/cmake/score`. So this follows the pattern the file already uses for `score_common_setup` and `setup_score_plugin`.

If you'd rather fix this by shipping those six modules in the SDK and including `ScoreFunctions` properly, I'm happy to redo it that way — it's the better long-term shape, just a larger change to the SDK payload.

### Verification

The copied bodies are byte-identical to the originals (`diff` clean apart from one blank line in `score_generate_command_list_file`). I also ran both the original and the copied `score_generate_command_list_file` over a header containing both a `SCORE_COMMAND_DECL` and a `SCORE_COMMAND_DECL_T`, and diffed the generated `_commands.hpp` / `_commands_files.hpp` — identical. Ran twice so that `score_write_file`'s existing-file branch (the one with the `REGEX REPLACE` escaping) is actually exercised rather than only the initial write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)