### PR TITLE
Allow custom apps to be started in UI debug mode

### DIFF
--- a/tools/create-app-linux.sh
+++ b/tools/create-app-linux.sh
@@ -151,6 +151,20 @@ if [[ -n "$APP_ENVIRONMENT" ]]; then
     cat "$APP_ENVIRONMENT" >> AppRun
 fi
 
+cat >> AppRun << 'APPRUN_EOF'
+
+# --debug opens the score editor window alongside the custom UI
+UI_FLAG="--ui"
+SCORE_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--debug" ]]; then
+        UI_FLAG="--ui-debug"
+    else
+        SCORE_ARGS+=("$arg")
+    fi
+done
+APPRUN_EOF
+
 if [[ -n "$SCORE_BASENAME" ]]; then
     # With score
     cat >> AppRun << APPRUN_EOF
@@ -158,9 +172,9 @@ if [[ -n "$SCORE_BASENAME" ]]; then
 # Launch with custom UI and score
 exec "\${APPDIR}/usr/bin/app-bin" \
     ${AUTOPLAY} \
-    --ui "\${APPDIR}/usr/bin/qml/${MAIN_QML}" \
+    "\${UI_FLAG}" "\${APPDIR}/usr/bin/qml/${MAIN_QML}" \
     "\${APPDIR}/usr/bin/${SCORE_BASENAME}" \
-    "\$@"
+    "\${SCORE_ARGS[@]}"
 APPRUN_EOF
 else
     # Without custom score
@@ -169,8 +183,8 @@ else
 # Launch with custom UI
 exec "\${APPDIR}/usr/bin/app-bin" \
     ${AUTOPLAY} \
-    --ui "\${APPDIR}/usr/bin/qml/${MAIN_QML}" \
-    "$@"
+    "\${UI_FLAG}" "\${APPDIR}/usr/bin/qml/${MAIN_QML}" \
+    "\${SCORE_ARGS[@]}"
 APPRUN_EOF
 fi
 

--- a/tools/create-app-macos.sh
+++ b/tools/create-app-macos.sh
@@ -209,15 +209,29 @@ if [[ -n "$APP_ENVIRONMENT" ]]; then
     cat "$APP_ENVIRONMENT" >> "$BUNDLE_MACOS/$APP_NAME" 
 fi
 
+cat >> "$BUNDLE_MACOS/$APP_NAME" << 'LAUNCHER_EOF'
+
+# --debug opens the score editor window alongside the custom UI
+UI_FLAG="--ui"
+SCORE_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--debug" ]]; then
+        UI_FLAG="--ui-debug"
+    else
+        SCORE_ARGS+=("$arg")
+    fi
+done
+LAUNCHER_EOF
+
 if [[ -n "$SCORE_BASENAME" ]]; then
     # With score
     cat >> "$BUNDLE_MACOS/$APP_NAME" << LAUNCHER_EOF
 
 exec "\$SCRIPT_DIR/app-bin" \
     ${AUTOPLAY} \
-    --ui "\${RESOURCES_DIR}/qml/${MAIN_QML}" \
+    "\${UI_FLAG}" "\${RESOURCES_DIR}/qml/${MAIN_QML}" \
     "\${RESOURCES_DIR}/${SCORE_BASENAME}" \
-    "\$@"
+    "\${SCORE_ARGS[@]}"
 LAUNCHER_EOF
 else
     # Without autoplay
@@ -225,8 +239,8 @@ else
 
 exec "\$SCRIPT_DIR/app-bin" \
     ${AUTOPLAY} \
-    --ui "\${RESOURCES_DIR}/qml/${MAIN_QML}" \
-    "\$@"
+    "\${UI_FLAG}" "\${RESOURCES_DIR}/qml/${MAIN_QML}" \
+    "\${SCORE_ARGS[@]}"
 LAUNCHER_EOF
 fi
 

--- a/tools/create-app-wasm.sh
+++ b/tools/create-app-wasm.sh
@@ -164,7 +164,9 @@ PRELOAD_JSON="$SITE_DIR/preload.json"
 } > "$PRELOAD_JSON"
 
 # Compose the argv passed to score's main().
-ARGS_JS="'--ui', '/app/qml/${MAIN_QML}'"
+# The UI flag itself is chosen at load time: ?debug in the URL opens the score
+# editor window alongside the custom UI.
+ARGS_JS="'/app/qml/${MAIN_QML}'"
 if [[ -n "$SCORE_BASENAME" ]]; then
     ARGS_JS="${ARGS_JS}, '/app/${SCORE_BASENAME}'"
 fi
@@ -210,12 +212,16 @@ cat > "$SITE_DIR/index.html" << HTML_EOF
             ui.style.display = 'block';
           };
 
+          const debugParam = new URLSearchParams(window.location.search).get('debug');
+          const uiFlag = (debugParam !== null && !['0', 'false', 'no', 'off'].includes(debugParam.toLowerCase()))
+            ? '--ui-debug' : '--ui';
+
           try {
             showUi(spinner);
             status.innerHTML = 'Loading...';
 
             await qtLoad({
-              arguments: [${ARGS_JS}],
+              arguments: [uiFlag, ${ARGS_JS}],
               qt: {
                 preload: ['preload.json'],
                 environment: { QML2_IMPORT_PATH: '/app/qml' },

--- a/tools/create-app.sh
+++ b/tools/create-app.sh
@@ -87,6 +87,10 @@ Example:
 This will create platform-specific packages that launch score with:
     --ui App.qml [App.score] [--autoplay]
 
+The generated applications accept --debug, which starts them with --ui-debug
+instead of --ui: the custom UI is shown along with the score editor window.
+For the wasm bundle, use the ?debug URL parameter instead.
+
 EOF
     exit 0
 }

--- a/tools/launcher/launcher.cpp
+++ b/tools/launcher/launcher.cpp
@@ -111,10 +111,18 @@ int main(int argc, char* argv[])
   snprintf(qml_path, MAX_PATH, "%s\\qml\\%s", exe_dir, MAIN_QML);
   snprintf(qml_import_path, MAX_PATH, "%s\\qml", exe_dir);
 
+  // --debug opens the score editor window alongside the custom UI
+  const char* ui_flag = "--ui";
+  for(int i = 1; i < argc; i++)
+  {
+    if(strcmp(argv[i], "--debug") == 0)
+      ui_flag = "--ui-debug";
+  }
+
   // Build command line
   snprintf(
-      command_line, sizeof(command_line), "\"%s\\app-bin.exe\" --ui \"%s\"", exe_dir,
-      qml_path);
+      command_line, sizeof(command_line), "\"%s\\app-bin.exe\" %s \"%s\"", exe_dir,
+      ui_flag, qml_path);
 
   if(HAS_AUTOPLAY)
   {
@@ -133,6 +141,8 @@ int main(int argc, char* argv[])
   // Add any additional command line arguments
   for(int i = 1; i < argc; i++)
   {
+    if(strcmp(argv[i], "--debug") == 0)
+      continue;
     strncat(command_line, " \"", sizeof(command_line) - strlen(command_line) - 1);
     strncat(command_line, argv[i], sizeof(command_line) - strlen(command_line) - 1);
     strncat(command_line, "\"", sizeof(command_line) - strlen(command_line) - 1);


### PR DESCRIPTION
Apps generated by `tools/create-app.sh` hardcoded score's `--ui` flag, so their end users had no way to get the score editor window alongside the custom QML UI without repackaging the app.

The generated launchers now accept `--debug`, which swaps `--ui` for `--ui-debug`. The flag is consumed by the launcher and not forwarded, so score's argument parser never sees an unknown option:

| Platform | How to enable |
|---|---|
| Linux | `./MyApp.AppImage --debug` |
| macOS | `MyApp.app/Contents/MacOS/MyApp --debug` |
| Windows | `MyApp.exe --debug` |
| wasm | `http://host/myapp/?debug` (no command line available; `?debug=0/false/no/off` disables) |

Also fixes a latent bug in the same block: the Linux AppRun scoreless branch used an unescaped `"$@"` inside the heredoc, baking `create-app-linux.sh`'s own arguments into the AppImage instead of forwarding the end user's.

## Testing

Syntax-checked the five scripts, generated a sample `AppRun` and macOS launcher and exercised the argument handling (no args -> `--ui`; `--debug` -> `--ui-debug`; `--debug file.score --no-opengl` -> flag swapped, remaining args forwarded, no stray empty argument), and ran the wasm URL-parameter logic through node.

The Windows launcher was reviewed but not compiled — no mingw compiler available on the machine this was written on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)