### PR TITLE
Audio: new WASAPI (miniaudio) driver on Windows`

### DIFF
--- a/src/plugins/score-plugin-audio/Audio/GenericMiniAudioInterface.hpp
+++ b/src/plugins/score-plugin-audio/Audio/GenericMiniAudioInterface.hpp
@@ -101,10 +101,12 @@ public:
     // set.changed();
 
     // Backends that can follow the OS default (WASAPI) default to that mode when
-    // nothing has been configured yet, so playback tracks the Windows mixer
-    // default output out of the box.
+    // nothing has been configured yet, so playback/capture track the Windows
+    // mixer default output/input out of the box.
     if(followsDefaultDevice() && set.getCardOut().isEmpty())
       set.setCardOut("Default");
+    if(followsDefaultDevice() && set.getCardIn().isEmpty())
+      set.setCardIn("Default");
 
     const MiniAudioCard* user_in{};
     const MiniAudioCard* user_out{};

--- a/src/plugins/score-plugin-audio/Audio/GenericMiniAudioInterface.hpp
+++ b/src/plugins/score-plugin-audio/Audio/GenericMiniAudioInterface.hpp
@@ -72,6 +72,24 @@ public:
   virtual void setDeviceId(ma_device_id& id, const QString& str) const noexcept = 0;
   virtual QString deviceIdToString(const ma_device_id& id) const noexcept = 0;
 
+  // When true, the factory exposes an extra "Default device" entry mapped to
+  // the OS default device. The selection is stored as the "Default" sentinel
+  // and make_engine passes a NULL miniaudio device id, so the backend follows
+  // the OS default (with automatic rerouting on WASAPI) while running.
+  virtual bool followsDefaultDevice() const noexcept { return false; }
+
+  static constexpr int DefaultDeviceItemData = -1;
+
+  int defaultDeviceChannels(ma_device_type tp) const noexcept
+  {
+    for(const auto& d : devices)
+    {
+      if(d.type == tp && d.info.isDefault && d.info.nativeDataFormatCount > 0)
+        return d.info.nativeDataFormats[0].channels;
+    }
+    return 2;
+  }
+
   void
   initialize(Audio::Settings::Model& set, const score::ApplicationContext& ctx) override
   {
@@ -81,6 +99,12 @@ public:
     // set.setRate(48000);
     // set.setBufferSize(256);
     // set.changed();
+
+    // Backends that can follow the OS default (WASAPI) default to that mode when
+    // nothing has been configured yet, so playback tracks the Windows mixer
+    // default output out of the box.
+    if(followsDefaultDevice() && set.getCardOut().isEmpty())
+      set.setCardOut("Default");
 
     const MiniAudioCard* user_in{};
     const MiniAudioCard* user_out{};
@@ -147,22 +171,50 @@ public:
     if(set.getCardOut().startsWith("No device"))
       card_out = nullptr;
 
-    if(card_in)
+    if(followsDefaultDevice() && set.getCardIn() == "Default")
     {
-      // qDebug() << Q_FUNC_INFO << card_in->id.coreaudio;
+      const MiniAudioCard* ref = default_in ? default_in : first_viable_in;
+      set.setDefaultIn(ref ? ref->info.nativeDataFormats[0].channels : 2);
+    }
+    else if(card_in)
+    {
       set.setCardIn(deviceIdToString(card_in->id));
       set.setDefaultIn(card_in->info.nativeDataFormats[0].channels);
     }
     else
     {
-      // qDebug() << Q_FUNC_INFO << "no input";
       set.setCardIn(devices.front().name);
       set.setDefaultIn(0);
     }
 
-    if(card_out)
+    if(followsDefaultDevice() && set.getCardOut() == "Default")
     {
-      // qDebug() << Q_FUNC_INFO << card_out->id.coreaudio;
+      // Keep the "Default device" sentinel so make_engine passes a NULL device
+      // id and miniaudio follows the OS default output. Derive channels/rate
+      // from the current OS default device.
+      const MiniAudioCard* ref = default_out ? default_out : first_viable_out;
+      if(ref)
+      {
+        set.setDefaultOut(ref->info.nativeDataFormats[0].channels);
+        int current_rate = set.getRate();
+        if(int fmt_count = ref->info.nativeDataFormatCount; fmt_count > 0)
+        {
+          auto* fmts = ref->info.nativeDataFormats;
+          if(std::none_of(fmts, fmts + fmt_count, [current_rate](auto fmt) {
+            return fmt.sampleRate == current_rate;
+          }))
+          {
+            set.setRate(ref->info.nativeDataFormats[0].sampleRate);
+          }
+        }
+      }
+      else
+      {
+        set.setDefaultOut(2);
+      }
+    }
+    else if(card_out)
+    {
       set.setCardOut(deviceIdToString(card_out->id));
       set.setDefaultOut(card_out->info.nativeDataFormats[0].channels);
 
@@ -180,7 +232,6 @@ public:
     }
     else
     {
-      // qDebug() << Q_FUNC_INFO << "no output";
       set.setCardOut(devices.front().name);
       set.setDefaultOut(0);
     }
@@ -245,18 +296,27 @@ public:
 
   void setCard(QComboBox* combo, ma_device_type tp, QString val)
   {
-    //qDebug() << Q_FUNC_INFO << "looking for: " << val << "in " << combo->count();
-    auto dev_it
-        = ossia::find_if(devices, [&, id = val.toStdString()](const MiniAudioCard& d) {
-      // qDebug() << d.id.coreaudio << " == " << id << bool(d.id.coreaudio == id) << " ???";
-      return d.id.coreaudio == id && d.type == tp;
+    // "Default device" sentinel: select the dedicated combo entry.
+    if(followsDefaultDevice() && val == "Default")
+    {
+      for(int i = 0; i < combo->count(); i++)
+      {
+        if(combo->itemData(i).toInt() == DefaultDeviceItemData)
+        {
+          combo->setCurrentIndex(i);
+          return;
+        }
+      }
+    }
+
+    auto dev_it = ossia::find_if(devices, [&](const MiniAudioCard& d) {
+      return compareDeviceId(d.id, val) && d.type == tp;
     });
     if(dev_it != devices.end())
     {
       int device_index = std::distance(devices.begin(), dev_it);
       for(int i = 0; i < combo->count(); i++)
       {
-        // qDebug() << device_index << i << combo->itemText(i) << combo->itemData(i);
         if(combo->itemData(i).toInt() == device_index)
         {
           combo->setCurrentIndex(i);
@@ -303,6 +363,15 @@ public:
     card_list_in->addItem(devices.front().name + " (capture)", 0);
     card_list_out->addItem(devices.front().name + " (playback)", 0);
 
+    // Optional "follow the OS default device" entry (e.g. WASAPI).
+    if(followsDefaultDevice())
+    {
+      card_list_in->addItem(
+          QObject::tr("Default device (follow system)"), DefaultDeviceItemData);
+      card_list_out->addItem(
+          QObject::tr("Default device (follow system)"), DefaultDeviceItemData);
+    }
+
     // qDebug() << Q_FUNC_INFO << "Devices: ";
     for(std::size_t i = 1; i < devices.size(); i++)
     {
@@ -347,11 +416,24 @@ public:
         }
       };
 
+      auto update_default_in = [this, &m, &m_disp]() {
+        if(m.getCardIn() != "Default")
+        {
+          m_disp.submitDeferredCommand<Audio::Settings::SetModelCardIn>(
+              m, QStringLiteral("Default"));
+          m_disp.submitDeferredCommand<Audio::Settings::SetModelDefaultIn>(
+              m, defaultDeviceChannels(ma_device_type_capture));
+        }
+      };
+
       QObject::connect(
           card_list_in, SignalUtils::QComboBox_currentIndexChanged_int(), &v,
-          [this, card_list_in, update_dev_in](int i) {
-        auto& device = devices[card_list_in->itemData(i).toInt()];
-        update_dev_in(device);
+          [this, card_list_in, update_dev_in, update_default_in](int i) {
+        int data = card_list_in->itemData(i).toInt();
+        if(data == DefaultDeviceItemData)
+          update_default_in();
+        else
+          update_dev_in(devices[data]);
       });
 
       if(m.getCardIn().isEmpty())
@@ -380,11 +462,24 @@ public:
         }
       };
 
+      auto update_default_out = [this, &m, &m_disp]() {
+        if(m.getCardOut() != "Default")
+        {
+          m_disp.submitDeferredCommand<Audio::Settings::SetModelCardOut>(
+              m, QStringLiteral("Default"));
+          m_disp.submitDeferredCommand<Audio::Settings::SetModelDefaultOut>(
+              m, defaultDeviceChannels(ma_device_type_playback));
+        }
+      };
+
       QObject::connect(
           card_list_out, SignalUtils::QComboBox_currentIndexChanged_int(), &v,
-          [this, card_list_out, update_dev_out](int i) {
-        auto& device = devices[card_list_out->itemData(i).toInt()];
-        update_dev_out(device);
+          [this, card_list_out, update_dev_out, update_default_out](int i) {
+        int data = card_list_out->itemData(i).toInt();
+        if(data == DefaultDeviceItemData)
+          update_default_out();
+        else
+          update_dev_out(devices[data]);
       });
 
       if(m.getCardOut().isEmpty())

--- a/src/plugins/score-plugin-audio/Audio/GenericMiniAudioInterface.hpp
+++ b/src/plugins/score-plugin-audio/Audio/GenericMiniAudioInterface.hpp
@@ -369,9 +369,9 @@ public:
     if(followsDefaultDevice())
     {
       card_list_in->addItem(
-          QObject::tr("Default device (follow system)"), DefaultDeviceItemData);
+          QObject::tr("Default device"), DefaultDeviceItemData);
       card_list_out->addItem(
-          QObject::tr("Default device (follow system)"), DefaultDeviceItemData);
+          QObject::tr("Default device"), DefaultDeviceItemData);
     }
 
     // qDebug() << Q_FUNC_INFO << "Devices: ";

--- a/src/plugins/score-plugin-audio/Audio/Settings/Model.cpp
+++ b/src/plugins/score-plugin-audio/Audio/Settings/Model.cpp
@@ -14,7 +14,7 @@ SETTINGS_PARAMETER_IMPL(Driver)
   QStringLiteral("Audio/Driver"),
 #if defined(_WIN32)
       Audio::AudioFactory::ConcreteKey{score::uuids::string_generator::compute(
-          "afcd9c64-0367-4fa1-b2bb-ee65b1c5e5a7")} // WASAPI
+          "2838b52b-9c0c-466e-a2b0-8c6d8cb8fc6d")} // WASAPI (miniaudio)
 #elif defined(__APPLE__)
     Audio::AudioFactory::ConcreteKey{
         score::uuids::string_generator::compute("85115103-694a-4a3b-9274-76ef47aec5a9")}

--- a/src/plugins/score-plugin-audio/Audio/Settings/Model.cpp
+++ b/src/plugins/score-plugin-audio/Audio/Settings/Model.cpp
@@ -79,6 +79,8 @@ static std::optional<Audio::AudioFactory::ConcreteKey> driverFromEnv()
     uid = "3533ee88-9a8d-486c-b20b-6c966cf4eaa0";
   else if(env == "alsa_miniaudio")
     uid = "e0c533da-a1f4-4795-90b5-a805cdfcb79f";
+  else if(env == "wasapi_miniaudio")
+    uid = "2838b52b-9c0c-466e-a2b0-8c6d8cb8fc6d";
 
   if(uid.isEmpty())
     return std::nullopt;

--- a/src/plugins/score-plugin-audio/Audio/WASAPIMiniAudioInterface.hpp
+++ b/src/plugins/score-plugin-audio/Audio/WASAPIMiniAudioInterface.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#if defined(_WIN32)
+#include <Audio/AudioInterface.hpp>
+
+#include <ossia/audio/miniaudio_protocol.hpp>
+#if OSSIA_ENABLE_MINIAUDIO
+#include <Audio/GenericMiniAudioInterface.hpp>
+
+#include <algorithm>
+
+namespace Audio
+{
+class WASAPIMiniAudioFactory final : public GenericMiniAudioFactory
+{
+  SCORE_CONCRETE("2838b52b-9c0c-466e-a2b0-8c6d8cb8fc6d")
+public:
+  WASAPIMiniAudioFactory() { rescan(); }
+  ~WASAPIMiniAudioFactory() override { }
+  QString prettyName() const override { return QObject::tr("WASAPI (miniaudio)"); }
+  bool available() const noexcept override { return true; }
+
+  // Expose the "Default device (follow system)" entry: when selected, the
+  // engine opens the OS default device with a NULL miniaudio device id, so
+  // WASAPI reroutes automatically when the Windows mixer default changes.
+  bool followsDefaultDevice() const noexcept override { return true; }
+
+  // WASAPI identifies devices with a wchar_t string (ma_device_id::wasapi).
+  bool
+  compareDeviceId(const ma_device_id& id, const QString& str) const noexcept override
+  {
+    return QString::fromWCharArray(id.wasapi) == str;
+  }
+  bool
+  compareDeviceId(const ma_device_id& id, std::string_view str) const noexcept override
+  {
+    return QString::fromWCharArray(id.wasapi)
+           == QString::fromUtf8(str.data(), (int)str.size());
+  }
+  void setDeviceId(ma_device_id& id, const QString& str) const noexcept override
+  {
+    std::fill_n(id.wasapi, 64, (ma_wchar_win32)0);
+    int n = (int)str.size();
+    if(n > 63)
+      n = 63;
+    str.left(n).toWCharArray(id.wasapi);
+    id.wasapi[n] = 0;
+  }
+
+  QString deviceIdToString(const ma_device_id& id) const noexcept override
+  {
+    return QString::fromWCharArray(id.wasapi);
+  }
+};
+}
+#endif
+#endif

--- a/src/plugins/score-plugin-audio/Audio/WASAPIMiniAudioInterface.hpp
+++ b/src/plugins/score-plugin-audio/Audio/WASAPIMiniAudioInterface.hpp
@@ -19,7 +19,7 @@ public:
   QString prettyName() const override { return QObject::tr("WASAPI (miniaudio)"); }
   bool available() const noexcept override { return true; }
 
-  // Expose the "Default device (follow system)" entry: when selected, the
+  // Expose the "Default device" entry: when selected, the
   // engine opens the OS default device with a NULL miniaudio device id, so
   // WASAPI reroutes automatically when the Windows mixer default changes.
   bool followsDefaultDevice() const noexcept override { return true; }

--- a/src/plugins/score-plugin-audio/Audio/WASAPIPortAudioInterface.hpp
+++ b/src/plugins/score-plugin-audio/Audio/WASAPIPortAudioInterface.hpp
@@ -83,7 +83,7 @@ public:
     }
   }
 
-  QString prettyName() const override { return QObject::tr("WASAPI"); }
+  QString prettyName() const override { return QObject::tr("WASAPI (PortAudio)"); }
   std::shared_ptr<ossia::audio_engine> make_engine(
       const Audio::Settings::Model& set, const score::ApplicationContext& ctx) override
   {

--- a/src/plugins/score-plugin-audio/CMakeLists.txt
+++ b/src/plugins/score-plugin-audio/CMakeLists.txt
@@ -25,6 +25,7 @@ set(HDRS
     "${CMAKE_CURRENT_SOURCE_DIR}/Audio/SDLInterface.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Audio/WASMMiniAudioInterface.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Audio/WASAPIPortAudioInterface.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Audio/WASAPIMiniAudioInterface.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Audio/WDMKSPortAudioInterface.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Audio/AudioApplicationPlugin.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Audio/AudioPreviewExecutor.hpp"
@@ -101,7 +102,7 @@ if(OSSIA_ENABLE_SDL)
   list(APPEND SCORE_FEATURES_LIST sdl)
 endif()
 
-if(LINUX OR BSD OR APPLE OR EMSCRIPTEN)
+if(LINUX OR BSD OR APPLE OR EMSCRIPTEN OR WIN32)
   target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE "${OSSIA_3RDPARTY_FOLDER}/miniaudio")
   if(APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE "-framework AudioUnit")

--- a/src/plugins/score-plugin-audio/score_plugin_audio.cpp
+++ b/src/plugins/score-plugin-audio/score_plugin_audio.cpp
@@ -20,6 +20,7 @@
 #include <Audio/SDLInterface.hpp>
 #include <Audio/Settings/Factory.hpp>
 #include <Audio/WASAPIPortAudioInterface.hpp>
+#include <Audio/WASAPIMiniAudioInterface.hpp>
 #include <Audio/WASMMiniAudioInterface.hpp>
 #include <Audio/WDMKSPortAudioInterface.hpp>
 
@@ -154,6 +155,14 @@ std::vector<score::InterfaceBase*> score_plugin_audio::factories(
       return vec;
 #endif
     }
+    else if(forced_backend == "wasapi_miniaudio")
+    {
+#if defined(_WIN32) && defined(OSSIA_AUDIO_MINIAUDIO)
+      add_factories<FW<Audio::AudioFactory, Audio::WASAPIMiniAudioFactory>>(
+          vec, ctx, key);
+      return vec;
+#endif
+    }
     else if(forced_backend == "dummy")
     {
       add_factories<FW<Audio::AudioFactory, Audio::DummyFactory>>(vec, ctx, key);
@@ -221,6 +230,10 @@ std::vector<score::InterfaceBase*> score_plugin_audio::factories(
 #if defined(__APPLE__) && defined(OSSIA_AUDIO_MINIAUDIO)
          ,
          Audio::CoreAudioFactory
+#endif
+#if defined(_WIN32) && defined(OSSIA_AUDIO_MINIAUDIO)
+         ,
+         Audio::WASAPIMiniAudioFactory
 #endif
 #if defined(__EMSCRIPTEN__) && defined(OSSIA_AUDIO_MINIAUDIO)
          ,


### PR DESCRIPTION
## What

Adds a miniaudio-backed WASAPI audio driver for Windows, offered alongside the
existing PortAudio one (now labelled "WASAPI (PortAudio)"). It supports
per-device selection in Settings > Audio and a "Default device (follow system)"
mode that tracks the Windows mixer default output/input on the fly. It becomes
the default driver on Windows for fresh configs.

> Depends on libossia PR: https://github.com/ossia/libossia/pull/911.
> This PR bumps the `3rdparty/libossia` submodule to the matching commit.

## Changes

- **`Audio/WASAPIMiniAudioInterface.hpp`** (new): `WASAPIMiniAudioFactory`, a
  subclass of `GenericMiniAudioFactory` (like the ALSA/CoreAudio miniaudio
  drivers). Pretty name "WASAPI (miniaudio)". Implements WASAPI's `wchar_t`
  device-id conversions (`ma_device_id::wasapi`) and enables the follow-default
  mode.
- **`Audio/GenericMiniAudioInterface.hpp`**
  - Add opt-in `followsDefaultDevice()` with a "Default device (follow system)"
    entry in the capture/playback combos, wired through `initialize` /
    `make_settings` / `setCard` via a `"Default"` sentinel. All gated behind the
    virtual, so ALSA/CoreAudio behavior is unchanged.
  - On a fresh config, follow-default backends default both playback and capture
    to the follow-system device.
  - Fix `setCard()` to resolve device ids via the virtual `compareDeviceId()`
    instead of the hard-coded `id.coreaudio` union member, which relied on union
    aliasing and broke WASAPI's wide-char ids.
- **`Audio/Settings/Model.cpp`**
  - Default Windows audio driver is now "WASAPI (miniaudio)" (applies to fresh
    configs only; existing users keep their setting).
  - Map `SCORE_AUDIO_BACKEND=wasapi_miniaudio` to the new driver key.
- **`score_plugin_audio.cpp`**: register the factory and add the forced-backend
  entry for Windows.
- **`CMakeLists.txt`**: ship the new header and add the miniaudio include dir on
  Windows.
- **`Audio/WASAPIPortAudioInterface.hpp`**: rename the PortAudio driver to
  "WASAPI (PortAudio)" so the two backends are distinguishable in the UI.
- Bump `3rdparty/libossia` to the matching `feat/wasapi-miniaudio` commit.

## Behavior

- Both WASAPI drivers coexist and are selectable in Settings > Audio.
- New default on Windows (fresh config): "WASAPI (miniaudio)" with playback and
  capture set to "Default device (follow system)".
- Changing the Windows default output while playing reroutes automatically
  (miniaudio WASAPI stream routing), without reopening the engine.

## Testing (Windows, clang64)

- Full build + link of the app.
- Runtime: WASAPI context init OK, all endpoints enumerated with correct default
  flags; `ma_device_init` + `ma_device_start` succeed for both an explicit
  device and the "Default" (NULL id) path.
- First-run defaults verified against a cleared registry: driver =
  `2838b52b-9c0c-466e-a2b0-8c6d8cb8fc6d` (WASAPI miniaudio), `Audio/CardOut` and
  `Audio/CardIn` = `Default`.

## Disclosure

The implementation in this PR was produced with an AI coding 
agent (Anthropic's Claude Opus 4.8) using [omp](https://omp.sh/).
I directed the work, reviewed every change, and ran the verification
described above; I take responsibility for its correctness and licensing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>