### PR TITLE
wasm: ship the user library with the build

### DIFF
--- a/ci/wasm.build.sh
+++ b/ci/wasm.build.sh
@@ -10,8 +10,15 @@ cd /build
 
 source /opt/ossia-sdk-wasm/emsdk/emsdk_env.sh
 
+SCORE_LIBRARY_DIR="${SCORE_LIBRARY_DIR:-$HOME/score-user-library}"
+LIBRARY_ARGS=()
+if [ -d "$SCORE_LIBRARY_DIR" ]; then
+  LIBRARY_ARGS+=("-DSCORE_WASM_PRELOAD_LIBRARY=$SCORE_LIBRARY_DIR")
+fi
+
 /opt/ossia-sdk-wasm/qt-wasm/bin/qt-cmake  $SCORE_DIR \
    -GNinja \
+   "${LIBRARY_ARGS[@]}" \
    -DCMAKE_CXX_STANDARD=23 \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_UNITY_BUILD=1 \

--- a/ci/wasm.deploy.sh
+++ b/ci/wasm.deploy.sh
@@ -10,8 +10,12 @@ git config --local user.name "github-actions[bot]"
 
 mv /build/*.js .
 mv /build/ossia-score.wasm .
-# Qt bundles preloaded plugins/resources into a .data file when present.
-[ -f /build/ossia-score.data ] && mv /build/ossia-score.data .
+# Preloaded MEMFS image: Qt's bundled plugins/resources, plus the user library
+# when it was baked in. Not an `&&` one-liner: under `set -e` a missing file
+# would abort the deploy.
+if [ -f /build/ossia-score.data ]; then
+  mv /build/ossia-score.data .
+fi
 mv $SCORE_DIR/cmake/Deployment/WASM/* .
 
 git add .

--- a/ci/wasm.deps.sh
+++ b/ci/wasm.deps.sh
@@ -21,4 +21,11 @@ tar xaf $SDK_ARCHIVE --strip-components=2 --directory /opt/ossia-sdk-wasm/
 
 rm *.tar.*
 
+# Preloaded into the wasm filesystem at link time; see SCORE_WASM_PRELOAD_LIBRARY
+# in src/app/CMakeLists.txt.
+export SCORE_LIBRARY_DIR="${SCORE_LIBRARY_DIR:-$HOME/score-user-library}"
+rm -rf "$SCORE_LIBRARY_DIR"
+git clone --depth=1 https://github.com/ossia/score-user-library "$SCORE_LIBRARY_DIR"
+rm -rf "$SCORE_LIBRARY_DIR/.git"
+
 source ci/common.deps.sh WASM

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -276,8 +276,25 @@ if(EMSCRIPTEN)
     target_link_options(libremidi INTERFACE
       "SHELL:-sEXPORTED_RUNTIME_METHODS=UTF16ToString,stringToUTF16,UTF8ToString,stringToUTF8,lengthBytesUTF8,JSEvents,specialHTMLTargets,FS,callMain,ENV,HEAPU8,HEAPF32,HEAP32,HEAPU32,HEAPF64")
   endif()
+
+  if(SCORE_WASM_PRELOAD_LIBRARY)
+    if(NOT IS_DIRECTORY "${SCORE_WASM_PRELOAD_LIBRARY}")
+      message(FATAL_ERROR "SCORE_WASM_PRELOAD_LIBRARY: not a directory: ${SCORE_WASM_PRELOAD_LIBRARY}")
+    endif()
+
+    # There is nowhere to download the library from at runtime: the browser
+    # cannot fetch github's codeload, which sends no CORS headers. Bake it into
+    # the MEMFS image instead, at the path Library::Settings::Model computes for
+    # the default package -- <DocumentsLocation>/<org>/<app>/packages/default.
+    # --use-preload-cache keeps the package in IndexedDB, so only the first
+    # visit pays for the download.
+    target_link_options(${APPNAME} PRIVATE
+      "SHELL:--preload-file ${SCORE_WASM_PRELOAD_LIBRARY}@/home/web_user/Documents/ossia/score/packages/default"
+      "SHELL:--use-preload-cache")
+  endif()
+
   enable_minimal_qt_plugins(${APPNAME} 1)
-else()  
+else()
   disable_qt_plugins(${APPNAME})
   enable_minimal_qt_plugins(${APPNAME} 1)
 endif()


### PR DESCRIPTION
wasm builds shipped with no library at all — no shaders, no presets, no device templates.

The runtime download cannot work in a browser: `PluginSettingsModel::firstTimeLibraryDownload()` fetches `github.com/ossia/score-user-library/archive/master.zip`, and codeload sends no CORS headers. So there is nowhere to get the library from at runtime.

This bakes it into the MEMFS image at link time instead, mounted at the path `Library::Settings::Model` already computes for the default package — so the existing scanning code finds a populated directory with no runtime change.

### Cost

| | |
|---|---|
| payload | 62.5 MB, 5816 files (CI clones at depth 1 and drops `.git`, which is a third of the checkout) |
| `ossia-score.data` | 62.5 MB — ~32 MB if the host negotiates gzip/brotli |
| `ossia-score.js` | 607 KB → 1.69 MB (the file index) |

`--use-preload-cache` keeps the package in IndexedDB, so only the first visit pays for the download. The `.js` growth is a per-load cost that the cache does not remove.

It compresses about 2×, not more, because roughly a third is already-compressed or binary: `Presets/Faust/SAM/SHARC` is 17.1 MB on its own, PNG+JPG another 11.3 MB. Trimming SHARC and `bela/ReadMe.pdf` alone would save ~19 MB with no shader loss, if the size ever becomes a problem.

Opt-in via `SCORE_WASM_PRELOAD_LIBRARY`, so a build that does not set it is unchanged.

### Also

`ci/wasm.deploy.sh` tested for the `.data` file with `[ -f … ] && mv …`. Under `set -e` that aborts the whole deploy when the file is absent, rather than skipping the move. Now an `if`.

### Verification

Automated, in headless Chrome against the built artifact:

- `FS.readdir` at `/home/web_user/Documents/ossia/score/packages/default` returns all **5816** files, with the expected top-level entries.
- The **User Library** panel lists `default` and expands to `Cues / Devices / Media / Presets / Scripts / Skins / Util / LICENSE / package.json / README.md` — i.e. score's own scanner walks it, not just files present in the filesystem.
- Boot is clean; the only console output is the pre-existing `QWebSocketServer: WebSocket servers are not supported by Qt for WebAssembly`.

The mount path was confirmed against the SDK rather than assumed: emscripten sets `HOME=/home/web_user`, and `libQt6Core.a` carries `/home/web_user` and `/Documents` as literals, so `QStandardPaths::DocumentsLocation` resolves as expected.
