### PR TITLE
gfx: fall back to RGBA8 where the backend has no BGRA8 (fixes images on wasm)

### DIFF
--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ImageNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ImageNode.cpp
@@ -365,7 +365,7 @@ private:
       if(m_textures.size() <= i)
       {
         QRhiTexture* tex = tex
-            = rhi.newTexture(QRhiTexture::BGRA8, tex_size, 1, QRhiTexture::Flag{});
+            = rhi.newTexture(imageTextureFormat(rhi), tex_size, 1, QRhiTexture::Flag{});
         tex->setName("ImagesNode::tex");
         tex->create();
         m_textures.push_back(tex);
@@ -702,7 +702,7 @@ private:
       maxSize.setHeight(std::max(maxSize.height(), sz.height()));
     }
 
-    auto tex = rhi.newTexture(QRhiTexture::BGRA8, maxSize, 1, QRhiTexture::Flag{});
+    auto tex = rhi.newTexture(imageTextureFormat(rhi), maxSize, 1, QRhiTexture::Flag{});
 
     tex->setName("OnTheFlyRenderer::tex");
     tex->create();
@@ -945,7 +945,7 @@ private:
     // Create GPU textures for the image
     const QSize sz = n.m_image.size();
     auto tex = rhi.newTexture(
-        QRhiTexture::BGRA8, QSize{sz.width(), sz.height()}, 1, QRhiTexture::Flag{});
+        imageTextureFormat(rhi), QSize{sz.width(), sz.height()}, 1, QRhiTexture::Flag{});
 
     tex->setName("FullScreenImageNode::tex");
     tex->create();

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.cpp
@@ -288,10 +288,33 @@ BufferView RenderList::bufferForOutput(const Edge& edge) const noexcept
   return {};
 }
 
+QRhiTexture::Format imageTextureFormat(const QRhi& rhi) noexcept
+{
+  return rhi.isTextureFormatSupported(QRhiTexture::BGRA8) ? QRhiTexture::BGRA8
+                                                          : QRhiTexture::RGBA8;
+}
+
+QImage adaptImageFormat(QImage img, QRhiTexture::Format fmt)
+{
+  const bool premultiplied = img.format() == QImage::Format_ARGB32_Premultiplied
+                             || img.format() == QImage::Format_RGBA8888_Premultiplied;
+
+  QImage::Format wanted{};
+  if(fmt == QRhiTexture::BGRA8)
+    wanted = premultiplied ? QImage::Format_ARGB32_Premultiplied : QImage::Format_ARGB32;
+  else
+    wanted = premultiplied ? QImage::Format_RGBA8888_Premultiplied
+                           : QImage::Format_RGBA8888;
+
+  if(img.format() != wanted)
+    img.convertTo(wanted);
+  return img;
+}
+
 QImage RenderList::adaptImage(const QImage& frame)
 {
   auto res = resizeTexture(frame, m_minTexSize, m_maxTexSize);
-  return res;
+  return adaptImageFormat(std::move(res), imageTextureFormat(*state.rhi));
   //if(m_flip)
   //  res = std::move(res).mirrored();
   //return res;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/RenderList.hpp
@@ -197,4 +197,23 @@ private:
   bool m_ready{};
   bool m_built{};
 };
+
+/**
+ * @brief Texture format to use for images uploaded from the CPU
+ *
+ * BGRA8 where the backend has it, RGBA8 otherwise. QRhiGles2 asks for
+ * GL_BGRA whenever a texture is BGRA8, and WebGL has no such format at all,
+ * so uploading one there is an INVALID_ENUM and the image never appears.
+ */
+SCORE_PLUGIN_GFX_EXPORT
+QRhiTexture::Format imageTextureFormat(const QRhi& rhi) noexcept;
+
+/**
+ * @brief Put an image in the byte order imageTextureFormat() asks for
+ *
+ * QRhi uploads a QImage's bits as-is, so the two have to agree.
+ * Premultiplication is preserved: only the channel order changes.
+ */
+SCORE_PLUGIN_GFX_EXPORT
+QImage adaptImageFormat(QImage img, QRhiTexture::Format fmt);
 }

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/TextNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/TextNode.cpp
@@ -125,7 +125,7 @@ private:
     QRhi& rhi = *renderer.state.rhi;
 
     {
-      auto tex = rhi.newTexture(QRhiTexture::BGRA8, sz, 1, QRhiTexture::Flag{});
+      auto tex = rhi.newTexture(imageTextureFormat(rhi), sz, 1, QRhiTexture::Flag{});
 
       tex->setName("TextNode::tex");
       tex->create();
@@ -167,7 +167,9 @@ private:
 
     if(!m_uploaded)
     {
-      res.uploadTexture(m_textures[0].second, m_img);
+      res.uploadTexture(
+          m_textures[0].second,
+          adaptImageFormat(m_img, imageTextureFormat(*renderer.state.rhi)));
 
       m_uploaded = true;
     }


### PR DESCRIPTION
On WebAssembly, uploading any image raised

```
WebGL: INVALID_ENUM: texSubImage2D: invalid format
  QRhiGles2::executeCommandBuffer -> QRhiGles2::endFrame -> score::gfx::Window::render
```

so most library shaders that use an image rendered nothing.

### Cause

`QRhiGles2::toGlTextureFormat()` sets `glformat = GL_BGRA` for `QRhiTexture::BGRA8` **unconditionally** (`qrhigles2.cpp:1395`). `caps.bgraExternalFormat` only gates `isTextureFormatSupported()`, which none of these call sites checked. WebGL has no BGRA format at all — `EXT_texture_format_BGRA8888` is not exposed — so both `texImage2D` and `texSubImage2D` reject it.

Reproduced against a plain WebGL2 context, replicating the exact `(internalformat, format, type)` triples Qt produces:

| format | texImage2D | texSubImage2D |
|---|---|---|
| RGBA8 | ok | ok |
| **BGRA8** | **INVALID_ENUM** | **INVALID_ENUM** |
| R8 | ok | ok |
| R32F | ok | ok |
| RGBA16F | ok | ok |
| RGBA32F | ok | ok |

Only BGRA8 fails; the context is WebGL2 / GLSL ES 3.00, so `GL_RED` and the float formats are all fine.

### Fix

Ask the QRhi whether it actually has BGRA8 and fall back to RGBA8 when it does not. A runtime check rather than a wasm `#ifdef`, so any other backend missing the format is covered; desktop keeps BGRA8 and its existing `QImage::Format_ARGB32` data unchanged.

QRhi uploads a QImage's bits as-is, so `adaptImageFormat()` puts the image in whichever byte order the texture ended up with, preserving premultiplication so only channel order changes.

Four call sites: `ImageNode` ×3, `TextNode` ×1. No shader changes.

### Verification

- The format matrix above is reproducible in seconds and is what identifies the failing enum.
- Builds clean for wasm.
- **Not yet confirmed end to end**: I could not get a shader rendering into a GL output under headless automation (no WebGL context is created until a gfx output exists), so that a library shader now displays its image is still unverified by me.