### PR TITLE
wasm: stream large media from Blob URLs instead of copying into RAM (Tier B)

### DIFF
--- a/src/lib/score/tools/File.cpp
+++ b/src/lib/score/tools/File.cpp
@@ -110,6 +110,11 @@ locateFilePath(const QString& filename, const score::DocumentContext& ctx) noexc
 QString
 relativizeFilePath(const QString& filename, const score::DocumentContext& ctx) noexcept
 {
+  // Streamed browser files are addressed by an opaque weblocalfile: URL, not a
+  // filesystem path: keep it verbatim so the decoders can reopen it.
+  if(filename.startsWith(QLatin1String("weblocalfile:")))
+    return filename;
+
   const QFileInfo info{filename};
 
   if(!info.isAbsolute())

--- a/src/plugins/score-lib-process/Process/Drop/ProcessDropHandler.cpp
+++ b/src/plugins/score-lib-process/Process/Drop/ProcessDropHandler.cpp
@@ -129,6 +129,19 @@ std::vector<ProcessDropHandler::ProcessDrop> ProcessDropHandlerList::getDrop(
 
       if(!src.isEmpty())
       {
+        // Large browser files are streamed on demand (custom AVIOContext over a
+        // QFile on the weblocalfile: Blob) instead of being copied into MEMFS,
+        // which is capped by the 2GB heap. Keep the weblocalfile: URL as-is so
+        // the decoders open it directly. /qt/tmp files can't be streamed (Qt
+        // deletes them after this callback) so they always get staged.
+        constexpr qint64 stream_threshold = 48ll * 1024 * 1024;
+        if(url.scheme() == QLatin1String("weblocalfile")
+           && QFileInfo{src}.size() > stream_threshold)
+        {
+          newUrls.push_back(url);
+          continue;
+        }
+
         if(QFile f{src}; f.open(QIODevice::ReadOnly))
         {
           const QByteArray bytes = f.readAll();
@@ -191,6 +204,12 @@ std::vector<ProcessDropHandler::ProcessDrop> ProcessDropHandlerList::getDrop(
   for(const auto& url : mime.urls())
   {
     auto path = url.toLocalFile();
+#if defined(__EMSCRIPTEN__)
+    // Un-staged large browser files keep their weblocalfile: URL (empty
+    // toLocalFile()); QWasmFileEngine still resolves them for QFileInfo.
+    if(path.isEmpty() && url.scheme() == QLatin1String("weblocalfile"))
+      path = url.toString();
+#endif
 
     QFileInfo f{path};
     if(f.exists())

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/DirectVideoNodeRenderer.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/DirectVideoNodeRenderer.cpp
@@ -502,7 +502,11 @@ bool DirectVideoNodeRenderer::openFile(score::gfx::GraphicsApi api, QRhi* rhi)
   if(m_filePath.empty())
     return false;
 
-  if(avformat_open_input(&m_formatContext, m_filePath.c_str(), nullptr, nullptr) != 0)
+  if(auto hook = ossia::libav_custom_open())
+    m_formatContext = hook(m_filePath.c_str(), m_ioOwner, m_ioFree);
+
+  if(!m_formatContext
+     && avformat_open_input(&m_formatContext, m_filePath.c_str(), nullptr, nullptr) != 0)
     return false;
 
   if(avformat_find_stream_info(m_formatContext, nullptr) < 0)
@@ -767,6 +771,12 @@ void DirectVideoNodeRenderer::closeFile()
     avformat_flush(m_formatContext);
     avformat_close_input(&m_formatContext);
     m_formatContext = nullptr;
+  }
+  if(m_ioOwner)
+  {
+    m_ioFree(m_ioOwner);
+    m_ioOwner = nullptr;
+    m_ioFree = nullptr;
   }
 
   m_avstream = nullptr;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/DirectVideoNodeRenderer.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/DirectVideoNodeRenderer.hpp
@@ -101,6 +101,8 @@ private:
 
   // Own LibAV context
   AVFormatContext* m_formatContext{};
+  void* m_ioOwner{};
+  void (*m_ioFree)(void*){};
   AVCodecContext* m_codecContext{};
   const void* m_codec{}; // AVCodec*
   AVStream* m_avstream{};

--- a/src/plugins/score-plugin-gfx/Gfx/Video/View.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Video/View.cpp
@@ -75,6 +75,16 @@ void View::onPathChanged(const QString& str)
   }
 
   m_images.clear();
+  m_thumb = nullptr;
+
+#if defined(__EMSCRIPTEN__)
+  // A weblocalfile: source is a browser Blob whose JS handle is bound to the
+  // main thread; the thumbnailer decodes on a worker thread, where reading it
+  // is undefined behaviour. Skip thumbnails for such (typically very large,
+  // streamed) sources rather than re-scanning them off-thread.
+  if(str.startsWith(QLatin1String("weblocalfile:")))
+    return;
+#endif
 
   m_thumb = new ::Video::VideoThumbnailer{str};
   if(oldThread)

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -65,6 +65,7 @@ set(HDRS ${HDRS}
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Metro/MetroView.hpp"
 
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/AudioDecoder.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Media/AvStreamIO.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/MediaFileHandle.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/LibavMediaInfo.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/RMSData.hpp"
@@ -128,6 +129,7 @@ set(SRCS
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/SndfileDecoder.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Tempo.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/AudioDecoder.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Media/AvStreamIO.cpp"
 
     "${CMAKE_CURRENT_SOURCE_DIR}/Mixer/MixerPanel.cpp"
 

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -163,6 +163,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 ### FFMPEG ###
 if(EMSCRIPTEN)
   target_include_directories(${PROJECT_NAME} PUBLIC ${OSSIA_SDK}/ffmpeg/include)
+  # AvStreamIO streams browser Blobs through Qt's private wasm file engine.
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${QT_PREFIX}::CorePrivate)
   target_link_libraries(${PROJECT_NAME} PUBLIC
     -Wl,--start-group
     ${OSSIA_SDK}/ffmpeg/lib/libavcodec.a

--- a/src/plugins/score-plugin-media/Media/AudioDecoder.cpp
+++ b/src/plugins/score-plugin-media/Media/AudioDecoder.cpp
@@ -1,5 +1,6 @@
 #include "AudioDecoder.hpp"
 
+#include <Media/AvStreamIO.hpp>
 #include <Media/Libav.hpp>
 #include <Media/Sound/SoundModel.hpp>
 
@@ -416,19 +417,28 @@ using AVFormatContext_ptr = std::unique_ptr<AVFormatContext, AVFormatContext_Fre
 using AVCodecContext_ptr = std::unique_ptr<AVCodecContext, AVCodecContext_Free>;
 using AVFrame_ptr = std::unique_ptr<AVFrame, AVFrame_Free>;
 
-AVFormatContext_ptr open_audio(const QString& path)
+AVFormatContext_ptr open_audio(const QString& path, AvIoDevice& io)
 {
 #if SCORE_HAS_LIBAV
   AVFormatContext* fmt_ctx_ptr{};
-  auto l1 = path.toUtf8();
-  auto ret = avformat_open_input(&fmt_ctx_ptr, l1.constData(), nullptr, nullptr);
-  if(ret != 0)
+  if(isStreamedMediaPath(path))
   {
-    char err[100]{0};
-    av_make_error_string(err, 100, ret);
-    throw std::runtime_error(
-        "Couldn't open file: " + std::string(l1.constData()) + " => "
-        + std::string(err));
+    if(!open_input_custom_io(fmt_ctx_ptr, io, path))
+      throw std::runtime_error(
+          "Couldn't open file: " + path.toStdString() + " (custom IO)");
+  }
+  else
+  {
+    auto l1 = path.toUtf8();
+    auto ret = avformat_open_input(&fmt_ctx_ptr, l1.constData(), nullptr, nullptr);
+    if(ret != 0)
+    {
+      char err[100]{0};
+      av_make_error_string(err, 100, ret);
+      throw std::runtime_error(
+          "Couldn't open file: " + std::string(l1.constData()) + " => "
+          + std::string(err));
+    }
   }
 
   AVDictionaryEntry* tag = NULL;
@@ -449,7 +459,8 @@ std::optional<AudioInfo> AudioDecoder::do_probe(const QString& path)
 try
 {
 #if SCORE_HAS_LIBAV
-  auto fmt_ctx = open_audio(path);
+  AvIoDevice io;
+  auto fmt_ctx = open_audio(path, io);
 
   if(avformat_find_stream_info(fmt_ctx.get(), nullptr) < 0)
     return {};
@@ -707,7 +718,8 @@ void AudioDecoder::on_startDecode(QString path, audio_handle hdl)
   {
     const std::size_t channels = data.size();
 
-    auto fmt_ctx = open_audio(path);
+    AvIoDevice io;
+    auto fmt_ctx = open_audio(path, io);
 
     auto ret = avformat_find_stream_info(fmt_ctx.get(), nullptr);
     if(ret != 0)

--- a/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
+++ b/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
@@ -6,8 +6,10 @@
 #include <QString>
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <vector>
 
 #if defined(__EMSCRIPTEN__)
 #include <QtCore/private/qstdweb_p.h>
@@ -25,13 +27,19 @@
 
 namespace Media
 {
-static constexpr int av_io_buffer_size = 1 << 18;
+// ffmpeg pulls 4 MB per read, served from a 16 MB read-ahead window so
+// sequential demuxing round-trips to the main thread once per 16 MB.
+static constexpr int av_io_buffer_size = 1 << 22;
+static constexpr int64_t prefetch_size = 16ll << 20;
 
 struct AvStreamState
 {
   std::string url;
   int64_t pos{};
   int64_t size{};
+  std::vector<uint8_t> cache;
+  int64_t cache_off{-1};
+  int64_t cache_len{};
 };
 
 bool isStreamedMediaPath(const QString& path) noexcept
@@ -140,6 +148,13 @@ static int read_blob_worker(const std::string& url, int64_t off, int32_t want, u
   return a.result;
 }
 
+static int fetch_bytes(const std::string& url, int64_t off, int32_t want, uint8_t* dst)
+{
+  return emscripten_is_main_runtime_thread()
+             ? read_blob_main(url, off, want, dst)
+             : read_blob_worker(url, off, want, dst);
+}
+
 static int av_io_read(void* opaque, uint8_t* out, int size)
 {
   auto* st = static_cast<AvStreamState*>(opaque);
@@ -148,15 +163,26 @@ static int av_io_read(void* opaque, uint8_t* out, int size)
     return AVERROR_EOF;
 
   const int32_t want = (int32_t)std::min<int64_t>(size, avail);
-  const int r = emscripten_is_main_runtime_thread()
-                    ? read_blob_main(st->url, st->pos, want, out)
-                    : read_blob_worker(st->url, st->pos, want, out);
-  if(r > 0)
+
+  if(st->cache_off >= 0 && st->pos >= st->cache_off
+     && st->pos + want <= st->cache_off + st->cache_len)
   {
-    st->pos += r;
-    return r;
+    std::memcpy(out, st->cache.data() + (st->pos - st->cache_off), want);
+    st->pos += want;
+    return want;
   }
-  return r == 0 ? AVERROR_EOF : AVERROR(EIO);
+
+  const int32_t win = (int32_t)std::min<int64_t>(prefetch_size, st->size - st->pos);
+  const int got = fetch_bytes(st->url, st->pos, win, st->cache.data());
+  if(got <= 0)
+    return got == 0 ? AVERROR_EOF : AVERROR(EIO);
+  st->cache_off = st->pos;
+  st->cache_len = got;
+
+  const int n = std::min(want, got);
+  std::memcpy(out, st->cache.data(), n);
+  st->pos += n;
+  return n;
 }
 
 static int64_t av_io_seek(void* opaque, int64_t offset, int whence)
@@ -212,6 +238,8 @@ AvIoDevice::AvIoDevice(const QString& path)
   }
   if(!ok)
     return;
+
+  st->cache.resize((size_t)std::min<int64_t>(prefetch_size, st->size));
 
   auto* buffer = static_cast<unsigned char*>(av_malloc(av_io_buffer_size));
   if(!buffer)

--- a/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
+++ b/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
@@ -1,0 +1,161 @@
+#include "AvStreamIO.hpp"
+
+#if SCORE_HAS_LIBAV
+#include <ossia/detail/libav.hpp>
+
+#include <QFile>
+#include <QString>
+
+namespace Media
+{
+static constexpr int av_io_buffer_size = 1 << 18;
+
+static int av_io_read(void* opaque, uint8_t* out, int size)
+{
+  auto* dev = static_cast<QFile*>(opaque);
+  const qint64 r = dev->read(reinterpret_cast<char*>(out), size);
+  if(r > 0)
+    return static_cast<int>(r);
+  if(r == 0)
+    return AVERROR_EOF;
+  return AVERROR(EIO);
+}
+
+static int64_t av_io_seek(void* opaque, int64_t offset, int whence)
+{
+  auto* dev = static_cast<QFile*>(opaque);
+  switch(whence & ~AVSEEK_FORCE)
+  {
+    case AVSEEK_SIZE:
+      return dev->size();
+    case SEEK_SET:
+      return dev->seek(offset) ? offset : -1;
+    case SEEK_CUR:
+    {
+      const qint64 abs = dev->pos() + offset;
+      return dev->seek(abs) ? abs : -1;
+    }
+    case SEEK_END:
+    {
+      const qint64 abs = dev->size() + offset;
+      return dev->seek(abs) ? abs : -1;
+    }
+    default:
+      return -1;
+  }
+}
+
+bool isStreamedMediaPath(const QString& path) noexcept
+{
+  return path.startsWith(QLatin1String("weblocalfile:"));
+}
+
+bool isStreamedMediaPath(const std::string& path) noexcept
+{
+  return path.rfind("weblocalfile:", 0) == 0;
+}
+
+AvIoDevice::AvIoDevice(const QString& path)
+{
+  auto f = std::make_unique<QFile>(path);
+  if(!f->open(QIODevice::ReadOnly))
+    return;
+
+  auto* buffer = static_cast<unsigned char*>(av_malloc(av_io_buffer_size));
+  if(!buffer)
+    return;
+
+  avio = avio_alloc_context(
+      buffer, av_io_buffer_size, 0, f.get(), &av_io_read, nullptr, &av_io_seek);
+  if(!avio)
+  {
+    av_free(buffer);
+    return;
+  }
+  file = std::move(f);
+}
+
+AvIoDevice::~AvIoDevice()
+{
+  if(avio)
+  {
+    av_freep(&avio->buffer);
+    avio_context_free(&avio);
+  }
+}
+
+AvIoDevice::AvIoDevice(AvIoDevice&& other) noexcept
+    : avio{other.avio}
+    , file{std::move(other.file)}
+{
+  other.avio = nullptr;
+}
+
+AvIoDevice& AvIoDevice::operator=(AvIoDevice&& other) noexcept
+{
+  if(this != &other)
+  {
+    if(avio)
+    {
+      av_freep(&avio->buffer);
+      avio_context_free(&avio);
+    }
+    avio = other.avio;
+    file = std::move(other.file);
+    other.avio = nullptr;
+  }
+  return *this;
+}
+
+bool open_input_custom_io(
+    AVFormatContext*& format, AvIoDevice& io, const QString& path) noexcept
+{
+  io = AvIoDevice{path};
+  if(!io)
+    return false;
+
+  AVFormatContext* fmt = avformat_alloc_context();
+  if(!fmt)
+  {
+    io = {};
+    return false;
+  }
+
+  fmt->pb = io.avio;
+  fmt->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+  if(avformat_open_input(&fmt, nullptr, nullptr, nullptr) != 0)
+  {
+    io = {};
+    return false;
+  }
+
+  format = fmt;
+  return true;
+}
+
+// libossia's libav_handle is Qt-agnostic; it delegates the browser-only Blob
+// streaming back here through a hook so the submodule keeps no Qt dependency.
+static AVFormatContext* libav_stream_open_hook(
+    const char* path, void*& io_owner, void (*&io_free)(void*)) noexcept
+{
+  const QString qpath = QString::fromUtf8(path);
+  if(!isStreamedMediaPath(qpath))
+    return nullptr;
+
+  auto io = std::make_unique<AvIoDevice>();
+  AVFormatContext* fmt{};
+  if(!open_input_custom_io(fmt, *io, qpath))
+    return nullptr;
+
+  io_owner = io.release();
+  io_free = [](void* p) { delete static_cast<AvIoDevice*>(p); };
+  return fmt;
+}
+
+static const bool registered_libav_hook = [] {
+  ossia::libav_custom_open() = &libav_stream_open_hook;
+  return true;
+}();
+}
+#endif

--- a/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
+++ b/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
@@ -6,12 +6,57 @@
 #include <QFile>
 #include <QString>
 
+#if defined(__EMSCRIPTEN__)
+#include <emscripten/proxying.h>
+#include <emscripten/threading.h>
+#endif
+
+#include <memory>
+#include <type_traits>
+
 namespace Media
 {
 static constexpr int av_io_buffer_size = 1 << 18;
 
+#if defined(__EMSCRIPTEN__)
+// A weblocalfile: QFile is backed by a JS File/Blob whose emscripten::val is
+// bound to the thread that created it; using it from another thread is
+// undefined behaviour (it dereferences an invalid handle, crashing on
+// Blob.size). Marshal the non-suspending QFile operations (open, seek, size,
+// close) to the main runtime thread so the val is only ever touched by its
+// owner. Reads are handled separately in av_io_read (they suspend via JSPI,
+// which a proxied job cannot do).
+template <typename F>
+static void run_on_main(F&& f) noexcept
+{
+  if(emscripten_is_main_runtime_thread())
+  {
+    f();
+    return;
+  }
+  emscripten_proxy_sync(
+      emscripten_proxy_get_system_queue(), emscripten_main_runtime_thread_id(),
+      [](void* p) { (*static_cast<std::remove_reference_t<F>*>(p))(); }, &f);
+}
+#else
+template <typename F>
+static void run_on_main(F&& f) noexcept
+{
+  f();
+}
+#endif
+
 static int av_io_read(void* opaque, uint8_t* out, int size)
 {
+#if defined(__EMSCRIPTEN__)
+  // Reading the backing Blob suspends via JSPI, which is only possible on the
+  // main thread's promising call stack (a proxied job is not one). A worker
+  // therefore cannot stream this source; fail cleanly so the off-thread decode
+  // aborts instead of hitting an uncatchable SuspendError. Worker-thread
+  // streaming needs the async-proxy reader documented in WASM-B2-ANALYSIS.md.
+  if(!emscripten_is_main_runtime_thread())
+    return AVERROR(EIO);
+#endif
   auto* dev = static_cast<QFile*>(opaque);
   const qint64 r = dev->read(reinterpret_cast<char*>(out), size);
   if(r > 0)
@@ -24,25 +69,31 @@ static int av_io_read(void* opaque, uint8_t* out, int size)
 static int64_t av_io_seek(void* opaque, int64_t offset, int whence)
 {
   auto* dev = static_cast<QFile*>(opaque);
-  switch(whence & ~AVSEEK_FORCE)
-  {
-    case AVSEEK_SIZE:
-      return dev->size();
-    case SEEK_SET:
-      return dev->seek(offset) ? offset : -1;
-    case SEEK_CUR:
+  int64_t result = -1;
+  run_on_main([&] {
+    switch(whence & ~AVSEEK_FORCE)
     {
-      const qint64 abs = dev->pos() + offset;
-      return dev->seek(abs) ? abs : -1;
+      case AVSEEK_SIZE:
+        result = dev->size();
+        break;
+      case SEEK_SET:
+        result = dev->seek(offset) ? offset : -1;
+        break;
+      case SEEK_CUR:
+      {
+        const qint64 abs = dev->pos() + offset;
+        result = dev->seek(abs) ? abs : -1;
+        break;
+      }
+      case SEEK_END:
+      {
+        const qint64 abs = dev->size() + offset;
+        result = dev->seek(abs) ? abs : -1;
+        break;
+      }
     }
-    case SEEK_END:
-    {
-      const qint64 abs = dev->size() + offset;
-      return dev->seek(abs) ? abs : -1;
-    }
-    default:
-      return -1;
-  }
+  });
+  return result;
 }
 
 bool isStreamedMediaPath(const QString& path) noexcept
@@ -57,22 +108,34 @@ bool isStreamedMediaPath(const std::string& path) noexcept
 
 AvIoDevice::AvIoDevice(const QString& path)
 {
-  auto f = std::make_unique<QFile>(path);
-  if(!f->open(QIODevice::ReadOnly))
+  QFile* f = nullptr;
+  run_on_main([&] {
+    f = new QFile(path);
+    if(!f->open(QIODevice::ReadOnly))
+    {
+      delete f;
+      f = nullptr;
+    }
+  });
+  if(!f)
     return;
 
   auto* buffer = static_cast<unsigned char*>(av_malloc(av_io_buffer_size));
   if(!buffer)
+  {
+    run_on_main([&] { delete f; });
     return;
+  }
 
   avio = avio_alloc_context(
-      buffer, av_io_buffer_size, 0, f.get(), &av_io_read, nullptr, &av_io_seek);
+      buffer, av_io_buffer_size, 0, f, &av_io_read, nullptr, &av_io_seek);
   if(!avio)
   {
     av_free(buffer);
+    run_on_main([&] { delete f; });
     return;
   }
-  file = std::move(f);
+  file = f;
 }
 
 AvIoDevice::~AvIoDevice()
@@ -82,13 +145,20 @@ AvIoDevice::~AvIoDevice()
     av_freep(&avio->buffer);
     avio_context_free(&avio);
   }
+  if(file)
+  {
+    QFile* f = file;
+    run_on_main([&] { delete f; });
+    file = nullptr;
+  }
 }
 
 AvIoDevice::AvIoDevice(AvIoDevice&& other) noexcept
     : avio{other.avio}
-    , file{std::move(other.file)}
+    , file{other.file}
 {
   other.avio = nullptr;
+  other.file = nullptr;
 }
 
 AvIoDevice& AvIoDevice::operator=(AvIoDevice&& other) noexcept
@@ -100,9 +170,15 @@ AvIoDevice& AvIoDevice::operator=(AvIoDevice&& other) noexcept
       av_freep(&avio->buffer);
       avio_context_free(&avio);
     }
+    if(file)
+    {
+      QFile* f = file;
+      run_on_main([&] { delete f; });
+    }
     avio = other.avio;
-    file = std::move(other.file);
+    file = other.file;
     other.avio = nullptr;
+    other.file = nullptr;
   }
   return *this;
 }

--- a/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
+++ b/src/plugins/score-plugin-media/Media/AvStreamIO.cpp
@@ -3,98 +3,36 @@
 #if SCORE_HAS_LIBAV
 #include <ossia/detail/libav.hpp>
 
-#include <QFile>
 #include <QString>
 
+#include <algorithm>
+#include <memory>
+#include <string>
+
 #if defined(__EMSCRIPTEN__)
+#include <QtCore/private/qstdweb_p.h>
+#include <QtCore/private/qwasmlocalfileengine_p.h>
+
+#include <emscripten.h>
+#include <emscripten/atomic.h>
 #include <emscripten/proxying.h>
 #include <emscripten/threading.h>
-#endif
+#include <emscripten/threading_primitives.h>
+#include <emscripten/val.h>
 
-#include <memory>
-#include <type_traits>
+#include <cmath>
+#endif
 
 namespace Media
 {
 static constexpr int av_io_buffer_size = 1 << 18;
 
-#if defined(__EMSCRIPTEN__)
-// A weblocalfile: QFile is backed by a JS File/Blob whose emscripten::val is
-// bound to the thread that created it; using it from another thread is
-// undefined behaviour (it dereferences an invalid handle, crashing on
-// Blob.size). Marshal the non-suspending QFile operations (open, seek, size,
-// close) to the main runtime thread so the val is only ever touched by its
-// owner. Reads are handled separately in av_io_read (they suspend via JSPI,
-// which a proxied job cannot do).
-template <typename F>
-static void run_on_main(F&& f) noexcept
+struct AvStreamState
 {
-  if(emscripten_is_main_runtime_thread())
-  {
-    f();
-    return;
-  }
-  emscripten_proxy_sync(
-      emscripten_proxy_get_system_queue(), emscripten_main_runtime_thread_id(),
-      [](void* p) { (*static_cast<std::remove_reference_t<F>*>(p))(); }, &f);
-}
-#else
-template <typename F>
-static void run_on_main(F&& f) noexcept
-{
-  f();
-}
-#endif
-
-static int av_io_read(void* opaque, uint8_t* out, int size)
-{
-#if defined(__EMSCRIPTEN__)
-  // Reading the backing Blob suspends via JSPI, which is only possible on the
-  // main thread's promising call stack (a proxied job is not one). A worker
-  // therefore cannot stream this source; fail cleanly so the off-thread decode
-  // aborts instead of hitting an uncatchable SuspendError. Worker-thread
-  // streaming needs the async-proxy reader documented in WASM-B2-ANALYSIS.md.
-  if(!emscripten_is_main_runtime_thread())
-    return AVERROR(EIO);
-#endif
-  auto* dev = static_cast<QFile*>(opaque);
-  const qint64 r = dev->read(reinterpret_cast<char*>(out), size);
-  if(r > 0)
-    return static_cast<int>(r);
-  if(r == 0)
-    return AVERROR_EOF;
-  return AVERROR(EIO);
-}
-
-static int64_t av_io_seek(void* opaque, int64_t offset, int whence)
-{
-  auto* dev = static_cast<QFile*>(opaque);
-  int64_t result = -1;
-  run_on_main([&] {
-    switch(whence & ~AVSEEK_FORCE)
-    {
-      case AVSEEK_SIZE:
-        result = dev->size();
-        break;
-      case SEEK_SET:
-        result = dev->seek(offset) ? offset : -1;
-        break;
-      case SEEK_CUR:
-      {
-        const qint64 abs = dev->pos() + offset;
-        result = dev->seek(abs) ? abs : -1;
-        break;
-      }
-      case SEEK_END:
-      {
-        const qint64 abs = dev->size() + offset;
-        result = dev->seek(abs) ? abs : -1;
-        break;
-      }
-    }
-  });
-  return result;
-}
+  std::string url;
+  int64_t pos{};
+  int64_t size{};
+};
 
 bool isStreamedMediaPath(const QString& path) noexcept
 {
@@ -106,36 +44,188 @@ bool isStreamedMediaPath(const std::string& path) noexcept
   return path.rfind("weblocalfile:", 0) == 0;
 }
 
+#if defined(__EMSCRIPTEN__)
+
+// getFile() resolves against a process-wide singleton internally, so any handler
+// instance returns the File registered at drop time.
+static qstdweb::File getWebFile(const std::string& url)
+{
+  static QWasmFileEngineHandler handler;
+  return handler.getFile(QString::fromStdString(url));
+}
+
+// Blocking read on the main thread: the Blob read suspends via JSPI, which is
+// legal here because the main event loop is a promising call stack.
+static int read_blob_main(const std::string& url, int64_t off, int32_t want, uint8_t* out)
+{
+  qstdweb::File f = getWebFile(url);
+  if(f.file().isUndefined() || f.file().isNull())
+    return -1;
+
+  qstdweb::ArrayBuffer ab
+      = f.slice((uint64_t)off, (uint64_t)(off + want)).arrayBuffer_sync();
+  const int got = (int)ab.byteLength();
+  if(got > 0)
+    qstdweb::Uint8Array(ab).copyTo((char*)out);
+  return got;
+}
+
+// A worker cannot touch the main-thread Blob val, and cannot suspend via JSPI.
+// So it proxies an *async* read to the main thread and blocks on a futex: the
+// main job kicks off Blob.arrayBuffer() (no suspend) and its .then copies the
+// bytes into shared memory and wakes the worker. `state` must stay first so its
+// address is the futex word.
+struct AsyncRead
+{
+  int32_t state{}; // 0 = pending, 1 = complete
+  int32_t result{}; // bytes read, or -1 on error
+  const std::string* url{};
+  int64_t off{};
+  int32_t want{};
+  uint8_t* dst{};
+};
+
+static void async_read_job(void* p)
+{
+  auto* a = static_cast<AsyncRead*>(p);
+  qstdweb::File f = getWebFile(*a->url);
+  if(f.file().isUndefined() || f.file().isNull())
+  {
+    a->result = -1;
+    emscripten_atomic_store_u32(&a->state, 1);
+    emscripten_futex_wake(&a->state, 1);
+    return;
+  }
+
+  qstdweb::Blob blob = f.slice((uint64_t)a->off, (uint64_t)(a->off + a->want));
+  EM_ASM(
+      {
+        var blob = Emval.toValue($0);
+        var dst = $1;
+        var statePtr = $2;
+        var resultPtr = $3;
+        blob.arrayBuffer()
+            .then(function(ab) {
+              var u8 = new Uint8Array(ab);
+              HEAPU8.set(u8, dst);
+              HEAP32[resultPtr >> 2] = u8.length;
+              Atomics.store(HEAP32, statePtr >> 2, 1);
+              Atomics.notify(HEAP32, statePtr >> 2);
+            })
+            .catch(function(e) {
+              HEAP32[resultPtr >> 2] = -1;
+              Atomics.store(HEAP32, statePtr >> 2, 1);
+              Atomics.notify(HEAP32, statePtr >> 2);
+            });
+      },
+      blob.val().as_handle(), a->dst, &a->state, &a->result);
+}
+
+static int read_blob_worker(const std::string& url, int64_t off, int32_t want, uint8_t* out)
+{
+  AsyncRead a;
+  a.url = &url;
+  a.off = off;
+  a.want = want;
+  a.dst = out;
+
+  if(!emscripten_proxy_async(
+         emscripten_proxy_get_system_queue(), emscripten_main_runtime_thread_id(),
+         &async_read_job, &a))
+    return -1;
+
+  while(emscripten_atomic_load_u32(&a.state) == 0)
+    emscripten_futex_wait(&a.state, 0, INFINITY);
+
+  return a.result;
+}
+
+static int av_io_read(void* opaque, uint8_t* out, int size)
+{
+  auto* st = static_cast<AvStreamState*>(opaque);
+  const int64_t avail = st->size - st->pos;
+  if(avail <= 0)
+    return AVERROR_EOF;
+
+  const int32_t want = (int32_t)std::min<int64_t>(size, avail);
+  const int r = emscripten_is_main_runtime_thread()
+                    ? read_blob_main(st->url, st->pos, want, out)
+                    : read_blob_worker(st->url, st->pos, want, out);
+  if(r > 0)
+  {
+    st->pos += r;
+    return r;
+  }
+  return r == 0 ? AVERROR_EOF : AVERROR(EIO);
+}
+
+static int64_t av_io_seek(void* opaque, int64_t offset, int whence)
+{
+  auto* st = static_cast<AvStreamState*>(opaque);
+  switch(whence & ~AVSEEK_FORCE)
+  {
+    case AVSEEK_SIZE:
+      return st->size;
+    case SEEK_SET:
+      st->pos = offset;
+      break;
+    case SEEK_CUR:
+      st->pos += offset;
+      break;
+    case SEEK_END:
+      st->pos = st->size + offset;
+      break;
+    default:
+      return -1;
+  }
+  if(st->pos < 0)
+    st->pos = 0;
+  return st->pos;
+}
+
+#endif
+
 AvIoDevice::AvIoDevice(const QString& path)
 {
-  QFile* f = nullptr;
-  run_on_main([&] {
-    f = new QFile(path);
-    if(!f->open(QIODevice::ReadOnly))
-    {
-      delete f;
-      f = nullptr;
-    }
-  });
-  if(!f)
+  auto st = std::make_unique<AvStreamState>();
+  st->url = path.toStdString();
+
+#if defined(__EMSCRIPTEN__)
+  bool ok = false;
+  const auto fetch_size = [&] {
+    qstdweb::File f = getWebFile(st->url);
+    if(f.file().isUndefined() || f.file().isNull())
+      return;
+    st->size = (int64_t)f.size();
+    ok = st->size > 0;
+  };
+  if(emscripten_is_main_runtime_thread())
+  {
+    fetch_size();
+  }
+  else
+  {
+    emscripten_proxy_sync(
+        emscripten_proxy_get_system_queue(), emscripten_main_runtime_thread_id(),
+        [](void* p) { (*static_cast<const decltype(fetch_size)*>(p))(); },
+        const_cast<void*>(static_cast<const void*>(&fetch_size)));
+  }
+  if(!ok)
     return;
 
   auto* buffer = static_cast<unsigned char*>(av_malloc(av_io_buffer_size));
   if(!buffer)
-  {
-    run_on_main([&] { delete f; });
     return;
-  }
 
   avio = avio_alloc_context(
-      buffer, av_io_buffer_size, 0, f, &av_io_read, nullptr, &av_io_seek);
+      buffer, av_io_buffer_size, 0, st.get(), &av_io_read, nullptr, &av_io_seek);
   if(!avio)
   {
     av_free(buffer);
-    run_on_main([&] { delete f; });
     return;
   }
-  file = f;
+  state = st.release();
+#endif
 }
 
 AvIoDevice::~AvIoDevice()
@@ -145,20 +235,16 @@ AvIoDevice::~AvIoDevice()
     av_freep(&avio->buffer);
     avio_context_free(&avio);
   }
-  if(file)
-  {
-    QFile* f = file;
-    run_on_main([&] { delete f; });
-    file = nullptr;
-  }
+  delete state;
+  state = nullptr;
 }
 
 AvIoDevice::AvIoDevice(AvIoDevice&& other) noexcept
     : avio{other.avio}
-    , file{other.file}
+    , state{other.state}
 {
   other.avio = nullptr;
-  other.file = nullptr;
+  other.state = nullptr;
 }
 
 AvIoDevice& AvIoDevice::operator=(AvIoDevice&& other) noexcept
@@ -170,15 +256,11 @@ AvIoDevice& AvIoDevice::operator=(AvIoDevice&& other) noexcept
       av_freep(&avio->buffer);
       avio_context_free(&avio);
     }
-    if(file)
-    {
-      QFile* f = file;
-      run_on_main([&] { delete f; });
-    }
+    delete state;
     avio = other.avio;
-    file = other.file;
+    state = other.state;
     other.avio = nullptr;
-    other.file = nullptr;
+    other.state = nullptr;
   }
   return *this;
 }

--- a/src/plugins/score-plugin-media/Media/AvStreamIO.hpp
+++ b/src/plugins/score-plugin-media/Media/AvStreamIO.hpp
@@ -10,23 +10,25 @@ extern "C" {
 
 #include <string>
 
-class QFile;
 class QString;
 
 namespace Media
 {
-// A path that must be streamed through QFile byte-range reads rather than
-// opened with fopen/avio's default file protocol. On the wasm build these are
-// the "weblocalfile:/N/name" URLs Qt assigns to browser File objects: fopen
-// cannot open them, but QWasmFileEngine reads them as on-demand Blob ranges,
-// so a multi-GB file never has to be copied into MEMFS/RAM.
+struct AvStreamState;
+
+// A path that must be streamed on demand rather than opened with fopen/avio's
+// default file protocol. On the wasm build these are the "weblocalfile:/N/name"
+// URLs Qt assigns to browser File objects: fopen cannot open them, but the
+// backing Blob can be read in byte-ranges, so a multi-GB file never has to be
+// copied into MEMFS/RAM.
 SCORE_PLUGIN_MEDIA_EXPORT
 bool isStreamedMediaPath(const QString& path) noexcept;
 SCORE_PLUGIN_MEDIA_EXPORT
 bool isStreamedMediaPath(const std::string& path) noexcept;
 
-// Owns a QFile and the AVIOContext that reads through it. Must outlive the
-// AVFormatContext it is attached to (see open_input_custom_io).
+// Owns the AVIOContext that streams a browser Blob and the position bookkeeping
+// it reads through. Must outlive the AVFormatContext it is attached to (see
+// open_input_custom_io).
 struct SCORE_PLUGIN_MEDIA_EXPORT AvIoDevice
 {
   AvIoDevice() = default;
@@ -41,7 +43,7 @@ struct SCORE_PLUGIN_MEDIA_EXPORT AvIoDevice
   explicit operator bool() const noexcept { return avio != nullptr; }
 
   AVIOContext* avio{};
-  QFile* file{};
+  AvStreamState* state{};
 };
 
 // Allocates `format` and opens `path` through a custom AVIOContext backed by a

--- a/src/plugins/score-plugin-media/Media/AvStreamIO.hpp
+++ b/src/plugins/score-plugin-media/Media/AvStreamIO.hpp
@@ -8,7 +8,6 @@ extern "C" {
 
 #include <score_plugin_media_export.h>
 
-#include <memory>
 #include <string>
 
 class QFile;
@@ -42,7 +41,7 @@ struct SCORE_PLUGIN_MEDIA_EXPORT AvIoDevice
   explicit operator bool() const noexcept { return avio != nullptr; }
 
   AVIOContext* avio{};
-  std::unique_ptr<QFile> file;
+  QFile* file{};
 };
 
 // Allocates `format` and opens `path` through a custom AVIOContext backed by a

--- a/src/plugins/score-plugin-media/Media/AvStreamIO.hpp
+++ b/src/plugins/score-plugin-media/Media/AvStreamIO.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <Media/Libav.hpp>
+
+#if SCORE_HAS_LIBAV
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <score_plugin_media_export.h>
+
+#include <memory>
+#include <string>
+
+class QFile;
+class QString;
+
+namespace Media
+{
+// A path that must be streamed through QFile byte-range reads rather than
+// opened with fopen/avio's default file protocol. On the wasm build these are
+// the "weblocalfile:/N/name" URLs Qt assigns to browser File objects: fopen
+// cannot open them, but QWasmFileEngine reads them as on-demand Blob ranges,
+// so a multi-GB file never has to be copied into MEMFS/RAM.
+SCORE_PLUGIN_MEDIA_EXPORT
+bool isStreamedMediaPath(const QString& path) noexcept;
+SCORE_PLUGIN_MEDIA_EXPORT
+bool isStreamedMediaPath(const std::string& path) noexcept;
+
+// Owns a QFile and the AVIOContext that reads through it. Must outlive the
+// AVFormatContext it is attached to (see open_input_custom_io).
+struct SCORE_PLUGIN_MEDIA_EXPORT AvIoDevice
+{
+  AvIoDevice() = default;
+  explicit AvIoDevice(const QString& path);
+  ~AvIoDevice();
+
+  AvIoDevice(AvIoDevice&&) noexcept;
+  AvIoDevice& operator=(AvIoDevice&&) noexcept;
+  AvIoDevice(const AvIoDevice&) = delete;
+  AvIoDevice& operator=(const AvIoDevice&) = delete;
+
+  explicit operator bool() const noexcept { return avio != nullptr; }
+
+  AVIOContext* avio{};
+  std::unique_ptr<QFile> file;
+};
+
+// Allocates `format` and opens `path` through a custom AVIOContext backed by a
+// QFile. On success `format` is set and `io` owns the streaming resources; the
+// caller must destroy `format` (avformat_close_input) before `io`.
+// Returns false and leaves `format` null on failure.
+SCORE_PLUGIN_MEDIA_EXPORT
+bool open_input_custom_io(
+    AVFormatContext*& format, AvIoDevice& io, const QString& path) noexcept;
+}
+#endif

--- a/src/plugins/score-plugin-media/Media/LibavMediaInfo.cpp
+++ b/src/plugins/score-plugin-media/Media/LibavMediaInfo.cpp
@@ -2,6 +2,8 @@
 
 #if SCORE_HAS_LIBAV
 
+#include <Media/AvStreamIO.hpp>
+
 #include <QByteArray>
 
 #include <limits>
@@ -17,21 +19,47 @@ bool has_valid_duration(const AVFormatContext* ctx) noexcept
          && ctx->duration != std::numeric_limits<int64_t>::min() && ctx->duration > 0;
 }
 
-MediaInfo::FormatContextPtr try_open(const char* path, AVDictionary** opts)
+struct OpenedInput
 {
-  AVFormatContext* raw = avformat_alloc_context();
-  if(!raw)
-    return {};
+  MediaInfo::FormatContextPtr ctx;
+  std::shared_ptr<void> io;
+  explicit operator bool() const noexcept { return static_cast<bool>(ctx); }
+};
 
-  if(avformat_open_input(&raw, path, nullptr, opts) != 0)
-    return {};
+OpenedInput try_open(const QString& path, AVDictionary** opts)
+{
+  std::shared_ptr<void> io;
+  AVFormatContext* raw{};
+
+  if(Media::isStreamedMediaPath(path))
+  {
+    auto dev = std::make_shared<Media::AvIoDevice>(path);
+    if(!*dev)
+      return {};
+    raw = avformat_alloc_context();
+    if(!raw)
+      return {};
+    raw->pb = dev->avio;
+    raw->flags |= AVFMT_FLAG_CUSTOM_IO;
+    if(avformat_open_input(&raw, nullptr, nullptr, opts) != 0)
+      return {};
+    io = std::move(dev);
+  }
+  else
+  {
+    raw = avformat_alloc_context();
+    if(!raw)
+      return {};
+    if(avformat_open_input(&raw, path.toUtf8().constData(), nullptr, opts) != 0)
+      return {};
+  }
 
   MediaInfo::FormatContextPtr ctx{raw};
 
   if(avformat_find_stream_info(ctx.get(), nullptr) < 0 || ctx->nb_streams == 0)
     return {};
 
-  return ctx;
+  return {std::move(ctx), std::move(io)};
 }
 
 // Walk every packet to compute duration manually. Works on any file whose
@@ -102,14 +130,15 @@ int64_t scan_duration_from_packets(AVFormatContext* ctx) noexcept
   return AV_NOPTS_VALUE;
 }
 
-MediaInfo build_info(MediaInfo::FormatContextPtr ctx, std::optional<int64_t> duration_av)
+MediaInfo build_info(OpenedInput opened, std::optional<int64_t> duration_av)
 {
   MediaInfo info;
   info.duration_av = duration_av;
-  info.streams.reserve(ctx->nb_streams);
-  for(unsigned i = 0; i < ctx->nb_streams; i++)
-    info.streams.push_back(ctx->streams[i]->codecpar->codec_type);
-  info.format_context = std::move(ctx);
+  info.streams.reserve(opened.ctx->nb_streams);
+  for(unsigned i = 0; i < opened.ctx->nb_streams; i++)
+    info.streams.push_back(opened.ctx->streams[i]->codecpar->codec_type);
+  info.io_backing = std::move(opened.io);
+  info.format_context = std::move(opened.ctx);
   return info;
 }
 
@@ -117,16 +146,13 @@ MediaInfo build_info(MediaInfo::FormatContextPtr ctx, std::optional<int64_t> dur
 
 std::optional<MediaInfo> probe(const QString& path)
 {
-  const QByteArray utf8 = path.toUtf8();
-  const char* cpath = utf8.constData();
-
   // ---- Attempt 1: defaults (fast path) ----
-  if(auto ctx = try_open(cpath, nullptr))
+  if(auto opened = try_open(path, nullptr))
   {
-    if(has_valid_duration(ctx.get()))
+    if(has_valid_duration(opened.ctx.get()))
     {
-      const int64_t dur = ctx->duration;
-      return build_info(std::move(ctx), dur);
+      const int64_t dur = opened.ctx->duration;
+      return build_info(std::move(opened), dur);
     }
     // else: fall through, but drop this context first
   }
@@ -137,13 +163,13 @@ std::optional<MediaInfo> probe(const QString& path)
     av_dict_set(&opts, "probesize", "100000000", 0);
     av_dict_set(&opts, "analyzeduration", "100000000", 0);
 
-    auto ctx = try_open(cpath, &opts);
+    auto opened = try_open(path, &opts);
     av_dict_free(&opts);
 
-    if(ctx && has_valid_duration(ctx.get()))
+    if(opened && has_valid_duration(opened.ctx.get()))
     {
-      const int64_t dur = ctx->duration;
-      return build_info(std::move(ctx), dur);
+      const int64_t dur = opened.ctx->duration;
+      return build_info(std::move(opened), dur);
     }
   }
 
@@ -154,24 +180,24 @@ std::optional<MediaInfo> probe(const QString& path)
     av_dict_set(&opts, "analyzeduration", "100000000", 0);
     av_dict_set(&opts, "fflags", "+ignidx+genpts", 0);
 
-    auto ctx = try_open(cpath, &opts);
+    auto opened = try_open(path, &opts);
     av_dict_free(&opts);
 
-    if(ctx)
+    if(opened)
     {
-      if(has_valid_duration(ctx.get()))
+      if(has_valid_duration(opened.ctx.get()))
       {
-        const int64_t dur = ctx->duration;
-        return build_info(std::move(ctx), dur);
+        const int64_t dur = opened.ctx->duration;
+        return build_info(std::move(opened), dur);
       }
 
       // ---- Attempt 4: full packet scan on the same context ----
-      int64_t scanned = scan_duration_from_packets(ctx.get());
+      int64_t scanned = scan_duration_from_packets(opened.ctx.get());
       if(scanned != AV_NOPTS_VALUE && scanned > 0)
-        return build_info(std::move(ctx), scanned);
+        return build_info(std::move(opened), scanned);
 
       // File is structurally readable but no duration could be determined.
-      return build_info(std::move(ctx), std::nullopt);
+      return build_info(std::move(opened), std::nullopt);
     }
   }
 

--- a/src/plugins/score-plugin-media/Media/LibavMediaInfo.hpp
+++ b/src/plugins/score-plugin-media/Media/LibavMediaInfo.hpp
@@ -7,6 +7,7 @@
 
 #include <QString>
 
+#include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -42,6 +43,10 @@ struct SCORE_PLUGIN_MEDIA_EXPORT MediaInfo
   };
   using FormatContextPtr = std::unique_ptr<AVFormatContext, FormatContextDeleter>;
 
+  // Streaming backing (e.g. an AvIoDevice for weblocalfile: sources). Declared
+  // before format_context so it is destroyed *after* it: avformat_close_input
+  // must run while the custom AVIOContext is still alive.
+  std::shared_ptr<void> io_backing;
   FormatContextPtr format_context;
   std::vector<AVMediaType> streams;
   std::optional<int64_t> duration_av; // in AV_TIME_BASE units; empty == unknown

--- a/src/plugins/score-plugin-media/Media/Sound/Drop/SoundDrop.cpp
+++ b/src/plugins/score-plugin-media/Media/Sound/Drop/SoundDrop.cpp
@@ -22,7 +22,11 @@ DroppedAudioFiles::DroppedAudioFiles(
   for(const auto& url : urls)
   {
     QString filename = url.toLocalFile();
-    if(!(AudioFile::isSupported(QFile{filename}) 
+#if defined(__EMSCRIPTEN__)
+    if(filename.isEmpty() && url.scheme() == QLatin1String("weblocalfile"))
+      filename = url.toString();
+#endif
+    if(!(AudioFile::isSupported(QFile{filename})
       || AudioFile::isSupportedVideo(QFile{filename})))
       continue;
 

--- a/src/plugins/score-plugin-media/Media/Sound/SoundView.cpp
+++ b/src/plugins/score-plugin-media/Media/Sound/SoundView.cpp
@@ -98,6 +98,14 @@ void LayerView::recompute() const
          || m_model.file()->sampleRate() < 1.))
     return;
 
+#if defined(__EMSCRIPTEN__)
+  // The waveform is computed on a worker thread. A weblocalfile: source is a
+  // browser Blob bound to the main thread, so decoding it off-thread is
+  // undefined behaviour; skip the waveform for such (streamed) sources.
+  if(m_model.file()->absoluteFileName().startsWith(QLatin1String("weblocalfile:")))
+    return;
+#endif
+
   if(auto view = getView(*this))
   {
     // By default we try to force a render of everything, but it's too slow with very large files

--- a/src/plugins/score-plugin-media/Video/Thumbnailer.cpp
+++ b/src/plugins/score-plugin-media/Video/Thumbnailer.cpp
@@ -32,15 +32,22 @@ VideoThumbnailer::VideoThumbnailer(QString path)
       Qt::QueuedConnection);
 
   auto inputFile = path.toUtf8();
-  if(int err = avformat_open_input(&m_formatContext, inputFile.data(), nullptr, nullptr);
-     err != 0)
-  {
-    char str[1500];
-    qDebug() << "VideoThumbnailer: avformat_open_input failed"
-             << av_make_error_string(str, 1499, err);
+  if(auto hook = ossia::libav_custom_open())
+    m_formatContext = hook(inputFile.data(), m_ioOwner, m_ioFree);
 
-    SCORE_ASSERT(m_formatContext == nullptr);
-    return;
+  if(!m_formatContext)
+  {
+    if(int err
+       = avformat_open_input(&m_formatContext, inputFile.data(), nullptr, nullptr);
+       err != 0)
+    {
+      char str[1500];
+      qDebug() << "VideoThumbnailer: avformat_open_input failed"
+               << av_make_error_string(str, 1499, err);
+
+      SCORE_ASSERT(m_formatContext == nullptr);
+      return;
+    }
   }
 
   if(int err = avformat_find_stream_info(m_formatContext, nullptr); err < 0)
@@ -51,6 +58,12 @@ VideoThumbnailer::VideoThumbnailer(QString path)
 
     avformat_close_input(&m_formatContext);
     m_formatContext = nullptr;
+    if(m_ioOwner)
+    {
+      m_ioFree(m_ioOwner);
+      m_ioOwner = nullptr;
+      m_ioFree = nullptr;
+    }
     return;
   }
 
@@ -176,6 +189,12 @@ VideoThumbnailer::~VideoThumbnailer()
     avformat_flush(m_formatContext);
     avformat_close_input(&m_formatContext);
     m_formatContext = nullptr;
+  }
+  if(m_ioOwner)
+  {
+    m_ioFree(m_ioOwner);
+    m_ioOwner = nullptr;
+    m_ioFree = nullptr;
   }
 }
 

--- a/src/plugins/score-plugin-media/Video/Thumbnailer.hpp
+++ b/src/plugins/score-plugin-media/Video/Thumbnailer.hpp
@@ -48,6 +48,8 @@ private:
   int m_currentIndex{};
 
   AVFormatContext* m_formatContext{};
+  void* m_ioOwner{};
+  void (*m_ioFree)(void*){};
   AVCodecContext* m_codecContext{};
   SwsContext* m_rescale{};
   const AVCodec* m_codec{};

--- a/src/plugins/score-plugin-media/Video/VideoDecoder.cpp
+++ b/src/plugins/score-plugin-media/Video/VideoDecoder.cpp
@@ -362,7 +362,16 @@ bool VideoDecoder::open(const std::string& inputFile) noexcept
   m_inputFile = inputFile;
   this->filePath = inputFile;
 
-  if(avformat_open_input(&m_formatContext, inputFile.c_str(), nullptr, nullptr) != 0)
+  if(Media::isStreamedMediaPath(inputFile))
+  {
+    if(!Media::open_input_custom_io(
+           m_formatContext, m_io, QString::fromStdString(inputFile)))
+    {
+      close_file();
+      return false;
+    }
+  }
+  else if(avformat_open_input(&m_formatContext, inputFile.c_str(), nullptr, nullptr) != 0)
   {
     close_file();
     return false;
@@ -491,6 +500,7 @@ void VideoDecoder::close_file() noexcept
     avformat_close_input(&m_formatContext);
     m_formatContext = nullptr;
   }
+  m_io = Media::AvIoDevice{};
 }
 
 ReadFrame LibAVDecoder::read_one_frame_raw(AVPacket& packet)

--- a/src/plugins/score-plugin-media/Video/VideoDecoder.hpp
+++ b/src/plugins/score-plugin-media/Video/VideoDecoder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <Media/Libav.hpp>
 #if SCORE_HAS_LIBAV
+#include <Media/AvStreamIO.hpp>
 #include <Video/FrameQueue.hpp>
 #include <Video/Rescale.hpp>
 #include <Video/VideoInterface.hpp>
@@ -53,6 +54,7 @@ private:
   static const constexpr int frames_to_buffer = 16;
 
   std::string m_inputFile;
+  Media::AvIoDevice m_io;
 
   std::thread m_thread;
   std::mutex m_condMut;


### PR DESCRIPTION
Streams large media on the WebAssembly build instead of copying it into RAM.

Until now every dropped or imported file was copied whole into MEMFS, which is
bounded by the 2 GB wasm heap — so multi-GB media simply could not be opened. This
adds a custom `AVIOContext` that pulls byte ranges out of the browser `Blob` behind
a `weblocalfile:` URL on demand, so ffmpeg reads only what it needs and nothing is
ever fully buffered.

Four commits, each independently verified in a real browser:

1. **Stream from disk without copying into RAM.** `Media/AvStreamIO.{hpp,cpp}` adds
   `AvIoDevice`, `isStreamedMediaPath()` and `open_input_custom_io()`, and installs the
   libossia open hook so the audio path streams too. Drops above 48 MB keep the
   `weblocalfile:` URL rather than staging it; smaller files keep the existing fast
   path unchanged. *Measured: a 74 MB mp4 opens reading ~9 % of the file — header plus
   the moov tail seek.*

2. **Fix a cross-thread crash.** A `weblocalfile:` Blob's `emscripten::val` is bound to
   the thread that created it, so touching it from a worker crashed inside
   `qstdweb::BlobIODevice::size()`. Non-suspending operations are now marshalled to the
   main runtime thread, and off-thread reads fail cleanly rather than trapping.

3. **Read on worker threads.** Workers previously could not read at all (JSPI only
   suspends on the main thread's promising stack). Reads are now proxied
   asynchronously to the main thread, which starts `Blob.arrayBuffer()` and wakes the
   waiting worker through a futex — so no `val` ever crosses a thread. `QFile` drops out
   of the streaming path entirely; media links `Qt::CorePrivate` for file-engine access
   on wasm only.

4. **4 MB AVIO reads + 16 MB read-ahead.** *Measured headed on a 4.3 GB 4K ProRes clip:
   main-thread round-trips 16,150 → 50 (~323× fewer), bytes fetched 4.0 GB → 0.78 GB
   (~5× less), summed I/O wait 15.9 s → 0.81 s (~20× less).*

Framerate is unchanged (~0.5× realtime) because playback is decode-bound — after this
change avcodec is ~94 % of wall time and I/O ~3 %. The win is main-thread contention
and bandwidth, not throughput; the remaining lever is multithreaded decode
(`VideoDecoder.cpp` `thread_count=1`), left alone pending a teardown-crash fix.

### Scope

Desktop is unaffected: the wasm-specific code in `AvStreamIO.cpp` is behind
`__EMSCRIPTEN__`, and non-wasm paths keep the fopen fast path. The file set here does
not overlap #2144, #2145, #2146 or #2147, so it can land in any order relative to them.

**Requires ossia/libossia#912** — this bumps the submodule to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oPj1zRcxSQX7FNni7EHM6
