### PR TITLE
wasm: make joysticks work, and restart the network context when polling it

### DIFF
--- a/src/plugins/score-plugin-deviceexplorer/Explorer/DocumentPlugin/DeviceDocumentPlugin.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/DocumentPlugin/DeviceDocumentPlugin.cpp
@@ -150,24 +150,7 @@ void DeviceDocumentPlugin::timerEvent(QTimerEvent* event)
 {
 #if defined(__EMSCRIPTEN__)
   if(m_processMessages)
-  {
-    using work_guard
-        = boost::asio::executor_work_guard<boost::asio::io_context::executor_type>;
-
-    work_guard wg{m_asioContext->context.get_executor()};
-    try
-    {
-      m_asioContext->context.poll();
-    }
-    catch(std::exception& e)
-    {
-      ossia::logger().error("Error while processing network events: {}", e.what());
-    }
-    catch(...)
-    {
-      ossia::logger().error("Error while processing network events.");
-    }
-  }
+    m_asioContext->poll();
 #endif
 }
 /** The following code handles device creation / loading.

--- a/src/plugins/score-plugin-protocols/Protocols/Joystick/JoystickProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/Joystick/JoystickProtocolFactory.cpp
@@ -7,9 +7,11 @@
 
 #include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
 
+#include <ossia/detail/algorithms.hpp>
 #include <ossia/protocols/joystick/joystick_protocol.hpp>
 
 #include <QObject>
+#include <QTimer>
 #include <QUrl>
 namespace Protocols
 {
@@ -35,10 +37,28 @@ public:
 class JoystickEnumerator : public Device::DeviceEnumerator
 {
 public:
+  JoystickEnumerator()
+  {
+    m_timer.setInterval(1000);
+    QObject::connect(&m_timer, &QTimer::timeout, this, [this] { rescan(); });
+    m_timer.start();
+  }
+
   void enumerate(std::function<void(const QString&, const Device::DeviceSettings&)> f)
       const override
   {
+    m_current = scan();
+    for(auto& [name, set] : m_current)
+      f(name, set);
+  }
+
+private:
+  using device_list = std::vector<std::pair<QString, Device::DeviceSettings>>;
+
+  static device_list scan()
+  {
     using info = ossia::net::joystick_info;
+    device_list res;
     const unsigned int joystick_count = info::get_joystick_count();
 
     for(unsigned int i = 0; i < joystick_count; ++i)
@@ -55,10 +75,40 @@ public:
         specif.gamepad = info::get_joystick_is_gamepad(i);
 
         set.deviceSpecificSettings = QVariant::fromValue(specif);
-        f(set.name, set);
+        res.emplace_back(set.name, set);
       }
     }
+    return res;
   }
+
+  void rescan()
+  {
+    auto next = scan();
+    auto has = [](const device_list& l, const QString& n) {
+      return ossia::any_of(l, [&n](const auto& p) { return p.first == n; });
+    };
+
+    for(auto& [name, set] : m_current)
+      if(!has(next, name))
+        deviceRemoved(name);
+
+    bool added = false;
+    for(auto& [name, set] : next)
+    {
+      if(!has(m_current, name))
+      {
+        deviceAdded(name, set);
+        added = true;
+      }
+    }
+
+    m_current = std::move(next);
+    if(added)
+      sort();
+  }
+
+  QTimer m_timer;
+  mutable device_list m_current;
 };
 
 QString JoystickProtocolFactory::prettyName() const noexcept

--- a/src/plugins/score-plugin-protocols/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/Joystick/JoystickProtocolSettingsWidget.cpp
@@ -13,6 +13,7 @@
 
 #include <QCheckBox>
 #include <QFormLayout>
+#include <QLabel>
 #include <QPushButton>
 #include <QVariant>
 
@@ -39,6 +40,16 @@ JoystickProtocolSettingsWidget::JoystickProtocolSettingsWidget(QWidget* parent)
   auto layout = new QFormLayout;
   layout->addRow(tr("Name"), m_deviceNameEdit);
   layout->addRow(tr("Gamepad API"), m_gamepad);
+
+#if defined(__EMSCRIPTEN__)
+  auto hint = new QLabel{
+      tr("Web browsers only reveal a joystick once a button has been pressed or "
+         "an axis moved on it. If the list of devices is empty, use the joystick "
+         "once and it will show up."),
+      this};
+  hint->setWordWrap(true);
+  layout->addRow(hint);
+#endif
 
   setLayout(layout);
 }


### PR DESCRIPTION
Makes gamepads usable on the WebAssembly build, and fixes an asio bug that was much wider than joysticks.

> **Depends on ossia/libossia#913 — do not merge before it.** The third commit bumps the submodule to it.

### The asio bug

`navigator.getGamepads()` was called **exactly 4 times, ever**, after adding a joystick device. The JS stack named the caller:

```
EMSCRIPTEN_JoystickUpdate <- SDL_JoystickUpdate <- SDL_WaitEventTimeout
  <- ossia::timer::start(joystick_event_processor::start)
```

`scheduler::work_finished()` calls `stop()` when outstanding work reaches zero. `DeviceDocumentPlugin::timerEvent` — the wasm polling path — polls with a work guard but never calls `restart()`. So the very first tick, ~8 ms into the document and before any device exists, stopped the io_context permanently, and every later `poll()` short-circuited on `if (stopped_) return 0`. `network_context::run()` restarts; the poll path did not.

**This killed every asio-driven protocol on wasm, not just joysticks.** Fixed in libossia#913 (`network_context::poll()` restarts before polling); this branch routes `timerEvent` through it.

After: `getGamepads` goes from 4 calls total to ~125/s, SDL emits axis and button events, and the device explorer shows `stick/left/x = 0.619989`.

### Enumeration

Emscripten's SDL joystick driver has a no-op `Detect()`: discovery happens only through the browser's `gamepadconnected` event, and the browser withholds gamepads until one is physically used in the page — a deliberate anti-fingerprinting rule with no opt-out. score's enumerator was a one-shot snapshot taken when the dialog opened, so the list stayed empty forever.

`JoystickEnumerator` now rescans at 1 Hz and emits `deviceAdded`/`deviceRemoved`, so a pad appears about a second after it is touched, without reopening the dialog. **This fixes hot-plug on desktop too**, where the same one-shot snapshot applied. The settings pane gains a wasm-only note telling the user to press a button.

### Verification

Measured in a browser with a fake pad injected via `navigator.getGamepads` plus a synthetic `gamepadconnected`, which exercises the chain from emscripten's HTML5 layer down. **A real gamepad was subsequently confirmed working by the maintainer.**

One SDL behaviour worth knowing: the first movement of a given axis is swallowed by SDL's initial-value gate — a second distinct value is needed. Not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oPj1zRcxSQX7FNni7EHM6
