### PR TITLE
tools: name custom app packages so they survive a release upload

### DIFF
--- a/tools/create-app-linux.sh
+++ b/tools/create-app-linux.sh
@@ -231,7 +231,7 @@ fi
 
 # Repackage the AppImage
 echo "Repackaging AppImage..."
-OUTPUT_APPIMAGE="${APP_NAME}-${PLATFORM}.AppImage"
+OUTPUT_APPIMAGE="${APP_NAME_SAFE}-${PLATFORM}.AppImage"
 
 ./appimagetool-${ARCH}.AppImage -n squashfs-root "$OUTPUT_APPIMAGE" \
     --runtime-file "runtime-${ARCH}"
@@ -249,13 +249,13 @@ mv "$OUTPUT_APPIMAGE" "$OUTPUT_DIR/"
 echo "✓ Created: $OUTPUT_DIR/$OUTPUT_APPIMAGE"
 
 # Create a simple run script
-cat > "$OUTPUT_DIR/${APP_NAME}-${PLATFORM}.sh" << EOF
+cat > "$OUTPUT_DIR/${APP_NAME_SAFE}-${PLATFORM}.sh" << EOF
 #!/bin/bash
 # Launcher script for ${APP_NAME}
 SCRIPT_DIR="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
 exec "\$SCRIPT_DIR/$OUTPUT_APPIMAGE" "\$@"
 EOF
 
-chmod +x "$OUTPUT_DIR/${APP_NAME}-${PLATFORM}.sh"
+chmod +x "$OUTPUT_DIR/${APP_NAME_SAFE}-${PLATFORM}.sh"
 
 echo "✓ Linux package created successfully"

--- a/tools/create-app-macos.sh
+++ b/tools/create-app-macos.sh
@@ -366,7 +366,7 @@ fi
 
 # Create a DMG
 echo "Creating DMG..."
-OUTPUT_DMG="${APP_NAME}-${PLATFORM}.dmg"
+OUTPUT_DMG="${APP_NAME_SAFE}-${PLATFORM}.dmg"
 
 # Simple method using hdiutil
 rm -f "$OUTPUT_DMG"

--- a/tools/create-app-windows.sh
+++ b/tools/create-app-windows.sh
@@ -208,7 +208,7 @@ cd "$WORK_DIR"
 
 # Create a ZIP package
 echo "Creating ZIP package..."
-OUTPUT_ZIP="${APP_NAME}-windows.zip"
+OUTPUT_ZIP="${APP_NAME_SAFE}-windows.zip"
 
 if command -v zip &> /dev/null; then
     (cd "$INSTALL_DIR" && zip -r -q "$WORK_DIR/$OUTPUT_ZIP" .)

--- a/tools/create-app.sh
+++ b/tools/create-app.sh
@@ -100,9 +100,9 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --qml)
             if [[ -f "$2" ]]; then
-                QML_FILES+=("$2")
+                QML_FILES+=("$(cd "$(dirname "$2")" && pwd)/$(basename "$2")")
             elif [[ -d "$2" ]]; then
-                QML_DIRS+=("$2")
+                QML_DIRS+=("$(cd "$2" && pwd)")
             else
                 echo "Error: QML path does not exist: $2"
                 exit 1


### PR DESCRIPTION
`create-app-{linux,macos,windows}.sh` name their output after `APP_NAME` verbatim. When an app name contains a space, GitHub rewrites it to a dot on release-asset upload, so what CI produces and what users download are different file names.

That silently breaks the Linux launcher. `create-app-linux.sh` writes a `.sh` next to the AppImage that execs it *by name*, so every published launcher points at a file that does not exist:

```bash
# in Spatial.Protocol.Mapper-linux-x86_64.sh, as published today
exec "$SCRIPT_DIR/Spatial Protocol Mapper-linux-x86_64.AppImage" "$@"
# the asset is actually Spatial.Protocol.Mapper-linux-x86_64.AppImage
```

Four sat-mtl apps ship one of these today (livepose, DomeportPro, koaia, spatial-protocol-mapper) and all four are dead on arrival.

The fix is to use `APP_NAME_SAFE` for file names — `create-app.sh` already derives it and `create-app-wasm.sh` already uses it, so this brings the three older scripts in line. `APP_NAME` still names the app itself: `.desktop` entry, DMG volume, window title.

Also: make `--qml` absolute the way `--score` and `--local-installer` already are. The platform scripts `cd` into their work directory before copying, so a relative `--qml` resolves to nothing there — and the copy is guarded with `|| true`, so the app gets packaged with an **empty qml directory and no error at all**. Only reachable from the command line; the `package-custom-app` action already passes absolute paths.

## Note for consumers

This changes published asset names, e.g. `Domeport.Pro-linux-x86_64.AppImage` → `Domeport-Pro-linux-x86_64.AppImage`. Anything pinning the old names (docs, download links) needs updating. Apps whose name has no spaces are unaffected.

## Validation

Packaged a wasm bundle with a relative `--qml` and a spaced app name, against the published `ossia.score-master-wasm.zip`:

- before: `app/qml/` empty, `preload.json` listing only the score file
- after: `livepose/`, `Main.qml`, `qtquickcontrols2.conf` present and in the manifest, output named `Spatial-Protocol-Mapper-wasm.zip`

`bash -n` clean on all five scripts. The AppImage/DMG/zip paths are the same substitution and were not run locally — the Linux/macOS/Windows packaging jobs in CI cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxtUwsfk4JN46WropbwfqC
