### PR TITLE
ci(wasm): honour SCORE_EXTRA_CMAKE_ARGS and SCORE_CMAKE_CACHE

### DIFF
--- a/ci/wasm.build.sh
+++ b/ci/wasm.build.sh
@@ -16,8 +16,19 @@ if [ -d "$SCORE_LIBRARY_DIR" ]; then
   LIBRARY_ARGS+=("-DSCORE_WASM_PRELOAD_LIBRARY=$SCORE_LIBRARY_DIR")
 fi
 
+if [[ -z "${SCORE_EXTRA_CMAKE_ARGS-}" ]]; then
+  export SCORE_EXTRA_CMAKE_ARGS=
+fi
+
+if [[ -z "${SCORE_CMAKE_CACHE-}" ]]; then
+  SCORE_CMAKE_CACHE_CMD=( )
+else
+  SCORE_CMAKE_CACHE_CMD=(-C "$SCORE_CMAKE_CACHE")
+fi
+
 /opt/ossia-sdk-wasm/qt-wasm/bin/qt-cmake  $SCORE_DIR \
    -GNinja \
+   "${SCORE_CMAKE_CACHE_CMD[@]}" \
    "${LIBRARY_ARGS[@]}" \
    -DCMAKE_CXX_STANDARD=23 \
    -DCMAKE_BUILD_TYPE=Release \
@@ -31,7 +42,8 @@ fi
    -DCMAKE_C_FLAGS='-pthread -O3 -ffast-math -fno-finite-math-only -msimd128 -msse -msse2 -msse3 -mssse3 -msse4 -msse4.1 -msse4.2 -flto -g0 ' \
    -DCMAKE_CXX_FLAGS='-fexperimental-library -DBOOST_ASIO_DISABLE_EPOLL=1 -pthread -O3 -ffast-math -fno-finite-math-only -msimd128 -msse -msse2 -msse3 -mssse3 -msse4 -msse4.1 -msse4.2 -flto -g0 '  \
    -DCMAKE_EXE_LINKER_FLAGS='-sJSPI -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=268435456 -sMAXIMUM_MEMORY=2147483648 -pthread -Oz -ffast-math -fno-finite-math-only -msimd128 -msse -msse2 -msse3 -mssse3 -msse4 -msse4.1 -msse4.2 -flto -g0 ' \
-   -DCMAKE_SHARED_LINKER_FLAGS='-sJSPI -sALLOW_MEMORY_GROWTH=1 -pthread -Oz -ffast-math -fno-finite-math-only -msimd128 -msse -msse2 -msse3 -mssse3 -msse4 -msse4.1 -msse4.2 -flto -g0 '
+   -DCMAKE_SHARED_LINKER_FLAGS='-sJSPI -sALLOW_MEMORY_GROWTH=1 -pthread -Oz -ffast-math -fno-finite-math-only -msimd128 -msse -msse2 -msse3 -mssse3 -msse4 -msse4.1 -msse4.2 -flto -g0 ' \
+   $SCORE_EXTRA_CMAKE_ARGS
 
 cmake --build .
 


### PR DESCRIPTION
Every other `ci/*.build.sh` forwards these — the AppImage recipe reads both, and the `custom-score-build` action passes its `cmake-options` through `SCORE_EXTRA_CMAKE_ARGS` — but `ci/wasm.build.sh` ignored them and always configured the default plugin set.

That is the blocker for custom apps on the web: DomeportPro (`score-addon-ndi`), koaia (`score-addon-librediffusion`) and spatial-protocol-mapper (`score-addon-spatgris`) can currently only get a *stock* wasm build, which doesn't behave like their desktop builds.

Same contract as `cmake/Deployment/Linux/AppImage/Recipe.llvm`, including leaving `SCORE_EXTRA_CMAKE_ARGS` unquoted so a list of `-D` flags splits into separate arguments, and the `SCORE_CMAKE_CACHE_CMD` array form for `-C`.

## Compatibility

With both variables unset — the path `wasm.yaml` takes — the generated command line is byte-for-byte what it was. Verified by extracting the argument assembly and printing the result:

```
-- empty env (score's own CI path):
[fake-cmake][-GNinja]
-- with custom args:
[fake-cmake][-C][/tmp/cache.cmake][-GNinja][-DSCORE_ENABLE_ADDONS=score-addon-spatgris][-DSCORE_DISABLE_PLUGINS=score-plugin-faust,score-plugin-jit]
```

`bash -n` clean. I did not run a full emscripten build locally (wasm SDK + link time); the WASM workflow on this PR exercises the unset path, which is the one that had to stay identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxtUwsfk4JN46WropbwfqC