### PR TITLE
tools: package custom apps for Windows on ARM64

### DIFF
--- a/tools/create-app-windows.sh
+++ b/tools/create-app-windows.sh
@@ -7,7 +7,14 @@ PLATFORM="$1"
 shift
 QML_ITEMS=("$@")
 
-echo "Creating Windows package..."
+# Matches the installer names ci/win32.deploy.sh publishes
+case "$PLATFORM" in
+    windows) ARCH="x86_64" ;;
+    windows-arm64) ARCH="aarch64" ;;
+    *) echo "Error: Invalid Windows platform: $PLATFORM"; exit 1 ;;
+esac
+
+echo "Creating Windows package for $ARCH..."
 
 cd "$WORK_DIR"
 
@@ -32,10 +39,10 @@ if [[ -n "$LOCAL_INSTALLER" ]]; then
 else
     # Download the official Windows installer
     if [[ "$RELEASE_TAG" == "continuous" ]]; then
-        INSTALLER_NAME="ossia.score-master-win64.exe"
+        INSTALLER_NAME="ossia.score-master-${ARCH}.exe"
     else
         VERSION="${RELEASE_TAG#v}"
-        INSTALLER_NAME="ossia.score-${VERSION}-win64.exe"
+        INSTALLER_NAME="ossia.score-${VERSION}-${ARCH}.exe"
     fi
     INSTALLER_URL="https://github.com/ossia/score/releases/download/${RELEASE_TAG}/${INSTALLER_NAME}"
 
@@ -208,7 +215,7 @@ cd "$WORK_DIR"
 
 # Create a ZIP package
 echo "Creating ZIP package..."
-OUTPUT_ZIP="${APP_NAME_SAFE}-windows.zip"
+OUTPUT_ZIP="${APP_NAME_SAFE}-${PLATFORM}.zip"
 
 if command -v zip &> /dev/null; then
     (cd "$INSTALL_DIR" && zip -r -q "$WORK_DIR/$OUTPUT_ZIP" .)

--- a/tools/create-app.sh
+++ b/tools/create-app.sh
@@ -55,7 +55,7 @@ Optional:
     --release TAG       Release tag to use (default: continuous)
                         Ignored if --local-installer is specified.
     --platform PLAT     Platform to build for: linux-x86_64, linux-aarch64,
-                        macos-intel, macos-arm, windows, wasm
+                        macos-intel, macos-arm, windows, windows-arm64, wasm
                         Can be specified multiple times. If not specified,
                         builds for current platform. 'wasm' produces a static
                         web bundle (served in a browser).
@@ -280,7 +280,10 @@ if [[ ${#PLATFORMS[@]} -eq 0 ]]; then
             esac
             ;;
         MINGW*|MSYS*|CYGWIN*)
-            PLATFORMS+=("windows")
+            case "$(uname -m)" in
+                aarch64|arm64) PLATFORMS+=("windows-arm64") ;;
+                *) PLATFORMS+=("windows") ;;
+            esac
             ;;
         *)
             echo "Error: Unsupported platform: $(uname -s)"
@@ -357,7 +360,7 @@ for platform in "${PLATFORMS[@]}"; do
         macos-intel|macos-arm)
             "$SCRIPT_DIR/create-app-macos.sh" "$platform" "${QML_FILES[@]+"${QML_FILES[@]}"}" "${QML_DIRS[@]+"${QML_DIRS[@]}"}"
             ;;
-        windows)
+        windows|windows-arm64)
             "$SCRIPT_DIR/create-app-windows.sh" "$platform" "${QML_FILES[@]+"${QML_FILES[@]}"}" "${QML_DIRS[@]+"${QML_DIRS[@]}"}"
             ;;
         wasm)


### PR DESCRIPTION
`ci/win32.deploy.sh` names its installers per architecture, and the `winarm64` job has been publishing `ossia.score-master-aarch64.exe` for a while — but `create-app-windows.sh` could only ever produce an x86_64 package.

Adds a `windows-arm64` platform to `create-app.sh` / `create-app-windows.sh`, selecting `ossia.score-<version>-x86_64.exe` or `-aarch64.exe` to match.

## This also fixes what plain `windows` downloads

It asked for `ossia.score-master-win64.exe` — a name `win32.deploy.sh` no longer produces. The asset still sitting on the continuous release is from **2026-07-14**, while the real one is current:

```
ossia.score-master-x86_64.exe   236MB  2026-07-27   <- what CI publishes now
ossia.score-master-aarch64.exe  222MB  2026-07-26   <- what this PR unlocks
ossia.score-master-win64.exe    235MB  2026-07-14   <- what the script asks for
```

So every custom app built with `--release` has been repackaging a two-week-old score, and would have broken outright the day that stale asset was cleaned up.

## Output naming

The zip is now `<app>-<platform>.zip`, so the two Windows builds don't overwrite each other. For `windows` that is byte-for-byte the same `<app>-windows.zip` as before — only `windows-arm64` is new.

## Validation

```
$ create-app.sh --platform windows-arm64 ...
Building for platform: windows-arm64
Creating Windows package for aarch64...

$ create-app.sh --platform windows-arm ...
Error: Unknown platform: windows-arm
```

Both installer URLs return HTTP 200. `bash -n` clean. The full repackaging path needs a Windows runner — sat-mtl PRs adding `windows-11-arm` jobs will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxtUwsfk4JN46WropbwfqC
