### PR TITLE
ci(wasm): ship the release asset with the binary uncompressed

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -62,7 +62,13 @@ jobs:
             NAME="ossia.score-master-wasm.zip"
           fi
           # site/ was assembled by wasm.deploy.sh (js/wasm[/data] + loader files).
-          ( cd site && zip -r -q "../staging/$NAME" . -x '.git/*' )
+          # The binary is gzipped there for the score-web push; ship it plain here.
+          ( cd site && zip -r -q "../staging/$NAME" . -x '.git/*' -x 'ossia-score.wasm.gz' )
+          if [[ -f site/ossia-score.wasm.gz ]]; then
+            gunzip -c site/ossia-score.wasm.gz > ossia-score.wasm
+            zip -q -j "staging/$NAME" ossia-score.wasm
+            rm -f ossia-score.wasm
+          fi
           ls -lah staging
 
       - name: Upload build


### PR DESCRIPTION
#2153 gzipped the wasm binary because `ci/wasm.deploy.sh` pushes `site/` into the score-web git repository, which GitHub caps at 100 MiB.

The release bundle is zipped from that same `site/`, so the asset picked up the compression too. Release assets have no such limit, and `tools/create-app-wasm.sh` needs the plain `ossia-score.wasm`, so `--release continuous` currently fails:

```
cp: cannot stat '.../wasm-build/ossia-score.wasm': No such file or directory
```

The git push keeps the compressed binary. `score-wasm-gz.js` decides by gzip magic rather than file name, so an uncompressed bundle takes emscripten's normal fetch.

Tested: rebuilt the asset from a site/ laid out like the real one, packaged an app from it successfully; the published asset fails the same command with exit 1.
