### PR TITLE
ui: make Value display show every value when the log is longer than 1

### DIFF
--- a/src/plugins/score-plugin-ui/Ui/ValueDisplay.hpp
+++ b/src/plugins/score-plugin-ui/Ui/ValueDisplay.hpp
@@ -10,7 +10,9 @@
 #include <score/application/ApplicationContext.hpp>
 #include <score/model/Skin.hpp>
 
+#include <ossia/dataflow/port.hpp>
 #include <ossia/network/value/format_value.hpp>
+#include <ossia/network/value/value_conversion.hpp>
 
 #include <boost/container/devector.hpp>
 
@@ -19,10 +21,28 @@
 #include <QMenu>
 #include <QPainter>
 
+#include <halp/audio.hpp>
 #include <halp/controls.hpp>
 #include <halp/meta.hpp>
+#include <halp/polyfill.hpp>
+#include <halp/static_string.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+#include <vector>
+
 namespace Ui::ValueDisplay
 {
+template <halp::static_string lit, typename T>
+struct raw_port
+{
+  halp_meta(is_event, true)
+  static clang_buggy_consteval auto name() { return std::string_view{lit.value}; }
+
+  T* value{};
+};
+
 struct Node
 {
   halp_meta(name, "Value display")
@@ -33,33 +53,94 @@ struct Node
   halp_meta(description, "Visualize an input value")
   halp_meta(uuid, "3f4a41f2-fa39-420f-ab0f-0af6b8409edb")
   halp_flag(fully_custom_item);
+
+  static constexpr int max_log = 100;
+
   struct
   {
-    struct : halp::val_port<"in", ossia::value>
+    // Reading the port directly rather than through a control input: a control
+    // input is fed with get_data().back(), so only the last value of a tick
+    // would ever be seen, and a burst - a note-off immediately followed by a
+    // note-on, several values written at the same sample - would show up as a
+    // single entry.
+    raw_port<"in", ossia::value_port> port;
+
+    halp::spinbox_i32<"Log", halp::range{1, max_log, 1}> log;
+  } inputs;
+
+  struct
+  {
+    // [sequence number of the first entry, values...]
+    struct : halp::val_port<"values", std::optional<ossia::value>>
     {
       enum widget
       {
         control
       };
-    } port;
+    } values;
+  } outputs;
 
-    halp::spinbox_i32<"Log", halp::range{1, 100, 1}> log;
-  } inputs;
+  // The engine -> UI queue for control outputs is drained keeping only the last
+  // entry, so a push has to carry everything the layer may still need. That is
+  // never more than the log length, which bounds the ring exactly.
+  boost::container::devector<ossia::value> m_ring;
+  int m_next_seq = 0;
+
+  void prepare(halp::setup) noexcept
+  {
+    m_ring.clear();
+    m_next_seq = 0;
+  }
+
+  void operator()()
+  {
+    outputs.values.value.reset();
+
+    if(!inputs.port.value)
+      return;
+
+    const auto& data = inputs.port.value->get_data();
+    if(data.empty())
+      return;
+
+    // Never more than what the layer displays: with a log of 1 this sends the
+    // last value and nothing else.
+    const int keep = std::clamp(inputs.log.value, 1, max_log);
+
+    for(const ossia::timed_value& tv : data)
+    {
+      m_ring.push_back(tv.value);
+      m_next_seq++;
+      if(std::ssize(m_ring) > keep)
+        m_ring.pop_front();
+    }
+    while(std::ssize(m_ring) > keep)
+      m_ring.pop_front();
+
+    std::vector<ossia::value> payload;
+    payload.reserve(1 + m_ring.size());
+    payload.push_back(int(m_next_seq - std::ssize(m_ring)));
+    for(const auto& v : m_ring)
+      payload.push_back(v);
+
+    outputs.values.value = ossia::value{std::move(payload)};
+  }
 
   struct Layer : public Process::EffectLayerView
   {
   public:
     boost::container::devector<ossia::value> values;
+    int m_next_seq = 0;
 
-    Process::ControlInlet* value_inlet;
-    Process::ControlInlet* log_inlet;
+    Process::ControlInlet* log_inlet{};
 
     mutable QString txt_cache;
 
     int logging() const noexcept
     {
-      return std::max(1, ossia::convert<int>(log_inlet->value()));
+      return std::clamp(ossia::convert<int>(log_inlet->value()), 1, max_log);
     }
+
     Layer(
         const Process::ProcessModel& process, const Process::Context& doc,
         QGraphicsItem* parent)
@@ -70,35 +151,62 @@ struct Node
       const Process::PortFactoryList& portFactory
           = doc.app.interfaces<Process::PortFactoryList>();
 
-      value_inlet = static_cast<Process::ControlInlet*>(process.inlets()[0]);
+      auto& value_inlet = *process.inlets()[0];
+      if(auto* fact = portFactory.get(value_inlet.concreteKey()))
+        if(auto* port = fact->makePortItem(value_inlet, doc, this, this))
+          port->setPos(0, 5);
+
       log_inlet = static_cast<Process::ControlInlet*>(process.inlets()[1]);
 
-      auto fact = portFactory.get(value_inlet->concreteKey());
-      auto port = fact->makePortItem(*value_inlet, doc, this, this);
-      port->setPos(0, 5);
-
+      auto* out = static_cast<Process::ControlOutlet*>(process.outlets()[0]);
       connect(
-          value_inlet, &Process::ControlInlet::executionValueChanged, this,
-          [this](const ossia::value& v) {
-        if(values.size() >= logging())
-          values.pop_back();
-        values.push_front(v);
-        update();
-      });
+          out, &Process::ControlOutlet::valueChanged, this,
+          [this](const ossia::value& v) { on_values(v); });
 
       connect(
           log_inlet, &Process::ControlInlet::valueChanged, this,
           [this](const ossia::value& v) {
-        const int N = std::max(1, ossia::convert<int>(v));
-        if(values.size() >= N)
-          values.resize(N);
+        while(std::ssize(values) > logging())
+          values.pop_back();
         update();
-      });
+          });
+    }
+
+    void on_values(const ossia::value& v)
+    {
+      auto* list = v.target<std::vector<ossia::value>>();
+      if(!list || list->size() < 2)
+        return;
+
+      const int base = ossia::convert<int>((*list)[0]);
+      const int n = std::ssize(*list) - 1;
+
+      // The batch is entirely older than what we hold: the process restarted.
+      if(base + n < m_next_seq)
+      {
+        values.clear();
+        m_next_seq = base;
+      }
+
+      for(int i = 0; i < n; i++)
+      {
+        const int seq = base + i;
+        if(seq < m_next_seq)
+          continue;
+        values.push_front((*list)[i + 1]);
+        m_next_seq = seq + 1;
+      }
+
+      while(std::ssize(values) > logging())
+        values.pop_back();
+
+      update();
     }
 
     void reset()
     {
       values.clear();
+      m_next_seq = 0;
       update();
     }
 
@@ -123,17 +231,17 @@ struct Node
 
   struct Presenter : public Process::EffectLayerPresenter
   {
-      using Process::EffectLayerPresenter::EffectLayerPresenter;
-      void fillContextMenu(
-          QMenu& menu, QPoint pos, QPointF scenepos,
-          const Process::LayerContextMenuManager& ) override
-      {
-        auto cp = menu.addAction(tr("Copy value"));
-        connect(cp, &QAction::triggered, this, [this] {
-          auto& v = *static_cast<Layer*>(this->m_view);
-          qApp->clipboard()->setText(v.txt_cache);
-        });
-      }
+    using Process::EffectLayerPresenter::EffectLayerPresenter;
+    void fillContextMenu(
+        QMenu& menu, QPoint pos, QPointF scenepos,
+        const Process::LayerContextMenuManager&) override
+    {
+      auto cp = menu.addAction(tr("Copy value"));
+      connect(cp, &QAction::triggered, this, [this] {
+        auto& v = *static_cast<Layer*>(this->m_view);
+        qApp->clipboard()->setText(v.txt_cache);
+      });
+    }
   };
 };
 }


### PR DESCRIPTION
`Value display` collapses a burst to a single entry. Feeding it from `MIDI to array` after a step sequencer shows `[144, 36, 100] [144, 38, 100] …` and never a note-off, even though the note-offs are emitted — the note-off and the note-on of a step share a sample offset and land in the same tick, and only one of them can survive the trip to the UI.

Two independent losses:

**Inside a tick.** The input was a plain `ossia::value` control port, and avendish feeds those with a single line (`port_run_preprocess.hpp:90`):

```cpp
auto& last = port.data.get_data().back().value;
```

so only the last value written during the tick ever reached the node. It now reads the `ossia::value_port` directly, which keeps every value in write order — including several written at the same sample, which a frame-keyed sample-accurate port (`halp::accurate`, a `flat_map<int, T>`) could not represent either.

**Across ticks.** Control values reach the UI through `ExecutorUpdateControlValueInUi::handle_controls`, which drains its queue keeping only the last entry and is polled on `coarseUpdateTimer` (~2× the UI event rate). At ~40 ticks/s against a ~10 Hz poll most ticks are dropped.

So the node keeps a ring and pushes **all of it** whenever it changes, prefixed with the sequence number of its first entry; the layer appends only the entries it has not seen. That makes the transport's lossiness irrelevant: the ring is bounded by the log length, which is by definition everything the layer can display, so one surviving push per UI poll is always sufficient.

With a log of 1 the ring holds one entry and the behaviour is unchanged — just the last value.

I modelled the ring + splice and exercised it against a deliberately lossy poll:

```
midi burst, log=1     ui_every=4 -> 1011
midi burst, log=4     ui_every=4 -> 1008 1009 1010 1011
midi burst, log=12    ui_every=4 -> 1000 1001 ... 1010 1011
midi burst, log=12    ui_every=6 -> 1000 1001 ... 1010 1011
one value/tick, log=5 ui_every=7 -> 15 16 17 18 19
```

(the 12-value cases are 6 steps of note-off + note-on at the same timestamp, all recovered in order.)

## Compatibility

The input goes from `ControlInlet` to `ValueInlet` and a control outlet is added. The outlet changes the port count, so `check_all_ports()` fires on load for existing documents, rebuilds the ports from the spec and re-routes them through `reloadPortsInNewProcess`.

Independent of ossia/libossia#915 — this reads the port's insertion order rather than the timestamps.