### PR TITLE
fix(widgets): scale custom cursor hotspots on xcb for HiDPI

### DIFF
--- a/src/lib/score/widgets/SetIcons.cpp
+++ b/src/lib/score/widgets/SetIcons.cpp
@@ -331,7 +331,11 @@ QCursor get_cursor(QString str, double hotspot_x, double hotspot_y)
   {
     img.load(str);
   }
-  cur = QCursor{img, (int)hotspot_x, (int)hotspot_y};
+  double hotspot_scale = 1.;
+  if(QGuiApplication::platformName() == QLatin1String("xcb"))
+    hotspot_scale = img.devicePixelRatio();
+
+  cur = QCursor{img, (int)(hotspot_x * hotspot_scale), (int)(hotspot_y * hotspot_scale)};
   return cur;
 }
 


### PR DESCRIPTION
Closes #2164.

## Problem

On X11, custom cursors are drawn ~16 device pixels down and to the right of the real pointer
position whenever `devicePixelRatio() >= 1.5`, so aiming by the visible cursor misses: every
small control looks like its hitbox is misplaced. It is most obvious with **Graphical Zoom**
above 100%, because Zoom raises the effective devicePixelRatio.

`score::get_cursor` loads the `@2x` asset and tags it `setDevicePixelRatio(2.)`. The hotspots
in `score::Skin` are in device-independent pixels, which is what `QCursor` expects. Qt's xcb
backend then hands `QCursor::hotSpot()` to `xcb_render_create_cursor` together with the raw
device-pixel image, without converting it:

```cpp
// qtbase/src/plugins/platforms/xcb/qxcbcursor.cpp, QXcbCursor::createBitmapCursor
QPoint spot = cursor->hotSpot();
c = qt_xcb_createCursorXRender(m_screen, cursor->pixmap().toImage(), spot);
```

so on a 64x64 cursor the hotspot ends up at (16,16) instead of (32,32).

## Fix

Express the hotspot in the image's own pixels on xcb only. Other platforms honour the pixmap
devicePixelRatio for cursors, and the `devicePixelRatio() < 1.5` path is unaffected because
the pixmap DPR is then 1.

## Verification

Qt 6.4.2, X11, `Xft.dpi: 192` plus Zoom 200% -> `devicePixelRatio() == 4`. Hotspots read back
from the X server with `XFixesGetCursorImage`, in a running score:

| cursor | logical hotspot | image | before | after |
|---|---|---|---|---|
| `CursorPointer` | (12,10) | 64x64 | (12,10) | **(24,20)** |
| `CursorMove` | (15,15) | 64x64 | (15,15) | **(30,30)** |
| `CursorPointingHand` | (16,16) | 64x64 | (16,16) | **(32,32)** |

Before the fix, pointing at a state's creation cross activated the state underneath it; after,
hovering the cross's own pixels gives the pointing-hand cursor as expected. Checked that Zoom
100% is unchanged.

Note for anyone testing a second cursor in the same process: the xcb backend caches cursors on
`(shape, pixmap cacheKey, mask cacheKey)` and the hotspot is *not* part of that key, so
rebuilding a cursor from the same pixmap returns the cached one. Not an issue in score, where
each cursor comes from its own asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTUi76cnUWh7dGZC64LqbZ