### PR TITLE
developer.sh: support for ubuntu 26.04 (resolute).

### DIFF
--- a/tools/developer.sh
+++ b/tools/developer.sh
@@ -47,6 +47,10 @@ detect_deps_script() {
       plucky)
         DEPS=ubuntu.plucky
         return 0;;
+      resolute)
+	DEPS=ubuntu.2604
+        export PKGS="${PKGS:-clang-22 lld-22 libclang-22-dev llvm-22-dev}"
+	return 0;;
       leap)
         DEPS=suse-leap
         return 0;;


### PR DESCRIPTION
resolute codename was missing so developer.sh fell back to ci/ubuntu.noble.deps.sh which fails on 26.04 because libqtwebsockets6-dev, libqt6serialport6-dev and libqtshadertools6-dev were renamed (qt6-websockets-dev, etc..). 

Mapped resolute to exisiting ci/ubuntu.2604.deps.sh and provided overridable PKGS default since script expects the compiler package to be passed (just like CI matrix). 

Also- PKGS were pinned to 22 because developer.sh selects the newest installed clang while unversioned libclang-dev tracks the distro default which created a breaking mismatch with score-plugin-jit find_package(Clang)


Test status: dependency install and CMake configure now succeed on resolute;  full build completed