### PR TITLE
Make the X11-dependent parts optional (gfx, vst3, linuxcheck)

### DIFF
--- a/src/linuxcheck/CMakeLists.txt
+++ b/src/linuxcheck/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT X11_FOUND)
+  return()
+endif()
+
 add_executable(linuxcheck
   x11.cpp
   wayland.cpp

--- a/src/plugins/score-plugin-gfx/CMakeLists.txt
+++ b/src/plugins/score-plugin-gfx/CMakeLists.txt
@@ -114,14 +114,23 @@ if(NOT EMSCRIPTEN)
     )
   else()
     list(APPEND WINDOW_CAPTURE_SRCS
-      Gfx/WindowCapture/WindowCapture_x11.cpp
       Gfx/WindowCapture/WindowCapture_pipewire.cpp
     )
     set_source_files_properties(
-      Gfx/WindowCapture/WindowCapture_x11.cpp
       Gfx/WindowCapture/WindowCapture_pipewire.cpp
       PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
     )
+
+    if(X11_FOUND)
+      list(APPEND WINDOW_CAPTURE_SRCS
+        Gfx/WindowCapture/WindowCapture_x11.cpp
+      )
+      set_source_files_properties(
+        Gfx/WindowCapture/WindowCapture_x11.cpp
+        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+      )
+      set(SCORE_GFX_HAS_X11_CAPTURE 1)
+    endif()
   endif()
 endif()
 
@@ -623,6 +632,10 @@ if(NOT EMSCRIPTEN)
   list(APPEND SCORE_FEATURES_LIST window_capture)
   if(APPLE)
     target_link_options(${PROJECT_NAME} PUBLIC -weak_framework ScreenCaptureKit)
+  endif()
+  if(SCORE_GFX_HAS_X11_CAPTURE)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HAS_X11_WINDOW_CAPTURE)
+    list(APPEND SCORE_FEATURES_LIST window_capture_x11)
   endif()
 endif()
 

--- a/src/plugins/score-plugin-gfx/Gfx/WindowCapture/WindowCapture_pipewire.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowCapture/WindowCapture_pipewire.cpp
@@ -314,7 +314,9 @@ namespace Gfx::WindowCapture
 {
 
 // Forward declaration from the X11 backend
+#if defined(HAS_X11_WINDOW_CAPTURE)
 std::unique_ptr<WindowCaptureBackend> createX11Backend();
+#endif
 
 // Function pointer types for the PipeWire C API (no headers needed)
 extern "C"
@@ -1559,8 +1561,10 @@ private:
 std::unique_ptr<WindowCaptureBackend> createWindowCaptureBackend()
 {
   // Try X11 first (works on X11 sessions and XWayland)
+#if defined(HAS_X11_WINDOW_CAPTURE)
   if(auto x11 = createX11Backend())
     return x11;
+#endif
 
   // Try PipeWire (native Wayland via xdg-desktop-portal)
   auto pw = std::make_unique<PipeWireWindowCaptureBackend>();

--- a/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
@@ -9,37 +9,7 @@
 namespace vst3
 {
 
-#if defined(_WIN32)
-class PlugFrame final : public Steinberg::IPlugFrame
-{
-public:
-  Steinberg::tresult queryInterface(const Steinberg::TUID _iid, void** obj) override
-  {
-    *obj = nullptr;
-    return Steinberg::kResultFalse;
-  }
-
-  Steinberg::uint32 addRef() override { return 1; }
-  Steinberg::uint32 release() override { return 1; }
-
-  QDialog* w;
-  WindowContainer wc;
-  PlugFrame(QDialog& w, WindowContainer& wc)
-      : w{&w}
-      , wc{wc}
-  {
-  }
-
-  Steinberg::tresult
-  resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override
-  {
-    wc.setSizeFromVst(*view, *newSize, *w);
-    return Steinberg::kResultOk;
-  }
-};
-#endif
-
-#if defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__) || !__has_include(<xcb/xcb.h>)
 class PlugFrame final : public Steinberg::IPlugFrame
 {
 public:


### PR DESCRIPTION
Make score's X11-dependent parts optional, so it can be configured and built on a Linux sysroot that has no X11/xcb headers (embedded images, headless containers).

## The problem

`find_package(X11 QUIET)` in the root `CMakeLists.txt` is fine on its own, but when X11 is absent it leaves `X11_X11_INCLUDE_PATH` set to `NOTFOUND`. `src/linuxcheck/CMakeLists.txt` passes that straight to `target_include_directories`, and CMake then fails the **whole project's** generate step, not just that one target:

```
CMake Error: The following variables are used in this project, but they are
set to NOTFOUND: .../src/linuxcheck/X11_X11_INCLUDE_PATH
```

Past that point, two more sites assumed X11/xcb:

- `score-plugin-gfx` compiled `Gfx/WindowCapture/WindowCapture_x11.cpp` unconditionally on non-Windows / non-Apple. It `#include`s `<X11/Xlib.h>` plus the XShm / Xcomposite / Xrandr extension headers for their types, even though it `dlopen`s the libraries at runtime through `dylib_loader`.
- `score-plugin-vst3` was already half-guarded: `Vst3/UI/Linux/PlugFrame.hpp` defines the xcb-based `PlugFrame` only under `__has_include(<xcb/xcb.h>)`, but `Vst3/UI/Window.cpp` uses `vst3::PlugFrame` unconditionally, so a Linux build without xcb failed with *"invalid use of incomplete type"*.

## The change

- **linuxcheck**: `return()` early when `X11_FOUND` is false. It is a diagnostics helper, so it costs nothing where there is no X11 to diagnose.
- **gfx**: add `WindowCapture_x11.cpp` to the sources only when `X11_FOUND`, and define `HAS_X11_WINDOW_CAPTURE` on exactly that same condition. The `createX11Backend()` forward declaration and its call in `createWindowCaptureBackend()` are guarded by that define. Window capture keeps working without X11 through the PipeWire backend, which the factory already falls through to.
- **vst3**: turn the plain resize-only `PlugFrame` that Windows and macOS already used into the general fallback, under `#if defined(_WIN32) || defined(__APPLE__) || !__has_include(<xcb/xcb.h>)` — the exact complement of the condition in `Linux/PlugFrame.hpp`, so exactly one definition of `vst3::PlugFrame` is ever visible. VST3 plug-ins still load and process audio on such a build; only editor embedding is unavailable.

Note that `src/lib/score/tools/InvisibleWindow.hpp` was **already** correctly optional via `__has_include` and needed no change — the codebase already had this pattern, and these two places had simply drifted from it.

Four files touched, all under `src/`.

## Verification status

**Verified — the X11-absent path.** With these commits, score configures, compiles, installs and packages cleanly in a Yocto/OpenEmbedded build for `qemux86-64` with `x11` removed from `DISTRO_FEATURES` (Qt 6.12, GCC 15, C++23, `-O3`, unity builds, static plugins). A full `ossia-score-image` was produced.

**Not verified here — the X11-present path**, i.e. a normal desktop build. Every guard added is the exact logical complement of a condition that already existed, so an X11-present build should be byte-for-byte unchanged in behaviour, but that has not been compiled locally. The distro CI legs are what will confirm it.

One thing to keep in mind on the X11-present side: `cmake/Deployment/Linux/AppImage/AppRun` invokes the `linuxcheck` binary, so it matters that the AppImage build environment does have the X11 headers — it does, and linuxcheck is still built there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
