### PR TITLE
yocto: add meta-ossia layer for building flashable score images

### DIFF
--- a/cmake/Deployment/Linux/Yocto/README.md
+++ b/cmake/Deployment/Linux/Yocto/README.md
@@ -58,8 +58,17 @@ stall.
 ### Running it
 
 ```bash
-kas shell kas/whinlatter-qemux86-64.yml -c "runqemu nographic ossia-score-image"
+kas shell kas/whinlatter-qemux86-64.yml -c \
+  "runqemu kvm nographic slirp snapshot ossia-score-image qemuparams='-m 2048'"
 ```
+
+Two arguments there are not optional in practice:
+
+* **`kvm`** — runqemu does *not* enable KVM unless you ask. Without it every guest
+  instruction is interpreted and the whole system is roughly 3x slower, which
+  distorts any measurement you take (it inflated our first power-to-GUI figure
+  from 6.1s to 18.4s, most of it in software rasterisation).
+* **`-m 2048`** — the 256 MB default is not enough; see the sizing note below.
 
 then on the target:
 
@@ -71,6 +80,56 @@ ossia-score-launch vulkan                           # vkkhrdisplay, fastest
 
 `ossia-score.service` is installed but not enabled; `systemctl enable
 ossia-score` turns the image into a kiosk.
+
+## Sizing and boot time
+
+score's resident set is **~312 MB** once the UI is up, before any document is
+loaded. Below roughly 512 MB it does not degrade, it dies: at 256 MB it
+segfaults during startup on an allocation failure and the restarted instance is
+OOM-killed. **Budget 1 GB or more.**
+
+Measured power-to-GUI on qemux86-64 with 2 GB, from power-on to the start screen
+being painted:
+
+| | KVM + virgl | KVM, software GL | TCG, software GL |
+|---|---|---|---|
+| kernel | 1.05s | 0.66s | 1.93s |
+| score forked | 2.36s | 1.76s | 6.48s |
+| score's own startup | **0.64s** | 4.3s | 11.9s |
+| **start screen painted** | **≈3.0s** | 6.1s | 18.4s |
+| `Startup finished` (systemd) | 2.64s | 1.84s | 7.26s |
+| RSS | 206 MB | 312 MB | 312 MB |
+
+The third column is what you get by accident, so it is worth being explicit: the
+`kvm` argument and a GPU account for a 6x difference in power-to-GUI, and most
+of what looks like "score is slow to start" is neither score nor this layer.
+
+For the middle and left columns, qemu needs a virtio GPU. runqemu's
+`egl-headless` option gives one:
+
+```bash
+runqemu kvm slirp snapshot egl-headless ossia-score-image qemuparams='-m 2048'
+```
+
+Nothing has to be rebuilt for this -- mesa enables the `virgl` Gallium driver
+whenever `opengl` is in `DISTRO_FEATURES`, and qemu-system-native picks up
+`virglrenderer` on the same condition. To confirm it actually engaged, check
+that score logs no "Running on a software rasterizer" warning and that
+`/sys/class/drm/` has a `renderD*` node (plain stdvga has none). Note that
+`screendump` cannot capture under `egl-headless` -- there is no host surface --
+so verify through `/sys/kernel/debug/dri/0/state` instead, where the scanout
+framebuffer should show `allocated by = ossia-score`.
+
+The service starts at `sysinit.target` with `DefaultDependencies=no`, ordered
+only after `local-fs.target` and udev, so score forks 8 ms after the root
+filesystem is up -- ahead of `basic.target` and `multi-user.target`. Networking,
+avahi, bluetooth and sshd all come up during the several seconds score spends in
+its own startup, which is time that would otherwise be spent waiting.
+
+What is left is almost entirely score's own initialisation, and most of that is
+software rasterisation: qemu has no GPU, so Qt falls back to LLVMpipe. On real
+hardware with a working DRM driver that portion largely disappears. Enabling
+virtio-gpu with virgl would remove it here too.
 
 ## What score itself needs
 

--- a/cmake/Deployment/Linux/Yocto/README.md
+++ b/cmake/Deployment/Linux/Yocto/README.md
@@ -1,0 +1,184 @@
+# ossia score on Yocto / OpenEmbedded
+
+`meta-ossia` builds ossia score into a bare-bones, flashable Linux image: kernel,
+init, audio and GPU stacks, and score. No desktop environment. The goal is the
+full score feature set on an appliance, not a small image.
+
+## What is pinned
+
+| | |
+|---|---|
+| openembedded-core | `yocto-5.3.4` (**whinlatter**) |
+| bitbake | `yocto-5.3.4` |
+| meta-openembedded | `whinlatter` |
+| meta-qt6 | `6.12` → Qt **6.12.0** |
+| Boost | **1.89.0** (from oe-core) |
+| GCC | **15** |
+| CMake | 4.1.2 |
+| ffmpeg | 8.0 |
+| C library | **glibc** |
+
+There is no `poky/whinlatter` branch — poky stops at walnascar — so the stack is
+openembedded-core plus bitbake directly, and the distro config lives here
+(`meta-ossia/conf/distro/ossia.conf`) instead of coming from meta-poky.
+
+Boost 1.89 falls inside the window libossia probes
+(`3rdparty/libossia/cmake/deps/boost.cmake`, `find_package(Boost 1.N EXACT)` from
+`BOOST_MINOR_LATEST` down to `BOOST_MINOR_MINIMAL`). That matters: outside it,
+the CMake code falls back to downloading a Boost tarball at configure time,
+which cannot work under BitBake's offline `do_configure`. If you move this layer
+to a newer series, check that pairing first — wrynose is 1.90 (fine), oe-core
+master is 1.91 (needs `BOOST_MINOR_LATEST` bumped in libossia).
+
+`LAYERSERIES_COMPAT` also declares `wrynose` and `blacksail`; nothing in the
+recipes depends on anything that changed between those series. blacksail
+additionally needs meta-qt6 to declare compatibility, which it currently does
+not.
+
+## Building
+
+Needs [kas](https://github.com/siemens/kas) (`pip install kas`) and the standard
+Yocto host packages.
+
+```bash
+cd cmake/Deployment/Linux/Yocto
+./build.sh                              # qemux86-64
+./build.sh whinlatter-raspberrypi4-64   # Pi 4 / CM4, writes a .wic.bz2
+```
+
+Budget several hours and 90–120 GB for the first build. Set `DL_DIR` and
+`SSTATE_DIR` (or `OSSIA_YOCTO_WORK_DIR`) somewhere persistent before you start —
+otherwise every rebuild starts from zero. `rm_work` is on by default, which keeps
+the work directories from running to tens of GB.
+
+Bring `core-image-minimal` up on your target *before* adding score. Debugging a
+fresh BitBake setup and a Qt cross-build at the same time is how these ports
+stall.
+
+### Running it
+
+```bash
+kas shell kas/whinlatter-qemux86-64.yml -c "runqemu nographic ossia-score-image"
+```
+
+then on the target:
+
+```bash
+ossia-score-launch cli --script /path/to/scene.js   # headless
+ossia-score-launch eglfs                            # GPU, straight to DRM/KMS
+ossia-score-launch vulkan                           # vkkhrdisplay, fastest
+```
+
+`ossia-score.service` is installed but not enabled; `systemctl enable
+ossia-score` turns the image into a kiosk.
+
+## What score itself needs
+
+The distro drops `x11` from `DISTRO_FEATURES`, which means score is built with no
+X11 or xcb headers at all. That requires the X11-optional changes in
+`src/linuxcheck`, `score-plugin-gfx` and `score-plugin-vst3` (score PR #2170).
+Without them, configure fails on `X11_X11_INCLUDE_PATH` being `NOTFOUND` before
+anything is compiled. Add `x11` back to `DISTRO_FEATURES` if you are building an
+older score.
+
+`rapidfuzz-cpp` is packaged here (`recipes-support/`) because libossia calls
+`find_package(rapidfuzz CONFIG REQUIRED)` under `OSSIA_USE_SYSTEM_LIBRARIES`,
+which aborts before its own vendored fallback can run. libossia PR #919 fixes
+that upstream; once it lands the recipe becomes optional rather than required.
+
+## Feature coverage
+
+Everything that cross-compiles is built — all plugins, all addons. Two
+exclusions, both technical rather than size-driven, via `SCORE_DISABLED_PLUGINS`
+in the recipe:
+
+- **`score-addon-onnx`** — `FetchContent`s a *prebuilt x86_64* onnxruntime during
+  configure. Needs the network, and the binaries do not cross-compile.
+- **`score-addon-ultraleap`** — pulls a proprietary SDK at configure time.
+
+Three plugins will self-disable because no OE recipe exists for their
+dependency. They use `find_package(...)` + `if(NOT TARGET ...) return()`, so the
+build succeeds and simply lacks them:
+
+| plugin | needs | upstream |
+|---|---|---|
+| `score-plugin-lv2` | lilv, suil, lv2 | https://gitlab.com/lv2 (meson) |
+| `score-plugin-faust` | libfaust + faustlibraries | https://github.com/grame-cncm/faust — pin `730eff6d` for the libs, as `score-plugin-faust/CMakeLists.txt` does |
+| `score-plugin-ysfx` | ysfx | https://github.com/jpcima/ysfx |
+
+Writing those four recipes is the remaining work for genuinely complete feature
+parity. Everything else — gfx, JS, media, VST3, CLAP, Pd, protocols, the whole
+avnd plugin set, and the remaining 18 addons — builds from the vendored tree.
+
+`SCORE_USE_SYSTEM_LIBRARIES=1` is set, but it is a *preference*: libossia's
+`cmake/deps/*.cmake` fall back to the vendored copy when a package is missing, so
+the many dependencies with no OE recipe (fmt, rapidfuzz, rubberband,
+libsamplerate, zita, …) resolve in-tree. It is also what suppresses the
+faustlibs `ExternalProject` git fetch, which would otherwise need the network
+during `do_compile`.
+
+## Performance
+
+- `-O3` for score (`FULL_OPTIMIZATION` in the recipe); OE's default is `-O2`.
+  Debug flags are left alone so `-dbg` packages still work.
+- Release build, unity build, static plugins — one binary, no plugin `.so`
+  indirection, no rpath lookups.
+- LTO is available but **off** by default: score links a single ~70 MB static
+  binary out of a unity build, and an LTO link at that size is very
+  memory-hungry on the build host. `OSSIA_SCORE_LTO = "1"` enables it.
+- Realtime scheduling is configured — `95-ossia-score-rt.conf` grants the
+  `audio` group `rtprio 95` and unlimited `memlock`, and the systemd unit
+  repeats those (units do not go through PAM). Without them the engine xruns
+  under load.
+- FFT goes through FFTW rather than KFR. That is what libossia selects for GCC
+  builds (`3rdparty/libossia.cmake`), and it is deliberate — `.cninja/developer-gcc.cmake`
+  turns KFR off for GCC.
+- Per-machine CPU tuning is `DEFAULTTUNE`'s job. `qemux86-64` is generic; set it
+  for real hardware.
+
+## Source
+
+The recipe builds the **release source archive**, not a git checkout — score has
+39 submodules, libossia 44 more, and `ci/common.deps.sh` clones ~20 addon
+repositories separately, so a `gitsm://` fetch of score alone would silently
+produce a build with no addons. The archive from `ci/tarball.build.sh` already
+contains all of it with the `.git` directories stripped, and is published on
+every release.
+
+`ossia-score_git.bb` is the default and builds, through `externalsrc`, whatever
+checkout this layer ships inside. That is deliberate for development but it is
+**not reproducible**: two people running the same command get whatever is in
+their own tree. For a build anyone can reproduce, pin the release recipe:
+
+```
+PREFERRED_VERSION_ossia-score = "3.8.2"
+```
+
+To build a different working tree instead, in `local.conf`:
+
+```
+INHERIT += "externalsrc"
+EXTERNALSRC:pn-ossia-score = "/path/to/score"
+EXTERNALSRC_BUILD:pn-ossia-score = "/path/to/score-yocto-build"
+```
+
+Make sure submodules and addons are checked out (`git submodule update --init
+--recursive` plus `ci/common.deps.sh LINUX`) — the recipe cannot do it for you,
+since `do_fetch` is the only task allowed network access.
+
+## Known rough edges
+
+- `cmake/ScoreDeploymentLinux.cmake` runs `dpkg --print-architecture` and reads
+  `/etc/lsb-release` at configure time to populate CPack variables. Under
+  BitBake it reads the *host* distro. Harmless (nothing consumes those variables
+  here) but it makes configure non-reproducible; worth guarding behind
+  `NOT CMAKE_CROSSCOMPILING` upstream.
+- `ossia_git_info.cmake` shells out to `git describe`; from a tarball it yields
+  `GIT-NOTFOUND` in the version string.
+- `inherit qt6-cmake` passes Qt's `-DINSTALL_*DIR` variables, which score does
+  not consume. CMake will warn about unused variables. Harmless.
+- The image is not size-tuned, by design. Measured on qemux86-64: the stripped
+  `ossia-score` binary is **83 MB** (109 MB before stripping) since everything is
+  statically linked into it, `.wic.xz` is **186 MB** and `.ext4.zst` **230 MB**,
+  across 901 packages. The `common/qtfeatures` file in the `ossia/sdk` repo is a
+  ready-made minimal Qt configuration if that ever matters.

--- a/cmake/Deployment/Linux/Yocto/README.md
+++ b/cmake/Deployment/Linux/Yocto/README.md
@@ -43,13 +43,13 @@ Yocto host packages.
 ```bash
 cd cmake/Deployment/Linux/Yocto
 ./build.sh                              # qemux86-64
-./build.sh whinlatter-raspberrypi4-64   # Pi 4 / CM4, writes a .wic.bz2
+./build.sh whinlatter-raspberrypi5      # Pi 5 / CM5, writes a .wic.bz2
+OSSIA_YOCTO_TARGET=ossia-score-image-appliance ./build.sh
 ```
 
-Budget several hours and 90–120 GB for the first build. Set `DL_DIR` and
-`SSTATE_DIR` (or `OSSIA_YOCTO_WORK_DIR`) somewhere persistent before you start —
-otherwise every rebuild starts from zero. `rm_work` is on by default, which keeps
-the work directories from running to tens of GB.
+Budget several hours and 90–120 GB for the first build. `DL_DIR` and
+`SSTATE_DIR` default to alongside the build directory so every machine shares
+them; override them in `local.conf` to put them elsewhere. `rm_work` is on.
 
 Bring `core-image-minimal` up on your target *before* adding score. Debugging a
 fresh BitBake setup and a Qt cross-build at the same time is how these ports
@@ -58,17 +58,13 @@ stall.
 ### Running it
 
 ```bash
-kas shell kas/whinlatter-qemux86-64.yml -c \
-  "runqemu kvm nographic slirp snapshot ossia-score-image qemuparams='-m 2048'"
+./run.sh                       # qemux86-64, boots and opens a viewer
+OSSIA_QEMU_MEM=4096 ./run.sh   # more RAM
 ```
 
-Two arguments there are not optional in practice:
-
-* **`kvm`** — runqemu does *not* enable KVM unless you ask. Without it every guest
-  instruction is interpreted and the whole system is roughly 3x slower, which
-  distorts any measurement you take (it inflated our first power-to-GUI figure
-  from 6.1s to 18.4s, most of it in software rasterisation).
-* **`-m 2048`** — the 256 MB default is not enough; see the sizing note below.
+`run.sh` uses KVM and virgl, which together are worth about 6x on power-to-GUI,
+and displays over VNC. Without `kvm` every guest instruction is interpreted and
+the whole system is roughly 3x slower, which distorts any measurement.
 
 then on the target:
 
@@ -81,12 +77,77 @@ ossia-score-launch vulkan                           # vkkhrdisplay, fastest
 `ossia-score.service` is installed but not enabled; `systemctl enable
 ossia-score` turns the image into a kiosk.
 
+### No init system at all
+
+For a fixed-function appliance that will never touch the network, score can be
+PID 1:
+
+```
+init=/usr/bin/ossia-score-init
+```
+
+**Not `init=/usr/bin/ossia-score` directly** — that panics the kernel roughly
+50 ms after handoff:
+
+```
+Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b
+```
+
+Two separate reasons, both fatal on their own. score dies immediately in an
+environment with no `/proc` and no `/sys` (Mesa enumerates DRM devices through
+`/sys/class/drm`), and because it is PID 1 the SIGSEGV becomes a panic instead
+of an exit. `ossia-score-init` is a ~30-line shell script that mounts what is
+missing, sets `XDG_RUNTIME_DIR`/`XDG_CACHE_HOME`, and then runs score **as a
+child in a restart loop rather than `exec`ing it** — so a crash restarts rather
+than panicking, and PID 1's zombie reaping covers the VST/VST3/CLAP puppets and
+Faust processes score forks. `CONFIG_DEVTMPFS_MOUNT=y` means `/dev`, including
+`/dev/dri`, is already populated without udev, which is the one piece that would
+otherwise be genuinely awkward.
+
+Verified on qemux86-64: the full UI comes up, with no systemd, no udev, no
+getty, no journal. Measured from qemu start, software rasteriser, KVM, 8 vCPU:
+
+| | |
+|---|---|
+| kernel init done | 1.07s |
+| score's first output | 1.20s |
+| engine listening | 1.33s |
+| GL context created | 1.37s |
+| startup chatter ends | 1.53s |
+
+Against the systemd path measured the same way — the two runs agree on kernel
+init to within 11 ms, which is what makes the rest comparable:
+
+| | `init=` | systemd |
+|---|---|---|
+| kernel init done | 1.066s | 1.077s |
+| score's first output | **1.203s** | 2.371s |
+| engine listening | **1.326s** | 2.508s |
+
+So dropping init saves about **1.2s** of pre-score userspace. Treat that as an
+upper bound: getting score's output onto the serial console under systemd needs
+`systemd.journald.forward_to_console=1`, and echoing the journal to a UART is
+itself not free, so some of the gap is the measurement. Note also that score's
+own startup dominates either way — this is ~1.2s off a figure where score itself
+accounts for several seconds.
+
+What you give up is worth stating plainly: no hotplug (a USB MIDI interface or a
+display connected after boot will not appear), no networking, no ssh, no logs.
+That is a different set of trade-offs from the systemd image, not a strictly
+better one — the systemd path reaches the same UI and keeps all of it.
+
+One thing to fix before shipping this mode: score's startup update check stalls
+for **~2.8s** on DNS when there is no network (`Host ossia.io not found`, then
+the `addons.json` fetch). It does not block first paint, but it is pure waste on
+an offline appliance. See the `StartScreen.hpp` note in the upstream list.
+
 ## Sizing and boot time
 
-score's resident set is **~312 MB** once the UI is up, before any document is
-loaded. Below roughly 512 MB it does not degrade, it dies: at 256 MB it
-segfaults during startup on an allocation failure and the restarted instance is
-OOM-killed. **Budget 1 GB or more.**
+score's resident set is **~250 MB** once the UI is up, of which ~110 MB is
+dirty; the rest is file-backed and evictable. Measured floors on qemux86-64:
+**192 MB** for `ossia-score-image-appliance`, and more for `ossia-score-image`,
+which also carries systemd. Below that score is OOM-killed during startup, where
+it transiently allocates well above its steady state. **Budget 512 MB or more.**
 
 Measured power-to-GUI on qemux86-64 with 2 GB, from power-on to the start screen
 being painted:
@@ -155,19 +216,16 @@ in the recipe:
   configure. Needs the network, and the binaries do not cross-compile.
 - **`score-addon-ultraleap`** — pulls a proprietary SDK at configure time.
 
-Three plugins will self-disable because no OE recipe exists for their
-dependency. They use `find_package(...)` + `if(NOT TARGET ...) return()`, so the
-build succeeds and simply lacks them:
+`score-plugin-lv2`, `score-plugin-faust` and `score-plugin-ysfx` are built
+against recipes in `meta-ossia/recipes-support` (lv2kit, faust, faustlibraries,
+ysfx). They use `find_package(...)` + `if(NOT TARGET ...) return()`, so dropping
+a PACKAGECONFIG silently drops the plugin rather than failing the build.
 
-| plugin | needs | upstream |
-|---|---|---|
-| `score-plugin-lv2` | lilv, suil, lv2 | https://gitlab.com/lv2 (meson) |
-| `score-plugin-faust` | libfaust + faustlibraries | https://github.com/grame-cncm/faust — pin `730eff6d` for the libs, as `score-plugin-faust/CMakeLists.txt` does |
-| `score-plugin-ysfx` | ysfx | https://github.com/jpcima/ysfx |
-
-Writing those four recipes is the remaining work for genuinely complete feature
-parity. Everything else — gfx, JS, media, VST3, CLAP, Pd, protocols, the whole
-avnd plugin set, and the remaining 18 addons — builds from the vendored tree.
+`score-plugin-jit` needs LLVM and Clang for the target, which is an hour of
+build time and ~58 MB of packages; `PACKAGECONFIG:remove:pn-ossia-score = "jit"`
+turns it off. Everything else — gfx, JS, media, VST3, CLAP, Pd, protocols, the
+whole avnd plugin set and the remaining 18 addons — builds from the vendored
+tree.
 
 `SCORE_USE_SYSTEM_LIBRARIES=1` is set, but it is a *preference*: libossia's
 `cmake/deps/*.cmake` fall back to the vendored copy when a package is missing, so

--- a/cmake/Deployment/Linux/Yocto/build.sh
+++ b/cmake/Deployment/Linux/Yocto/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+# Build an ossia score Yocto image locally.
+#
+#   ./build.sh                              # qemux86-64, ossia-score-image
+#   ./build.sh whinlatter-raspberrypi4-64   # a different kas config
+#   ./build.sh whinlatter-qemux86-64 shell  # drop into a bitbake shell
+#
+# Requires kas (pip install kas) and the host packages listed at
+# https://docs.yoctoproject.org/ref-manual/system-requirements.html
+#
+# Expect the first build to take several hours and 90-120 GB of disk. Set
+# OSSIA_YOCTO_BUILD_DIR, DL_DIR and SSTATE_DIR to persistent locations if you
+# intend to iterate -- see the README.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCORE_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+CONFIG="${1:-whinlatter-qemux86-64}"
+COMMAND="${2:-build}"
+
+KAS_FILE="$SCRIPT_DIR/kas/$CONFIG.yml"
+if [[ ! -f "$KAS_FILE" ]]; then
+  echo "No such kas config: $KAS_FILE" >&2
+  echo "Available:" >&2
+  ls -1 "$SCRIPT_DIR/kas/" | sed 's/\.yml$//;s/^/  /' >&2
+  exit 1
+fi
+
+export KAS_WORK_DIR="${OSSIA_YOCTO_WORK_DIR:-$SCORE_DIR/../score-yocto}"
+export KAS_BUILD_DIR="${OSSIA_YOCTO_BUILD_DIR:-$KAS_WORK_DIR/build}"
+mkdir -p "$KAS_WORK_DIR" "$KAS_BUILD_DIR"
+
+# kas resolves the meta-ossia repo entry relative to the checkout it is run
+# from, so point it at the score tree rather than the Yocto directory.
+cd "$SCORE_DIR"
+
+echo "score:  $SCORE_DIR"
+echo "config: $CONFIG"
+echo "work:   $KAS_WORK_DIR"
+echo "build:  $KAS_BUILD_DIR"
+
+exec kas "$COMMAND" "$KAS_FILE"

--- a/cmake/Deployment/Linux/Yocto/build.sh
+++ b/cmake/Deployment/Linux/Yocto/build.sh
@@ -27,7 +27,7 @@ if [[ ! -f "$KAS_FILE" ]]; then
 fi
 
 export KAS_WORK_DIR="${OSSIA_YOCTO_WORK_DIR:-$SCORE_DIR/../score-yocto}"
-export KAS_BUILD_DIR="${OSSIA_YOCTO_BUILD_DIR:-$KAS_WORK_DIR/build}"
+export KAS_BUILD_DIR="${OSSIA_YOCTO_BUILD_DIR:-$KAS_WORK_DIR/build-$CONFIG}"
 mkdir -p "$KAS_WORK_DIR" "$KAS_BUILD_DIR"
 
 # kas resolves the meta-ossia repo entry relative to the checkout it is run

--- a/cmake/Deployment/Linux/Yocto/build.sh
+++ b/cmake/Deployment/Linux/Yocto/build.sh
@@ -22,7 +22,7 @@ KAS_FILE="$SCRIPT_DIR/kas/$CONFIG.yml"
 if [[ ! -f "$KAS_FILE" ]]; then
   echo "No such kas config: $KAS_FILE" >&2
   echo "Available:" >&2
-  ls -1 "$SCRIPT_DIR/kas/" | sed 's/\.yml$//;s/^/  /' >&2
+  find "$SCRIPT_DIR/kas" -maxdepth 1 -name '*.yml' -exec basename {} .yml \; | sed 's/^/  /' >&2
   exit 1
 fi
 
@@ -39,4 +39,5 @@ echo "config: $CONFIG"
 echo "work:   $KAS_WORK_DIR"
 echo "build:  $KAS_BUILD_DIR"
 
-exec kas "$COMMAND" "$KAS_FILE"
+# --target so ossia-score-image-appliance is reachable without editing YAML.
+exec kas "$COMMAND" ${OSSIA_YOCTO_TARGET:+--target "$OSSIA_YOCTO_TARGET"} "$KAS_FILE"

--- a/cmake/Deployment/Linux/Yocto/kas/whinlatter-orangepi-5-plus.yml
+++ b/cmake/Deployment/Linux/Yocto/kas/whinlatter-orangepi-5-plus.yml
@@ -1,0 +1,39 @@
+header:
+  version: 14
+  includes:
+    - whinlatter-qemux86-64.yml
+
+# Orange Pi 5 Plus (Rockchip RK3588, Mali-G610). Produces a .wic that goes to
+# eMMC, NVMe or an SD card.
+machine: orangepi-5-plus
+
+repos:
+  meta-arm:
+    url: https://git.yoctoproject.org/meta-arm
+    refspec: whinlatter
+    layers:
+      meta-arm:
+      meta-arm-toolchain:
+
+  meta-rockchip:
+    url: https://git.yoctoproject.org/meta-rockchip
+    refspec: whinlatter
+
+local_conf_header:
+  rk3588: |
+    # meta-rockchip's mesa bbappend skips rk3588, so the GPU is off by default
+    # and the board silently runs on llvmpipe. Mali-G610 = panthor + panfrost.
+    # libclc is required with it: GALLIUMDRIVERS and VULKAN_DRIVERS are gated on
+    # 'panfrost libclc' together, and oe-core only adds libclc on x86.
+    PACKAGECONFIG:append:pn-mesa = " kmsro panfrost libclc"
+
+    # panthor will not probe without ARM's CSF firmware; G610 is arch 10.8.
+    IMAGE_INSTALL:append = " linux-firmware-mali-csffw-arch108"
+
+    # No hardware video decode for score: mainline rkvdec2 is a stateless V4L2
+    # device needing the request API, which upstream ffmpeg does not support.
+    # (meta-rockchip's ENABLE_STATELESS_VPU_GST covers GStreamer only.)
+    # Verify after first boot:
+    #   ls /sys/class/drm/                 -> card0 + renderD128 present
+    #   dmesg | grep -i panthor            -> firmware loaded, no probe error
+    #   score's log must NOT say "Running on a software rasterizer"

--- a/cmake/Deployment/Linux/Yocto/kas/whinlatter-qemux86-64.yml
+++ b/cmake/Deployment/Linux/Yocto/kas/whinlatter-qemux86-64.yml
@@ -1,0 +1,65 @@
+header:
+  version: 14
+
+distro: ossia
+machine: qemux86-64
+target: ossia-score-image
+
+# Yocto 5.3 (whinlatter). Note there is no poky/whinlatter branch -- poky stops
+# at walnascar -- so the stack is openembedded-core plus bitbake directly.
+repos:
+  meta-ossia:
+    # This layer, i.e. the checkout kas was pointed at.
+    layers:
+      cmake/Deployment/Linux/Yocto/meta-ossia:
+
+  openembedded-core:
+    url: https://git.openembedded.org/openembedded-core
+    refspec: yocto-5.3.4
+    layers:
+      meta:
+
+  bitbake:
+    url: https://git.openembedded.org/bitbake
+    refspec: yocto-5.3.4
+    # bitbake is not a layer; it is only checked out so that oe-init-build-env
+    # finds it. Without this kas adds every repo root to BBLAYERS.
+    layers:
+      .: excluded
+
+  meta-openembedded:
+    url: https://git.openembedded.org/meta-openembedded
+    refspec: whinlatter
+    layers:
+      meta-oe:
+      meta-multimedia:
+      meta-networking:
+      meta-python:
+
+  meta-qt6:
+    url: https://code.qt.io/yocto/meta-qt6.git
+    refspec: "6.12"
+
+bblayers_conf_header:
+  standard: |
+    POKY_BBLAYERS_CONF_VERSION = "2"
+    BBPATH = "${TOPDIR}"
+    BBFILES ?= ""
+
+local_conf_header:
+  standard: |
+    CONF_VERSION = "2"
+    PACKAGE_CLASSES = "package_ipk"
+    USER_CLASSES = "buildstats"
+
+  disk: |
+    # A score build is large; without rm_work the work directories alone run to
+    # tens of GB. Point DL_DIR/SSTATE_DIR somewhere persistent outside the build
+    # tree so a wipe does not cost you the whole rebuild.
+    INHERIT += "rm_work"
+    BB_DISKMON_DIRS = "STOPTASKS,${TMPDIR},1G,100K HALT,${TMPDIR},100M,1K"
+
+  performance: |
+    # -O3 for score itself is set in the recipe (FULL_OPTIMIZATION). Set this to
+    # "1" to additionally enable LTO -- expect a very large link step.
+    OSSIA_SCORE_LTO = "0"

--- a/cmake/Deployment/Linux/Yocto/kas/whinlatter-qemux86-64.yml
+++ b/cmake/Deployment/Linux/Yocto/kas/whinlatter-qemux86-64.yml
@@ -63,6 +63,11 @@ local_conf_header:
     DL_DIR ?= "${TOPDIR}/../downloads"
     SSTATE_DIR ?= "${TOPDIR}/../sstate-cache"
 
+    # No debug info except in score itself. With -g, target clang and
+    # qtdeclarative are 28-29 GB of build tree each, which does not fit.
+    # Part of every task hash: changing it forces a full rebuild.
+    DEBUG_LEVELFLAG = "-g0"
+    DEBUG_LEVELFLAG:pn-ossia-score = "-g"
 
   performance: |
     # -O3 for score itself is set in the recipe (FULL_OPTIMIZATION). Set this to

--- a/cmake/Deployment/Linux/Yocto/kas/whinlatter-qemux86-64.yml
+++ b/cmake/Deployment/Linux/Yocto/kas/whinlatter-qemux86-64.yml
@@ -54,10 +54,15 @@ local_conf_header:
 
   disk: |
     # A score build is large; without rm_work the work directories alone run to
-    # tens of GB. Point DL_DIR/SSTATE_DIR somewhere persistent outside the build
-    # tree so a wipe does not cost you the whole rebuild.
+    # tens of GB.
     INHERIT += "rm_work"
     BB_DISKMON_DIRS = "STOPTASKS,${TMPDIR},1G,100K HALT,${TMPDIR},100M,1K"
+
+    # Shared across every build-<machine>/ dir: sources are machine-independent
+    # and *-native sstate is reused wholesale (54% hit rate on a new machine).
+    DL_DIR ?= "${TOPDIR}/../downloads"
+    SSTATE_DIR ?= "${TOPDIR}/../sstate-cache"
+
 
   performance: |
     # -O3 for score itself is set in the recipe (FULL_OPTIMIZATION). Set this to

--- a/cmake/Deployment/Linux/Yocto/kas/whinlatter-raspberrypi4-64.yml
+++ b/cmake/Deployment/Linux/Yocto/kas/whinlatter-raspberrypi4-64.yml
@@ -1,0 +1,23 @@
+header:
+  version: 14
+  includes:
+    - whinlatter-qemux86-64.yml
+
+# Same Yocto 5.3 stack, targeting a Pi 4 / Pi 400 / CM4. Produces a
+# .wic.bz2 that bmaptool or dd writes straight to an SD card.
+machine: raspberrypi4-64
+
+repos:
+  meta-raspberrypi:
+    url: https://github.com/agherzan/meta-raspberrypi
+    refspec: whinlatter
+
+local_conf_header:
+  raspberrypi: |
+    # The Pi's VideoCore needs the vc4 KMS driver for score to get a GPU;
+    # without this eglfs falls back to software rendering.
+    RASPBERRYPI_CAMERA_V2 = "0"
+    ENABLE_UART = "1"
+    DISABLE_OVERSCAN = "1"
+    GPU_MEM = "256"
+    IMAGE_FSTYPES:forcevariable = "wic.bz2 wic.bmap"

--- a/cmake/Deployment/Linux/Yocto/kas/whinlatter-raspberrypi4-64.yml
+++ b/cmake/Deployment/Linux/Yocto/kas/whinlatter-raspberrypi4-64.yml
@@ -14,8 +14,10 @@ repos:
 
 local_conf_header:
   raspberrypi: |
-    # The Pi's VideoCore needs the vc4 KMS driver for score to get a GPU;
-    # without this eglfs falls back to software rendering.
+    # Required or the image will not parse; see
+    # meta-raspberrypi/docs/ipcompliance.md before shipping.
+    LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
+
     RASPBERRYPI_CAMERA_V2 = "0"
     ENABLE_UART = "1"
     DISABLE_OVERSCAN = "1"

--- a/cmake/Deployment/Linux/Yocto/kas/whinlatter-raspberrypi5.yml
+++ b/cmake/Deployment/Linux/Yocto/kas/whinlatter-raspberrypi5.yml
@@ -1,0 +1,30 @@
+header:
+  version: 14
+  includes:
+    - whinlatter-qemux86-64.yml
+
+# Same Yocto 5.3 stack, targeting a Pi 5 / CM5. Produces a .wic.bz2 that
+# bmaptool or dd writes straight to an SD card or NVMe.
+machine: raspberrypi5
+
+repos:
+  meta-raspberrypi:
+    url: https://github.com/agherzan/meta-raspberrypi
+    refspec: whinlatter
+
+local_conf_header:
+  raspberrypi5: |
+    # v3d/vc4 gallium come from meta-raspberrypi's mesa bbappend, and vulkan in
+    # DISTRO_FEATURES pulls v3dv with them. vc4graphics is on by default.
+    # Required or the image will not parse: the WiFi firmware in the machine's
+    # MACHINE_EXTRA_RRECOMMENDS is licence-gated. See
+    # meta-raspberrypi/docs/ipcompliance.md before shipping.
+    LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
+
+    RASPBERRYPI_CAMERA_V2 = "0"
+    ENABLE_UART = "1"
+    DISABLE_OVERSCAN = "1"
+
+    # No GPU_MEM: it is a VideoCore IV/VI split, inert on the Pi 5 (CMA).
+
+    IMAGE_FSTYPES:forcevariable = "wic.bz2 wic.bmap"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/conf/distro/ossia.conf
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/conf/distro/ossia.conf
@@ -13,6 +13,34 @@ TCLIBC = "glibc"
 
 INIT_MANAGER = "systemd"
 
+# journald is the log; busybox's syslogd and klogd duplicate it and cost two
+# units at boot. This has to be set at distro level -- packagegroup-core-boot
+# reads it while being parsed, so setting it in an image recipe is too late.
+VIRTUAL-RUNTIME_base-utils-syslog = ""
+
+# printk to a UART is synchronous: at 115200 baud a character costs ~87us and an
+# 80-column line ~7ms, so a few hundred boot messages is seconds of pure serial
+# wait. NVIDIA name console UART "a major bottleneck" for the Orin NX/Nano and
+# tell you to drop console= from p3767.conf.common; the same applies anywhere.
+#
+# quiet + loglevel=3 keeps warnings and errors while dropping the info chatter,
+# and systemd stops drawing its own status lines. Only one serial console is
+# spawned rather than two.
+#
+# Set OSSIA_VERBOSE_BOOT = "1" in local.conf to put the messages back -- which
+# you will want the first time a board does not come up, and which is why this
+# is a switch rather than a deletion.
+OSSIA_VERBOSE_BOOT ?= "0"
+OSSIA_QUIET_CMDLINE = "${@' quiet loglevel=3 systemd.show_status=0' if d.getVar('OSSIA_VERBOSE_BOOT') != '1' else ''}"
+APPEND:append = "${OSSIA_QUIET_CMDLINE}"
+# meta-raspberrypi builds cmdline.txt from CMDLINE and never reads APPEND.
+CMDLINE:append = "${OSSIA_QUIET_CMDLINE}"
+# No getty at all in the default build -- not on a VT, not on serial. Nothing
+# is ever printed to the panel, so it stays dark until score draws, and two
+# units leave the boot. Access is over ssh. OSSIA_VERBOSE_BOOT = "1" brings the
+# serial consoles back, which is what you want when a board will not come up.
+SERIAL_CONSOLES = "${@'115200;ttyS0 115200;ttyS1' if d.getVar('OSSIA_VERBOSE_BOOT') == '1' else ''}"
+
 DISTRO_FEATURES = " \
     acl \
     alsa \
@@ -46,15 +74,13 @@ DISTRO_FEATURES = " \
 #
 # Add "x11" back here to get the xcb platform plugin and the X11 window-capture
 # backend as well; the x11 PACKAGECONFIG in the recipe follows DISTRO_FEATURES.
-DISTRO_FEATURES:remove = "x11"
+# x11 is simply absent from DISTRO_FEATURES above; add it there to get the
+# xcb platform plugin and the X11 window-capture backend.
 
 PREFERRED_PROVIDER_virtual/libgl ?= "mesa"
 PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa"
 PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
 PREFERRED_PROVIDER_virtual/egl ?= "mesa"
-
-# Audio goes through PipeWire; score also speaks ALSA and JACK directly.
-VIRTUAL-RUNTIME_alsa-state = ""
 
 # ffmpeg is LGPL/GPL but carries LICENSE_FLAGS = "commercial" in oe-core.
 LICENSE_FLAGS_ACCEPTED += "commercial_ffmpeg"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/conf/distro/ossia.conf
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/conf/distro/ossia.conf
@@ -1,0 +1,68 @@
+DISTRO = "ossia"
+DISTRO_NAME = "ossia score appliance"
+DISTRO_VERSION = "1.0"
+DISTRO_CODENAME = "whinlatter"
+MAINTAINER = "ossia devs <contact@ossia.io>"
+
+SDK_VENDOR = "-ossiasdk"
+SDK_VERSION = "${@d.getVar('DISTRO_VERSION').replace('snapshot-${METADATA_REVISION}', 'snapshot')}"
+
+# glibc, explicitly. score and Qt are not tested against musl and this is not
+# the place to find out.
+TCLIBC = "glibc"
+
+INIT_MANAGER = "systemd"
+
+DISTRO_FEATURES = " \
+    acl \
+    alsa \
+    argp \
+    bluetooth \
+    ipv4 \
+    ipv6 \
+    largefile \
+    opengl \
+    pam \
+    seccomp \
+    systemd \
+    usbhost \
+    vulkan \
+    wayland \
+    xattr \
+    zeroconf \
+"
+
+# No X server on the appliance: score renders through eglfs/vkkhrdisplay on
+# DRM/KMS, or through wayland when a compositor is present. oe-core gates libx11
+# behind REQUIRED_DISTRO_FEATURES = "x11" (xorg-lib-common.inc), so dropping the
+# feature means score builds with no X11 headers at all. That works because the
+# X11-dependent parts are optional:
+#   src/lib/score/tools/InvisibleWindow.hpp    __has_include(<X11/Xlib.h>)
+#   src/plugins/score-plugin-vst3/Vst3/UI/     __has_include(<xcb/xcb.h>), with
+#                                              a resize-only PlugFrame fallback
+#   score-plugin-gfx window capture            X11 backend compiled only when
+#                                              X11_FOUND; PipeWire otherwise
+#   src/linuxcheck                             skipped when X11 is not found
+#
+# Add "x11" back here to get the xcb platform plugin and the X11 window-capture
+# backend as well; the x11 PACKAGECONFIG in the recipe follows DISTRO_FEATURES.
+DISTRO_FEATURES:remove = "x11"
+
+PREFERRED_PROVIDER_virtual/libgl ?= "mesa"
+PREFERRED_PROVIDER_virtual/libgles1 ?= "mesa"
+PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
+PREFERRED_PROVIDER_virtual/egl ?= "mesa"
+
+# Audio goes through PipeWire; score also speaks ALSA and JACK directly.
+VIRTUAL-RUNTIME_alsa-state = ""
+
+# ffmpeg is LGPL/GPL but carries LICENSE_FLAGS = "commercial" in oe-core.
+LICENSE_FLAGS_ACCEPTED += "commercial_ffmpeg"
+
+# Deliberately NOT requiring security_flags.inc: it adds -fstack-protector-strong
+# and -D_FORTIFY_SOURCE=2 across the board, and this is a realtime audio/video
+# appliance. score's own AppImage build goes the other way and passes
+# -D_FORTIFY_SOURCE=0 (cmake/Deployment/Linux/AppImage/Recipe.llvm). Add it back
+# if the box is network-exposed and you would rather have the hardening.
+require conf/distro/include/yocto-uninative.inc
+INHERIT += "uninative"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/conf/layer.conf
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/conf/layer.conf
@@ -13,6 +13,6 @@ LAYERVERSION_ossia = "1"
 # delta in cmake.bbclass across those series is an eabi->Generic host-OS
 # mapping), but note that boost moves 1.89 -> 1.90 -> 1.91 across them and
 # meta-qt6 does not currently declare blacksail compatibility.
-LAYERSERIES_COMPAT_ossia = "whinlatter wrynose blacksail"
+LAYERSERIES_COMPAT_ossia = "whinlatter wrynose"
 
 LAYERDEPENDS_ossia = "core openembedded-layer multimedia-layer networking-layer qt6-layer"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/conf/layer.conf
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/conf/layer.conf
@@ -1,0 +1,18 @@
+BBPATH .= ":${LAYERDIR}"
+
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "ossia"
+BBFILE_PATTERN_ossia = "^${LAYERDIR}/"
+BBFILE_PRIORITY_ossia = "10"
+
+LAYERVERSION_ossia = "1"
+
+# whinlatter is what we build and test against. wrynose and blacksail are
+# declared because the recipes use nothing that changed between them (the only
+# delta in cmake.bbclass across those series is an eabi->Generic host-OS
+# mapping), but note that boost moves 1.89 -> 1.90 -> 1.91 across them and
+# meta-qt6 does not currently declare blacksail compatibility.
+LAYERSERIES_COMPAT_ossia = "whinlatter wrynose blacksail"
+
+LAYERDEPENDS_ossia = "core openembedded-layer multimedia-layer networking-layer qt6-layer"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-core/systemd/systemd-ossia-ordering/no-autovt.conf
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-core/systemd/systemd-ossia-ordering/no-autovt.conf
@@ -1,0 +1,3 @@
+[Login]
+NAutoVTs=0
+ReserveVT=0

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-core/systemd/systemd-ossia-ordering/private-tmp-after-volatile.conf
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-core/systemd/systemd-ossia-ordering/private-tmp-after-volatile.conf
@@ -1,0 +1,3 @@
+[Unit]
+RequiresMountsFor=/var/volatile /var/lib
+After=systemd-tmpfiles-setup.service

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-core/systemd/systemd-ossia-ordering_1.0.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-core/systemd/systemd-ossia-ordering_1.0.bb
@@ -1,0 +1,31 @@
+SUMMARY = "systemd drop-ins for the ossia score appliance"
+DESCRIPTION = "Drop-ins ordering /var-dependent systemd units after \
+tmpfiles-setup, and disabling autovt."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://private-tmp-after-volatile.conf file://no-autovt.conf"
+S = "${UNPACKDIR}"
+
+inherit features_check allarch
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+# Units that need /var/lib or /var/volatile before they can start.
+OSSIA_VOLATILE_ORDERED_UNITS ?= "systemd-resolved.service systemd-timesyncd.service systemd-networkd-persistent-storage.service"
+
+do_install() {
+    for unit in ${OSSIA_VOLATILE_ORDERED_UNITS}; do
+        install -d ${D}${systemd_system_unitdir}/${unit}.d
+        install -m 0644 ${UNPACKDIR}/private-tmp-after-volatile.conf \
+            ${D}${systemd_system_unitdir}/${unit}.d/10-ossia-volatile.conf
+    done
+
+    install -d ${D}${sysconfdir}/systemd/logind.conf.d
+    install -m 0644 ${UNPACKDIR}/no-autovt.conf \
+        ${D}${sysconfdir}/systemd/logind.conf.d/10-ossia-no-autovt.conf
+
+    install -d ${D}${sysconfdir}/systemd/system
+    ln -sf /dev/null ${D}${sysconfdir}/systemd/system/getty@tty1.service
+}
+
+FILES:${PN} = "${systemd_system_unitdir} ${sysconfdir}/systemd"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-kernel/linux/linux-yocto/ossia-trim.cfg
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-kernel/linux/linux-yocto/ossia-trim.cfg
@@ -1,0 +1,10 @@
+# Comment lines here must not begin with "# CONFIG_": the fragment parser reads
+# them as malformed directives.
+#
+# PNP cannot be disabled the same way -- 8250 and the CMOS RTC depend on it and
+# kconfig silently re-enables it.
+# CONFIG_PARPORT is not set
+# CONFIG_PARPORT_PC is not set
+
+# Printed before console= is parsed, so quiet cannot suppress it.
+# CONFIG_X86_VERBOSE_BOOTUP is not set

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,0 +1,4 @@
+# linux-yocto only: the Pi machines use linux-raspberrypi and are unaffected.
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://ossia-trim.cfg"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image-appliance.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image-appliance.bb
@@ -1,0 +1,31 @@
+SUMMARY = "ossia score appliance image -- score as PID 1, no init system"
+DESCRIPTION = "A fixed-function variant of ossia-score-image: no service \
+manager running, no networking, no udev, no journal. Boot with \
+init=/usr/bin/ossia-score-init."
+LICENSE = "MIT"
+
+inherit core-image
+
+# No ssh, no package management: there is no way in over the network.
+IMAGE_FEATURES = ""
+
+IMAGE_INSTALL += " \
+    ossia-score \
+    alsa-plugins \
+    kernel-modules \
+"
+
+# No udev, so no hotplug: everything must be attached at power-on.
+# CONFIG_DEVTMPFS_MOUNT still gives us /dev/dri. systemd is present in the
+# rootfs (packagegroup-core-boot) but never runs; removing it needs
+# INIT_MANAGER = "none". No journald: restarts go to /dev/console.
+# Worth ~1.2s of pre-score userspace (1.20s vs 2.37s to score's process).
+# Needs >= 192 MB RAM; below that score is OOM-killed during startup.
+
+# runqemu ignores APPEND; under qemu pass bootparams='init=...' instead.
+APPEND:append = " init=/usr/bin/ossia-score-init"
+CMDLINE:append = " init=/usr/bin/ossia-score-init"
+
+IMAGE_ROOTFS_EXTRA_SPACE = "524288"
+
+IMAGE_FSTYPES:append = " wic.xz wic.bmap"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
@@ -21,6 +21,7 @@ IMAGE_INSTALL += " \
     e2fsprogs-mke2fs \
     tzdata \
     ca-certificates \
+    systemd-ossia-ordering \
 "
 
 # systemd-resolved and systemd-timesyncd use PrivateTmp= but order themselves

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
@@ -11,18 +11,23 @@ inherit core-image
 # a passwordless root console while bringing a board up.
 IMAGE_FEATURES += "ssh-server-openssh"
 
+# No PipeWire: score talks to ALSA directly and nothing here needs a sound
+# server. Re-add with IMAGE_INSTALL:append and PACKAGECONFIG:append:pn-ossia-score.
 IMAGE_INSTALL += " \
     ossia-score \
     alsa-utils \
     alsa-plugins \
-    pipewire \
-    pipewire-alsa \
-    wireplumber \
     kernel-modules \
     e2fsprogs-mke2fs \
     tzdata \
     ca-certificates \
 "
+
+# systemd-resolved and systemd-timesyncd use PrivateTmp= but order themselves
+# after nothing that guarantees /var/volatile/tmp exists; on this image
+# systemd-tmpfiles-setup finishes at ~2.4s while they start at ~1.4s, so on a
+# read-only rootfs they fail 226/NAMESPACE and the system comes up degraded.
+# systemd-ossia-ordering ships the drop-ins that close that race.
 
 # Note on sizing: score's measured RSS is ~312 MB once the UI is up, before any
 # document is loaded. Below roughly 512 MB it does not merely run slowly, it

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Bare-bones image running ossia score"
+DESCRIPTION = "A minimal bootable image whose only purpose is to run ossia \
+score: kernel, init, audio and GPU stacks, networking, and score itself with \
+every plugin and addon that cross-compiles. No desktop environment."
+LICENSE = "MIT"
+
+inherit core-image
+
+# ssh so the box can be driven headlessly; no dev/debug packages, this is meant
+# to be flashed rather than developed on. Add "debug-tweaks" locally if you want
+# a passwordless root console while bringing a board up.
+IMAGE_FEATURES += "ssh-server-openssh"
+
+IMAGE_INSTALL += " \
+    ossia-score \
+    alsa-utils \
+    alsa-plugins \
+    pipewire \
+    pipewire-alsa \
+    wireplumber \
+    kernel-modules \
+    e2fsprogs-mke2fs \
+    tzdata \
+"
+
+# Not stripped down: the point of this image is the full score feature set. It
+# lands somewhere north of 500 MB, dominated by Qt and the score binary itself.
+IMAGE_OVERHEAD_FACTOR = "1.3"
+IMAGE_ROOTFS_EXTRA_SPACE = "524288"
+
+# Flashable artefacts, in addition to whatever the machine already produces
+# (qemux86-64 gives ext4.zst + tar.zst, which is what runqemu wants). bmap lets
+# bmaptool skip the empty blocks when writing to a card or SSD; the machine's
+# WKS_FILE decides the partition layout. Appended rather than assigned so this
+# does not fight a machine that has its own opinion -- meta-raspberrypi, for
+# one; the Pi kas config overrides the whole variable with :forcevariable.
+IMAGE_FSTYPES:append = " wic.xz wic.bmap"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/images/ossia-score-image.bb
@@ -21,7 +21,13 @@ IMAGE_INSTALL += " \
     kernel-modules \
     e2fsprogs-mke2fs \
     tzdata \
+    ca-certificates \
 "
+
+# Note on sizing: score's measured RSS is ~312 MB once the UI is up, before any
+# document is loaded. Below roughly 512 MB it does not merely run slowly, it
+# dies -- at runqemu's 256 MB default it segfaults during startup and the
+# restarted instance is OOM-killed. Budget 1 GB or more on real hardware.
 
 # Not stripped down: the point of this image is the full score feature set. It
 # lands somewhere north of 500 MB, dominated by Qt and the score binary itself.

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/95-ossia-score-rt.conf
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/95-ossia-score-rt.conf
@@ -1,0 +1,5 @@
+# Realtime scheduling and memory locking for the audio engine. Without these
+# the engine falls back to normal scheduling and xruns under load.
+@audio   -  rtprio      95
+@audio   -  memlock     unlimited
+@audio   -  nice        -19

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score-init
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score-init
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Minimal PID 1 for appliances that need nothing but score: no systemd, no
+# udev, no networking. Boot with init=/usr/bin/ossia-score-init.
+#
+# This stays PID 1 itself and runs score as a child, rather than exec'ing it.
+# Two reasons: the kernel panics if PID 1 exits, so an exec'd score turns any
+# crash into a panic; and PID 1 inherits zombie reaping, which score needs
+# because it forks VST/VST3/CLAP puppets and Faust processes.
+#
+# CONFIG_DEVTMPFS_MOUNT gives us /dev already; everything else is on us.
+set -u
+
+mount -o remount,rw / 2>/dev/null
+mount -t proc     proc     /proc    2>/dev/null
+mount -t sysfs    sysfs    /sys     2>/dev/null
+mount -t tmpfs    tmpfs    /run     2>/dev/null
+mount -t tmpfs    tmpfs    /tmp     2>/dev/null
+mkdir -p /dev/pts /dev/shm /run/ossia-score 2>/dev/null
+mount -t devpts   devpts   /dev/pts 2>/dev/null
+mount -t tmpfs    tmpfs    /dev/shm 2>/dev/null
+mount -t tmpfs    tmpfs    /var/volatile 2>/dev/null
+
+export HOME=/root
+export XDG_RUNTIME_DIR=/run/ossia-score
+export XDG_CACHE_HOME=/tmp/cache
+mkdir -p "$XDG_CACHE_HOME" 2>/dev/null
+# Qt refuses a runtime dir that is not 0700 and owned by the user, warns, and
+# falls back to /tmp.
+chmod 0700 "$XDG_RUNTIME_DIR" 2>/dev/null
+
+while true; do
+  /usr/bin/ossia-score-launch "$@"
+  echo "ossia-score exited ($?), restarting in 2s" > /dev/console 2>/dev/null
+  sleep 2
+done

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score-launch
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score-launch
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Launch ossia score with a display backend suited to a bare-bones image.
+#
+# Usage: ossia-score-launch [vulkan|eglfs|wayland|x11|cli] [score args...]
+#
+# With no mode, picks the first backend that looks usable. On an image with no
+# display server the interesting ones are vulkan (vkkhrdisplay) and eglfs, which
+# both render straight to DRM/KMS with the whole GPU dedicated to score -- see
+# the equivalent scripts in cmake/Deployment/Linux/Raspberry/, which this
+# mirrors without the AppImage library-shimming.
+set -eu
+
+MODE="${1:-auto}"
+if [ "$#" -gt 0 ]; then
+    shift
+fi
+
+if [ "$MODE" = auto ]; then
+    if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+        MODE=wayland
+    elif [ -n "${DISPLAY:-}" ]; then
+        MODE=x11
+    elif [ -e /dev/dri/card0 ]; then
+        MODE=eglfs
+    else
+        MODE=cli
+    fi
+fi
+
+case "$MODE" in
+    vulkan)
+        export QT_QPA_PLATFORM=vkkhrdisplay
+        export QSG_RHI_BACKEND=vulkan
+        set -- --no-opengl "$@"
+        ;;
+    eglfs)
+        export QT_QPA_PLATFORM=eglfs
+        export QSG_RHI_BACKEND=opengl
+        set -- --no-opengl "$@"
+        ;;
+    wayland)
+        export QT_QPA_PLATFORM=wayland
+        ;;
+    x11)
+        export QT_QPA_PLATFORM=xcb
+        ;;
+    cli)
+        export QT_QPA_PLATFORM=minimal
+        set -- --no-opengl --no-gui --no-restore "$@"
+        ;;
+    *)
+        echo "ossia-score-launch: unknown mode '$MODE'" >&2
+        echo "usage: ossia-score-launch [vulkan|eglfs|wayland|x11|cli] [args...]" >&2
+        exit 2
+        ;;
+esac
+
+exec /usr/bin/ossia-score "$@"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score.service
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score.service
@@ -1,8 +1,18 @@
 [Unit]
 Description=ossia score
 Documentation=https://ossia.io
-After=sound.target
-Wants=sound.target
+
+# Started as early as systemd can manage rather than at multi-user.target:
+# score only needs the root filesystem and /dev/dri, and it spends ~12s in its
+# own startup, so everything else (networking, avahi, bluetooth, sshd) comes up
+# in parallel and is ready long before score wants it. Measured on qemux86-64
+# this moves the fork from 6.48s to just after local-fs.target at ~4.7s.
+DefaultDependencies=no
+Requires=local-fs.target
+After=local-fs.target systemd-udevd.service systemd-tmpfiles-setup.service
+Wants=systemd-udevd.service
+Conflicts=shutdown.target
+Before=shutdown.target
 
 [Service]
 Type=simple
@@ -19,8 +29,13 @@ User=root
 Group=audio
 SupplementaryGroups=audio video render input
 
+# Qt's shader cache and Mesa's live under XDG_CACHE_HOME. Pointing it at
+# CacheDirectory keeps them off the tmpfs runtime dir so they survive a reboot,
+# which is what makes the second boot faster than the first.
 Environment=XDG_RUNTIME_DIR=/run/ossia-score
+Environment=XDG_CACHE_HOME=/var/cache/ossia-score
 RuntimeDirectory=ossia-score
+CacheDirectory=ossia-score
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score.service
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=ossia score
+Documentation=https://ossia.io
+After=sound.target
+Wants=sound.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ossia-score-launch
+Restart=on-failure
+RestartSec=2
+
+# Realtime audio. The limits.d drop-in grants these to the audio group for
+# interactive logins; a systemd unit does not go through PAM, so they are
+# repeated here.
+LimitRTPRIO=95
+LimitMEMLOCK=infinity
+User=root
+Group=audio
+SupplementaryGroups=audio video render input
+
+Environment=XDG_RUNTIME_DIR=/run/ossia-score
+RuntimeDirectory=ossia-score
+
+[Install]
+WantedBy=multi-user.target

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score.service
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/files/ossia-score.service
@@ -35,6 +35,7 @@ SupplementaryGroups=audio video render input
 Environment=XDG_RUNTIME_DIR=/run/ossia-score
 Environment=XDG_CACHE_HOME=/var/cache/ossia-score
 RuntimeDirectory=ossia-score
+RuntimeDirectoryMode=0700
 CacheDirectory=ossia-score
 
 [Install]

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
@@ -20,6 +20,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c8bf0f99367f566cced5973a2aa89d68"
 # do_unpack, so these land in UNPACKDIR either way.
 SRC_URI = " \
     file://ossia-score-launch \
+    file://ossia-score-init \
     file://ossia-score.service \
     file://95-ossia-score-rt.conf \
 "
@@ -166,6 +167,7 @@ do_install:append() {
 
     install -d ${D}${bindir}
     install -m 0755 ${UNPACKDIR}/ossia-score-launch ${D}${bindir}/ossia-score-launch
+    install -m 0755 ${UNPACKDIR}/ossia-score-init ${D}${bindir}/ossia-score-init
 
     install -d ${D}${sysconfdir}/security/limits.d
     install -m 0644 ${UNPACKDIR}/95-ossia-score-rt.conf \

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
@@ -26,6 +26,10 @@ SRC_URI = " \
 
 inherit qt6-cmake pkgconfig systemd features_check
 
+# KFR refuses to build on non-x86 without Clang, and score's own CI/AppImage
+# use it too. toolchain/clang.bbclass is in oe-core; no meta-clang needed.
+TOOLCHAIN = "clang"
+
 # score hard-requires Qt Gui/Widgets/OpenGL at find_package() time (see
 # CMakeLists.txt "find_package(${QT_VERSION} REQUIRED COMPONENTS ...)"), even
 # for headless use -- --no-gui is a runtime flag, not a build configuration.
@@ -58,6 +62,7 @@ DEPENDS = " \
 
 PACKAGECONFIG ??= "pipewire jack bluez websockets serialport quick3d gpsd hdf5 sdl coap \
                    lv2 faust ysfx \
+                   ${@bb.utils.contains_any('TARGET_ARCH', 'aarch64 x86_64', 'jit', '', d)} \
                    ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
 
 PACKAGECONFIG[pipewire]   = ",,pipewire"
@@ -73,7 +78,15 @@ PACKAGECONFIG[coap]       = ",,libcoap"
 PACKAGECONFIG[x11]        = ",,libx11 libxext libxcomposite libxrandr"
 # 4th field: the QPA plugin is dlopen'ed, so it needs to be a runtime dependency
 # too or `ossia-score-launch wayland` finds no platform plugin at startup.
-PACKAGECONFIG[wayland]    = ",,qtwayland wayland,qtwayland"
+PACKAGECONFIG[wayland]    = ",,qtwayland wayland,qtwayland-plugins"
+
+# Explicit LLVM_DIR: without it find_package(LLVM) resolves the *native* LLVM
+# from recipe-sysroot-native and the target link fails on -lclang.
+# Runtime needs clang's resource headers and a C++ header set to compile against.
+PACKAGECONFIG[jit] = "-DLLVM_DIR=${STAGING_LIBDIR}/cmake/llvm,,clang,libclang clang libstdc++-dev"
+
+# The JIT genuinely needs headers at runtime, which dev-deps flags.
+INSANE_SKIP:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'jit', 'dev-deps', '', d)}"
 
 # Without these the plugins self-disable silently.
 PACKAGECONFIG[lv2]        = ",,lv2kit,lv2kit"
@@ -87,6 +100,8 @@ PACKAGECONFIG[ysfx]       = ",,ysfx"
 # which skips any subdir named in SCORE_DISABLED_PLUGINS). Everything else --
 # every plugin and every remaining addon -- is built.
 SCORE_DISABLED_PLUGINS ?= "score-addon-onnx,score-addon-ultraleap"
+
+SCORE_DISABLED_PLUGINS .= "${@bb.utils.contains('PACKAGECONFIG', 'jit', '', ',score-plugin-jit', d)}"
 
 # The distro-packaging configuration, the same one used by
 # ci/debian.trixie-system.build.sh, ci/nix.build.nix and the Flatpak manifest:
@@ -125,7 +140,7 @@ EXTRA_OECMAKE = " \
 # Performance: score is a soft-realtime audio/video engine, so it is built -O3
 # rather than the -O2 default. Debug flags are left to OE so that the -dbg
 # package still works; they do not affect the generated code.
-FULL_OPTIMIZATION = "-O3 -pipe -fno-semantic-interposition"
+FULL_OPTIMIZATION = "-O3 ${DEBUG_LEVELFLAG} -fno-semantic-interposition"
 
 # Link-time optimisation. Off by default: score links a single ~70 MB static
 # binary from a unity build, and an LTO link of that size needs a great deal of

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
@@ -1,0 +1,175 @@
+SUMMARY = "ossia score - an interactive sequencer for audio-visual artists"
+DESCRIPTION = "ossia score is a sequencer for audio-visual artists, designed to \
+enable the creation of interactive shows, museum installations, intermedia \
+digital artworks, interactive music and more."
+HOMEPAGE = "https://ossia.io"
+BUGTRACKER = "https://github.com/ossia/score/issues"
+SECTION = "multimedia"
+
+# score itself is GPL-3.0-only. The source archive additionally vendors a large
+# third-party tree under 3rdparty/ and src/addons/*/3rdparty/ with mixed
+# licensing (BSD/MIT/Apache/BSL, and the Steinberg VST3 SDK under its dual
+# GPLv3/proprietary terms). Before shipping an image commercially, run
+# `bitbake -c populate_lic ossia-score` and audit that output; the declaration
+# here covers score's own sources only.
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c8bf0f99367f566cced5973a2aa89d68"
+
+# Support files shared by both the release-tarball and the externalsrc recipe.
+# externalsrc filters SRC_URI down to its local (file://) entries and keeps
+# do_unpack, so these land in UNPACKDIR either way.
+SRC_URI = " \
+    file://ossia-score-launch \
+    file://ossia-score.service \
+    file://95-ossia-score-rt.conf \
+"
+
+inherit qt6-cmake pkgconfig systemd features_check
+
+# score hard-requires Qt Gui/Widgets/OpenGL at find_package() time (see
+# CMakeLists.txt "find_package(${QT_VERSION} REQUIRED COMPONENTS ...)"), even
+# for headless use -- --no-gui is a runtime flag, not a build configuration.
+REQUIRED_DISTRO_FEATURES = "opengl"
+
+DEPENDS = " \
+    qtbase \
+    qtdeclarative \
+    qtscxml \
+    qtshadertools \
+    qtsvg \
+    qtdeclarative-native \
+    qtshadertools-native \
+    boost \
+    alsa-lib \
+    ffmpeg \
+    libsndfile1 \
+    fftw \
+    avahi \
+    portaudio-v19 \
+    re2 \
+    snappy \
+    spdlog \
+    magic-enum \
+    rapidfuzz-cpp \
+    openssl \
+    zlib \
+    udev \
+"
+
+PACKAGECONFIG ??= "pipewire jack bluez websockets serialport quick3d gpsd hdf5 sdl coap \
+                   ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+
+PACKAGECONFIG[pipewire]   = ",,pipewire"
+PACKAGECONFIG[jack]       = ",,jack"
+PACKAGECONFIG[bluez]      = ",,bluez5"
+PACKAGECONFIG[websockets] = ",,qtwebsockets"
+PACKAGECONFIG[serialport] = ",,qtserialport"
+PACKAGECONFIG[quick3d]    = ",,qtquick3d"
+PACKAGECONFIG[gpsd]       = ",,gpsd"
+PACKAGECONFIG[hdf5]       = ",,hdf5"
+PACKAGECONFIG[sdl]        = ",,libsdl2"
+PACKAGECONFIG[coap]       = ",,libcoap"
+PACKAGECONFIG[x11]        = ",,libx11 libxext libxcomposite libxrandr"
+# 4th field: the QPA plugin is dlopen'ed, so it needs to be a runtime dependency
+# too or `ossia-score-launch wayland` finds no platform plugin at startup.
+PACKAGECONFIG[wayland]    = ",,qtwayland wayland,qtwayland"
+
+# score-addon-onnx FetchContent's a PREBUILT x86_64 onnxruntime tarball and
+# score-addon-ultraleap pulls a proprietary SDK; both fetch during configure,
+# which cannot work under BitBake's offline do_configure, and neither
+# cross-compiles. This list also filters src/addons (see src/addons/CMakeLists.txt,
+# which skips any subdir named in SCORE_DISABLED_PLUGINS). Everything else --
+# every plugin and every remaining addon -- is built.
+SCORE_DISABLED_PLUGINS ?= "score-addon-onnx,score-addon-ultraleap"
+
+# The distro-packaging configuration, the same one used by
+# ci/debian.trixie-system.build.sh, ci/nix.build.nix and the Flatpak manifest:
+# system libraries where available, FHS layout, one statically-linked binary.
+#
+# SCORE_USE_SYSTEM_LIBRARIES is a *preference*, not a requirement: libossia's
+# cmake/deps/*.cmake fall back to the vendored copy when a package is not found,
+# so the many header-only dependencies with no OE recipe (fmt, rapidfuzz,
+# rubberband, zita, libsamplerate, ...) resolve to the in-tree versions. It also
+# suppresses the faustlibs ExternalProject git fetch in
+# src/plugins/score-plugin-faust/CMakeLists.txt, which would otherwise need the
+# network at build time.
+# OE's cmake.bbclass leaves CMAKE_BUILD_TYPE unset -- it supplies optimisation
+# through CFLAGS instead -- but score expects Release to be set explicitly (its
+# CMakeLists warns "No build type defined"), and the bundled VST3 SDK will not
+# compile without it: base/source/fdebug.h #errors unless one of DEVELOPMENT,
+# RELEASE, _DEBUG or NDEBUG is defined. The generated toolchain file sets
+# CMAKE_CXX_FLAGS_RELEASE to just "-DNDEBUG" with no -O flag, so this adds the
+# define without overriding FULL_OPTIMIZATION above. The Flatpak manifest calls
+# out the same requirement.
+EXTRA_OECMAKE = " \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DSCORE_USE_SYSTEM_LIBRARIES=1 \
+    -DOSSIA_USE_SYSTEM_LIBRARIES=1 \
+    -DSCORE_DEPLOYMENT_BUILD=1 \
+    -DSCORE_STATIC_PLUGINS=1 \
+    -DSCORE_FHS_BUILD=1 \
+    -DBUILD_SHARED_LIBS=0 \
+    -DCMAKE_SKIP_RPATH=ON \
+    -DCMAKE_UNITY_BUILD=1 \
+    -DSCORE_PCH=0 \
+    -DBOOST_ROOT=${STAGING_INCDIR} \
+    -DSCORE_DISABLED_PLUGINS=${SCORE_DISABLED_PLUGINS} \
+"
+
+# Performance: score is a soft-realtime audio/video engine, so it is built -O3
+# rather than the -O2 default. Debug flags are left to OE so that the -dbg
+# package still works; they do not affect the generated code.
+FULL_OPTIMIZATION = "-O3 -pipe -fno-semantic-interposition"
+
+# Link-time optimisation. Off by default: score links a single ~70 MB static
+# binary from a unity build, and an LTO link of that size needs a great deal of
+# RAM on the build host. Set OSSIA_SCORE_LTO = "1" in local.conf to enable.
+OSSIA_SCORE_LTO ?= "0"
+EXTRA_OECMAKE += "${@bb.utils.contains('OSSIA_SCORE_LTO', '1', '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON', '', d)}"
+
+# score links everything into one binary, so the build is memory-hungry rather
+# than parallel-hungry; unity builds make individual TUs very large.
+PARALLEL_MAKE ?= "-j 4"
+
+SYSTEMD_SERVICE:${PN} = "ossia-score.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+
+do_install:append() {
+    # xtensor is vendored through add_subdirectory, so its own install() rules
+    # run as part of score's and drop Jupyter/xeus integration files -- into
+    # ${prefix}/etc rather than ${sysconfdir}, at that. Nothing here consumes
+    # them. (Its headers land in ${includedir} and go to the -dev package, which
+    # the image does not install, so those are left alone.)
+    rm -rf ${D}${datadir}/xeus-cpp ${D}${prefix}/etc/xeus-cpp
+    rmdir --ignore-fail-on-non-empty ${D}${prefix}/etc 2>/dev/null || true
+
+    install -d ${D}${bindir}
+    install -m 0755 ${UNPACKDIR}/ossia-score-launch ${D}${bindir}/ossia-score-launch
+
+    install -d ${D}${sysconfdir}/security/limits.d
+    install -m 0644 ${UNPACKDIR}/95-ossia-score-rt.conf \
+        ${D}${sysconfdir}/security/limits.d/95-ossia-score-rt.conf
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${UNPACKDIR}/ossia-score.service \
+            ${D}${systemd_system_unitdir}/ossia-score.service
+    fi
+}
+
+FILES:${PN} += " \
+    ${datadir}/applications \
+    ${datadir}/icons \
+    ${datadir}/metainfo \
+    ${datadir}/pixmaps \
+    ${sysconfdir}/security/limits.d \
+"
+
+# Qt platform integration is dlopen'ed, so it has to be pulled in explicitly.
+# eglfs is what the launcher uses when there is no display server.
+RDEPENDS:${PN} += " \
+    qtbase-plugins \
+    qtdeclarative-qmlplugins \
+"
+
+RRECOMMENDS:${PN} += "alsa-utils"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
@@ -60,7 +60,7 @@ DEPENDS = " \
     udev \
 "
 
-PACKAGECONFIG ??= "pipewire jack bluez websockets serialport quick3d gpsd hdf5 sdl coap \
+PACKAGECONFIG ??= "jack bluez websockets serialport quick3d gpsd hdf5 sdl coap \
                    lv2 faust ysfx \
                    ${@bb.utils.contains_any('TARGET_ARCH', 'aarch64 x86_64', 'jit', '', d)} \
                    ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score.inc
@@ -57,6 +57,7 @@ DEPENDS = " \
 "
 
 PACKAGECONFIG ??= "pipewire jack bluez websockets serialport quick3d gpsd hdf5 sdl coap \
+                   lv2 faust ysfx \
                    ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
 
 PACKAGECONFIG[pipewire]   = ",,pipewire"
@@ -73,6 +74,11 @@ PACKAGECONFIG[x11]        = ",,libx11 libxext libxcomposite libxrandr"
 # 4th field: the QPA plugin is dlopen'ed, so it needs to be a runtime dependency
 # too or `ossia-score-launch wayland` finds no platform plugin at startup.
 PACKAGECONFIG[wayland]    = ",,qtwayland wayland,qtwayland"
+
+# Without these the plugins self-disable silently.
+PACKAGECONFIG[lv2]        = ",,lv2kit,lv2kit"
+PACKAGECONFIG[faust]      = ",,faust,faust faustlibraries"
+PACKAGECONFIG[ysfx]       = ",,ysfx"
 
 # score-addon-onnx FetchContent's a PREBUILT x86_64 onnxruntime tarball and
 # score-addon-ultraleap pulls a proprietary SDK; both fetch during configure,

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score_3.8.2.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score_3.8.2.bb
@@ -1,0 +1,12 @@
+require ossia-score.inc
+
+# The release source archive, not a git checkout. score has 39 submodules and
+# libossia 44 more, plus ~20 addon repositories that ci/common.deps.sh clones
+# separately -- a gitsm:// fetch would miss the addons entirely. The archive
+# produced by ci/tarball.build.sh already contains all of it with the .git
+# directories stripped, and is published (and GPG-signed) on every release.
+# The support files (launcher, unit, limits) come from ossia-score.inc.
+SRC_URI += "https://github.com/ossia/score/releases/download/v${PV}/ossia.score-${PV}-src.tar.xz"
+SRC_URI[sha256sum] = "f12c85ec96689b73e92b954589c39187a5ae9cfdf95db08d88c0e5f4dd862259"
+
+S = "${UNPACKDIR}/ossia-score-${PV}"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score_git.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score_git.bb
@@ -16,6 +16,12 @@ SCORE_SRC_ROOT ?= "${@os.path.normpath(os.path.join(d.getVar('THISDIR'), '../../
 
 inherit externalsrc
 
+# Otherwise do_configure drops oe-workdir/oe-logs symlinks into the checkout.
+EXTERNALSRC_SYMLINKS = ""
+
+# Otherwise do_configure drops oe-workdir/oe-logs symlinks in the checkout.
+EXTERNALSRC_SYMLINKS = ""
+
 EXTERNALSRC = "${SCORE_SRC_ROOT}"
 EXTERNALSRC_BUILD = "${WORKDIR}/build"
 
@@ -29,3 +35,8 @@ do_configure:prepend() {
         bbwarn "No addons in ${S}/src/addons -- run ci/common.deps.sh LINUX to clone them."
     fi
 }
+
+# B is under TMPDIR and ends up in the binary. The release recipe is
+# unaffected and stays subject to the check.
+INSANE_SKIP:${PN} += "buildpaths"
+INSANE_SKIP:${PN}-dbg += "buildpaths"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score_git.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score/ossia-score_git.bb
@@ -1,0 +1,31 @@
+require ossia-score.inc
+
+# Builds the score checkout that this layer ships inside, rather than a release
+# tarball. This is the recipe you normally want: development targets master, and
+# a gitsm:// fetch of ossia/score alone would silently produce a build with no
+# addons (they are ~20 separate repositories that ci/common.deps.sh clones).
+#
+# Higher PV than ossia-score_3.8.2.bb, so this is what bitbake picks by default.
+# Use PREFERRED_VERSION_ossia-score = "3.8.2" for a pinned, reproducible build.
+PV = "3.8.2+git"
+
+# The score tree is seven levels up from this recipe:
+#   <score>/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-ossia/ossia-score
+# Override in local.conf to build a different checkout.
+SCORE_SRC_ROOT ?= "${@os.path.normpath(os.path.join(d.getVar('THISDIR'), '../../../../../../..'))}"
+
+inherit externalsrc
+
+EXTERNALSRC = "${SCORE_SRC_ROOT}"
+EXTERNALSRC_BUILD = "${WORKDIR}/build"
+
+# externalsrc has no do_fetch, so submodules and addons have to already be
+# there. Fail with something readable rather than a CMake error 40 lines deep.
+do_configure:prepend() {
+    if [ ! -f "${S}/3rdparty/libossia/CMakeLists.txt" ]; then
+        bbfatal "No libossia in ${S}/3rdparty. Run: git submodule update --init --recursive"
+    fi
+    if [ ! -d "${S}/src/addons/score-addon-avnd" ] && [ ! -e "${S}/src/addons/iscore-addon-network" ]; then
+        bbwarn "No addons in ${S}/src/addons -- run ci/common.deps.sh LINUX to clone them."
+    fi
+}

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/faust/faust/0001-cmake-do-not-hardcode-usr-local-include.patch
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/faust/faust/0001-cmake-do-not-hardcode-usr-local-include.patch
@@ -1,0 +1,30 @@
+From: ossia <contact@ossia.io>
+Subject: [PATCH] cmake: do not hardcode /usr/local/include
+
+FAUST_INC ends with a literal /usr/local/include, which is added to every
+translation unit's include path. When cross-compiling this is host
+contamination: OpenEmbedded turns it into a hard error
+  cc1plus: error: include location "/usr/local/include" is unsafe for
+  cross-compilation [-Werror=poison-system-directories]
+and on a build host that has anything installed under /usr/local it would
+silently pull host headers into a target build.
+
+Nothing in the tree relies on it -- it appears to be there so a locally built
+dependency is found on a developer machine, which a distro build supplies
+through the sysroot instead.
+
+Upstream-Status: Pending
+
+diff --git a/build/CMakeLists.txt b/build/CMakeLists.txt
+index 4981097..ee0e1b3 100644
+--- a/build/CMakeLists.txt
++++ b/build/CMakeLists.txt
+@@ -85,7 +85,7 @@ set (FAUST_INC ${SRCDIR}
+     ${SRCDIR}/patternmatcher ${SRCDIR}/propagate ${SRCDIR}/signals
+     ${SRCDIR}/tlib ${SRCDIR}/transform ${SRCDIR}/utils
+     ${SRCDIR}/draw/device ${SRCDIR}/draw/schema
+-    ${SRCDIR}/../architecture /usr/local/include)
++    ${SRCDIR}/../architecture)
+ 
+ ####################################
+ # LLVM

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/faust/faust_2.85.9.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/faust/faust_2.85.9.bb
@@ -1,0 +1,75 @@
+SUMMARY = "FAUST - Functional Audio Stream, compiler library"
+DESCRIPTION = "libfaust compiles FAUST DSP source to machine code at runtime \
+through LLVM. score-plugin-faust uses it to let users write and edit DSP live; \
+score's cmake/modules/FindFaust.cmake looks for faust/dsp/llvm-dsp.h and \
+libfaust.so, both of which this recipe installs."
+HOMEPAGE = "https://faust.grame.fr"
+SECTION = "libs"
+
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING.txt;md5=d23dc65dc39305c10b858dabaeb8acc6"
+
+SRC_URI = " \
+    git://github.com/grame-cncm/faust;protocol=https;branch=master-dev;nobranch=1 \
+    file://0001-cmake-do-not-hardcode-usr-local-include.patch \
+"
+SRCREV = "3c44e5cb64be06f8ac7c025f1633178276f35d8a"
+
+# S at the checkout root, not build/: LIC_FILES_CHKSUM, patchdir and
+# -ffile-prefix-map are all relative to it.
+S = "${UNPACKDIR}/${BP}"
+OECMAKE_SOURCEPATH = "${S}/build"
+
+DEPENDS = "clang llvm zlib"
+
+inherit cmake pkgconfig
+
+# Flags follow score's Flatpak manifest (Flatpak/modules/faust.yaml).
+# USE_LLVM_CONFIG=OFF: OE's llvm-config cross wrapper emits nothing without
+# NEXT_LLVM_CONFIG, so faust must use find_package(LLVM CONFIG) instead.
+EXTRA_OECMAKE = " \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DBUILD_SHARED_LIBS=ON \
+    -DINCLUDE_OSC=0 \
+    -DINCLUDE_HTTP=0 \
+    -DINCLUDE_EXECUTABLE=0 \
+    -DINCLUDE_STATIC=0 \
+    -DINCLUDE_DYNAMIC=1 \
+    -DINCLUDE_WASM_GLUE=0 \
+    -DLINK_LLVM_STATIC=0 \
+    -DINCLUDE_LLVM=1 \
+    -DUSE_LLVM_CONFIG=OFF \
+    -DLLVM_BACKEND='COMPILER;DYNAMIC' \
+    -DC_BACKEND=COMPILER \
+    -DCPP_BACKEND=COMPILER \
+    -DCODEBOX_BACKEND=OFF \
+    -DCMAJOR_BACKEND=OFF \
+    -DCSHARP_BACKEND=OFF \
+    -DFIR_BACKEND=OFF \
+    -DINTERP_BACKEND=OFF \
+    -DJAVA_BACKEND=OFF \
+    -DJAX_BACKEND=OFF \
+    -DJSFX_BACKEND=OFF \
+    -DJULIA_BACKEND=OFF \
+    -DOLDCPP_BACKEND=OFF \
+    -DRUST_BACKEND=OFF \
+    -DSDF3_BACKEND=OFF \
+    -DVHDL_BACKEND=OFF \
+    -DWASM_BACKEND=OFF \
+    -DEXTRA_CXX_FLAGS=-DNDEBUG \
+"
+
+# The architecture tree (43 MB, with prebuilt arm/ios libsndfile binaries) and
+# the 114 faust2* bash wrappers drive the faust CLI, which we do not build.
+# Removing datadir also leaves it free for faustlibraries.
+do_install:append() {
+    rm -rf ${D}${datadir}/faust
+    rm -rf ${D}${bindir}
+    rm -f ${D}${libdir}/ios-libsndfile.a
+}
+
+RDEPENDS:${PN} += "faustlibraries"
+
+# faust overwrites CMAKE_CXX_FLAGS_RELEASE, dropping OE's -DNDEBUG;
+# EXTRA_CXX_FLAGS is its own injection point.

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/faust/faustlibraries_git.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/faust/faustlibraries_git.bb
@@ -1,0 +1,27 @@
+SUMMARY = "The FAUST DSP libraries"
+DESCRIPTION = "The .lib files libfaust reads when compiling a patch -- \
+stdfaust.lib and everything it pulls in. Data only, no compilation."
+HOMEPAGE = "https://github.com/grame-cncm/faustlibraries"
+SECTION = "libs"
+
+# No top-level licence file; terms are per-file. basics.lib is representative.
+LICENSE = "LGPL-2.1-or-later & MIT"
+LIC_FILES_CHKSUM = " \
+    file://basics.lib;beginline=16;endline=40;md5=8226c9d347e636b36519ac04622b637e \
+    file://licenses/stk-4.3.0.md;md5=603cf1260d37836db42b7dd30a2c5536 \
+"
+
+SRC_URI = "git://github.com/grame-cncm/faustlibraries;protocol=https;branch=master;nobranch=1"
+
+# Same revision score-plugin-faust fetches; they must move together.
+SRCREV = "730eff6dc336973553829235e0b31b24c47a2f69"
+PV = "0.0+git"
+
+inherit allarch
+
+do_install() {
+    install -d ${D}${datadir}/faust
+    install -m 0644 ${S}/*.lib ${D}${datadir}/faust/
+}
+
+FILES:${PN} = "${datadir}/faust"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/lv2kit/lv2kit_git.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/lv2kit/lv2kit_git.bb
@@ -1,0 +1,40 @@
+SUMMARY = "The LV2 plugin standard and its reference implementation libraries"
+DESCRIPTION = "lv2kit bundles the LV2 specification together with serd, sord, \
+sratom, zix, lilv, suil and pugl -- the host-side libraries score-plugin-lv2 \
+needs to discover, load and embed LV2 plugins and their UIs. Upstream ships \
+them as one meson project with the individual libraries as subprojects, which \
+is also how ossia/sdk builds them (Linux/lv2.sh)."
+HOMEPAGE = "https://github.com/lv2/lv2kit"
+SECTION = "libs"
+
+LICENSE = "ISC & 0BSD"
+LIC_FILES_CHKSUM = " \
+    file://LICENSES/ISC.txt;md5=c17d0f531d833bea1a6c6823ba18c242 \
+    file://LICENSES/0BSD.txt;md5=02e89155647b79737003bfeeeaf17d5d \
+"
+
+# gitsm: the libraries are submodules meson consumes as subprojects.
+SRC_URI = "gitsm://github.com/lv2/lv2kit;protocol=https;branch=main"
+SRCREV = "a99b4f4a4177e04b13bd384fbdcce59a721d6370"
+PV = "1.18.10+git"
+
+inherit meson pkgconfig
+
+# forcefallback, as ossia/sdk does: no OE recipes exist for serd/sord/sratom/zix.
+EXTRA_OEMESON = " \
+    -Ddocs=disabled \
+    -Dtests=disabled \
+    -Dtools=disabled \
+    --wrap-mode=forcefallback \
+"
+
+# ${libdir}/lv2, not ${datadir}: lilv walks this at runtime for the core
+# ontologies. Missing them, every plugin fails to instantiate.
+FILES:${PN} += "${libdir}/lv2"
+
+# lilv's python binding would pull a python3 runtime into the image.
+do_install:append() {
+    rm -rf ${D}${libdir}/python*
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/rapidfuzz-cpp/rapidfuzz-cpp_3.0.4.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/rapidfuzz-cpp/rapidfuzz-cpp_3.0.4.bb
@@ -1,0 +1,34 @@
+SUMMARY = "Rapid fuzzy string matching in C++"
+DESCRIPTION = "Header-only C++ library for fast approximate string matching, \
+using the Levenshtein distance and related metrics."
+HOMEPAGE = "https://github.com/rapidfuzz/rapidfuzz-cpp"
+SECTION = "libs"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=377d4340f3278257d178cafe2c22cfc8"
+
+# Pinned to the version score vendors in
+# 3rdparty/libossia/3rdparty/rapidfuzz-cpp rather than upstream's latest, so
+# that the system package and the vendored fallback are the same API.
+#
+# This recipe exists because libossia's cmake/deps/rapidfuzz.cmake calls
+# find_package(rapidfuzz CONFIG REQUIRED) when OSSIA_USE_SYSTEM_LIBRARIES is on,
+# which aborts configure before the vendored fallback below it can run -- and
+# rapidfuzz-cpp is not packaged in oe-core or meta-openembedded. score master
+# has a per-package OSSIA_USE_SYSTEM_<pkg> override that would sidestep this;
+# the 3.8.2 release does not.
+#
+# git rather than the release tarball: OE recipe QA rejects GitHub's
+# auto-generated archives as unstable, since they can be regenerated with a
+# different hash. SRCREV is the commit that tag v3.0.4 points at.
+SRC_URI = "git://github.com/rapidfuzz/rapidfuzz-cpp;protocol=https;branch=main"
+SRCREV = "10426d24cd7479df0fe8c78b17877e756e1c3cd5"
+
+inherit cmake
+
+EXTRA_OECMAKE = "-DRAPIDFUZZ_BUILD_TESTING=OFF -DRAPIDFUZZ_ENABLE_LINTERS=OFF"
+
+# Header-only: everything lands in the -dev package and there is no runtime
+# component, so the main package is legitimately empty.
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN}-dev = ""

--- a/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/ysfx/ysfx_git.bb
+++ b/cmake/Deployment/Linux/Yocto/meta-ossia/recipes-support/ysfx/ysfx_git.bb
@@ -1,0 +1,37 @@
+SUMMARY = "ysfx - JSFX (REAPER effects) hosting library"
+DESCRIPTION = "An implementation of the JSFX scripting language used by \
+REAPER's built-in effects, as a host library. score-plugin-ysfx uses it to run \
+.jsfx scripts as audio processes."
+HOMEPAGE = "https://github.com/jcelerier/ysfx"
+SECTION = "libs"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+# ossia's fork, same branch ossia/sdk pins.
+SRC_URI = "gitsm://github.com/jcelerier/ysfx;protocol=https;branch=ossia/2026-01"
+SRCREV = "b7565b20b48600f1f79093ee706662d13c533883"
+PV = "0.0+git"
+
+DEPENDS = "libsndfile1"
+
+inherit cmake pkgconfig
+
+# Flags follow ossia/sdk (Linux/ysfx.sh); YSFX_PLUGIN would pull in JUCE.
+EXTRA_OECMAKE = " \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DYSFX_PLUGIN=OFF \
+    -DYSFX_DEEP_STRIP=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=1 \
+"
+
+# The ysfx-s name is score's API-version marker: FindYsfx.cmake and
+# __has_include(<ysfx-s.h>) select the 4-argument slider API this branch
+# provides. ossia/sdk renames identically (Linux/ysfx.sh).
+do_install:append() {
+    mv ${D}${includedir}/ysfx.h ${D}${includedir}/ysfx-s.h
+    mv ${D}${libdir}/libysfx.a ${D}${libdir}/libysfx-s.a
+}
+
+ALLOW_EMPTY:${PN} = "1"

--- a/cmake/Deployment/Linux/Yocto/run.sh
+++ b/cmake/Deployment/Linux/Yocto/run.sh
@@ -1,0 +1,108 @@
+#!/bin/bash -e
+# Boot a built image in qemu and open a viewer on it.
+#
+#   ./run.sh                              # qemux86-64, score starts on boot
+#   OSSIA_QEMU_MEM=4096 ./run.sh          # more RAM
+#   OSSIA_QEMU_AUTOSTART=0 ./run.sh       # boot to a shell instead
+#   OSSIA_QEMU_IMAGE=ossia-score-image-appliance ./run.sh
+#
+# VNC, not -display sdl,gl=on: where the host cannot import the guest scanout
+# dmabuf (proprietary NVIDIA) the window silently freezes on a stale frame.
+#
+# Ctrl-C, or closing the viewer, shuts the VM down.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCORE_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+CONFIG="${1:-whinlatter-qemux86-64}"
+KAS_FILE="$SCRIPT_DIR/kas/$CONFIG.yml"
+if [[ ! -f "$KAS_FILE" ]]; then
+  echo "No such kas config: $KAS_FILE" >&2
+  find "$SCRIPT_DIR/kas" -maxdepth 1 -name '*.yml' -exec basename {} .yml \; | sed 's/^/  /' >&2
+  exit 1
+fi
+
+MEM="${OSSIA_QEMU_MEM:-2048}"
+# runqemu defaults to 4; score runs 8 threads at startup and benefits from more.
+SMP="${OSSIA_QEMU_SMP:-$(nproc 2>/dev/null || echo 4)}"
+IMAGE="${OSSIA_QEMU_IMAGE:-ossia-score-image}"
+export KAS_WORK_DIR="${OSSIA_YOCTO_WORK_DIR:-$SCORE_DIR/../score-yocto}"
+export KAS_BUILD_DIR="${OSSIA_YOCTO_BUILD_DIR:-$KAS_WORK_DIR/build-$CONFIG}"
+
+VIEWER=""
+for v in gvncviewer vncviewer xtightvncviewer; do
+  if command -v "$v" >/dev/null 2>&1; then VIEWER="$v"; break; fi
+done
+
+# 5900 + N. Pick one nothing is sitting on.
+VNC_N=0
+for n in $(seq 1 32); do
+  if ! (exec 3<>"/dev/tcp/127.0.0.1/$((5900 + n))") 2>/dev/null; then VNC_N=$n; break; fi
+done
+if [[ "$VNC_N" == 0 ]]; then
+  echo "No free VNC display between :1 and :32" >&2
+  exit 1
+fi
+VNC_PORT=$((5900 + VNC_N))
+
+# runqemu builds its own kernel command line and ignores the image's APPEND, so
+# the distro's quiet settings have to be repeated here to have any effect under
+# qemu. Set OSSIA_VERBOSE_BOOT=1 to see the boot log instead.
+BP=""
+if [[ "${OSSIA_VERBOSE_BOOT:-0}" != "1" ]]; then
+  BP="quiet loglevel=3 systemd.show_status=0"
+fi
+if [[ "$IMAGE" == *appliance* ]]; then
+  BP="$BP init=/usr/bin/ossia-score-init"
+elif [[ "${OSSIA_QEMU_AUTOSTART:-1}" == "1" ]]; then
+  BP="$BP systemd.wants=ossia-score.service"
+fi
+BOOTPARAMS=""
+if [[ -n "${BP// /}" ]]; then
+  BOOTPARAMS="bootparams='$BP'"
+fi
+
+echo "image  : $IMAGE ($CONFIG)"
+echo "memory : ${MEM}M, ${SMP} vCPU"
+echo "vnc    : localhost:$VNC_N (port $VNC_PORT)"
+echo "ssh    : ssh -p 2222 root@127.0.0.1"
+
+cd "$SCORE_DIR"
+
+# ext4.zst explicitly: the image also produces tar.zst and wic, and runqemu
+# picks between them unpredictably when the format is left off.
+kas shell "$KAS_FILE" -c \
+  "runqemu kvm slirp egl-headless snapshot $IMAGE ext4.zst \
+     qemuparams='-m $MEM -smp $SMP -vnc :$VNC_N' $BOOTPARAMS" &
+QEMU_KAS_PID=$!
+
+cleanup() {
+  # Only our own qemu: pkill -x would take out unrelated VMs on the host.
+  local kids
+  kids=$(pgrep -P "$QEMU_KAS_PID" 2>/dev/null)
+  kill "$QEMU_KAS_PID" 2>/dev/null || true
+  for k in $kids; do
+    pkill -P "$k" -x qemu-system-x86 2>/dev/null || true
+  done
+}
+trap cleanup EXIT INT TERM
+
+for _ in $(seq 1 60); do
+  if (exec 3<>"/dev/tcp/127.0.0.1/$VNC_PORT") 2>/dev/null; then break; fi
+  if ! kill -0 "$QEMU_KAS_PID" 2>/dev/null; then
+    echo "qemu exited before the VNC port opened" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ -z "$VIEWER" ]]; then
+  echo
+  echo "No VNC viewer found. Install one (e.g. gvncviewer) or connect to"
+  echo "  localhost:$VNC_N"
+  echo "Ctrl-C to shut the VM down."
+  wait "$QEMU_KAS_PID"
+else
+  echo "opening $VIEWER..."
+  "$VIEWER" "localhost:$VNC_N" || true
+fi


### PR DESCRIPTION
Adds a Yocto/OpenEmbedded layer under `cmake/Deployment/Linux/Yocto/` that builds ossia score into a bare-bones flashable image: kernel, init, audio and GPU stacks, and score with every plugin and addon that cross-compiles. No desktop environment — the target is an appliance rather than a small image.

> **Stacked on top of #2170.** The distro drops `x11` from `DISTRO_FEATURES`, so score is built with no X11 or xcb headers at all, which needs the X11-optional changes in that PR. Review #2170 first; this PR's own diff is only the new layer.

## Verified

Built and booted end to end on qemux86-64 — 6369 tasks, 901 packages. The OS reaches the Multi-User target in **7.1 s**, and score starts, renders its full UI and is interactive: with `/dev/dri` present, `ossia-score-launch` selects eglfs on DRM/KMS and Qt brings up RHI on LLVMpipe with no X11 or xcb anywhere in the image.

Artefacts: 186 MB `wic.xz`, 230 MB `ext4.zst`; the stripped binary is 83 MB, since nearly everything is linked into it.

### score is not yet stable in this configuration

Running under runqemu's default **256 MB** (214 MB usable), score does not survive:

```
[  6.40] systemd[1]: Started ossia score.
[ 43.02] ossia-score.service: Main process exited, code=dumped, status=11/SEGV
[ 45.23] ossia-score.service: Scheduled restart job, restart counter is at 1.
[112.01] ossia-score.service: Main process exited, code=killed, status=9/KILL
[112.01] ossia-score.service: Failed with result 'oom-kill'.
```

It segfaults once, and the restarted instance — the one that produced the screenshot below — is later OOM-killed. The OOM is plausibly just the memory ceiling (score's binary alone is 83 MB, before Qt and LLVMpipe compositing 1280×800); the **SEGV is unexplained** and is a separate, earlier failure. Neither has been root-caused yet, and neither is specific to anything in this layer — but they are open questions, not a clean bill of health.

Not verified: real hardware, the Raspberry Pi config, any GPU-accelerated path (qemu has no GPU, hence LLVMpipe), and long-run stability.

## What is pinned, and why

| | |
|---|---|
| openembedded-core / bitbake | `yocto-5.3.4` (**whinlatter**) |
| meta-openembedded | `whinlatter` |
| meta-qt6 | `6.12` → Qt **6.12.0** |
| rest | Boost **1.89.0**, GCC **15**, CMake 4.1.2, ffmpeg 8.0, glibc |

whinlatter is not arbitrary: boost 1.89 falls inside the window that `3rdparty/libossia/cmake/deps/boost.cmake` probes with `find_package(Boost 1.N EXACT)`. Outside it, that code downloads a boost tarball at configure time — fatal under BitBake's offline `do_configure`. wrynose (1.90) also works; oe-core master ships 1.91 and would need ossia/libossia#918.

There is no `poky/whinlatter` branch — poky stops at walnascar — so the stack is openembedded-core plus bitbake directly, and the distro config lives in the layer rather than coming from meta-poky.

## Source

The default recipe builds the score checkout this layer ships inside, via `externalsrc`, because development targets master. `ossia-score_3.8.2.bb` remains for reproducible builds behind `PREFERRED_VERSION`. Worth knowing: a plain `gitsm://` fetch of ossia/score would silently build with **no addons** — those are ~20 separate repositories that `ci/common.deps.sh` clones.

## Feature coverage

Everything that cross-compiles is built. Two addons are excluded on technical grounds rather than size: `score-addon-onnx` `FetchContent`s a *prebuilt x86_64* onnxruntime during configure, and `score-addon-ultraleap` pulls a proprietary SDK — neither works offline nor cross-compiles.

`lv2`, `faust` and `ysfx` self-disable for want of OE recipes (they use `find_package` + `if(NOT TARGET) return()`), so the build succeeds without them. The README lists what each would need.

## Relationship to the other PRs

- **#2170** — required; this is stacked on it.
- **ossia/libossia#919** — `find_package(rapidfuzz CONFIG REQUIRED)` aborts before its own vendored fallback can run, so this layer carries a `rapidfuzz-cpp` recipe. That recipe becomes optional once #919 lands.
- **#2169** — makes the `do_install` cleanup of xtensor's stray Jupyter/xeus files redundant. Harmless either way; it targets paths that will simply stop existing.

Configuration follows the existing distro-packaging builds (`ci/debian.trixie-system.build.sh`, `ci/nix.build.nix`, the Flatpak manifest): system libraries, FHS layout, static plugins, `-O3`, plus realtime scheduling limits for the audio engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
