### PR TITLE
sysinfo addon

### DIFF
--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -83,6 +83,7 @@ then
   clone_addon         https://github.com/ossia/score-addon-ndi
   clone_addon    https://github.com/ossia/score-addon-spatgris
   clone_addon   https://github.com/ossia/score-addon-ultraleap
+  clone_addon     https://github.com/ossia/score-addon-sysinfo
 fi
 
 if [[ "$CI_PLATFORM" == "LINUX" || "$CI_PLATFORM" == "WIN32" ]]; then

--- a/src/plugins/score-lib-device/Device/ItemModels/NodeDisplayMethods.cpp
+++ b/src/plugins/score-lib-device/Device/ItemModels/NodeDisplayMethods.cpp
@@ -157,6 +157,11 @@ QVariant valueColumnData(const Device::Node& node, int role)
       // TODO a nice editor for lists.
       return State::convert::toPrettyString(val);
     }
+    else if(role == Qt::DisplayRole && val.get_type() == ossia::val_type::FLOAT)
+    {
+      // Done here explicitely to avoid Qt's default scientific notation QLocale conversion
+      return State::convert::toPrettyString(*val.target<float>());
+    }
     else
     {
       return State::convert::value<QVariant>(val);

--- a/src/plugins/score-lib-state/State/ValueConversion.cpp
+++ b/src/plugins/score-lib-state/State/ValueConversion.cpp
@@ -24,7 +24,10 @@
 #include <QVector3D>
 #include <QVector4D>
 
+#include <algorithm>
 #include <array>
+#include <cmath>
+#include <limits>
 
 namespace State
 {
@@ -558,6 +561,39 @@ char value(const ossia::value& val)
   return value<QChar>(val).toLatin1();
 }
 
+QString toPrettyString(float f)
+{
+  // A float carries this many decimal digits; asking for more only prints the
+  // binary expansion (108.89f as a double is 108.88999938964844).
+  static constexpr int significant = std::numeric_limits<float>::digits10 + 1;
+
+  // Below this, decimal notation can no longer hold every digit the float has,
+  // and above it, it starts spelling out digits the float never had.
+  static constexpr int max_decimals = 20;
+  static constexpr double max_value = 1e15;
+
+  const double d = f;
+  if(!std::isfinite(d))
+    return QString::number(d);
+
+  const double a = std::abs(d);
+  const int magnitude = (a == 0.) ? 0 : int(std::floor(std::log10(a)));
+  const int decimals = significant - magnitude - 1;
+
+  if(a != 0. && (decimals > max_decimals || a >= max_value))
+    return QString::number(d, 'g', significant);
+
+  QString str = QString::number(d, 'f', std::max(decimals, 0));
+  if(str.contains('.'))
+  {
+    while(str.endsWith('0'))
+      str.chop(1);
+    if(str.endsWith('.'))
+      str.chop(1);
+  }
+  return str;
+}
+
 QString toPrettyString(const ossia::value& val)
 {
   struct vis
@@ -571,13 +607,7 @@ QString toPrettyString(const ossia::value& val)
       str.remove(loc.groupSeparator());
       return str;
     }
-    QString operator()(float f) const
-    {
-      const auto& loc = QLocale::c();
-      auto str = loc.toString(f);
-      str.remove(loc.groupSeparator());
-      return str;
-    }
+    QString operator()(float f) const { return toPrettyString(f); }
     QString operator()(bool b) const
     {
       return QString::fromStdString(

--- a/src/plugins/score-lib-state/State/ValueConversion.hpp
+++ b/src/plugins/score-lib-state/State/ValueConversion.hpp
@@ -52,6 +52,11 @@ SCORE_LIB_STATE_EXPORT bool convert(const ossia::value& orig, ossia::value& toCo
 // 'a', ['a', 12], or "str" for a string.
 SCORE_LIB_STATE_EXPORT QString toPrettyString(const ossia::value& val);
 
+// Decimal notation, so that e.g. a byte count reads 137438953472 instead of
+// 1.37439e+11. Falls back to the exponent form for magnitudes where decimal
+// notation would be unreadable.
+SCORE_LIB_STATE_EXPORT QString toPrettyString(float f);
+
 // We require the type to crrectly read back (e.g. int / float / char)
 // and as an optimization, since we may need it multiple times,
 // we chose to leave the caller save it however he wants. Hence the specific


### PR DESCRIPTION
- **explorer: do not use scientific notation for large / small numbers**
- **addons: add sysinfo addon**
