### PR TITLE
media: link the codec libraries ossia SDK 38's ffmpeg needs

### DIFF
--- a/ci/appimage.deps.sh
+++ b/ci/appimage.deps.sh
@@ -19,7 +19,7 @@ else
   export CPU_ARCH_SUFFIX="-x86_64"
 fi
 
-wget -nv "https://github.com/ossia/sdk/releases/download/sdk37/sdk-linux${CPU_ARCH_SUFFIX}.tar.xz"
+wget -nv "https://github.com/ossia/sdk/releases/download/sdk38/sdk-linux${CPU_ARCH_SUFFIX}.tar.xz"
 tar xaf sdk-linux${CPU_ARCH_SUFFIX}.tar.xz
 rm -rf  sdk-linux${CPU_ARCH_SUFFIX}.tar.xz
 

--- a/ci/osx.package.deps.sh
+++ b/ci/osx.package.deps.sh
@@ -33,7 +33,7 @@ brew install gnu-tar ninja xz
 wget -nv "https://github.com/jcelerier/cninja/releases/download/v3.7.9/cninja-v3.7.9-macOS-$MACOS_ARCH.tar.gz" -O cninja.tgz &
 
 SDK_ARCHIVE=sdk-macOS-$MACOS_ARCH.tar.xz
-wget -nv https://github.com/ossia/sdk/releases/download/sdk37/$SDK_ARCHIVE -O "$SDK_ARCHIVE"
+wget -nv https://github.com/ossia/sdk/releases/download/sdk38/$SDK_ARCHIVE -O "$SDK_ARCHIVE"
 
 sudo mkdir -p "/opt/ossia-sdk-$MACOS_ARCH/"
 sudo chown -R "$(whoami)" /opt

--- a/ci/wasm.deps.sh
+++ b/ci/wasm.deps.sh
@@ -14,7 +14,7 @@ $SUDO apt-get install -y --no-install-recommends \
 
 # The wasm SDK built by ossia/sdk CI (Qt 6.12, emsdk 5.0.5, ffmpeg 8.1).
 export SDK_ARCHIVE=sdk-wasm.tar.xz
-wget -nv https://github.com/ossia/sdk/releases/download/sdk37/$SDK_ARCHIVE -O $SDK_ARCHIVE
+wget -nv https://github.com/ossia/sdk/releases/download/sdk38/$SDK_ARCHIVE -O $SDK_ARCHIVE
 
 $SUDO mkdir -p /opt/ossia-sdk-wasm
 $SUDO chown -R "$(whoami)" /opt/ossia-sdk-wasm

--- a/ci/win32.deps.sh
+++ b/ci/win32.deps.sh
@@ -15,7 +15,7 @@ fi
 set -x
 mkdir /c/ossia-sdk-$SDK_ARCH
 cd /c/ossia-sdk-$SDK_ARCH
-curl -L https://github.com/ossia/sdk/releases/download/sdk37/sdk-mingw-$SDK_ARCH.7z --output sdk-mingw-$SDK_ARCH.7z
+curl -L https://github.com/ossia/sdk/releases/download/sdk38/sdk-mingw-$SDK_ARCH.7z --output sdk-mingw-$SDK_ARCH.7z
 7z x sdk-mingw-$SDK_ARCH.7z
 rm sdk-mingw-$SDK_ARCH.7z
 ls

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -252,6 +252,79 @@ elseif(TARGET avcodec)
           )
       endif()
     endif()
+
+    # ossia SDK 37 (ffmpeg 9) builds libavcodec / libavformat against a set of
+    # codec and protocol libraries that earlier SDKs did not have: dav1d, x264,
+    # x265, opus, vpx, webp, SVT-JPEG-XS, mp3lame, libxml2, SRT (which itself
+    # links the SDK's openssl) and freetype+harfbuzz for the drawtext filter.
+    #
+    # FindFFmpeg.cmake imports only the av* archives: it asks pkg-config for the
+    # include and library DIRECTORIES but never for Libs.private, so none of the
+    # above reaches the link line on its own and a static score dies in a wall of
+    # undefined references.
+    #
+    # Every entry is looked up rather than required. SDK 36 has none of them, and
+    # even in 37 some are target-dependent -- Windows-on-ARM has no OpenSSL mingw
+    # target, so libsrt is built there without encryption. Found => linked,
+    # missing => nothing changes; that is what keeps this file building against
+    # both SDKs, and it is inert for a distro/homebrew ffmpeg since the whole
+    # block is under if(OSSIA_SDK).
+    set(SCORE_SDK_LIBDIRS
+      "${OSSIA_SDK}/sysroot/lib"     # Linux + Windows: shared dep prefix
+      "${OSSIA_SDK}/sysroot/lib64"   # Linux, RedHat layout
+      "${OSSIA_SDK}/lib"             # macOS: media-deps installs into the prefix
+      "${OSSIA_SDK}/openssl/lib"
+      "${OSSIA_SDK}/openssl/lib64"
+      "${OSSIA_SDK}/freetype/lib"    # macOS keeps these in their own prefixes
+      "${OSSIA_SDK}/harfbuzz/lib"
+    )
+    # Ordered for a static link: dependants before their dependencies.
+    # libwebp needs sharpyuv, libsrt needs ssl+crypto, freetype needs harfbuzz.
+    foreach(_sdk_lib
+        dav1d x264 x265 opus vpx webpmux webp sharpyuv SvtJpegxs mp3lame xml2
+        srt ssl crypto freetype harfbuzz)
+      # NO_DEFAULT_PATH is deliberate: these have to be the SDK's own copies.
+      # Silently linking a system libssl or libfreetype here is exactly the kind
+      # of leak the SDK exists to prevent, and it would only show up as a crash
+      # on someone else's machine.
+      find_library(SCORE_SDK_LIB_${_sdk_lib}
+        NAMES ${_sdk_lib}
+        PATHS ${SCORE_SDK_LIBDIRS}
+        NO_DEFAULT_PATH
+      )
+      mark_as_advanced(SCORE_SDK_LIB_${_sdk_lib})
+      if(SCORE_SDK_LIB_${_sdk_lib})
+        # PUBLIC: score-plugin-gfx links avcodec/avformat directly and picks
+        # these up through this target's interface, after them, which is the
+        # order a static link needs.
+        target_link_libraries(${PROJECT_NAME} PUBLIC "${SCORE_SDK_LIB_${_sdk_lib}}")
+      endif()
+    endforeach()
+
+    # libvpx, libwebp, libsrt and x265 all use pthreads. Being raw archive paths
+    # they carry no dependency information for CMake to order around, so name
+    # this last rather than relying on whatever libossia's find_package(Threads)
+    # happens to place earlier in the line. No-op where the compiler implies it.
+    find_package(Threads)
+    if(TARGET Threads::Threads)
+      target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
+    endif()
+
+    if(WIN32)
+      # System import libraries the SDK's ffmpeg now pulls in, taken from the
+      # Libs: lines of the .pc files it installs:
+      #   libavcodec   mediafoundation -> mfuuid, ole32, strmiids
+      #   libavformat  schannel        -> secur32, ncrypt, crypt32
+      #                srt             -> ws2_32, wsock32, advapi32, shell32
+      #   libavutil                    -> bcrypt
+      #   libavdevice                  -> psapi, uuid, oleaut32, shlwapi, gdi32
+      # All are OS import libraries present in both mingw and MSVC, so listing
+      # them costs nothing where they were already coming in via Qt.
+      target_link_libraries(${PROJECT_NAME} PRIVATE
+        mfuuid ole32 oleaut32 uuid shlwapi psapi gdi32 advapi32 shell32
+        secur32 ncrypt crypt32 bcrypt ws2_32 wsock32
+      )
+    endif()
   endif()
   target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})
 endif()

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -253,7 +253,7 @@ elseif(TARGET avcodec)
       endif()
     endif()
 
-    # ossia SDK 37 (ffmpeg 9) builds libavcodec / libavformat against a set of
+    # ossia SDK 38 (ffmpeg 9) builds libavcodec / libavformat against a set of
     # codec and protocol libraries that earlier SDKs did not have: dav1d, x264,
     # x265, opus, vpx, webp, SVT-JPEG-XS, mp3lame, libxml2, SRT (which itself
     # links the SDK's openssl) and freetype+harfbuzz for the drawtext filter.

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -280,9 +280,13 @@ elseif(TARGET avcodec)
     )
     # Ordered for a static link: dependants before their dependencies.
     # libwebp needs sharpyuv, libsrt needs ssl+crypto, freetype needs harfbuzz.
+    #
+    # jpeg: the SDK builds libjpeg-turbo (Qt is configured -system-libjpeg), and
+    # on aarch64 Linux libavdevice reaches it too -- ffmpeg's --enable-libv4l2
+    # resolves libv4l2.pc statically, whose Libs.private ends in "-ljpeg".
     foreach(_sdk_lib
         dav1d x264 x265 opus vpx webpmux webp sharpyuv SvtJpegxs mp3lame xml2
-        srt ssl crypto freetype harfbuzz)
+        srt ssl crypto freetype harfbuzz jpeg)
       # NO_DEFAULT_PATH is deliberate: these have to be the SDK's own copies.
       # Silently linking a system libssl or libfreetype here is exactly the kind
       # of leak the SDK exists to prevent, and it would only show up as a crash
@@ -348,7 +352,20 @@ if(OSSIA_SDK)
   endif()
 
   if(LINUX)
-    target_link_libraries(${PROJECT_NAME} PUBLIC v4l2)
+    # v4lconvert alongside v4l2: on aarch64 the SDK's ffmpeg is built
+    # --enable-libv4l2 and, because it resolves libv4l2.pc with --static,
+    # libavdevice's EXTRALIBS carry the whole private chain
+    # "-lv4l2 -lpthread -lv4lconvert -lrt -lm -ljpeg". v4l2 and v4lconvert are
+    # the distro's (they are what libv4l is); jpeg comes from the SDK, above.
+    # find_library rather than a bare name so an x86_64 machine without
+    # libv4lconvert.so keeps building -- that leg is --disable-libv4l2 anyway.
+    find_library(SCORE_V4LCONVERT_LIBRARY v4lconvert)
+    mark_as_advanced(SCORE_V4LCONVERT_LIBRARY)
+    if(SCORE_V4LCONVERT_LIBRARY)
+      target_link_libraries(${PROJECT_NAME} PUBLIC v4l2 "${SCORE_V4LCONVERT_LIBRARY}")
+    else()
+      target_link_libraries(${PROJECT_NAME} PUBLIC v4l2)
+    endif()
   endif()
 endif()
 

--- a/tools/fetch-sdk.sh
+++ b/tools/fetch-sdk.sh
@@ -3,7 +3,7 @@
 if [[ $# > 0 ]]; then
   export SDK_VERSION=$1
 else
-  export SDK_VERSION=sdk37
+  export SDK_VERSION=sdk38
 fi
 
 echo "Running on OSTYPE: '$OSTYPE'"


### PR DESCRIPTION
Companion to **ossia/sdk#30** (ffmpeg 9 + network/TLS + hardware decoding + codecs). Without this, a static score against SDK 37 does not link.

### Why

SDK 37's `libavcodec`/`libavformat` reference dav1d, x264, x265, opus, vpx, webp (+`sharpyuv`, `webpmux`), SVT-JPEG-XS, mp3lame, libxml2, SRT (which links the SDK's openssl) and freetype+harfbuzz for `drawtext`.

`cmake/modules/FindFFmpeg.cmake` imports only the `av*` archives — it runs pkg-config for the include/library *directories* and then `find_library()`s each component, so `Libs.private` never reaches the link line. Nothing else in the tree names these libraries, so the link fails with undefined references.

### Why it can't break the matrix

- The whole block is inside the existing `if(OSSIA_SDK)` — distro and Homebrew ffmpeg builds are untouched.
- Every library is *looked up*, not required. SDK 36 has none of them → nothing is added. Even inside SDK 37 some are target-dependent (Windows-on-ARM has no OpenSSL mingw target, so libsrt is built without encryption there and no libssl exists).
- `NO_DEFAULT_PATH` on every lookup, searching only the SDK's own directories, so a host `libssl`/`libfreetype` can never be picked up silently.
- The WASM path is a separate branch (`if(EMSCRIPTEN)`) and is not touched.

### Ordering

`PUBLIC`, because score-plugin-gfx links `avcodec`/`avformat` directly and lists `score_plugin_media` after them, so it inherits these in the order a static link needs. Within the list dependants precede dependencies (webp → sharpyuv, srt → ssl/crypto), and `Threads::Threads` is last because raw archive paths carry no dependency info for CMake to order around.

### Validation

| what | result |
|---|---|
| Windows, real SDK 37 prefix on a mingw box: program calling `avdevice_register_all` + `avformat_network_init` and iterating every codec, filter, demuxer, muxer and protocol | links with exactly this list, runs clean (exit 0) |
| its import table | system DLLs only — no `libcuda`, `vulkan-1` or `amfrt64`, so the SDK's hardware acceleration is confirmed dlopen-only |
| CMake logic vs. SDK 37 Linux/Windows layout | all 16 resolved, in order |
| vs. SDK 36 layout | nothing added |
| vs. macOS layout (`$OSSIA_SDK/lib`) | all resolved |
| vs. an SDK with no openssl | system `libssl` correctly **not** picked up |

The Windows system import libraries added under `if(WIN32)` (mfuuid/ole32/strmiids for MediaFoundation, secur32/ncrypt/crypt32 for schannel, ws2_32/wsock32 for SRT, bcrypt, psapi/uuid/oleaut32/shlwapi/gdi32 for libavdevice) were read off the `Libs:` lines of the `.pc` files the SDK installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)