### PR TITLE
Start score when the machine starts

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -125,6 +125,7 @@ set(HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/score/document/ChangeId.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/document/DocumentContext.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/document/DocumentInterface.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/score/application/Autostart.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/gfx/DisplayConfig.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/gfx/OpenGL.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score/gfx/Vulkan.hpp"
@@ -390,6 +391,7 @@ set(SRCS
 "${CMAKE_CURRENT_SOURCE_DIR}/score/tools/IdentifierGeneration.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/score/command/CommandDataSerialization.cpp"
 
+"${CMAKE_CURRENT_SOURCE_DIR}/score/application/Autostart.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/score/gfx/DisplayConfig.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/score/gfx/OpenGL.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/score/gfx/Vulkan.cpp"

--- a/src/lib/score/application/Autostart.cpp
+++ b/src/lib/score/application/Autostart.cpp
@@ -1,0 +1,245 @@
+#include <score/application/Autostart.hpp>
+
+#include <QDir>
+#include <QtGlobal>
+#include <QFileInfo>
+
+namespace score
+{
+namespace
+{
+//! Quoting for a place that takes one string and splits it itself.
+QString quoted(const QString& s)
+{
+  return QStringLiteral("\"") + QString{s}.replace('"', QStringLiteral("\\\""))
+         + QStringLiteral("\"");
+}
+
+QString xmlEscaped(const QString& s)
+{
+  QString r = s;
+  r.replace('&', QStringLiteral("&amp;"));
+  r.replace('<', QStringLiteral("&lt;"));
+  r.replace('>', QStringLiteral("&gt;"));
+  r.replace('"', QStringLiteral("&quot;"));
+  return r;
+}
+
+//! ISO 8601, which is how both Task Scheduler and launchd spell a duration.
+QString isoSeconds(int seconds)
+{
+  return QStringLiteral("PT%1S").arg(seconds);
+}
+}
+
+QString autostartIdentifier()
+{
+  return QStringLiteral("ossia-score");
+}
+
+QStringList autostartCommandLine(const AutostartSettings& s, const QString& executable)
+{
+  QStringList args;
+  if(s.hideEditor)
+    args << QStringLiteral("--no-gui");
+  if(s.waitLoad)
+    args << QStringLiteral("--wait-load");
+  if(s.autoplay)
+    args << QStringLiteral("--autoplay");
+
+  // Last: everything before it is an option, and a document whose name starts
+  // with a dash would otherwise be read as one.
+  if(!s.document.isEmpty())
+    args << s.document;
+
+  return QStringList{executable} << args;
+}
+
+QString systemdUnit(const AutostartSettings& s, const QString& executable)
+{
+  const auto cmd = autostartCommandLine(s, executable);
+
+  QString exec;
+  for(const auto& part : cmd)
+    exec += (exec.isEmpty() ? QString{} : QStringLiteral(" ")) + quoted(part);
+
+  QString u;
+  u += QStringLiteral("[Unit]\n");
+  u += QStringLiteral("Description=ossia score\n");
+  // Without this the score starts before there is a display or a network to
+  // use, which on a machine that boots straight into a show is the same as not
+  // starting.
+  u += QStringLiteral("After=network-online.target sound.target\n");
+  u += QStringLiteral("Wants=network-online.target\n\n");
+
+  u += QStringLiteral("[Service]\n");
+  u += QStringLiteral("Type=simple\n");
+  if(s.delaySeconds > 0)
+    u += QStringLiteral("ExecStartPre=/bin/sleep %1\n").arg(s.delaySeconds);
+  u += QStringLiteral("ExecStart=%1\n").arg(exec);
+
+  if(s.restartOnCrash)
+  {
+    u += QStringLiteral("Restart=always\n");
+    u += QStringLiteral("RestartSec=5\n");
+    // The guard: five failures in two minutes and systemd stops trying. A
+    // score that cannot start would otherwise be restarted forever, and a
+    // machine in that state cannot be logged into to fix it.
+    u += QStringLiteral("StartLimitIntervalSec=120\n");
+    u += QStringLiteral("StartLimitBurst=5\n");
+  }
+  u += QStringLiteral("\n[Install]\n");
+  u += s.systemScope ? QStringLiteral("WantedBy=multi-user.target\n")
+                     : QStringLiteral("WantedBy=default.target\n");
+  return u;
+}
+
+QString xdgDesktopEntry(const AutostartSettings& s, const QString& executable)
+{
+  auto cmd = autostartCommandLine(s, executable);
+
+  // Nothing here can wait, so the delay is spent by the command itself.
+  if(s.delaySeconds > 0)
+  {
+    QStringList wrapped{
+        QStringLiteral("/bin/sh"), QStringLiteral("-c"),
+        QStringLiteral("sleep %1; exec ").arg(s.delaySeconds) + cmd.join(' ')};
+    cmd = wrapped;
+  }
+
+  QString exec;
+  for(const auto& part : cmd)
+    exec += (exec.isEmpty() ? QString{} : QStringLiteral(" ")) + part;
+
+  QString d;
+  d += QStringLiteral("[Desktop Entry]\n");
+  d += QStringLiteral("Type=Application\n");
+  d += QStringLiteral("Name=ossia score\n");
+  d += QStringLiteral("Exec=%1\n").arg(exec);
+  d += QStringLiteral("X-GNOME-Autostart-enabled=true\n");
+  d += QStringLiteral("Terminal=false\n");
+  return d;
+}
+
+QString windowsTaskXml(const AutostartSettings& s, const QString& executable)
+{
+  QStringList args = autostartCommandLine(s, executable);
+  args.removeFirst();
+
+  QString arguments;
+  for(const auto& a : args)
+    arguments += (arguments.isEmpty() ? QString{} : QStringLiteral(" ")) + quoted(a);
+
+  const auto trigger = s.systemScope ? QStringLiteral("BootTrigger")
+                                     : QStringLiteral("LogonTrigger");
+
+  QString x;
+  x += QStringLiteral("<?xml version=\"1.0\" encoding=\"UTF-16\"?>\n");
+  x += QStringLiteral("<Task version=\"1.2\" "
+                      "xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/"
+                      "task\">\n");
+  x += QStringLiteral("  <RegistrationInfo>\n    <Description>ossia "
+                      "score</Description>\n  </RegistrationInfo>\n");
+
+  x += QStringLiteral("  <Triggers>\n    <%1>\n      "
+                      "<Enabled>true</Enabled>\n")
+           .arg(trigger);
+  if(s.delaySeconds > 0)
+    x += QStringLiteral("      <Delay>%1</Delay>\n").arg(isoSeconds(s.delaySeconds));
+  x += QStringLiteral("    </%1>\n  </Triggers>\n").arg(trigger);
+
+  x += QStringLiteral("  <Principals>\n    <Principal id=\"Author\">\n");
+  x += s.systemScope
+           ? QStringLiteral("      <UserId>S-1-5-18</UserId>\n      "
+                            "<RunLevel>HighestAvailable</RunLevel>\n")
+           : QStringLiteral("      <LogonType>InteractiveToken</LogonType>\n      "
+                            "<RunLevel>LeastPrivilege</RunLevel>\n");
+  x += QStringLiteral("    </Principal>\n  </Principals>\n");
+
+  x += QStringLiteral("  <Settings>\n");
+  // Both of these default the wrong way for something that has to stay up: a
+  // task will not start on battery, and is stopped after three days.
+  x += QStringLiteral("    <DisallowStartIfOnBatteries>false</"
+                      "DisallowStartIfOnBatteries>\n");
+  x += QStringLiteral("    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>\n");
+  x += QStringLiteral("    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>\n");
+  // A second copy started by a later trigger would fight the first over the
+  // audio device and the screen.
+  x += QStringLiteral("    <MultipleInstancesPolicy>IgnoreNew</"
+                      "MultipleInstancesPolicy>\n");
+  if(s.restartOnCrash)
+  {
+    // Bounded, for the same reason as StartLimitBurst.
+    x += QStringLiteral("    <RestartOnFailure>\n      <Interval>PT1M</Interval>\n     "
+                        " <Count>5</Count>\n    </RestartOnFailure>\n");
+  }
+  x += QStringLiteral("  </Settings>\n");
+
+  x += QStringLiteral("  <Actions Context=\"Author\">\n    <Exec>\n");
+  x += QStringLiteral("      <Command>%1</Command>\n").arg(xmlEscaped(executable));
+  if(!arguments.isEmpty())
+    x += QStringLiteral("      <Arguments>%1</Arguments>\n").arg(xmlEscaped(arguments));
+  x += QStringLiteral("      <WorkingDirectory>%1</WorkingDirectory>\n")
+           .arg(xmlEscaped(QFileInfo{executable}.absolutePath()));
+  x += QStringLiteral("    </Exec>\n  </Actions>\n</Task>\n");
+  return x;
+}
+
+QString windowsRunCommand(const AutostartSettings& s, const QString& executable)
+{
+  const auto cmd = autostartCommandLine(s, executable);
+  QString line;
+  for(const auto& part : cmd)
+    line += (line.isEmpty() ? QString{} : QStringLiteral(" ")) + quoted(part);
+  return line;
+}
+
+QString launchdPlist(const AutostartSettings& s, const QString& executable)
+{
+  const auto cmd = autostartCommandLine(s, executable);
+
+  QString p;
+  p += QStringLiteral("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+  p += QStringLiteral("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
+                      "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n");
+  p += QStringLiteral("<plist version=\"1.0\">\n<dict>\n");
+  p += QStringLiteral("  <key>Label</key>\n  <string>%1</string>\n")
+           .arg(autostartIdentifier());
+
+  p += QStringLiteral("  <key>ProgramArguments</key>\n  <array>\n");
+  for(const auto& part : cmd)
+    p += QStringLiteral("    <string>%1</string>\n").arg(xmlEscaped(part));
+  p += QStringLiteral("  </array>\n");
+
+  p += QStringLiteral("  <key>RunAtLoad</key>\n  <true/>\n");
+  if(s.restartOnCrash)
+  {
+    p += QStringLiteral("  <key>KeepAlive</key>\n  <true/>\n");
+    // launchd throttles a job that exits repeatedly; asking for less than ten
+    // seconds is ignored, so this is the floor rather than a choice.
+    p += QStringLiteral("  <key>ThrottleInterval</key>\n  <integer>10</integer>\n");
+  }
+  if(s.delaySeconds > 0)
+    p += QStringLiteral("  <key>StartInterval</key>\n  <integer>%1</integer>\n")
+             .arg(s.delaySeconds);
+  p += QStringLiteral("</dict>\n</plist>\n");
+  return p;
+}
+
+bool runningUnderSupervisor()
+{
+#if defined(__linux__)
+  // systemd stamps every service it starts with this; nothing else sets it.
+  return qEnvironmentVariableIsSet("INVOCATION_ID");
+#elif defined(__APPLE__)
+  // launchd names the job it is running in. A shell has it unset or "0".
+  const auto xpc = qgetenv("XPC_SERVICE_NAME");
+  return !xpc.isEmpty() && xpc != "0";
+#else
+  // Task Scheduler leaves nothing in the environment to recognise it by, so
+  // this answers no and score restarts itself as it would unsupervised. The
+  // task's MultipleInstancesPolicy is what keeps that from doubling up.
+  return false;
+#endif
+}
+}

--- a/src/lib/score/application/Autostart.hpp
+++ b/src/lib/score/application/Autostart.hpp
@@ -1,0 +1,135 @@
+#pragma once
+#include <QString>
+#include <QStringList>
+
+#include <score_lib_base_export.h>
+
+namespace score
+{
+/**
+ * @brief Starting score when the machine does, and keeping it started.
+ *
+ * An appliance is a computer somebody switched on. Nobody logs into it, nobody
+ * opens a file, and when it stops nobody is there to start it again. What that
+ * needs from score is small -- register with whatever the system uses to launch
+ * things -- but the systems disagree about what can be asked of them, and the
+ * ways they disagree are the whole design.
+ */
+struct SCORE_LIB_BASE_EXPORT AutostartSettings
+{
+  bool enabled{};
+
+  //! Seconds to wait before starting. A machine that has just booted may not
+  //! have its network, its audio device or its displays yet.
+  int delaySeconds{};
+
+  //! Document to open, or empty for none.
+  QString document;
+
+  bool autoplay{};
+
+  //! Come up without an editor. On a board with no window manager this is also
+  //! what lets the render output own the screen.
+  bool hideEditor{};
+
+  //! Finish loading before starting to play.
+  bool waitLoad{};
+
+  bool restartOnCrash{};
+
+  /**
+   * Start with the machine rather than with a login.
+   *
+   * A box in a rack has no session for a per-user registration to hang from.
+   * Costs elevation to install, everywhere.
+   */
+  bool systemScope{};
+
+  bool operator==(const AutostartSettings&) const noexcept = default;
+};
+
+/**
+ * @brief What the mechanism available here can actually be asked to do.
+ *
+ * Asked by the settings page so it can refuse to offer what nothing behind it
+ * will honour. A control that silently does nothing is worse than an absent
+ * one: it is believed.
+ */
+struct SCORE_LIB_BASE_EXPORT AutostartCapabilities
+{
+  bool available{};
+  bool canDelay{};
+  bool canRestartOnCrash{};
+  //! Whether starting without a login session is possible at all.
+  bool canRunWithoutSession{};
+  //! Whether the settings as given would need administrator rights.
+  bool needsElevation{};
+  //! What will actually be written, in words, for the page to show.
+  QString mechanism;
+};
+
+//! Whether something is registered, and whether it is still us.
+enum class AutostartState
+{
+  NotInstalled,
+  Installed,
+  //! Registered, but pointing at another binary -- score was moved, or a second
+  //! copy registered itself.
+  InstalledElsewhere
+};
+
+/**
+ * @brief The command line the registration will run.
+ *
+ * The registration carries the whole invocation rather than score reading a
+ * second configuration at startup: the unit, task or entry then says what it
+ * does, and can be pasted into a terminal when it does not do it.
+ */
+SCORE_LIB_BASE_EXPORT QStringList
+autostartCommandLine(const AutostartSettings& s, const QString& executable);
+
+/**
+ * @brief A systemd unit for these settings.
+ *
+ * Restart is bounded on purpose. Unbounded restart plus a score that fails at
+ * startup is a boot loop, and on a machine with no keyboard that is not
+ * recoverable.
+ */
+SCORE_LIB_BASE_EXPORT QString
+systemdUnit(const AutostartSettings& s, const QString& executable);
+
+//! A desktop entry, for a session with no systemd. It can express neither a
+//! restart nor a start without a login.
+SCORE_LIB_BASE_EXPORT QString
+xdgDesktopEntry(const AutostartSettings& s, const QString& executable);
+
+/**
+ * @brief A Task Scheduler task for these settings.
+ *
+ * Several of its defaults are wrong for something that must keep running: a
+ * task refuses to start on battery, and is stopped after three days. Both are
+ * turned off here.
+ */
+SCORE_LIB_BASE_EXPORT QString
+windowsTaskXml(const AutostartSettings& s, const QString& executable);
+
+//! The value for the Run key, which is a command line and nothing else.
+SCORE_LIB_BASE_EXPORT QString
+windowsRunCommand(const AutostartSettings& s, const QString& executable);
+
+//! A launchd agent property list.
+SCORE_LIB_BASE_EXPORT QString
+launchdPlist(const AutostartSettings& s, const QString& executable);
+
+//! The name score registers itself under, on every system.
+SCORE_LIB_BASE_EXPORT QString autostartIdentifier();
+
+/**
+ * @brief Whether something else is already responsible for restarting score.
+ *
+ * A supervisor and score both restarting it gives two of them, one of which
+ * nothing is watching. Anything that wants to restart score has to ask this
+ * first and simply exit instead.
+ */
+SCORE_LIB_BASE_EXPORT bool runningUnderSupervisor();
+}

--- a/tests/unit/AutostartTest.cpp
+++ b/tests/unit/AutostartTest.cpp
@@ -1,0 +1,204 @@
+// Starting score when the machine starts.
+//
+// What is worth testing here is what gets written: a unit, a task or an entry
+// is read by something else entirely, and a mistake in it shows up as a
+// machine that does not come up -- often one with no keyboard attached. So the
+// generation is pure and pinned here, including the parts whose absence would
+// be silent.
+
+#include <score/application/Autostart.hpp>
+
+#include <QRegularExpression>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace score;
+
+namespace
+{
+AutostartSettings appliance()
+{
+  AutostartSettings s;
+  s.enabled = true;
+  s.document = "/home/user/show.score";
+  s.autoplay = true;
+  s.hideEditor = true;
+  s.waitLoad = true;
+  s.restartOnCrash = true;
+  s.delaySeconds = 30;
+  return s;
+}
+}
+
+TEST_CASE("The command line carries the whole intent", "[autostart]")
+{
+  const auto cmd = autostartCommandLine(appliance(), "/usr/bin/ossia-score");
+
+  REQUIRE(cmd.size() == 5);
+  CHECK(cmd[0] == "/usr/bin/ossia-score");
+  CHECK(cmd.contains("--no-gui"));
+  CHECK(cmd.contains("--autoplay"));
+  CHECK(cmd.contains("--wait-load"));
+
+  // The document goes last: an option after it would be read as a file, and a
+  // file named like an option would be read as one.
+  CHECK(cmd.last() == "/home/user/show.score");
+}
+
+TEST_CASE("Nothing asked for, nothing passed", "[autostart]")
+{
+  AutostartSettings s;
+  const auto cmd = autostartCommandLine(s, "/usr/bin/ossia-score");
+
+  REQUIRE(cmd.size() == 1);
+  CHECK(cmd[0] == "/usr/bin/ossia-score");
+}
+
+TEST_CASE("A systemd unit that cannot loop for ever", "[autostart]")
+{
+  const auto u = systemdUnit(appliance(), "/usr/bin/ossia-score");
+
+  CHECK(u.contains("ExecStart="));
+  CHECK(u.contains("--no-gui"));
+  CHECK(u.contains("/bin/sleep 30"));
+
+  CHECK(u.contains("Restart=always"));
+  // The guard. Without it a score that fails at startup is restarted for ever
+  // and the machine cannot be logged into to fix it -- which on an appliance
+  // means a trip to the hardware. This assertion is the whole reason the test
+  // exists.
+  CHECK(u.contains("StartLimitBurst="));
+  CHECK(u.contains("StartLimitIntervalSec="));
+}
+
+TEST_CASE("No restart asked, no restart written", "[autostart]")
+{
+  AutostartSettings s;
+  s.enabled = true;
+  const auto u = systemdUnit(s, "/usr/bin/ossia-score");
+
+  CHECK(!u.contains("Restart=always"));
+  CHECK(!u.contains("StartLimitBurst="));
+  CHECK(!u.contains("sleep"));
+}
+
+TEST_CASE("Scope decides what the unit is wanted by", "[autostart]")
+{
+  AutostartSettings user;
+  CHECK(systemdUnit(user, "/x").contains("WantedBy=default.target"));
+
+  AutostartSettings system;
+  system.systemScope = true;
+  CHECK(systemdUnit(system, "/x").contains("WantedBy=multi-user.target"));
+}
+
+TEST_CASE("A desktop entry spends the delay itself", "[autostart]")
+{
+  const auto d = xdgDesktopEntry(appliance(), "/usr/bin/ossia-score");
+
+  CHECK(d.startsWith("[Desktop Entry]"));
+  CHECK(d.contains("Type=Application"));
+  // It has nowhere to put a delay, so the command waits instead.
+  CHECK(d.contains("sleep 30"));
+  CHECK(d.contains("--no-gui"));
+}
+
+TEST_CASE("A Task Scheduler task that keeps running", "[autostart]")
+{
+  const auto x = windowsTaskXml(appliance(), "C:\\Program Files\\score\\ossia-score.exe");
+
+  CHECK(x.contains("<LogonTrigger>"));
+  CHECK(x.contains("<Delay>PT30S</Delay>"));
+
+  // Three defaults that are wrong for something meant to stay up. A task will
+  // not start on battery, will be stopped after three days, and a second
+  // trigger would start a second copy to fight the first for the audio device.
+  CHECK(x.contains("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>"));
+  CHECK(x.contains("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>"));
+  CHECK(x.contains("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>"));
+  CHECK(x.contains("<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>"));
+
+  // Bounded, exactly as the systemd unit is.
+  CHECK(x.contains("<RestartOnFailure>"));
+  CHECK(x.contains("<Count>5</Count>"));
+
+  CHECK(x.contains("<Command>C:\\Program Files\\score\\ossia-score.exe</Command>"));
+  CHECK(x.contains("--no-gui"));
+}
+
+TEST_CASE("A task that starts with the machine runs as the system", "[autostart]")
+{
+  auto s = appliance();
+  s.systemScope = true;
+  const auto x = windowsTaskXml(s, "C:\\score.exe");
+
+  CHECK(x.contains("<BootTrigger>"));
+  CHECK(!x.contains("<LogonTrigger>"));
+  // S-1-5-18 is LocalSystem: there is no session to borrow a token from.
+  CHECK(x.contains("<UserId>S-1-5-18</UserId>"));
+  CHECK(x.contains("HighestAvailable"));
+}
+
+TEST_CASE("XML that would not parse is XML that does not run", "[autostart]")
+{
+  AutostartSettings s;
+  s.document = "C:\\shows\\rock & roll <final>.score";
+  const auto x = windowsTaskXml(s, "C:\\score.exe");
+
+  CHECK(x.contains("&amp;"));
+  CHECK(x.contains("&lt;final&gt;"));
+  // The raw forms must not survive anywhere in the document.
+  CHECK(!x.contains("roll & roll"));
+}
+
+TEST_CASE("The Run key takes one line", "[autostart]")
+{
+  auto s = appliance();
+  s.delaySeconds = 0;
+  s.restartOnCrash = false;
+  const auto c = windowsRunCommand(s, "C:\\Program Files\\score\\ossia-score.exe");
+
+  // The registry hands the whole value to the shell, which splits on spaces:
+  // an unquoted Program Files becomes two arguments and nothing starts.
+  CHECK(c.startsWith("\"C:\\Program Files\\score\\ossia-score.exe\""));
+  CHECK(c.contains("\"--no-gui\""));
+  CHECK(!c.contains("\n"));
+}
+
+TEST_CASE("A launchd agent", "[autostart]")
+{
+  const auto p = launchdPlist(appliance(), "/Applications/score.app/Contents/MacOS/score");
+
+  CHECK(p.contains("<key>Label</key>"));
+  CHECK(p.contains(autostartIdentifier()));
+  CHECK(p.contains("<key>RunAtLoad</key>"));
+  CHECK(p.contains("<key>KeepAlive</key>"));
+  // launchd ignores anything under ten seconds, so asking for less would be a
+  // setting that silently does nothing.
+  CHECK(p.contains("<key>ThrottleInterval</key>"));
+
+  // One argument per string: launchd does no splitting of its own.
+  CHECK(p.contains("<string>--no-gui</string>"));
+  CHECK(p.contains("<string>/home/user/show.score</string>"));
+}
+
+TEST_CASE("A document whose path has spaces survives every mechanism", "[autostart]")
+{
+  AutostartSettings s;
+  s.document = "/home/user/My Shows/opening night.score";
+
+  CHECK(systemdUnit(s, "/usr/bin/ossia-score")
+            .contains("\"/home/user/My Shows/opening night.score\""));
+  CHECK(windowsRunCommand(s, "C:\\score.exe")
+            .contains("\"/home/user/My Shows/opening night.score\""));
+  CHECK(launchdPlist(s, "/x").contains(
+      "<string>/home/user/My Shows/opening night.score</string>"));
+}
+
+TEST_CASE("Whether something else is already restarting score", "[autostart]")
+{
+  // The tests do not run under a supervisor, and score must not decide it is
+  // supervised when it is not: that would turn its own restart into a plain
+  // exit and the way back to an editor would stop working.
+  CHECK(!runningUnderSupervisor());
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -632,3 +632,9 @@ score_add_test(test_unit_dshow_subtype
 # producing exactly what each understands is the whole feature.
 score_add_test(test_unit_display_config
   SOURCES DisplayConfigTest.cpp)
+
+# --- starting score when the machine starts ---------------------------------
+# What a unit, task or entry says is read by something else entirely, and a
+# mistake in one shows up as a machine that does not come up.
+score_add_test(test_unit_autostart
+  SOURCES AutostartTest.cpp)


### PR DESCRIPTION
Stacked on #2183, which it needs: coming up without an editor is a display setting, and this passes the flag that produces it.

An appliance is a computer somebody switched on. Nobody logs into it, nobody opens a file, and when it stops nobody is there to start it again.

This first commit is the part that can be tested without touching the machine: what would be written, and what each system will honour.

## Model

`AutostartSettings` — enabled, delay, document, autoplay, hide editor, wait for load, restart on crash, and whether to start with the machine rather than with a login.

`AutostartCapabilities` — what the mechanism available here can actually do, so the settings page can refuse to offer what nothing behind it will honour. A control that silently does nothing is worse than an absent one, because it is believed.

## The registration carries the command line

```
ossia-score --no-gui --wait-load --autoplay /path/to/show.score
```

rather than score reading a second configuration at startup. It reuses flags that already exist, the unit says what it does, and it can be pasted into a terminal when it does not do it.

## Defaults that are corrected rather than inherited

Each of these fails silently, on a machine that usually has no keyboard attached:

- **systemd** gets `StartLimitBurst` / `StartLimitIntervalSec`. Unbounded restart plus a score that fails at startup is a boot loop that nobody can log in to interrupt.
- **Task Scheduler** gets the same bound via `RestartOnFailure/Count`, plus three defaults turned off: a task refuses to start on battery, is stopped after three days by `ExecutionTimeLimit`, and a second trigger would start a second copy to fight the first over the audio device and the screen.
- **launchd** gets `ThrottleInterval`, since it ignores anything under ten seconds.
- **Desktop entries** can express neither a restart nor a start without a login, so the delay is spent by the command itself and the capability flags say what is missing.

## `runningUnderSupervisor()`

A supervisor and score both restarting it gives two of them, one of which nothing is watching. Nothing uses this yet — the shortcut that already restarts score into an editor will, in a later commit.

## Tests

`test_unit_autostart`, 13 cases: command line assembly and ordering, the presence of each guard above, boot-vs-logon scope, XML escaping of a document name containing `&` and `<`, and quoting of paths with spaces through every mechanism. All generation is pure, so none of it writes to the system.

## Still to come

Backends that install and remove, status read back from the system rather than from score's own settings, the settings page, and making the editor restart supervisor-aware.
