### PR TITLE
Make the range controls editable, and reload curve controls from their value

### DIFF
--- a/src/lib/score/graphics/widgets/QGraphicsRangeSlider.cpp
+++ b/src/lib/score/graphics/widgets/QGraphicsRangeSlider.cpp
@@ -49,10 +49,21 @@ void QGraphicsRangeSlider::setEnd(double end)
   }
 }
 
+double QGraphicsRangeSlider::to01(double v) const noexcept
+{
+  const double range = m_max - m_min;
+  return range > 0. ? (v - m_min) / range : 0.;
+}
+
+double QGraphicsRangeSlider::from01(double v) const noexcept
+{
+  return m_min + v * (m_max - m_min);
+}
+
 void QGraphicsRangeSlider::setValue(ossia::vec2f value)
 {
-  setStart(value[0]);
-  setEnd(value[1]);
+  setStart(to01(value[0]));
+  setEnd(to01(value[1]));
 }
 
 void QGraphicsRangeSlider::setExecutionValue(ossia::vec2f v)
@@ -71,15 +82,23 @@ void QGraphicsRangeSlider::resetExecution()
 
 ossia::vec2f QGraphicsRangeSlider::value() const noexcept
 {
-  return {float(m_start), float(m_end)};
+  return {float(from01(m_start)), float(from01(m_end))};
 }
 
 void QGraphicsRangeSlider::setRange(double min, double max, ossia::vec2f init)
 {
+  if(max <= min)
+    max = min + 1.;
+
+  // Keep pointing at the same absolute value across a domain change
+  const auto previous = value();
+
   m_min = min;
   m_max = max;
   m_init_start = init[0];
   m_init_end = init[1];
+
+  setValue(previous);
   update();
 }
 
@@ -102,7 +121,14 @@ void QGraphicsRangeSlider::mousePressEvent(QGraphicsSceneMouseEvent* event)
       ypos = event->pos().y();
     }
     else
-      handle = NONE;
+    {
+      // No strict winner. This notably happens when the range is empty, where
+      // the three handles sit on top of each other: leaving it at NONE made the
+      // slider impossible to move at all. Grab whichever bound the click landed
+      // on the side of.
+      const double center = (m_start + (m_end - m_start) / 2) * m_rect.width();
+      handle = (event->pos().x() < center) ? START : END;
+    }
   }
   event->accept();
 }
@@ -111,14 +137,20 @@ void QGraphicsRangeSlider::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 {
   switch(handle)
   {
-    case START:
+    case START: {
+      // std::clamp is UB when lo > hi, which happens as soon as the range
+      // collapses onto 0 (resp. 1 for the end handle).
+      const double hi = std::max(0., m_end - 0.001);
       d2s = event->pos().x() - m_start * m_rect.width();
-      m_start = std::clamp(m_start + d2s / m_rect.width(), 0., m_end - 0.001);
+      m_start = std::clamp(m_start + d2s / m_rect.width(), 0., hi);
       break;
-    case END:
+    }
+    case END: {
+      const double lo = std::min(1., m_start + 0.001);
       d2e = event->pos().x() - m_end * m_rect.width();
-      m_end = std::clamp(m_end + d2e / m_rect.width(), m_start + 0.001, 1.);
+      m_end = std::clamp(m_end + d2e / m_rect.width(), lo, 1.);
       break;
+    }
     case CENTER:
       d2c = event->pos().x() - (m_start + (m_end - m_start) / 2) * m_rect.width();
       ydiff = ypos - event->pos().y();

--- a/src/lib/score/graphics/widgets/QGraphicsRangeSlider.hpp
+++ b/src/lib/score/graphics/widgets/QGraphicsRangeSlider.hpp
@@ -33,10 +33,13 @@ public:
   explicit QGraphicsRangeSlider(QGraphicsItem* parent);
   ~QGraphicsRangeSlider();
 
+  //! Normalized positions, in [0; 1]
   void setStart(double start);
   void setEnd(double end);
   void setRange(double min, double max, ossia::vec2f init);
 
+  //! Absolute values, in [min; max] -- the handles are stored normalized but
+  //! the outside world speaks in the units of the control's domain.
   void setValue(ossia::vec2f value);
   ossia::vec2f value() const noexcept;
   ossia::vec2f m_execValue{};
@@ -49,6 +52,9 @@ public:
   void sliderMoved() E_SIGNAL(SCORE_LIB_BASE_EXPORT, sliderMoved)
   void sliderReleased() E_SIGNAL(SCORE_LIB_BASE_EXPORT, sliderReleased)
 private:
+  [[nodiscard]] double to01(double v) const noexcept;
+  [[nodiscard]] double from01(double v) const noexcept;
+
   void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
   void mouseMoveEvent(QGraphicsSceneMouseEvent* event) override;
   void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;

--- a/src/lib/score/widgets/ControlWidgets.cpp
+++ b/src/lib/score/widgets/ControlWidgets.cpp
@@ -7,7 +7,9 @@
 #include <ossia/network/dataspace/gain.hpp>
 
 #include <QAction>
+#include <QDoubleSpinBox>
 #include <QGuiApplication>
+#include <QHBoxLayout>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QStyle>
@@ -17,8 +19,108 @@
 #include <cmath>
 #include <wobjectimpl.h>
 W_OBJECT_IMPL(score::SearchLineEdit)
+W_OBJECT_IMPL(score::RangeWidget)
 namespace score
 {
+RangeWidget::RangeWidget(bool integral, QWidget* parent)
+    : QWidget{parent}
+    , m_start{new QDoubleSpinBox{this}}
+    , m_end{new QDoubleSpinBox{this}}
+{
+  auto lay = new QHBoxLayout{this};
+  lay->setContentsMargins(0, 0, 0, 0);
+  lay->setSpacing(2);
+  lay->addWidget(m_start);
+  lay->addWidget(m_end);
+
+  for(auto* sb : {m_start, m_end})
+  {
+    sb->setDecimals(integral ? 0 : 3);
+    sb->setSingleStep(integral ? 1. : 0.01);
+    sb->setKeyboardTracking(false);
+    sb->setContentsMargins(0, 0, 0, 0);
+  }
+  m_start->setPrefix(tr("min "));
+  m_end->setPrefix(tr("max "));
+
+  connect(
+      m_start, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
+      &RangeWidget::onStartEdited);
+  connect(
+      m_end, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
+      &RangeWidget::onEndEdited);
+}
+
+RangeWidget::~RangeWidget() = default;
+
+void RangeWidget::setRange(double min, double max, ossia::vec2f init)
+{
+  if(max <= min)
+    max = min + 1.;
+
+  m_init = init;
+
+  // Only the bounds change here: the current value must survive a domain
+  // change, it is set separately through setValue.
+  m_updating = true;
+  m_start->setRange(min, max);
+  m_end->setRange(min, max);
+  m_updating = false;
+}
+
+void RangeWidget::setValue(ossia::vec2f value)
+{
+  const double lo = std::min(value[0], value[1]);
+  const double hi = std::max(value[0], value[1]);
+
+  m_updating = true;
+  m_start->setValue(lo);
+  m_end->setValue(hi);
+  m_updating = false;
+}
+
+ossia::vec2f RangeWidget::value() const noexcept
+{
+  return ossia::vec2f{(float)m_start->value(), (float)m_end->value()};
+}
+
+void RangeWidget::onStartEdited()
+{
+  if(m_updating)
+    return;
+
+  // Keep the pair ordered by pushing the other bound out of the way
+  if(m_start->value() > m_end->value())
+  {
+    m_updating = true;
+    m_end->setValue(m_start->value());
+    m_updating = false;
+  }
+
+  moving = true;
+  sliderMoved();
+  moving = false;
+  sliderReleased();
+}
+
+void RangeWidget::onEndEdited()
+{
+  if(m_updating)
+    return;
+
+  if(m_end->value() < m_start->value())
+  {
+    m_updating = true;
+    m_start->setValue(m_end->value());
+    m_updating = false;
+  }
+
+  moving = true;
+  sliderMoved();
+  moving = false;
+  sliderReleased();
+}
+
 SearchLineEdit::SearchLineEdit(QWidget* parent)
     : QLineEdit{parent}
 {

--- a/src/lib/score/widgets/ControlWidgets.hpp
+++ b/src/lib/score/widgets/ControlWidgets.hpp
@@ -2,11 +2,18 @@
 #include <score/widgets/DoubleSlider.hpp>
 #include <score/widgets/IntSlider.hpp>
 
+#include <ossia/network/value/vec.hpp>
+
 #include <QPushButton>
 
 #include <score_lib_base_export.h>
 
 #include <array>
+
+#include <verdigris>
+
+class QDoubleSpinBox;
+
 namespace score
 {
 struct SCORE_LIB_BASE_EXPORT ToggleButton : public QPushButton
@@ -109,6 +116,45 @@ public:
 
 protected:
   void paintEvent(QPaintEvent* event) override;
+};
+
+/**
+ * @brief Editor for a pair (start, end), the QWidget counterpart of
+ * score::QGraphicsRangeSlider.
+ *
+ * The API deliberately mirrors QGraphicsRangeSlider -- setRange / setValue /
+ * value / moving / sliderMoved / sliderReleased -- so that the two can be
+ * driven by the same code in WidgetFactory.
+ *
+ * The two bounds are kept ordered: pushing the start above the end drags the
+ * end along, and vice-versa, so the control can never be put in a state where
+ * start > end.
+ */
+class SCORE_LIB_BASE_EXPORT RangeWidget final : public QWidget
+{
+  W_OBJECT(RangeWidget)
+
+public:
+  explicit RangeWidget(bool integral, QWidget* parent = nullptr);
+  ~RangeWidget();
+
+  void setRange(double min, double max, ossia::vec2f init);
+  void setValue(ossia::vec2f value);
+  [[nodiscard]] ossia::vec2f value() const noexcept;
+
+  bool moving = false;
+
+  void sliderMoved() E_SIGNAL(SCORE_LIB_BASE_EXPORT, sliderMoved)
+  void sliderReleased() E_SIGNAL(SCORE_LIB_BASE_EXPORT, sliderReleased)
+
+private:
+  void onStartEdited();
+  void onEndEdited();
+
+  QDoubleSpinBox* m_start{};
+  QDoubleSpinBox* m_end{};
+  ossia::vec2f m_init{};
+  bool m_updating{};
 };
 
 SCORE_LIB_BASE_EXPORT const QPalette& transparentPalette();

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -269,6 +269,36 @@ struct IntSlider
   }
 };
 
+//! Shared inspector editor for the (start, end) controls. The graphics view has
+//! score::QGraphicsRangeSlider; this is its QWidget counterpart.
+template <typename T>
+static auto make_range_widget(
+    T& inlet, const score::DocumentContext& ctx, QWidget* parent, QObject* context,
+    bool integral)
+{
+  auto sl = new score::RangeWidget{integral, parent};
+  if(integral)
+    bindIntDomain(inlet, inlet, *sl);
+  else
+    bindFloatDomain(inlet, inlet, *sl);
+  sl->setValue(ossia::convert<ossia::vec2f>(inlet.value()));
+  sl->setContentsMargins(0, 0, 0, 0);
+
+  QObject::connect(sl, &score::RangeWidget::sliderMoved, context, [sl, &inlet, &ctx] {
+    ctx.dispatcher.submit<SetControlValue<T>>(inlet, sl->value());
+  });
+  QObject::connect(sl, &score::RangeWidget::sliderReleased, context, [&ctx] {
+    ctx.dispatcher.commit();
+  });
+
+  QObject::connect(&inlet, &T::valueChanged, sl, [sl](const ossia::value& val) {
+    if(!sl->moving)
+      sl->setValue(ossia::convert<ossia::vec2f>(val));
+  });
+
+  return sl;
+}
+
 struct IntRangeSlider
 {
   static Process::PortItemLayout layout() noexcept
@@ -280,8 +310,7 @@ struct IntRangeSlider
   static auto make_widget(
       T& inlet, const score::DocumentContext& ctx, QWidget* parent, QObject* context)
   {
-    // TODO
-    return nullptr;
+    return make_range_widget(inlet, ctx, parent, context, /* integral */ true);
   }
 
   template <typename T, typename Control_T>
@@ -332,8 +361,7 @@ struct FloatRangeSlider
   static auto make_widget(
       T& inlet, const score::DocumentContext& ctx, QWidget* parent, QObject* context)
   {
-    // TODO
-    return nullptr;
+    return make_range_widget(inlet, ctx, parent, context, /* integral */ false);
   }
 
   template <typename T, typename Control_T>
@@ -384,8 +412,7 @@ struct FloatRangeSpinBox
   static auto make_widget(
       T& inlet, const score::DocumentContext& ctx, QWidget* parent, QObject* context)
   {
-    SCORE_TODO;
-    return nullptr; // TODO
+    return make_range_widget(inlet, ctx, parent, context, /* integral */ false);
   }
 
   template <typename T, typename Control_T>

--- a/src/plugins/score-plugin-dataflow/Dataflow/CurveInlet.cpp
+++ b/src/plugins/score-plugin-dataflow/Dataflow/CurveInlet.cpp
@@ -7,12 +7,14 @@
 #include <Curve/CurveStyle.hpp>
 #include <Curve/CurveView.hpp>
 #include <Curve/Palette/CurvePalette.hpp>
+#include <Curve/Segment/CurveSegmentData.hpp>
 #include <Curve/Segment/CurveSegmentList.hpp>
 #include <Curve/Segment/Power/PowerSegment.hpp>
 
 #include <score/application/GUIApplicationContext.hpp>
 #include <score/command/Dispatchers/CommandDispatcher.hpp>
 #include <score/document/DocumentContext.hpp>
+#include <score/document/DocumentInterface.hpp>
 #include <score/graphics/RectItem.hpp>
 #include <score/graphics/TextItem.hpp>
 
@@ -232,10 +234,125 @@ CurveInlet::CurveInlet(Id<Port> id, QObject* parent)
 void CurveInlet::init()
 {
   connect(m_curve, &Curve::Model::changed, this, &CurveInlet::on_curveChange);
+  connect(
+      this, &Process::ControlInlet::valueChanged, this, &CurveInlet::on_valueChange);
+}
+
+static std::optional<Curve::Point> curveInletPoint(const ossia::value& v)
+{
+  if(auto vec = v.target<ossia::vec2f>())
+    return Curve::Point{(*vec)[0], (*vec)[1]};
+
+  if(auto arr = v.target<std::vector<ossia::value>>())
+    if(arr->size() == 2)
+      return Curve::Point{
+          ossia::convert<float>((*arr)[0]), ossia::convert<float>((*arr)[1])};
+
+  return std::nullopt;
+}
+
+void CurveInlet::on_valueChange(const ossia::value& v)
+{
+  // Our own serialization coming back around
+  if(m_syncing)
+    return;
+
+  const auto* segments = v.target<std::vector<ossia::value>>();
+  if(!segments || segments->empty())
+    return;
+
+  // Curve::Model::fromCurveData resolves the document context from its parent
+  // chain, so it cannot run before the port has been inserted in a document --
+  // which happens when a preset is applied as the process is being created.
+  if(!score::IDocument::documentFromObject(*this))
+    return;
+
+  auto& csl = score::GUIAppContext().interfaces<Curve::SegmentList>();
+
+  std::vector<Curve::SegmentData> data;
+  data.reserve(segments->size());
+
+  for(const auto& seg : *segments)
+  {
+    // Same shapes as oscr::convert_to_curve accepts: [start, end] or
+    // [start, end, map], with map a gamma or the name of a segment type.
+    const auto* arr = seg.target<std::vector<ossia::value>>();
+    if(!arr || arr->size() < 2)
+      return;
+
+    const auto start = curveInletPoint((*arr)[0]);
+    const auto end = curveInletPoint((*arr)[1]);
+    if(!start || !end)
+      return;
+
+    auto type = Curve::PowerSegment::static_concreteKey();
+    QVariant specific = QVariant::fromValue(
+        Curve::PowerSegmentData{Curve::PowerSegmentData::linearGamma});
+
+    if(arr->size() >= 3)
+    {
+      const auto& map = (*arr)[2];
+      if(auto gamma = map.target<float>())
+      {
+        specific = QVariant::fromValue(Curve::PowerSegmentData{(double)*gamma});
+      }
+      else if(auto name = map.target<std::string>())
+      {
+        // on_curveChange writes the factory's pretty name for anything that is
+        // not a power segment; look it back up so those round-trip too.
+        const auto wanted = QString::fromStdString(*name);
+        for(auto& factory : csl)
+        {
+          if(factory.prettyName() == wanted)
+          {
+            type = factory.concreteKey();
+            specific = {};
+            break;
+          }
+        }
+      }
+    }
+
+    data.push_back(Curve::SegmentData{
+        Id<Curve::SegmentModel>{(int32_t)data.size()}, *start, *end, {}, {}, type,
+        std::move(specific)});
+  }
+
+  // Drop anything degenerate: Curve::Model cannot represent a segment that does
+  // not advance in x, and would assert on it.
+  std::erase_if(data, [](const Curve::SegmentData& s) {
+    return s.end.x() - s.start.x() < 0.0001;
+  });
+  if(data.empty())
+    return;
+
+  std::sort(
+      data.begin(), data.end(),
+      [](const Curve::SegmentData& a, const Curve::SegmentData& b) {
+    return a.x() < b.x();
+  });
+
+  // fromCurveData asserts that the chain is closed at both ends
+  const int N = std::ssize(data);
+  for(int i = 0; i < N; i++)
+  {
+    data[i].previous
+        = (i > 0) ? OptionalId<Curve::SegmentModel>{data[i - 1].id} : std::nullopt;
+    data[i].following
+        = (i < N - 1) ? OptionalId<Curve::SegmentModel>{data[i + 1].id} : std::nullopt;
+  }
+
+  m_syncing = true;
+  m_curve->fromCurveData(data);
+  m_syncing = false;
 }
 
 void CurveInlet::on_curveChange()
 {
+  // Rebuilding the model from the value must not write it straight back
+  if(m_syncing)
+    return;
+
   const auto& sorted = m_curve->sortedSegments();
 
   std::vector<ossia::value> segments;

--- a/src/plugins/score-plugin-dataflow/Dataflow/CurveInlet.hpp
+++ b/src/plugins/score-plugin-dataflow/Dataflow/CurveInlet.hpp
@@ -54,8 +54,17 @@ struct SCORE_PLUGIN_DATAFLOW_EXPORT CurveInlet : public Process::ControlInlet
   CurveInlet(JSONObject::Deserializer&& vis, QObject* parent);
 
   void init();
+
+  //! Curve editor -> port value
   void on_curveChange();
+  //! Port value -> curve editor, so that presets and any other external write
+  //! to the control actually show up in the editor.
+  void on_valueChange(const ossia::value& v);
 
   Curve::Model* m_curve{};
+
+  //! Guards the two directions against each other: rebuilding the model emits
+  //! changed(), which would otherwise immediately serialize it back.
+  bool m_syncing{};
 };
 }


### PR DESCRIPTION
Two independent fixes to shared control infrastructure, found while building MIDI objects that use these ports. Neither is specific to those objects.

## The range controls were not editable

`score::QGraphicsRangeSlider` keeps its handles **normalized to [0;1]** — `setStart`/`setEnd` clamp to that, painting multiplies by the item width — but `WidgetFactory::FloatRangeSlider::make_item` fed it **absolute** values and read them back as absolute. The `m_min`/`m_max` it was already storing went unused.

With a 1–127 domain and a full-range value, both handles clamped to `1.0` — sitting exactly on top of each other. `mousePressEvent` picks a handle with three strict `<` comparisons, which then have no winner, so it fell through to `handle = NONE` and **every drag silently did nothing**.

It works in `Calibrator` only by accident: its domain is 0–1, where normalized and absolute coincide.

Fixed in the widget, where the bounds already live. Two more defects found on the way:

- the handle-picking tie-break now always picks a handle, instead of giving up when the range is empty;
- `std::clamp(v, 0., m_end - 0.001)` and `std::clamp(v, m_start + 0.001, 1.)` had **`lo > hi` — undefined behaviour** — whenever the range collapsed onto an endpoint.

The inspector side had nothing at all: `IntRangeSlider`, `FloatRangeSlider` and `FloatRangeSpinBox` all `return nullptr` from `make_widget`, so there was no widget to interact with. Adds `score::RangeWidget`, the QWidget counterpart of `QGraphicsRangeSlider` with a deliberately identical API surface so both are driven by the same factory code, and wires it into all three.

## Curve controls did not reload from their value

`Dataflow::CurveInlet` was one-way: `init()` connects `Curve::Model::changed` → `on_curveChange` → `setValue`. Nothing did the reverse, and `setValue` isn't virtual, so **loading a preset stored the new segments and left the editor showing the old curve**.

Worse, the executor reads the port value (`initialize_control` → `from_ossia_value` → `convert_to_curve`), so the *sound* followed the preset while the display didn't — and the first edit afterwards fired `on_curveChange` and wrote the stale displayed curve back over it, silently reverting the preset.

Document save/load was never affected; that serializes the model directly. Only the preset path went through `setValue`.

Adds the value → model direction via `Curve::Model::fromCurveData`, the same entry point document loading uses. It accepts the shapes `oscr::convert_to_curve` accepts, so anything the DSP takes the editor now takes too. Three details worth noting:

- a single guard keeps the two directions from re-entering each other, since `fromCurveData` ends by emitting `changed()`;
- segments are sorted and linked head-to-tail with null at both ends, because `fromCurveData` asserts exactly that, and degenerate ones are dropped as `CurveEditor` does;
- it bails out when the port isn't in a document yet, which happens when a preset is applied *as* a process is being created — `fromCurveData` resolves the document context from its parent chain.

I checked the redraw path rather than assuming it: `Curve::Presenter` connects `curveReset` → `modelReset`, and `fromCurveData` blocks signals during the rebuild then emits `curveReset()`.

## Testing

Both are GUI-level and need a live `QApplication` plus a document, so they're exercised manually rather than by a unit test — `score_add_test(... APP)` would be the route if you want them covered. To reproduce the first: any object with a `range_slider` control whose domain isn't 0–1 (e.g. 1–127) is undraggable on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5kNpDQVQfbvHQBtv8LCNv