### PR TITLE
avnd: register Midi Humanize, and pin the Midi Envelope fixes with tests

### DIFF
--- a/src/plugins/score-plugin-avnd/CMakeLists.txt
+++ b/src/plugins/score-plugin-avnd/CMakeLists.txt
@@ -158,6 +158,7 @@ add_library(
   score_plugin_avnd
 
   "${AVND_FOLDER}/examples/Advanced/Utilities/ADSR.hpp"
+  "${AVND_FOLDER}/examples/Advanced/MidiScaler/MidiEnvelope.hpp"
   "${AVND_FOLDER}/examples/Advanced/Audio/AudioFilters.hpp"
   "${AVND_FOLDER}/examples/Advanced/Audio/Bitcrush.hpp"
   "${AVND_FOLDER}/examples/Advanced/Audio/Convolver.hpp"
@@ -563,6 +564,13 @@ avnd_make_score(
   SOURCES "${AVND_FOLDER}/examples/Advanced/MidiScaler/MidiScaler.hpp"
   TARGET midiscaler
   MAIN_CLASS MidiScaler
+  NAMESPACE mtk
+)
+
+avnd_make_score(
+  SOURCES "${AVND_FOLDER}/examples/Advanced/MidiScaler/MidiEnvelope.hpp"
+  TARGET midienvelope
+  MAIN_CLASS MidiEnvelope
   NAMESPACE mtk
 )
 

--- a/src/plugins/score-plugin-avnd/CMakeLists.txt
+++ b/src/plugins/score-plugin-avnd/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(
 
   "${AVND_FOLDER}/examples/Advanced/Utilities/ADSR.hpp"
   "${AVND_FOLDER}/examples/Advanced/MidiScaler/MidiEnvelope.hpp"
+  "${AVND_FOLDER}/examples/Advanced/MidiScaler/MidiHumanizer.hpp"
   "${AVND_FOLDER}/examples/Advanced/Audio/AudioFilters.hpp"
   "${AVND_FOLDER}/examples/Advanced/Audio/Bitcrush.hpp"
   "${AVND_FOLDER}/examples/Advanced/Audio/Convolver.hpp"
@@ -571,6 +572,13 @@ avnd_make_score(
   SOURCES "${AVND_FOLDER}/examples/Advanced/MidiScaler/MidiEnvelope.hpp"
   TARGET midienvelope
   MAIN_CLASS MidiEnvelope
+  NAMESPACE mtk
+)
+
+avnd_make_score(
+  SOURCES "${AVND_FOLDER}/examples/Advanced/MidiScaler/MidiHumanizer.hpp"
+  TARGET midihumanizer
+  MAIN_CLASS MidiHumanizer
   NAMESPACE mtk
 )
 

--- a/src/plugins/score-plugin-avnd/Crousti/ExecutorPortSetup.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/ExecutorPortSetup.hpp
@@ -25,6 +25,16 @@ struct con_unvalidated
   const Execution::Context& ctx;
   std::weak_ptr<ExecNode> weak_node;
   Field& field;
+
+  // NPred is the index of the port in whichever list it was dispatched from in
+  // Executor::connect_controls -- the controls, but also e.g. the curve ports.
+  // control_updated_from_ui indexes the control list, so the two only coincide
+  // when the port happens to be at the same position in both. Recompute it from
+  // the field index, which is unambiguous.
+  static constexpr std::size_t control_index
+      = avnd::control_input_introspection<Node>::field_index_to_index(
+          avnd::field_index<NField>{});
+
   void operator()(const ossia::value& val)
   {
     using control_value_type = std::decay_t<decltype(Field::value)>;
@@ -36,7 +46,8 @@ struct con_unvalidated
       ctx.executionQueue.enqueue([weak_node = weak_node, v = std::move(v)]() mutable {
         if(auto n = weak_node.lock())
         {
-          n->template control_updated_from_ui<control_value_type, NPred>(std::move(v));
+          n->template control_updated_from_ui<control_value_type, control_index>(
+              std::move(v));
         }
       });
     }

--- a/src/plugins/score-plugin-faust/Tests/FaustTester.cpp
+++ b/src/plugins/score-plugin-faust/Tests/FaustTester.cpp
@@ -31,9 +31,13 @@ int main(int argc, char** argv)
   llvm_dsp_factory* fac{};
 
   {
-    int argc = 0;
-    const char* argv[1] = {nullptr};
-    fac = createDSPFactoryFromString("score", str.c_str(), argc, argv, triple, err, -1);
+    fac = createDSPFactoryFromString("score", str.c_str(), argc-2, (const char**)(argv+2), triple, err, -1);
+
+    if(err[0] != 0)
+    {
+      qDebug() << "Faust error: " << err;
+    }
+
     assert(fac);
 
     auto obj = fac->createDSPInstance();

--- a/src/plugins/score-plugin-gfx/CMakeLists.txt
+++ b/src/plugins/score-plugin-gfx/CMakeLists.txt
@@ -459,7 +459,7 @@ target_include_directories(${PROJECT_NAME}
 # Link
 target_link_libraries(${PROJECT_NAME} PUBLIC
   score_lib_base  score_lib_localtree score_lib_process score_plugin_dataflow score_plugin_engine
-   ${QT_PREFIX}::ShaderTools ${QT_PREFIX}::ShaderToolsPrivate  ${QT_PREFIX}::GuiPrivate
+   ${QT_PREFIX}::ShaderTools ${QT_PREFIX}::ShaderToolsPrivate  ${QT_PREFIX}::GuiPrivate ${QT_PREFIX}::Quick
    "$<BUILD_INTERFACE:r8brain>"
 )
 if(TARGET ${QT_PREFIX}::Svg)

--- a/src/plugins/score-plugin-gfx/Gfx/Settings/Model.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Settings/Model.cpp
@@ -4,6 +4,7 @@
 #include <score/gfx/Vulkan.hpp>
 
 #include <QGuiApplication>
+#include <QQuickWindow>
 
 #include <wobjectimpl.h>
 #include <score/tools/Bind.hpp>
@@ -126,25 +127,25 @@ Gfx::Settings::HardwareVideoDecoder::operator QStringList() const noexcept
   return lst;
 }
 
-static void update_QSG_RHI_BACKEND(const score::gfx::GraphicsApi& api)
+static void update_qtquick_graphics_api(const score::gfx::GraphicsApi& api)
 {
   using enum score::gfx::GraphicsApi;
   switch(api)
   {
     case OpenGL:
-      qputenv("QSG_RHI_BACKEND", "opengl");
+      QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
       break;
     case Vulkan:
-      qputenv("QSG_RHI_BACKEND", "vulkan");
+      QQuickWindow::setGraphicsApi(QSGRendererInterface::Vulkan);
       break;
     case Metal:
-      qputenv("QSG_RHI_BACKEND", "metal");
+      QQuickWindow::setGraphicsApi(QSGRendererInterface::Metal);
       break;
     case D3D11:
-      qputenv("QSG_RHI_BACKEND", "d3d11");
+      QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D11);
       break;
     case D3D12:
-      qputenv("QSG_RHI_BACKEND", "d3d12");
+      QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D12);
       break;
     default:
       break;
@@ -186,22 +187,18 @@ Model::Model(
     } else if(rhi == "d3d12") {
       m_GraphicsApi = apis.D3D12;
     }
+  }
 
-    connect(this, &Gfx::Settings::Model::GraphicsApiChanged, this, [this] (const QString& api)
-    {
-      update_QSG_RHI_BACKEND(this->graphicsApiEnum());
-    });
-  }
-  else
+  // The backend is applied through QQuickWindow instead of the environment:
+  // plug-ins that embed their own Qt build inherit our environment and would
+  // pick up a backend their build may not support. e.g. Kontakt 8 statically
+  // links a Qt without Vulkan and fails to create its RHI on QSG_RHI_BACKEND=vulkan.
+  qunsetenv("QSG_RHI_BACKEND");
+
+  ::bind(*this, Gfx::Settings::Model::p_GraphicsApi{}, this, [this] (const QString& api)
   {
-    // User does not set QSG_RHI_BACKEND: we update it whenever settings
-    // change
-    using enum score::gfx::GraphicsApi;
-    ::bind(*this, Gfx::Settings::Model::p_GraphicsApi{}, this, [this] (const QString& api)
-    {
-      update_QSG_RHI_BACKEND(this->graphicsApiEnum());
-    });
-  }
+    update_qtquick_graphics_api(this->graphicsApiEnum());
+  });
 }
 
 int Model::resolveSamples(score::gfx::GraphicsApi api) const noexcept

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
@@ -348,6 +348,12 @@ public:
   QVariant prompt(QVariant v);
   W_SLOT(prompt)
 
+  bool hasProcessUI(QObject* process);
+  W_SLOT(hasProcessUI)
+
+  void showProcessUI(QObject* process, bool show);
+  W_SLOT(showProcessUI)
+
   /////////////////////
   /// Introspection ///
   /////////////////////
@@ -355,6 +361,8 @@ public:
   W_SLOT(availableProcesses)
   QVariant availableProcessesAndPresets() const noexcept;
   W_SLOT(availableProcessesAndPresets)
+  QVariantList libraryEntries(QString filter) const noexcept;
+  W_SLOT(libraryEntries)
   QVariant availableProtocols() const noexcept;
   W_SLOT(availableProtocols)
 

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.introspection.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.introspection.cpp
@@ -47,14 +47,61 @@ QVariant EditJsContext::availableProcessesAndPresets() const noexcept
       return;
     }
     auto uid = score::uuids::toByteArray(n.key.impl());
-    auto& proc = *procs.get(n.key);
-    // auto desc = proc.descriptor("");
+    auto proc = procs.get(n.key);
+    if(!proc)
+      return;
+    // auto desc = proc->descriptor("");
     v.push_back(
         QVariantMap{
-            {"ProcessName", proc.prettyName()},
+            {"ProcessName", proc->prettyName()},
             {"Name", n.prettyName},
             {"Key", QString::fromLatin1(uid)},
             {"CustomData", n.customData}});
+  });
+
+  return v;
+}
+
+static QString libraryNodePath(const Library::ProcessNode& n)
+{
+  QString path = n.prettyName;
+  for(auto* p = n.parent(); p && p->parent(); p = p->parent())
+    path.prepend(p->prettyName + '/');
+  return path;
+}
+
+QVariantList EditJsContext::libraryEntries(QString filter) const noexcept
+{
+  QVariantList v;
+  auto& ctx = score::GUIAppContext();
+  auto& procs = ctx.interfaces<Process::ProcessFactoryList>();
+  auto& lib = ctx.panel<Library::ProcessPanel>().processWidget().processModel();
+
+  lib.rootNode().visit([&](const Library::ProcessNode& n) {
+    if(n.key.impl().is_nil())
+      return;
+    auto proc = procs.get(n.key);
+    if(!proc)
+      return;
+
+    const auto path = libraryNodePath(n);
+    if(!filter.isEmpty() && !path.contains(filter, Qt::CaseInsensitive)
+       && !proc->prettyName().contains(filter, Qt::CaseInsensitive))
+      return;
+
+    const auto desc = proc->descriptor(n.customData);
+    v.push_back(
+        QVariantMap{
+            {"Key", QString::fromLatin1(score::uuids::toByteArray(n.key.impl()))},
+            {"ProcessName", proc->prettyName()},
+            {"Name", n.prettyName},
+            {"Path", path},
+            {"CustomData", n.customData},
+            {"Category", proc->category()},
+            {"Author", desc.author},
+            {"Description", desc.description},
+            {"Tags", desc.tags},
+            {"Documentation", desc.documentationLink}});
   });
 
   return v;

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.ui.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.ui.cpp
@@ -1,3 +1,7 @@
+#include <Process/Process.hpp>
+#include <Process/ProcessList.hpp>
+
+#include <Effect/EffectLayer.hpp>
 #include <Scenario/Document/ScenarioDocument/ScenarioDocumentView.hpp>
 
 #include <JS/Qml/EditContext.hpp>
@@ -42,6 +46,32 @@ void EditJsContext::scroll(double dx, double dy)
     return;
 
   main_view->scroll(dx, dy);
+}
+
+bool EditJsContext::hasProcessUI(QObject* process)
+{
+  auto doc = ctx();
+  if(!doc)
+    return false;
+  auto* proc = qobject_cast<Process::ProcessModel*>(process);
+  if(!proc)
+    return false;
+
+  auto& facts = doc->app.interfaces<Process::LayerFactoryList>();
+  auto fact = facts.findDefaultFactory(*proc);
+  return fact && fact->hasExternalUI(*proc, *doc);
+}
+
+void EditJsContext::showProcessUI(QObject* process, bool show)
+{
+  auto doc = ctx();
+  if(!doc)
+    return;
+  auto* proc = qobject_cast<Process::ProcessModel*>(process);
+  if(!proc)
+    return;
+
+  Process::setupExternalUI(*proc, *doc, show);
 }
 
 QVariant EditJsContext::prompt(QVariant v)

--- a/src/plugins/score-plugin-vst/Vst/EffectModel.cpp
+++ b/src/plugins/score-plugin-vst/Vst/EffectModel.cpp
@@ -638,7 +638,7 @@ void releasePluginInstance(int uid)
       it->second->use_count--;
       if(it->second->use_count == 0)
       {
-        delete it->second;
+//        delete it->second;
         it->second = nullptr;
       }
     }

--- a/src/plugins/score-plugin-ysfx/YSFX/ProcessModel.cpp
+++ b/src/plugins/score-plugin-ysfx/YSFX/ProcessModel.cpp
@@ -1,6 +1,8 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
+#include <ctre.hpp>
+
 #include "ProcessModel.hpp"
 
 #include "YSFX/ApplicationPlugin.hpp"
@@ -236,25 +238,73 @@ QString ProcessModel::script() const noexcept
 {
   return m_jsfx_path;
 }
+// "[Author] Preset name" -> ("Author", "Preset name")
+// applied repeatedly so that "[A][B] name" nests as A/B
+static constexpr ctll::fixed_string preset_category_pattern
+    = R"(\s*\[\s*([^\[\]]+?)\s*\]\s*([\s\S]*))";
 
+struct CategorizedPreset
+{
+  QString category;
+  QString name;
+};
+
+CategorizedPreset
+splitPresetName(std::string_view raw, QHash<QString, QString>& knownCategories)
+{
+  QStringList components;
+  std::string_view rest = raw;
+
+  while(auto m = ctre::match<preset_category_pattern>(rest))
+  {
+    auto part = m.get<1>().to_view();
+    QString category = QString::fromUtf8(part.data(), part.size()).trimmed();
+
+    // '/' is the nesting separator, so it can't survive inside one component
+    category.replace(QLatin1Char('/'), QLatin1Char('-'));
+
+    if(!category.isEmpty())
+    {
+      // "[saike] foo" and "[Saike] bar" must land in the same submenu:
+      // reuse whichever spelling was seen first
+      const auto folded = category.toCaseFolded();
+      auto it = knownCategories.constFind(folded);
+      if(it == knownCategories.cend())
+        it = knownCategories.insert(folded, category);
+      components.push_back(*it);
+    }
+    rest = m.get<2>().to_view();
+  }
+
+  QString leaf = QString::fromUtf8(rest.data(), rest.size()).trimmed();
+  if(leaf.isEmpty() && !components.isEmpty())
+    leaf = components.takeLast(); // "[Foo]" alone: the category *is* the name
+
+  return {components.join(QLatin1Char('/')), leaf};
+}
 std::vector<Process::Preset> ProcessModel::builtinPresets() const noexcept
 {
   std::vector<Process::Preset> presets;
-  if(m_bank)
+  if(!m_bank)
+    return presets;
+
+  presets.reserve(m_bank->preset_count);
+
+  QHash<QString, QString> knownCategories;
+  for(std::size_t i = 0; i < m_bank->preset_count; i++)
   {
-    for(std::size_t i = 0; i < m_bank->preset_count; i++)
-    {
-      Process::Preset p;
-      p.key.key = this->static_concreteKey();
-      p.key.effect = m_jsfx_path;
-      p.name = m_bank->presets[i].name;
-      p.data = QStringLiteral(R"({ "ProgramIndex": %1 } )").arg(i).toLatin1();
-      presets.push_back(p);
-    }
+    auto [category, name] = splitPresetName(m_bank->presets[i].name, knownCategories);
+
+    Process::Preset p;
+    p.key.key = this->static_concreteKey();
+    p.key.effect = m_jsfx_path;
+    p.category = std::move(category);
+    p.name = name.isEmpty() ? QStringLiteral("Preset %1").arg(i) : std::move(name);
+    p.data = QStringLiteral(R"({ "ProgramIndex": %1 })").arg(i).toLatin1();
+    presets.push_back(std::move(p));
   }
   return presets;
 }
-
 void ProcessModel::loadPreset(const Process::Preset& preset)
 {
   if(!m_bank)

--- a/tests/unit/AvndMidiEnvelopeTest.cpp
+++ b/tests/unit/AvndMidiEnvelopeTest.cpp
@@ -1,0 +1,451 @@
+#include <Advanced/MidiScaler/MidiEnvelope.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+
+using Catch::Approx;
+using Env = mtk::MidiEnvelope;
+
+namespace
+{
+// A sample rate of 1000 makes one sample exactly one millisecond, so the
+// stage times below can be read directly as sample counts.
+constexpr double rate = 1000.;
+
+struct driver
+{
+  Env fx;
+
+  driver()
+  {
+    fx.prepare(halp::setup{
+        .input_channels = 0, .output_channels = 0, .frames = 64, .rate = rate});
+  }
+
+  void note_on(int note, int vel, int ts = 0, int channel = 1)
+  {
+    auto m = libremidi::channel_events::note_on(channel, note, vel);
+    m.timestamp = ts;
+    fx.inputs.midi.push_back(m);
+  }
+
+  void note_off(int note, int ts = 0, int channel = 1)
+  {
+    auto m = libremidi::channel_events::note_off(channel, note, 0);
+    m.timestamp = ts;
+    fx.inputs.midi.push_back(m);
+  }
+
+  //! Run one processing block. The host clears the ports around each tick, so
+  //! we emulate that here.
+  void tick(int frames)
+  {
+    fx.outputs.out.values.clear();
+    fx.outputs.midi.midi_messages.clear();
+    fx(halp::tick_musical{.frames = frames});
+    fx.inputs.midi.midi_messages.clear();
+  }
+
+  //! Value of the envelope at the end of the last block
+  float last() const
+  {
+    REQUIRE(!fx.outputs.out.values.empty());
+    return fx.outputs.out.values.rbegin()->second;
+  }
+};
+}
+
+TEST_CASE("mtk::MidiEnvelope ADSR follows its stage times", "[avnd][midi][envelope]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.attack.value = 0.010f;  // 10 samples
+  in.decay.value = 0.100f;   // 100 samples
+  in.sustain.value = 0.5f;
+  in.release.value = 0.050f; // 50 samples
+
+  SECTION("attack rises linearly from 0 to the peak")
+  {
+    // A long, linear decay so that what happens just past the attack does not
+    // pollute the measurement of the peak.
+    in.decay.value = 10.f;
+    in.decay_curve.value = 0.f;
+
+    d.note_on(60, 127);
+    d.tick(10);
+    CHECK(d.last() == Approx(1.f).margin(1e-3));
+
+    // Halfway through a fresh attack
+    driver e;
+    e.fx.inputs.attack.value = 0.010f;
+    e.note_on(60, 127);
+    e.tick(5);
+    CHECK(e.last() == Approx(0.5f).margin(1e-5));
+  }
+
+  SECTION("decay settles on the sustain level and stays there")
+  {
+    d.note_on(60, 127);
+    d.tick(10);  // end of attack
+    d.tick(100); // end of decay
+    CHECK(d.last() == Approx(0.5f).margin(1e-3));
+
+    // Sustain does not elapse: the level is unchanged after long blocks
+    d.tick(64);
+    CHECK(d.last() == Approx(0.5f).margin(1e-3));
+    d.tick(64);
+    CHECK(d.last() == Approx(0.5f).margin(1e-3));
+  }
+
+  SECTION("note off releases down to zero")
+  {
+    d.note_on(60, 127);
+    d.tick(10);
+    d.tick(100);
+    CHECK(d.fx.outputs.gate.value == 1.f);
+
+    d.note_off(60);
+    d.tick(60); // comfortably past the 50-sample release
+    CHECK(d.last() == Approx(0.f).margin(1e-3));
+    CHECK(d.fx.outputs.gate.value == 0.f);
+    CHECK(d.fx.outputs.active.value == 0);
+  }
+}
+
+TEST_CASE(
+    "mtk::MidiEnvelope honours the note-on sample offset", "[avnd][midi][envelope]")
+{
+  driver d;
+  d.fx.inputs.attack.value = 0.010f; // 10 samples
+  d.fx.inputs.decay.value = 10.f;    // long enough not to interfere
+  d.fx.inputs.decay_curve.value = 0.f;
+
+  // The note starts 20 samples into a 32-sample block: 12 samples of attack
+  // elapse, so the (10-sample) attack has completed by the end of the block.
+  d.note_on(60, 127, 20);
+  d.tick(32);
+  CHECK(d.last() == Approx(1.f).margin(1e-3));
+
+  // Same block, but the note starts late enough that the attack is unfinished.
+  driver e;
+  e.fx.inputs.attack.value = 0.032f; // 32 samples
+  e.fx.inputs.decay.value = 10.f;
+  e.note_on(60, 127, 24);
+  e.tick(32); // only 8 of the 32 attack samples elapsed
+  CHECK(e.last() == Approx(8.f / 32.f).margin(1e-2));
+}
+
+TEST_CASE("mtk::MidiEnvelope scales the peak by velocity", "[avnd][midi][envelope]")
+{
+  SECTION("velocity amount 1: peak is the normalized velocity")
+  {
+    driver d;
+    d.fx.inputs.attack.value = 0.010f;
+    d.fx.inputs.decay.value = 10.f;
+    d.fx.inputs.velocity_amount.value = 1.f;
+    d.note_on(60, 64);
+    d.tick(10);
+    CHECK(d.last() == Approx(64.f / 127.f).margin(1e-3));
+  }
+
+  SECTION("velocity amount 0: velocity is ignored, peak is always 1")
+  {
+    driver d;
+    d.fx.inputs.attack.value = 0.010f;
+    d.fx.inputs.decay.value = 10.f;
+    d.fx.inputs.velocity_amount.value = 0.f;
+    d.note_on(60, 1);
+    d.tick(10);
+    CHECK(d.last() == Approx(1.f).margin(1e-3));
+  }
+}
+
+TEST_CASE("mtk::MidiEnvelope filters by channel and key range", "[avnd][midi][envelope]")
+{
+  SECTION("notes outside the key range are ignored")
+  {
+    driver d;
+    d.fx.inputs.attack.value = 0.010f;
+    d.fx.inputs.key_range.value = {60.f, 72.f};
+
+    d.note_on(48, 127); // below
+    d.tick(10);
+    CHECK(d.last() == Approx(0.f).margin(1e-6));
+    CHECK(d.fx.outputs.active.value == 0);
+
+    d.note_on(64, 127); // inside
+    d.tick(10);
+    CHECK(d.last() > 0.5f);
+  }
+
+  SECTION("channel 0 accepts everything, a set channel filters")
+  {
+    driver d;
+    d.fx.inputs.attack.value = 0.010f;
+    d.fx.inputs.channel.value = 3;
+
+    d.note_on(60, 127, 0, /* channel */ 1);
+    d.tick(10);
+    CHECK(d.last() == Approx(0.f).margin(1e-6));
+
+    d.note_on(60, 127, 0, /* channel */ 3);
+    d.tick(10);
+    CHECK(d.last() > 0.5f);
+  }
+}
+
+TEST_CASE(
+    "mtk::MidiEnvelope polyphony allocates one voice per note",
+    "[avnd][midi][envelope]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.voicing.value = Env::Poly;
+  in.voice_count.value = 4;
+  in.attack.value = 0.010f;
+  in.decay.value = 10.f;
+  in.velocity_amount.value = 1.f;
+
+  d.note_on(60, 127);
+  d.note_on(64, 64);
+  d.note_on(67, 32);
+  d.tick(10);
+
+  CHECK(d.fx.outputs.active.value == 3);
+  REQUIRE(d.fx.outputs.voices.value.size() == 4);
+
+  // Max combine: the loudest voice wins
+  CHECK(d.last() == Approx(1.f).margin(1e-3));
+
+  SECTION("each voice carries its own velocity-scaled level")
+  {
+    const auto& v = d.fx.outputs.voices.value;
+    CHECK(v[0] == Approx(1.f).margin(1e-3));
+    CHECK(v[1] == Approx(64.f / 127.f).margin(1e-3));
+    CHECK(v[2] == Approx(32.f / 127.f).margin(1e-3));
+    CHECK(v[3] == Approx(0.f).margin(1e-6));
+  }
+
+  SECTION("releasing one note leaves the others running")
+  {
+    d.fx.inputs.release.value = 0.001f;
+    d.note_off(64);
+    d.tick(4);
+    CHECK(d.fx.outputs.active.value == 2);
+  }
+
+  SECTION("more notes than voices steals the oldest")
+  {
+    d.note_on(70, 127);
+    d.note_on(72, 127); // 5th note on a 4-voice engine
+    d.tick(10);
+    CHECK(d.fx.outputs.active.value == 4);
+  }
+}
+
+TEST_CASE("mtk::MidiEnvelope mono mode uses the note priority", "[avnd][midi][envelope]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.attack.value = 0.f;
+  in.decay.value = 10.f;
+  in.velocity_amount.value = 0.f;
+
+  SECTION("last-note priority falls back to the previous note on release")
+  {
+    in.priority.value = Env::Last;
+    d.note_on(60, 100);
+    d.tick(4);
+    REQUIRE(d.fx.outputs.pitch.value.has_value());
+    CHECK(*d.fx.outputs.pitch.value == Approx(60.f));
+
+    d.note_on(67, 100);
+    d.tick(4);
+    CHECK(*d.fx.outputs.pitch.value == Approx(67.f));
+
+    // Releasing the top note falls back to the one still held
+    d.note_off(67);
+    d.tick(4);
+    CHECK(*d.fx.outputs.pitch.value == Approx(60.f));
+    CHECK(d.fx.outputs.gate.value == 1.f);
+  }
+
+  SECTION("lowest-note priority")
+  {
+    in.priority.value = Env::Lowest;
+    d.note_on(72, 100);
+    d.note_on(48, 100);
+    d.note_on(60, 100);
+    d.tick(4);
+    REQUIRE(d.fx.outputs.pitch.value.has_value());
+    CHECK(*d.fx.outputs.pitch.value == Approx(48.f));
+  }
+
+  SECTION("highest-note priority")
+  {
+    in.priority.value = Env::Highest;
+    d.note_on(72, 100);
+    d.note_on(48, 100);
+    d.note_on(60, 100);
+    d.tick(4);
+    REQUIRE(d.fx.outputs.pitch.value.has_value());
+    CHECK(*d.fx.outputs.pitch.value == Approx(72.f));
+  }
+}
+
+TEST_CASE("mtk::MidiEnvelope AD mode is percussive", "[avnd][midi][envelope]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.envelope.value = Env::AD;
+  in.attack.value = 0.010f;
+  in.decay.value = 0.020f;
+  in.decay_curve.value = 0.f;
+
+  d.note_on(60, 127);
+  d.tick(10);
+  CHECK(d.last() == Approx(1.f).margin(1e-3));
+
+  // The note-off is ignored: the decay plays to completion
+  d.note_off(60);
+  d.tick(10);
+  CHECK(d.last() > 0.f);
+  CHECK(d.fx.outputs.active.value == 1);
+
+  d.tick(20);
+  CHECK(d.last() == Approx(0.f).margin(1e-5));
+  CHECK(d.fx.outputs.active.value == 0);
+}
+
+TEST_CASE(
+    "mtk::MidiEnvelope maps the output into the output range",
+    "[avnd][midi][envelope]")
+{
+  SECTION("a plain range offsets and scales")
+  {
+    driver d;
+    d.fx.inputs.attack.value = 0.010f;
+    d.fx.inputs.decay.value = 10.f;
+    d.fx.inputs.output_range.value = {20.f, 120.f};
+
+    d.tick(4); // idle
+    CHECK(d.last() == Approx(20.f).margin(1e-3));
+
+    d.note_on(60, 127);
+    d.tick(10);
+    CHECK(d.last() == Approx(120.f).margin(1e-2));
+  }
+
+  SECTION("an inverted range flips the envelope")
+  {
+    driver d;
+    d.fx.inputs.attack.value = 0.010f;
+    d.fx.inputs.decay.value = 10.f;
+    d.fx.inputs.output_range.value = {1.f, 0.f};
+
+    d.tick(4);
+    CHECK(d.last() == Approx(1.f).margin(1e-3));
+
+    d.note_on(60, 127);
+    d.tick(10);
+    CHECK(d.last() == Approx(0.f).margin(1e-2));
+  }
+}
+
+TEST_CASE("mtk::MidiEnvelope curve modes use the drawn curve", "[avnd][midi][envelope]")
+{
+  SECTION("an empty curve behaves as the identity ramp")
+  {
+    driver d;
+    d.fx.inputs.envelope.value = Env::Curve;
+    d.fx.inputs.curve_duration.value = 0.100f; // 100 samples
+
+    d.note_on(60, 127);
+    d.tick(50);
+    CHECK(d.last() == Approx(0.5f).margin(1e-2));
+
+    d.tick(60); // comfortably past the 100-sample curve
+    CHECK(d.fx.outputs.active.value == 0); // one-shot: finished
+  }
+
+  SECTION("the curve acts as a transfer function in the ADSR modes")
+  {
+    driver d;
+    // A curve mapping everything to 0.25
+    d.fx.inputs.curve.value.push_back(halp::custom_curve_segment{
+        .start = 0.f, .end = 1.f, .function = [](float) { return 0.25f; }});
+    d.fx.inputs.attack.value = 0.010f;
+    d.fx.inputs.decay.value = 10.f;
+
+    d.note_on(60, 127);
+    d.tick(10);
+    CHECK(d.last() == Approx(0.25f).margin(1e-3));
+  }
+}
+
+TEST_CASE("mtk::MidiEnvelope passes MIDI through", "[avnd][midi][envelope]")
+{
+  driver d;
+  d.note_on(60, 127, 0);
+  d.note_on(64, 100, 8);
+  d.tick(16);
+
+  REQUIRE(d.fx.outputs.midi.midi_messages.size() == 2);
+  CHECK(d.fx.outputs.midi.midi_messages[0].bytes[1] == 60);
+  CHECK(d.fx.outputs.midi.midi_messages[1].bytes[1] == 64);
+  CHECK(d.fx.outputs.midi.midi_messages[1].timestamp == 8);
+}
+
+TEST_CASE("mtk::MidiEnvelope survives degenerate settings", "[avnd][midi][envelope]")
+{
+  SECTION("all stage times zero: the envelope collapses without hanging")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.envelope.value = Env::DAHDSR;
+    in.delay.value = 0.f;
+    in.attack.value = 0.f;
+    in.hold.value = 0.f;
+    in.decay.value = 0.f;
+    in.release.value = 0.f;
+    in.sustain.value = 0.3f;
+
+    d.note_on(60, 127);
+    d.tick(16);
+    CHECK(d.last() == Approx(0.3f).margin(1e-4));
+
+    d.note_off(60);
+    d.tick(16);
+    CHECK(d.last() == Approx(0.f).margin(1e-4));
+  }
+
+  SECTION("a zero-length block does nothing")
+  {
+    driver d;
+    d.note_on(60, 127);
+    d.fx.outputs.out.values.clear();
+    d.fx(halp::tick_musical{.frames = 0});
+    CHECK(d.fx.outputs.out.values.empty());
+  }
+
+  SECTION("all-notes-off releases everything")
+  {
+    driver d;
+    d.fx.inputs.voicing.value = Env::Poly;
+    d.fx.inputs.voice_count.value = 4;
+    d.fx.inputs.release.value = 0.001f;
+    d.note_on(60, 127);
+    d.note_on(64, 127);
+    d.tick(4);
+    CHECK(d.fx.outputs.gate.value == 1.f);
+
+    auto cc = libremidi::channel_events::control_change(1, 123, 0);
+    cc.timestamp = 0;
+    d.fx.inputs.midi.push_back(cc);
+    d.tick(8);
+    CHECK(d.fx.outputs.gate.value == 0.f);
+    CHECK(d.fx.outputs.active.value == 0);
+  }
+}

--- a/tests/unit/AvndMidiEnvelopeTest.cpp
+++ b/tests/unit/AvndMidiEnvelopeTest.cpp
@@ -293,6 +293,247 @@ TEST_CASE("mtk::MidiEnvelope mono mode uses the note priority", "[avnd][midi][en
     REQUIRE(d.fx.outputs.pitch.value.has_value());
     CHECK(*d.fx.outputs.pitch.value == Approx(72.f));
   }
+
+  SECTION("a note that loses the priority contest does not retrigger")
+  {
+    in.priority.value = Env::Highest;
+    in.trigger.value = Env::Reset;
+    in.attack.value = 0.020f; // 20 samples
+    in.decay.value = 10.f;
+    in.decay_curve.value = 0.f;
+
+    d.note_on(72, 100);
+    d.tick(20); // attack completed
+    CHECK(d.last() == Approx(1.f).margin(1e-3));
+
+    // A lower note under Highest priority leaves the sounding note alone, so
+    // the envelope must stay at the top instead of restarting from zero.
+    d.note_on(48, 100);
+    d.tick(4);
+    CHECK(d.last() == Approx(1.f).margin(1e-2));
+    CHECK(*d.fx.outputs.pitch.value == Approx(72.f));
+
+    // ...whereas a note that does win the contest retriggers
+    d.note_on(84, 100);
+    d.tick(4);
+    CHECK(d.last() < 0.5f);
+  }
+}
+
+TEST_CASE("mtk::MidiEnvelope slews the output over the Smooth time", "[avnd][midi][envelope]")
+{
+  // The slew coefficient has to follow the real emission spacing, which is the
+  // block when Resolution is coarser than it -- otherwise Smooth runs far too
+  // fast and the control loses most of its effect.
+  const auto level_after = [](int blocks, int frames, float resolution) {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.attack.value = 0.f;
+    in.decay.value = 0.f;
+    in.sustain.value = 1.f;
+    in.smooth.value = 0.100f;      // 100 samples at rate 1000
+    in.resolution.value = resolution;
+
+    d.note_on(60, 127);
+    for(int i = 0; i < blocks; i++)
+      d.tick(frames);
+    return d.last();
+  };
+
+  // One time constant of a one-pole settles to ~63%; after 100 samples the
+  // output must be near that whatever the block size or resolution.
+  const float coarse = level_after(10, 10, 0.1f);  // resolution >> block
+  const float fine = level_after(10, 10, 0.0005f); // resolution << block
+
+  CHECK(coarse == Approx(0.63f).margin(0.10));
+  CHECK(fine == Approx(0.63f).margin(0.10));
+
+  // Smooth at 0 must pass straight through
+  driver d;
+  d.fx.inputs.attack.value = 0.f;
+  d.fx.inputs.decay.value = 0.f;
+  d.fx.inputs.sustain.value = 1.f;
+  d.fx.inputs.smooth.value = 0.f;
+  d.note_on(60, 127);
+  d.tick(4);
+  CHECK(d.last() == Approx(1.f).margin(1e-4));
+}
+
+TEST_CASE(
+    "mtk::MidiEnvelope releases a sustaining voice after the mode changes",
+    "[avnd][midi][envelope]")
+{
+  // stage::sustain is a holding stage, so a voice left in it when the mode no
+  // longer has one would never be advanced again.
+  driver d;
+  auto& in = d.fx.inputs;
+  in.envelope.value = Env::ADSR;
+  in.attack.value = 0.f;
+  in.decay.value = 0.f;
+  in.sustain.value = 0.8f;
+  in.release.value = 0.002f;
+
+  d.note_on(60, 127);
+  d.tick(16);
+  CHECK(d.last() == Approx(0.8f).margin(1e-3));
+
+  in.envelope.value = Env::AD; // no sustain stage any more
+  d.note_off(60);
+  d.tick(16);
+
+  CHECK(d.fx.outputs.active.value == 0);
+  CHECK(d.last() == Approx(0.f).margin(1e-3));
+}
+
+TEST_CASE(
+    "mtk::MidiEnvelope never enters a holding stage with no note down",
+    "[avnd][midi][envelope]")
+{
+  // A holding stage waits for a note-off. Reaching one after the note-off has
+  // already been ignored -- by switching to a sustaining mode mid-flight --
+  // would strand the voice, since nothing is left to release it.
+  SECTION("percussive note released mid-decay, then switched to ADSR")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.envelope.value = Env::AD;
+    in.attack.value = 0.f;
+    in.decay.value = 0.050f; // 50 samples
+    in.sustain.value = 0.8f;
+    in.release.value = 0.002f;
+
+    d.note_on(60, 127);
+    d.tick(10);
+    d.note_off(60); // ignored: AD is one-shot
+    d.tick(10);
+
+    in.envelope.value = Env::ADSR; // now the mode has a sustain stage
+    d.tick(64);                    // decay completes here
+    d.tick(64);
+
+    CHECK(d.fx.outputs.active.value == 0);
+    CHECK(d.last() == Approx(0.f).margin(1e-3));
+  }
+
+  SECTION("one-shot curve released mid-rise, then switched to CurveSustain")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.envelope.value = Env::Curve;
+    in.curve_duration.value = 0.050f;
+    in.release.value = 0.002f;
+
+    d.note_on(60, 127);
+    d.tick(10);
+    d.note_off(60); // ignored: one-shot
+    d.tick(10);
+
+    in.envelope.value = Env::CurveSustain;
+    d.tick(64);
+    d.tick(64);
+
+    CHECK(d.fx.outputs.active.value == 0);
+  }
+}
+
+TEST_CASE("mtk::MidiEnvelope legato follows held notes, not the release tail", "[avnd][midi][envelope]")
+{
+  // A restart resumes from the current level, so the level alone does not say
+  // whether one happened. Settling at the sustain level does: only a voice that
+  // did NOT restart is still sitting there.
+  driver d;
+  auto& in = d.fx.inputs;
+  in.trigger.value = Env::Legato;
+  in.attack.value = 0.020f; // 20 samples
+  in.decay.value = 0.020f;  // 20 samples
+  in.decay_curve.value = 0.f;
+  in.sustain.value = 0.3f;
+  in.release.value = 10.f; // long enough to barely move
+  in.velocity_amount.value = 0.f;
+
+  d.note_on(60, 100);
+  d.tick(20); // attack done
+  d.tick(20); // decay done -> sustain
+  CHECK(d.last() == Approx(0.3f).margin(1e-2));
+
+  SECTION("a second note while the first is held does not restart")
+  {
+    d.note_on(67, 100);
+    d.tick(20);
+    // Still in sustain: a restart would have climbed back to the peak
+    CHECK(d.last() == Approx(0.3f).margin(1e-2));
+  }
+
+  SECTION("a detached note during the release tail does restart")
+  {
+    d.note_off(60);
+    d.tick(4); // release barely moved: the tail is 10 s
+    CHECK(d.last() == Approx(0.3f).margin(0.05));
+
+    // No note is down any more, so this is not a legato move: it must retrigger
+    // and climb back to the peak.
+    d.note_on(67, 100);
+    d.tick(20);
+    CHECK(d.last() > 0.9f);
+  }
+}
+
+TEST_CASE(
+    "mtk::MidiEnvelope does not resurrect voices when the count shrinks",
+    "[avnd][midi][envelope]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.voicing.value = Env::Poly;
+  in.voice_count.value = 8;
+  in.attack.value = 0.f;
+  in.decay.value = 0.f;
+  in.sustain.value = 1.f;
+  in.velocity_amount.value = 0.f;
+
+  d.note_on(60, 127);
+  d.note_on(64, 127);
+  d.note_on(67, 127);
+  d.tick(16);
+  CHECK(d.fx.outputs.active.value == 3);
+
+  // Shrinking the pool must not leave the dropped voices sounding...
+  in.voice_count.value = 1;
+  d.tick(16);
+  CHECK(d.fx.outputs.active.value == 1);
+
+  // ...nor bring them back when it grows again
+  in.voice_count.value = 8;
+  d.tick(16);
+  CHECK(d.fx.outputs.active.value == 1);
+}
+
+TEST_CASE(
+    "mtk::MidiEnvelope releases voices past the held-note cap", "[avnd][midi][envelope]")
+{
+  // The held-note stack is bounded; a note that overflows it must still be able
+  // to release the voice it triggered.
+  driver d;
+  auto& in = d.fx.inputs;
+  in.voicing.value = Env::Poly;
+  in.voice_count.value = 32;
+  in.attack.value = 0.f;
+  in.decay.value = 0.f;
+  in.sustain.value = 1.f;
+  in.release.value = 0.002f;
+
+  // More notes than the stack can hold, so the last few are never recorded in
+  // it and their note-offs have to release their voices some other way.
+  constexpr int notes = 40;
+  for(int i = 0; i < notes; i++)
+    d.note_on(30 + i, 100);
+  d.tick(16);
+  CHECK(d.fx.outputs.active.value == 32); // 32 voices, oldest stolen
+
+  for(int i = 0; i < notes; i++)
+    d.note_off(30 + i);
+  d.tick(16);
+  CHECK(d.fx.outputs.active.value == 0);
 }
 
 TEST_CASE("mtk::MidiEnvelope AD mode is percussive", "[avnd][midi][envelope]")

--- a/tests/unit/AvndMidiHumanizerTest.cpp
+++ b/tests/unit/AvndMidiHumanizerTest.cpp
@@ -1,0 +1,704 @@
+#include <Advanced/MidiScaler/MidiHumanizer.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <complex>
+#include <map>
+#include <numbers>
+#include <vector>
+
+using Catch::Approx;
+using Hum = mtk::MidiHumanizer;
+
+namespace
+{
+constexpr double rate = 48000.;
+
+struct event
+{
+  int64_t at{};      //!< absolute sample date
+  int type{};        //!< 0x90 note on, 0x80 note off, other = raw status
+  int pitch{};
+  int velocity{};
+};
+
+struct driver
+{
+  Hum fx;
+  int64_t now{};
+  std::vector<event> out;
+
+  driver()
+  {
+    fx.prepare(halp::setup{
+        .input_channels = 0, .output_channels = 0, .frames = 4096, .rate = rate});
+  }
+
+  void note_on(int note, int vel, int ts = 0, int channel = 1)
+  {
+    auto m = libremidi::channel_events::note_on(channel, note, vel);
+    m.timestamp = ts;
+    fx.inputs.midi.push_back(m);
+  }
+
+  void note_off(int note, int ts = 0, int channel = 1)
+  {
+    auto m = libremidi::channel_events::note_off(channel, note, 0);
+    m.timestamp = ts;
+    fx.inputs.midi.push_back(m);
+  }
+
+  //! Run a block, appending whatever came out to `out` with absolute dates.
+  void tick(int frames)
+  {
+    fx.outputs.midi.midi_messages.clear();
+    fx(halp::tick_musical{.frames = frames});
+
+    for(const auto& m : fx.outputs.midi.midi_messages)
+    {
+      REQUIRE(m.timestamp >= 0);
+      REQUIRE(m.timestamp < frames);
+      out.push_back(event{
+          now + m.timestamp, (int)m.get_message_type(),
+          m.size() > 1 ? (int)m.bytes[1] : 0, m.size() > 2 ? (int)m.bytes[2] : 0});
+    }
+
+    fx.inputs.midi.midi_messages.clear();
+    now += frames;
+  }
+
+  //! Drain anything still queued.
+  void drain(int blocks = 8, int frames = 4096)
+  {
+    for(int i = 0; i < blocks; i++)
+      tick(frames);
+  }
+
+  std::vector<event> notes_on() const
+  {
+    std::vector<event> r;
+    for(auto& e : out)
+      if(e.type == (int)libremidi::message_type::NOTE_ON)
+        r.push_back(e);
+    return r;
+  }
+  std::vector<event> notes_off() const
+  {
+    std::vector<event> r;
+    for(auto& e : out)
+      if(e.type == (int)libremidi::message_type::NOTE_OFF)
+        r.push_back(e);
+    return r;
+  }
+};
+
+//! Feed one note per block and return the timing deviation applied to each,
+//! in samples, relative to the object's own latency.
+//!
+//! The block must be comfortably larger than latency + a few sigma, so that a
+//! note never overtakes the next one; the i-th note-on is then the i-th input.
+std::vector<double>
+collect_offsets(int count, float colour, float timing_s, int seed, int block = 16384)
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = timing_s;
+  in.colour.value = colour;
+  in.early.value = 1.f; // symmetric, so nothing is clamped
+  in.velocity.value = 0;
+  in.length.value = 0.f;
+  in.chance.value = 1.f;
+  in.seed.value = seed;
+
+  const double latency = 3.0 * std::llround(double(timing_s) * rate);
+
+  for(int i = 0; i < count; i++)
+  {
+    d.note_on(60, 100, 0);
+    d.note_off(60, 64);
+    d.tick(block);
+  }
+  d.drain(4, block);
+
+  const auto ons = d.notes_on();
+  std::vector<double> offsets;
+  offsets.reserve(ons.size());
+  for(std::size_t i = 0; i < ons.size(); i++)
+    offsets.push_back(double(ons[i].at - int64_t(i) * block) - latency);
+  return offsets;
+}
+
+double mean(const std::vector<double>& v)
+{
+  double s = 0.;
+  for(double x : v)
+    s += x;
+  return v.empty() ? 0. : s / v.size();
+}
+
+double stddev(const std::vector<double>& v)
+{
+  const double m = mean(v);
+  double s = 0.;
+  for(double x : v)
+    s += (x - m) * (x - m);
+  return v.size() < 2 ? 0. : std::sqrt(s / (v.size() - 1));
+}
+
+//! Power at normalized frequency k/N, by direct evaluation of the DFT bin.
+double power_at_bin(const std::vector<double>& x, int k)
+{
+  const std::size_t N = x.size();
+  const double w = 2. * std::numbers::pi * double(k) / double(N);
+  double re = 0., im = 0.;
+  for(std::size_t n = 0; n < N; n++)
+  {
+    re += x[n] * std::cos(w * double(n));
+    im -= x[n] * std::sin(w * double(n));
+  }
+  return (re * re + im * im) / double(N);
+}
+
+/**
+ * Estimate the spectral exponent of a series.
+ *
+ * The generator is the fractional-difference filter (1 - z^-1)^(-beta/2), whose
+ * exact power spectrum is |1 - e^-jw|^-beta = (2 sin(w/2))^-beta. So we regress
+ * log(P) against log(2 sin(w/2)): the slope is -beta, exactly, without the
+ * low-frequency approximation w^-beta.
+ *
+ * The lowest bins are skipped: the impulse response is damped by a leak and cut
+ * off at 256 taps, which flattens the spectrum at the very lowest frequencies.
+ */
+double spectral_slope(
+    const std::vector<std::vector<double>>& realizations, const std::vector<int>& bins)
+{
+  const std::size_t N = realizations.front().size();
+
+  double sx = 0., sy = 0., sxx = 0., sxy = 0.;
+  int n = 0;
+  for(int k : bins)
+  {
+    double p = 0.;
+    for(const auto& r : realizations)
+      p += power_at_bin(r, k);
+    p /= double(realizations.size());
+    if(p <= 0.)
+      continue;
+
+    const double w = 2. * std::numbers::pi * double(k) / double(N);
+    const double x = std::log(2. * std::sin(w / 2.));
+    const double y = std::log(p);
+
+    sx += x;
+    sy += y;
+    sxx += x * x;
+    sxy += x * y;
+    ++n;
+  }
+
+  return (double(n) * sxy - sx * sy) / (double(n) * sxx - sx * sx);
+}
+}
+
+TEST_CASE("mtk::MidiHumanizer is a passthrough with everything at zero", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.f;
+  in.velocity.value = 0;
+  in.length.value = 0.f;
+  in.chance.value = 1.f;
+  in.early.value = 0.f;
+
+  d.note_on(60, 100, 10);
+  d.note_off(60, 500);
+  d.note_on(64, 42, 20);
+  d.note_off(64, 900);
+  d.tick(1024);
+
+  REQUIRE(d.out.size() == 4);
+  CHECK(d.out[0].at == 10);
+  CHECK(d.out[0].pitch == 60);
+  CHECK(d.out[0].velocity == 100);
+  CHECK(d.out[1].at == 20);
+  CHECK(d.out[1].pitch == 64);
+  CHECK(d.out[1].velocity == 42);
+  CHECK(d.out[2].at == 500);
+  CHECK(d.out[3].at == 900);
+}
+
+TEST_CASE("mtk::MidiHumanizer emits in order and never in the past", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.03f;
+  in.early.value = 1.f;
+  in.velocity.value = 20;
+  in.length.value = 0.5f;
+  in.seed.value = 7;
+
+  for(int i = 0; i < 64; i++)
+  {
+    d.note_on(60 + (i % 12), 100, (i % 8) * 64);
+    d.note_off(60 + (i % 12), (i % 8) * 64 + 200);
+    d.tick(1024);
+  }
+  d.drain();
+
+  REQUIRE(!d.out.empty());
+  for(std::size_t i = 1; i < d.out.size(); i++)
+    CHECK(d.out[i - 1].at <= d.out[i].at);
+}
+
+TEST_CASE("mtk::MidiHumanizer never plays early when Early is 0", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.02f;
+  in.early.value = 0.f;
+  in.seed.value = 3;
+
+  for(int i = 0; i < 200; i++)
+  {
+    d.note_on(60, 100, 0);
+    d.note_off(60, 64);
+    d.tick(8192);
+  }
+  d.drain();
+
+  const auto ons = d.notes_on();
+  REQUIRE(ons.size() > 150);
+  for(std::size_t i = 0; i < ons.size(); i++)
+    CHECK(ons[i].at >= int64_t(i) * 8192);
+}
+
+TEST_CASE("mtk::MidiHumanizer keeps unit variance across noise colours", "[avnd][midi][humanize]")
+{
+  // The deviation amount must mean the same thing whatever the colour is,
+  // otherwise changing Colour would silently change how loose the part feels.
+  const float timing = 0.02f;
+  const double sigma_samples = timing * rate;
+
+  for(float colour : {0.f, 1.f, 2.f})
+  {
+    const auto off = collect_offsets(1500, colour, timing, 11);
+    REQUIRE(off.size() > 1400);
+
+    const double s = stddev(off);
+    INFO("colour = " << colour << " sigma = " << s << " expected " << sigma_samples);
+    CHECK(s == Approx(sigma_samples).epsilon(0.20));
+  }
+}
+
+TEST_CASE("mtk::MidiHumanizer produces 1/f^beta timing deviations", "[avnd][midi][humanize]")
+{
+  // The point of the object: human rhythmic fluctuations are long-range
+  // correlated (Hennig et al., PLoS ONE 2011), not white. Verify that the
+  // generated deviation series really has the requested spectral exponent.
+  constexpr int N = 2048;
+  constexpr int realizations = 6;
+
+  // Skip the lowest bins: the response is leaky and cut off at 256 taps, so the
+  // spectrum flattens below the leak knee. Log-spaced bins keep the regression
+  // balanced (and the direct DFT affordable).
+  std::vector<int> bins;
+  for(double k = 32.; k <= 512.; k *= 1.06)
+  {
+    const int b = (int)std::lround(k);
+    if(bins.empty() || bins.back() != b)
+      bins.push_back(b);
+  }
+
+  for(float beta : {0.f, 1.f, 2.f})
+  {
+    std::vector<std::vector<double>> series;
+    for(int r = 0; r < realizations; r++)
+    {
+      auto s = collect_offsets(N, beta, 0.02f, 100 + r);
+      REQUIRE(s.size() == N);
+      series.push_back(std::move(s));
+    }
+
+    const double slope = spectral_slope(series, bins);
+    INFO("beta = " << beta << " measured slope = " << slope);
+    CHECK(slope == Approx(-double(beta)).margin(0.10));
+  }
+}
+
+TEST_CASE("mtk::MidiHumanizer keeps note lengths when Length is 0", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.02f;
+  in.early.value = 1.f;
+  in.length.value = 0.f;
+  in.seed.value = 5;
+
+  constexpr int64_t duration = 1000;
+  for(int i = 0; i < 100; i++)
+  {
+    d.note_on(60, 100, 0);
+    d.note_off(60, duration);
+    d.tick(8192);
+  }
+  d.drain();
+
+  const auto ons = d.notes_on();
+  const auto offs = d.notes_off();
+  REQUIRE(ons.size() == offs.size());
+  REQUIRE(ons.size() > 90);
+
+  // The note-off inherits the exact displacement of its note-on
+  for(std::size_t i = 0; i < ons.size(); i++)
+    CHECK(offs[i].at - ons[i].at == duration);
+}
+
+TEST_CASE("mtk::MidiHumanizer scales lengths without inverting notes", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.f;
+  in.length.value = 1.f; // maximum scaling
+  in.seed.value = 9;
+
+  constexpr int64_t duration = 800;
+  for(int i = 0; i < 200; i++)
+  {
+    d.note_on(60, 100, 0);
+    d.note_off(60, duration);
+    d.tick(8192);
+  }
+  d.drain();
+
+  const auto ons = d.notes_on();
+  const auto offs = d.notes_off();
+  REQUIRE(ons.size() == offs.size());
+
+  bool any_different = false;
+  for(std::size_t i = 0; i < ons.size(); i++)
+  {
+    const int64_t len = offs[i].at - ons[i].at;
+    CHECK(len >= 1); // never zero-length or inverted
+    if(len != duration)
+      any_different = true;
+  }
+  CHECK(any_different);
+}
+
+TEST_CASE("mtk::MidiHumanizer drops notes whole", "[avnd][midi][humanize]")
+{
+  SECTION("chance 0 silences everything, note-offs included")
+  {
+    driver d;
+    d.fx.inputs.chance.value = 0.f;
+    d.fx.inputs.seed.value = 2;
+
+    for(int i = 0; i < 50; i++)
+    {
+      d.note_on(60, 100, 0);
+      d.note_off(60, 200);
+      d.tick(1024);
+    }
+    d.drain();
+    CHECK(d.out.empty());
+  }
+
+  SECTION("partial chance never leaves an orphan note-on or note-off")
+  {
+    driver d;
+    d.fx.inputs.chance.value = 0.5f;
+    d.fx.inputs.timing.value = 0.01f;
+    d.fx.inputs.early.value = 1.f;
+    d.fx.inputs.seed.value = 4;
+
+    for(int i = 0; i < 200; i++)
+    {
+      d.note_on(60, 100, 0);
+      d.note_off(60, 300);
+      d.tick(8192);
+    }
+    d.drain();
+
+    CHECK(d.notes_on().size() == d.notes_off().size());
+    CHECK(d.notes_on().size() > 50);
+    CHECK(d.notes_on().size() < 150);
+
+    // Strictly alternating on/off: no note is ever left hanging
+    int held = 0;
+    for(auto& e : d.out)
+    {
+      if(e.type == (int)libremidi::message_type::NOTE_ON)
+        held++;
+      else if(e.type == (int)libremidi::message_type::NOTE_OFF)
+        held--;
+      CHECK(held >= 0);
+      CHECK(held <= 1);
+    }
+    CHECK(held == 0);
+  }
+}
+
+TEST_CASE("mtk::MidiHumanizer displaces chords as a whole", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.02f;
+  in.early.value = 1.f;
+  in.chord_window.value = 0.02f; // 960 samples
+  in.spread.value = 0.f;
+  in.seed.value = 8;
+
+  // Three notes inside the chord window, then one well outside it
+  d.note_on(60, 100, 0);
+  d.note_on(64, 100, 100);
+  d.note_on(67, 100, 200);
+  d.note_on(72, 100, 4000);
+  d.tick(16384);
+  d.drain();
+
+  const auto ons = d.notes_on();
+  REQUIRE(ons.size() == 4);
+
+  std::map<int, int64_t> at;
+  for(auto& e : ons)
+    at[e.pitch] = e.at;
+
+  // Same deviation for the chord: the relative spacing is preserved exactly
+  CHECK(at[64] - at[60] == 100);
+  CHECK(at[67] - at[60] == 200);
+
+  // The note outside the window got its own draw
+  CHECK(at[72] - at[60] != 4000);
+}
+
+TEST_CASE("mtk::MidiHumanizer strums a chord by the Spread amount", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.f; // isolate the strum
+  in.early.value = 0.f;
+  in.chord_window.value = 0.05f;
+  in.spread.value = 0.01f; // 480 samples
+  in.seed.value = 1;
+
+  d.note_on(60, 100, 0);
+  d.note_on(64, 100, 0);
+  d.note_on(67, 100, 0);
+  d.tick(16384);
+  d.drain();
+
+  const auto ons = d.notes_on();
+  REQUIRE(ons.size() == 3);
+  CHECK(ons[0].at == 0);
+  CHECK(ons[1].at == 480);
+  CHECK(ons[2].at == 960);
+}
+
+TEST_CASE("mtk::MidiHumanizer only touches notes in scope", "[avnd][midi][humanize]")
+{
+  SECTION("out-of-range keys pass through untouched")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.timing.value = 0.02f;
+    in.early.value = 0.f;
+    in.velocity.value = 40;
+    in.key_range.value = {60.f, 72.f};
+    in.seed.value = 6;
+
+    d.note_on(40, 100, 128); // below the range
+    d.tick(8192);
+    d.drain();
+
+    const auto ons = d.notes_on();
+    REQUIRE(ons.size() == 1);
+    CHECK(ons[0].at == 128);
+    CHECK(ons[0].velocity == 100);
+  }
+
+  SECTION("other channels pass through untouched")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.timing.value = 0.02f;
+    in.velocity.value = 40;
+    in.channel.value = 1;
+    in.seed.value = 6;
+
+    d.note_on(60, 100, 128, /* channel */ 5);
+    d.tick(8192);
+    d.drain();
+
+    const auto ons = d.notes_on();
+    REQUIRE(ons.size() == 1);
+    CHECK(ons[0].at == 128);
+    CHECK(ons[0].velocity == 100);
+  }
+}
+
+TEST_CASE("mtk::MidiHumanizer clamps velocity into its range", "[avnd][midi][humanize]")
+{
+  driver d;
+  auto& in = d.fx.inputs;
+  in.timing.value = 0.f;
+  in.velocity.value = 64; // huge deviation
+  in.velocity_range.value = {40.f, 80.f};
+  in.seed.value = 12;
+
+  for(int i = 0; i < 200; i++)
+  {
+    d.note_on(60, 100, 0);
+    d.note_off(60, 200);
+    d.tick(1024);
+  }
+  d.drain();
+
+  const auto ons = d.notes_on();
+  REQUIRE(ons.size() > 190);
+  bool saw_variation = false;
+  for(auto& e : ons)
+  {
+    CHECK(e.velocity >= 40);
+    CHECK(e.velocity <= 80);
+    if(e.velocity != ons[0].velocity)
+      saw_variation = true;
+  }
+  CHECK(saw_variation);
+}
+
+TEST_CASE("mtk::MidiHumanizer never hangs a note", "[avnd][midi][humanize]")
+{
+  // Every path that throws away the pending queue has to turn off whatever it
+  // has already sent out, otherwise the note sounds forever.
+  const auto held = [](const driver& d) {
+    int n = 0;
+    for(const auto& e : d.out)
+    {
+      if(e.type == (int)libremidi::message_type::NOTE_ON)
+        n++;
+      else if(e.type == (int)libremidi::message_type::NOTE_OFF)
+        n--;
+    }
+    return n;
+  };
+
+  SECTION("changing the seed mid-note")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.timing.value = 0.02f;
+    in.early.value = 1.f; // ~60 ms of latency, so notes sit in the queue
+    in.seed.value = 1;
+
+    d.note_on(60, 100, 0);
+    d.tick(1024);
+    d.note_off(60, 0);
+    d.fx.inputs.seed.value = 99; // used to drop the queued note-off
+    d.tick(1024);
+    d.drain();
+
+    CHECK(held(d) == 0);
+  }
+
+  SECTION("all-notes-off while notes are queued")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.timing.value = 0.02f;
+    in.early.value = 1.f;
+    in.seed.value = 2;
+
+    d.note_on(60, 100, 0);
+    d.note_on(64, 100, 0);
+    d.note_on(67, 100, 0);
+
+    auto cc = libremidi::channel_events::control_change(1, 123, 0);
+    cc.timestamp = 8;
+    d.fx.inputs.midi.push_back(cc);
+
+    d.tick(64); // shorter than the latency: the note-ons are still queued
+    d.drain();
+
+    CHECK(held(d) == 0);
+  }
+
+  SECTION("more overlapping notes than the tracking table holds")
+  {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.timing.value = 0.02f;
+    in.early.value = 1.f;
+    in.seed.value = 3;
+
+    for(int i = 0; i < 100; i++)
+      d.note_on(20 + i, 100, 0);
+    d.tick(4096);
+
+    for(int i = 0; i < 100; i++)
+      d.note_off(20 + i, 0);
+    d.tick(4096);
+    d.drain();
+
+    // Past the tracking and queue limits, notes may be stolen or dropped -- but
+    // never left sounding, which is the only failure that cannot be recovered
+    // from. An unmatched note-off is inert.
+    CHECK(held(d) <= 0);
+
+    // and no individual pitch is left on
+    std::map<int, int> per_pitch;
+    for(const auto& e : d.out)
+    {
+      if(e.type == (int)libremidi::message_type::NOTE_ON)
+        per_pitch[e.pitch]++;
+      else if(e.type == (int)libremidi::message_type::NOTE_OFF)
+        per_pitch[e.pitch]--;
+    }
+    for(const auto& [pitch, n] : per_pitch)
+    {
+      INFO("pitch " << pitch);
+      CHECK(n <= 0);
+    }
+  }
+}
+
+TEST_CASE("mtk::MidiHumanizer is reproducible for a given seed", "[avnd][midi][humanize]")
+{
+  const auto run = [](int seed) {
+    driver d;
+    auto& in = d.fx.inputs;
+    in.timing.value = 0.02f;
+    in.early.value = 1.f;
+    in.velocity.value = 20;
+    in.length.value = 0.3f;
+    in.seed.value = seed;
+
+    for(int i = 0; i < 40; i++)
+    {
+      d.note_on(60, 100, 0);
+      d.note_off(60, 400);
+      d.tick(8192);
+    }
+    d.drain();
+    return d.out;
+  };
+
+  const auto a = run(1234);
+  const auto b = run(1234);
+  const auto c = run(4321);
+
+  REQUIRE(a.size() == b.size());
+  for(std::size_t i = 0; i < a.size(); i++)
+  {
+    CHECK(a[i].at == b[i].at);
+    CHECK(a[i].velocity == b[i].velocity);
+  }
+
+  bool differs = false;
+  for(std::size_t i = 0; i < std::min(a.size(), c.size()); i++)
+    if(a[i].at != c[i].at || a[i].velocity != c[i].velocity)
+      differs = true;
+  CHECK(differs);
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -135,6 +135,12 @@ target_include_directories(test_unit_avnd_audio_effects SYSTEM PRIVATE
   "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/include"
   "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/examples")
 
+score_add_test(test_unit_avnd_midi_envelope
+  SOURCES AvndMidiEnvelopeTest.cpp)
+target_include_directories(test_unit_avnd_midi_envelope SYSTEM PRIVATE
+  "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/include"
+  "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/examples")
+
 if(TARGET score_plugin_fx)
   score_add_test(test_unit_fx_audio_dsp
     SOURCES FxAudioDspTest.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -141,6 +141,12 @@ target_include_directories(test_unit_avnd_midi_envelope SYSTEM PRIVATE
   "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/include"
   "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/examples")
 
+score_add_test(test_unit_avnd_midi_humanizer
+  SOURCES AvndMidiHumanizerTest.cpp)
+target_include_directories(test_unit_avnd_midi_humanizer SYSTEM PRIVATE
+  "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/include"
+  "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/examples")
+
 if(TARGET score_plugin_fx)
   score_add_test(test_unit_fx_audio_dsp
     SOURCES FxAudioDspTest.cpp


### PR DESCRIPTION
**Draft: stacked on #2182, and blocked on celtera/avendish#188.**

Rebased onto `feature/win32-fixes-08`, which already registers `Midi Envelope`, carries the execution index fix (`avnd: fix an index offset issue for execution`) and has the base envelope test. This PR is now pure additions on top of that — no duplication.

Still blocked on the submodule: celtera/avendish#188 adds `MidiHumanizer.hpp` **and** fixes a set of correctness bugs in `Midi Envelope`. The tests here pin those fixes, so they only pass once `3rdparty/avendish` is bumped past it. I deliberately did not pin the submodule to my unmerged branch head — a pin to a commit that may be squashed away is worse than an obvious missing bump.

## Contents

- Registers `midihumanizer`.
- The `Midi Humanize` test suite.
- Extends the existing envelope test suite with a regression test for each fix in avendish#188.

## Tests

**Midi Humanize** — 14 cases / ~171k assertions. The centrepiece is a direct **DFT check of the noise exponent**: the object's own timing deviations are collected, then their periodogram is regressed against `log(2·sin(ω/2))` — the exact spectrum of the fractional-difference filter, so no low-frequency approximation — and must show the requested `1/f^β` slope. Measured **-0.010 / -1.012 / -1.999** for β = 0 / 1 / 2, held to ±0.10. That is the object's entire reason to exist (Hennig et al. 2011: human rhythmic fluctuation is long-range correlated, and listeners prefer it over the white noise every other humanizer produces), so it is worth pinning numerically rather than by eye.

Also covered: unit variance across colours, so the amount control means the same thing at any β; note-off/note-on pairing and note-length preservation; chord grouping and strum; velocity clamping; seed reproducibility; and a "never hangs a note" suite covering seed change mid-note, all-notes-off with a full queue, and more overlapping notes than the tracking table holds.

**Midi Envelope** — extended to 17 cases / 129 assertions, adding regression tests for the stranded-voice bugs (both the note-off path and the `advance()` path), the mono-priority spurious retrigger, voice-count shrink, the held-note cap, legato semantics and the smoothing time step.

I verified these fail against the unfixed object rather than assuming: reverting the header shows every one of them failing with the expected wrong values.

Two deliberate test choices: the saturation case asserts `held <= 0` per pitch (never *left sounding*) rather than perfectly balanced, since past the queue and tracking limits notes may legitimately be dropped and an unmatched note-off is inert; and the legato test discriminates on whether the voice is still at the sustain level, because a non-`Reset` restart resumes from the current level and so cannot be detected from the level alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5kNpDQVQfbvHQBtv8LCNv