### PR TITLE
windows: use the right calling convention for 32-bit callbacks

### DIFF
--- a/src/lib/score/tools/InvisibleWindow.hpp
+++ b/src/lib/score/tools/InvisibleWindow.hpp
@@ -122,20 +122,25 @@ struct invisible_window
     WNDCLASSEXA wc = {0};
     wc.cbSize = sizeof(WNDCLASSEX);
     wc.style = CS_VREDRAW | CS_HREDRAW;
-    wc.lpfnWndProc = [](HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) -> LRESULT {
-      switch(msg)
+    struct WndProc
+    {
+      static LRESULT CALLBACK run(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
       {
-        case WM_CLOSE:
-          DestroyWindow(hwnd);
-          break;
-        case WM_DESTROY:
-          PostQuitMessage(0);
-          break;
-        default:
-          return DefWindowProc(hwnd, msg, wParam, lParam);
+        switch(msg)
+        {
+          case WM_CLOSE:
+            DestroyWindow(hwnd);
+            break;
+          case WM_DESTROY:
+            PostQuitMessage(0);
+            break;
+          default:
+            return DefWindowProc(hwnd, msg, wParam, lParam);
+        }
+        return 0;
       }
-      return 0;
     };
+    wc.lpfnWndProc = &WndProc::run;
     wc.hInstance = hInstance;
     wc.lpszClassName = "window";
     RegisterClassExA(&wc);

--- a/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.hpp
@@ -33,7 +33,7 @@ struct HostApp final : public Steinberg::Vst::IHostApplication
   Steinberg::Vst::PlugInterfaceSupport m_support;
   HostApp() { }
   virtual ~HostApp() { }
-  Steinberg::tresult getName(Steinberg::Vst::String128 name) override
+  Steinberg::tresult PLUGIN_API getName(Steinberg::Vst::String128 name) override
   {
     Steinberg::String str("ossia score");
     str.copyTo16(name, 0, 127);
@@ -41,7 +41,7 @@ struct HostApp final : public Steinberg::Vst::IHostApplication
   }
 
   Steinberg::tresult
-  createInstance(Steinberg::TUID cid, Steinberg::TUID _iid, void** obj) override
+  PLUGIN_API createInstance(Steinberg::TUID cid, Steinberg::TUID _iid, void** obj) override
   {
     using namespace Steinberg;
     using namespace Steinberg::Vst;
@@ -62,7 +62,7 @@ struct HostApp final : public Steinberg::Vst::IHostApplication
     return kResultFalse;
   }
 
-  Steinberg::tresult queryInterface(const char* _iid, void** obj) override
+  Steinberg::tresult PLUGIN_API queryInterface(const char* _iid, void** obj) override
   {
     using namespace Steinberg;
     using namespace Steinberg::Vst;
@@ -76,9 +76,9 @@ struct HostApp final : public Steinberg::Vst::IHostApplication
     return kResultFalse;
   }
 
-  Steinberg::uint32 addRef() override { return 1; }
+  Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
 
-  Steinberg::uint32 release() override { return 1; }
+  Steinberg::uint32 PLUGIN_API release() override { return 1; }
 };
 
 class ApplicationPlugin

--- a/src/plugins/score-plugin-vst3/Vst3/DataStream.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/DataStream.hpp
@@ -15,15 +15,15 @@ public:
   {
     s.setByteOrder(QDataStream::LittleEndian);
   }
-  Steinberg::tresult queryInterface(const Steinberg::TUID _iid, void** obj) override
+  Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID _iid, void** obj) override
   {
     return Steinberg::kResultFalse;
   }
-  Steinberg::uint32 addRef() override { return 1; }
-  Steinberg::uint32 release() override { return 1; }
+  Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
+  Steinberg::uint32 PLUGIN_API release() override { return 1; }
 
   Steinberg::tresult
-  read(void* buffer, Steinberg::int32 numBytes, Steinberg::int32* numBytesRead) override
+  PLUGIN_API read(void* buffer, Steinberg::int32 numBytes, Steinberg::int32* numBytesRead) override
   {
     int count = stream.readRawData((char*)buffer, numBytes);
     if(numBytesRead)
@@ -31,7 +31,7 @@ public:
     return Steinberg::kResultTrue;
   }
 
-  Steinberg::tresult write(
+  Steinberg::tresult PLUGIN_API write(
       void* buffer, Steinberg::int32 numBytes,
       Steinberg::int32* numBytesWritten) override
   {
@@ -42,7 +42,7 @@ public:
     return Steinberg::kResultTrue;
   }
   Steinberg::tresult
-  seek(Steinberg::int64 pos, Steinberg::int32 mode, Steinberg::int64* result) override
+  PLUGIN_API seek(Steinberg::int64 pos, Steinberg::int32 mode, Steinberg::int64* result) override
   {
     bool ok = stream.device()->seek(pos);
     if(result)
@@ -50,7 +50,7 @@ public:
 
     return ok ? Steinberg::kResultTrue : Steinberg::kResultFalse;
   }
-  Steinberg::tresult tell(Steinberg::int64* pos) override
+  Steinberg::tresult PLUGIN_API tell(Steinberg::int64* pos) override
   {
     if(pos)
       *pos = stream.device()->pos();

--- a/src/plugins/score-plugin-vst3/Vst3/EditHandler.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/EditHandler.hpp
@@ -25,7 +25,7 @@ public:
 
   ~ComponentHandler() { }
 
-  Steinberg::tresult queryInterface(const Steinberg::TUID _iid, void** obj) override
+  Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID _iid, void** obj) override
   {
     using namespace Steinberg;
     if(FUID::fromTUID(_iid) == Steinberg::Vst::IComponentHandler2::iid)
@@ -36,10 +36,10 @@ public:
     *obj = nullptr;
     return kResultFalse;
   }
-  Steinberg::uint32 addRef() override { return 1; }
-  Steinberg::uint32 release() override { return 1; }
+  Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
+  Steinberg::uint32 PLUGIN_API release() override { return 1; }
 
-  Steinberg::tresult beginEdit(Steinberg::Vst::ParamID id) override
+  Steinberg::tresult PLUGIN_API beginEdit(Steinberg::Vst::ParamID id) override
   {
     // TODO implement ongoingdispatcher
     if(auto ctrl = m_model.controls.find(id); ctrl == m_model.controls.end())
@@ -55,7 +55,7 @@ public:
     return Steinberg::kResultOk;
   }
 
-  Steinberg::tresult performEdit(
+  Steinberg::tresult PLUGIN_API performEdit(
       Steinberg::Vst::ParamID id, Steinberg::Vst::ParamValue valueNormalized) override
   {
     if(auto ctrl = m_model.controls.find(id); ctrl != m_model.controls.end())
@@ -65,29 +65,29 @@ public:
     return Steinberg::kResultOk;
   }
 
-  Steinberg::tresult endEdit(Steinberg::Vst::ParamID id) override
+  Steinberg::tresult PLUGIN_API endEdit(Steinberg::Vst::ParamID id) override
   {
     return Steinberg::kResultOk;
   }
 
-  Steinberg::tresult restartComponent(Steinberg::int32 flags) override
+  Steinberg::tresult PLUGIN_API restartComponent(Steinberg::int32 flags) override
   {
     return m_model.restartComponent(flags);
   }
 
-  Steinberg::tresult setDirty(Steinberg::TBool state) override
+  Steinberg::tresult PLUGIN_API setDirty(Steinberg::TBool state) override
   {
     return Steinberg::kResultOk;
   }
 
-  Steinberg::tresult requestOpenEditor(Steinberg::FIDString name) override
+  Steinberg::tresult PLUGIN_API requestOpenEditor(Steinberg::FIDString name) override
   {
     Process::setupExternalUI(m_model, score::IDocument::documentContext(m_model), true);
     return Steinberg::kResultOk;
   }
 
-  Steinberg::tresult startGroupEdit() override { return Steinberg::kResultOk; }
+  Steinberg::tresult PLUGIN_API startGroupEdit() override { return Steinberg::kResultOk; }
 
-  Steinberg::tresult finishGroupEdit() override { return Steinberg::kResultOk; }
+  Steinberg::tresult PLUGIN_API finishGroupEdit() override { return Steinberg::kResultOk; }
 };
 }

--- a/src/plugins/score-plugin-vst3/Vst3/Node.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Node.hpp
@@ -35,16 +35,16 @@ public:
   ossia::small_vector<std::pair<int32_t, Steinberg::Vst::ParamValue>, 1> data;
   Steinberg::Vst::ParamValue lastValue{};
 
-  Steinberg::tresult queryInterface(const Steinberg::TUID _iid, void** obj) override
+  Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID _iid, void** obj) override
   {
     return Steinberg::kResultOk;
   }
-  Steinberg::uint32 addRef() override { return 1; }
-  Steinberg::uint32 release() override { return 1; }
+  Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
+  Steinberg::uint32 PLUGIN_API release() override { return 1; }
 
-  Steinberg::Vst::ParamID getParameterId() override { return id; }
-  Steinberg::int32 getPointCount() override { return data.size(); }
-  Steinberg::tresult getPoint(
+  Steinberg::Vst::ParamID PLUGIN_API getParameterId() override { return id; }
+  Steinberg::int32 PLUGIN_API getPointCount() override { return data.size(); }
+  Steinberg::tresult PLUGIN_API getPoint(
       Steinberg::int32 index, Steinberg::int32& sampleOffset,
       Steinberg::Vst::ParamValue& value) override
   {
@@ -59,7 +59,7 @@ public:
     return Steinberg::kResultOk;
   }
 
-  Steinberg::tresult addPoint(
+  Steinberg::tresult PLUGIN_API addPoint(
       Steinberg::int32 sampleOffset, Steinberg::Vst::ParamValue value,
       Steinberg::int32& index) override
   {
@@ -73,21 +73,21 @@ class param_changes final : public Steinberg::Vst::IParameterChanges
 {
 public:
   std::vector<param_queue> queues;
-  Steinberg::tresult queryInterface(const Steinberg::TUID _iid, void** obj) override
+  Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID _iid, void** obj) override
   {
     return Steinberg::kResultOk;
   }
-  Steinberg::uint32 addRef() override { return 1; }
-  Steinberg::uint32 release() override { return 1; }
+  Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
+  Steinberg::uint32 PLUGIN_API release() override { return 1; }
 
-  Steinberg::int32 getParameterCount() override { return queues.size(); }
+  Steinberg::int32 PLUGIN_API getParameterCount() override { return queues.size(); }
 
-  param_queue* getParameterData(Steinberg::int32 index) override
+  param_queue* PLUGIN_API getParameterData(Steinberg::int32 index) override
   {
     return &queues[index];
   }
 
-  param_queue* addParameterData(
+  param_queue* PLUGIN_API addParameterData(
       const Steinberg::Vst::ParamID& id, Steinberg::int32& index /*out*/) override
   {
     index = queues.size();

--- a/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/PlugFrame.hpp
@@ -13,14 +13,14 @@ namespace vst3
 class PlugFrame final : public Steinberg::IPlugFrame
 {
 public:
-  Steinberg::tresult queryInterface(const Steinberg::TUID _iid, void** obj) override
+  Steinberg::tresult PLUGIN_API queryInterface(const Steinberg::TUID _iid, void** obj) override
   {
     *obj = nullptr;
     return Steinberg::kResultFalse;
   }
 
-  Steinberg::uint32 addRef() override { return 1; }
-  Steinberg::uint32 release() override { return 1; }
+  Steinberg::uint32 PLUGIN_API addRef() override { return 1; }
+  Steinberg::uint32 PLUGIN_API release() override { return 1; }
 
   QDialog* w;
   WindowContainer wc;
@@ -31,7 +31,7 @@ public:
   }
 
   Steinberg::tresult
-  resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override
+  PLUGIN_API resizeView(Steinberg::IPlugView* view, Steinberg::ViewRect* newSize) override
   {
     wc.setSizeFromVst(*view, *newSize, *w);
     return Steinberg::kResultOk;


### PR DESCRIPTION
On i386 Windows `__stdcall` and the C++ default are distinct calling conventions, so two things that compile fine on x86_64 — where `__stdcall` is a no-op and there is only one convention — are rejected on a 32-bit target.

- The VST3 interfaces are declared `PLUGIN_API`, i.e. `__stdcall` on i386, and 40 of our overrides omitted it. `PLUGIN_API` is empty off Windows, so this is a no-op everywhere else.
- `invisible_window` assigned a captureless lambda to `WNDPROC`. A lambda converts to a function pointer with the *default* convention; a `CALLBACK`-qualified static function carries the right one on both architectures.

No behaviour change on any currently shipped target.