### PR TITLE
vst3: link uuid for the KNOWNFOLDERID symbols

### DIFF
--- a/src/plugins/score-plugin-vst3/CMakeLists.txt
+++ b/src/plugins/score-plugin-vst3/CMakeLists.txt
@@ -105,6 +105,8 @@ if(APPLE)
     ${Foundation_FK}
     ${AppKit_FK}
     )
+elseif(WIN32)
+  target_link_libraries(${PROJECT_NAME} PRIVATE uuid)
 endif()
 
 # Target-specific options

--- a/src/vst3puppet/CMakeLists.txt
+++ b/src/vst3puppet/CMakeLists.txt
@@ -41,7 +41,7 @@ if(APPLE)
         ${Cocoa_FK}
         )
 elseif(WIN32)
-  target_link_libraries(ossia-score-vst3puppet PRIVATE user32 gdi32 ws2_32)
+  target_link_libraries(ossia-score-vst3puppet PRIVATE user32 gdi32 ws2_32 uuid)
 else()
   target_include_directories(ossia-score-vstpuppet PRIVATE "${X11_X11_INCLUDE_PATH}")
 endif()


### PR DESCRIPTION
The VST3 SDK's `module_win32.cpp` locates plugin directories with `getKnownFolder(FOLDERID_ProgramFilesCommon)` and `FOLDERID_UserProgramFilesCommon`.

Those are data symbols rather than functions, so nothing else drags them in, and the link fails with `undefined symbol: _FOLDERID_ProgramFilesCommon` on a toolchain that does not happen to pull `uuid` in for another reason.