### PR TITLE
TaskPool: a throwing task must not abort the process

### DIFF
--- a/src/lib/score/tools/ThreadPool.cpp
+++ b/src/lib/score/tools/ThreadPool.cpp
@@ -1,6 +1,8 @@
 #include <score/application/ApplicationServices.hpp>
 #include <score/tools/ThreadPool.hpp>
 
+#include <QDebug>
+
 #include <thread>
 #if __has_include(<sys/resource.h>)
 #include <sys/resource.h>
@@ -109,7 +111,18 @@ TaskPool::TaskPool()
       {
         if(m_queue.wait_dequeue_timed(t, 100000))
         {
-          t();
+          try
+          {
+            t();
+          }
+          catch(const std::exception& e)
+          {
+            qDebug() << "TaskPool: task threw:" << e.what();
+          }
+          catch(...)
+          {
+            qDebug() << "TaskPool: task threw an unknown exception";
+          }
         }
       }
     }};


### PR DESCRIPTION
The worker invoked the task with no exception handling at all, and nothing catches above that point, so anything escaping a task left the thread function and `std::terminate` took the whole application down — with no diagnostic beyond the exit code.

One failed task should cost that task, not the process. The handler logs and carries on.