### PR TITLE
RecursiveWatch: validate the directory before entering LLFIO

### DIFF
--- a/src/lib/score/tools/RecursiveWatch.cpp
+++ b/src/lib/score/tools/RecursiveWatch.cpp
@@ -64,7 +64,16 @@ namespace score
 void for_all_files(std::string_view root, std::function<void(std::string_view)> f)
 {
   using namespace LLFIO_V2_NAMESPACE;
+  {
+    std::error_code ec;
+    const std::filesystem::path rootp{root};
+    if(!std::filesystem::is_directory(rootp, ec) || ec)
+      return;
+  }
+
   auto pp = path_handle::path(path_view(root, path_view::zero_terminated));
+  if(!pp)
+    return;
   algorithm::contents_visitor vis;
   vis.contents_include_symlinks = true;
   try


### PR DESCRIPTION
`for_all_files` unwrapped `path_handle::path()` with `result::value()` and walked whatever came back. A missing or unreadable directory is completely ordinary — a fresh install has no user library yet — but that unwrap cannot be caught: outcome is configured without exceptions here, so it calls `std::terminate` directly rather than throwing something the surrounding `catch` blocks could absorb, and this runs on a TaskPool thread.

Checking with the `std::error_code` overloads first, which cannot throw, and returning when there is nothing to walk.

Unrelated observation while in here: `algorithm::contents_visitor vis` is constructed and `contents_include_symlinks` set on it, but it is never passed to `algorithm::contents`, so it has no effect at all today. Left alone here since changing it would change which entries are visited.