### PR TITLE
cmake: only refuse a 32-bit build when KFR is actually wanted

### DIFF
--- a/cmake/ScoreConfiguration.cmake
+++ b/cmake/ScoreConfiguration.cmake
@@ -141,9 +141,11 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif()
 endif()
 
-if (NOT EMSCRIPTEN)
+if (NOT EMSCRIPTEN AND OSSIA_ENABLE_KFR)
   if(NOT ("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8"))
-    message(FATAL_ERROR "score depends on kfrlib which only supports 64-bit systems.")
+    message(FATAL_ERROR
+      "kfrlib only supports 64-bit systems. Configure with -DOSSIA_ENABLE_KFR=0 "
+      "to build score for a 32-bit target without it.")
   endif()
 endif()
 


### PR DESCRIPTION
The 64-bit requirement comes from kfrlib, but score no longer depends on it unconditionally: every use site is guarded by `if(OSSIA_ENABLE_KFR AND TARGET kfr)`, and FFTW covers the FFT otherwise.

The check refused any 32-bit configuration regardless, so a target that never asked for KFR could not be configured at all. Now gated on `OSSIA_ENABLE_KFR`, with the message pointing at the way out. Emscripten stays exempt as before.