### PR TITLE
Allow custom apps to select video decoding via environment

### DIFF
--- a/src/plugins/score-plugin-gfx/Gfx/Settings/Model.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Settings/Model.cpp
@@ -159,6 +159,22 @@ Model::Model(
 {
   score::setupDefaultSettings(set, Parameters::list(), *this);
 
+  // Custom applications can select a decoder without depending on a
+  // pre-existing user preference. Keep the regular setting as the fallback.
+  if(const auto requested = qEnvironmentVariable("SCORE_VIDEO_DECODING_METHOD");
+     !requested.isEmpty())
+  {
+    const QStringList decoders = HardwareVideoDecoder{};
+    for(const auto& decoder : decoders)
+    {
+      if(decoder.compare(requested, Qt::CaseInsensitive) == 0)
+      {
+        m_HardwareDecode = decoder;
+        break;
+      }
+    }
+  }
+
   const auto apis = GraphicsApis{};
 
   const auto platform = QGuiApplication::platformName();


### PR DESCRIPTION
## Summary

- read an optional `SCORE_VIDEO_DECODING_METHOD` environment variable at startup
- match the requested decoder case-insensitively against the decoders available in the build
- preserve the existing persisted setting when the variable is absent or invalid

This lets downstream applications such as Domeport Pro request `Auto` without changing score defaults or adding application-specific code to score.

## Verification

The combined Domeport Pro macOS artifact built successfully in run 31439148108. With the persisted hardware-decoder preference deliberately set to `None`, the packaged process had `SCORE_VIDEO_DECODING_METHOD=Auto` and continuously played the affected HEVC 4320x2160 file at about 52-54 FPS. This confirms the application environment overrides the stored preference while leaving the global default unchanged.