### PR TITLE
Accept enumerated device settings in the QML API

### DIFF
--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.device.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.device.cpp
@@ -231,6 +231,11 @@ void EditJsContext::connectOSCQueryDevice(QString name, QString ip)
 
 void EditJsContext::createDevice(QString name, QString uuid, QJSValue obj)
 {
+  createDevice(std::move(name), std::move(uuid), obj.toVariant());
+}
+
+void EditJsContext::createDevice(QString name, QString uuid, QVariant var)
+{
   auto doc = ctx();
   if(!doc)
     return;
@@ -243,7 +248,6 @@ void EditJsContext::createDevice(QString name, QString uuid, QJSValue obj)
   Device::DeviceSettings set;
   set.name = name;
   set.protocol = UuidKey<Device::ProtocolFactory>::fromString(uuid);
-  const QVariant& var = obj.toVariant();
   if(var.canConvert<Device::DeviceSettings>())
   {
     set.deviceSpecificSettings

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
@@ -66,7 +66,10 @@ public:
   W_SLOT(deviceToOSCQuery)
 
   void createDevice(QString name, QString uuid, QJSValue obj);
-  W_SLOT(createDevice)
+  W_SLOT(createDevice, (QString, QString, QJSValue))
+
+  void createDevice(QString name, QString uuid, QVariant obj);
+  W_SLOT(createDevice, (QString, QString, QVariant))
 
   void createOSCDevice(QString name, QString host, int in, int out);
   W_SLOT(createOSCDevice)


### PR DESCRIPTION
## Summary

- add a `QVariant` overload for `EditJsContext::createDevice`
- keep the existing `QJSValue` overload for JavaScript object literals
- allow `Device::DeviceSettings` values returned by `enumerateDevices()` to be passed back to `createDevice()`

Without this overload, current Qt rejects the enumerated native value before the existing `canConvert<Device::DeviceSettings>()` path can run. This is reproducible with Domeport Pro selecting a Syphon source.

## Verification

The clean macOS integration artifact built successfully in DomeportPro run 31439148108. Runtime selection of `VR Converter Live Output` then logged `Created Syphon input`, rendered moving Metal frames in both equirectangular and domemaster modes, and no longer emitted the QVariant-to-QJSValue conversion error.