### PR TITLE
JS: include the context this file reads through

### DIFF
--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.ui.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.ui.cpp
@@ -6,6 +6,7 @@
 
 #include <JS/Qml/EditContext.hpp>
 
+#include <score/application/GUIApplicationContext.hpp>
 #include <score/tools/std/StringHash.hpp>
 #include <score/widgets/DoubleSlider.hpp>
 


### PR DESCRIPTION
`master` does not currently build:

```
src/plugins/score-plugin-js/JS/Qml/EditContext.ui.cpp:60:25:
error: member access into incomplete type 'const score::GUIApplicationContext'
```

`EditContext.ui.cpp` reaches into `doc->app` to ask the layer factories whether a process has an external UI, but never included the header that defines `GUIApplicationContext`. It had been arriving transitively and no longer does.

A precompiled header supplies it wherever one is in use, so the failure depends on configuration — which is why it is not failing everywhere.

Found while checking that each commit of a stacked branch builds on its own: every commit failed identically, including the first, which pointed at the base rather than at the branch. Verified by building `master` alone (fails) and `master` plus this one line (592/592, clean).