### PR TITLE
lib: stop linking avrt

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -732,10 +732,6 @@ target_include_directories(score_lib_base PUBLIC ${OSSIA_3RDPARTY_FOLDER}/verdig
 
 setup_score_library(score_lib_base)
 
-if(WIN32)
-  target_link_libraries(score_lib_base PRIVATE avrt)
-endif()
-
 if(SCORE_PCH)
   if(APPLE)
     target_precompile_headers(score_lib_base PRIVATE


### PR DESCRIPTION
`ossia::priority_boost_handle` resolves MMCSS through `LoadLibrary` since libossia `b9f1770f6`, so `score_lib_base` no longer needs `avrt` on its link line — and the `if(WIN32)` block it lived in becomes empty, so it goes too.

This is the follow-up to #2190, which removed `avrt` from `score-plugin-gfx`. That one was safe on its own because nothing in the gfx plugin uses MMCSS; this one is not, because `Timers.cpp` does, so it needs the submodule.

Bumps `3rdparty/libossia` by three commits to pick it up:

- `b9f1770f6` windows: resolve MMCSS at run time instead of linking avrt
- `88082225e` cmake: OSSIA_OVERRIDE_PROTOCOLS must write the cache
- `192f5747e` 3rdparty: update fmt