### PR TITLE
avnd: gate kabang and minibang on a GCC that can instantiate them

### DIFF
--- a/src/plugins/score-plugin-avnd/CMakeLists.txt
+++ b/src/plugins/score-plugin-avnd/CMakeLists.txt
@@ -1061,8 +1061,12 @@ avnd_make_score(
   NAMESPACE ao
 )
 
-# Too much binary size
-if(NOT EMSCRIPTEN AND NOT CXX_IS_GCC)
+# Too much binary size for wasm. On GCC these land on the boost.pfr fallback,
+# whose instantiation exhausts the compiler's memory; GCC only leaves that
+# fallback with P1061 packs, which need g++ >= 16 in C++26 mode.
+if(NOT EMSCRIPTEN AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+                           AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16
+                                OR NOT CXX_VERSION_FLAG STREQUAL "cxx_std_26")))
 avnd_make_score(
   SOURCES
     "${AVND_FOLDER}/examples/Advanced/Kabang/Kabang.hpp"


### PR DESCRIPTION
`kabang` and `minibang` are currently excluded from **every** GCC (`NOT CXX_IS_GCC`). The actual constraint is narrower, so this replaces the blanket exclusion with the real one.

### Why GCC fails

On GCC these objects land on avendish's `boost.pfr` aggregate fallback, and instantiating pfr over an aggregate this large exhausts the compiler's memory. Measured on the equivalent Kaboom TU with g++-14: peak **40.9 GB**, OOM-killed, growing ~9.4 GB/min.

It is front-end instantiation, not codegen — `-fsyntax-only` (no code generation at all) still reaches 10 GB in 64 s, and `-O0`, `-O1`, `-O2`, `-fno-inline-functions`, `-finline-limit=40/100`, `--param inline-unit-growth` and the `ggc-*` params all behave identically. No flag can help.

GCC only leaves the pfr fallback when it has P1061 structured-binding packs:

| compiler | result |
|---|---|
| g++-14 `gnu++23` | OOM-killed (40.9 GB) |
| g++-15 `gnu++23` / `gnu++26` | OOM-killed |
| g++-16 `gnu++23` | OOM-killed (16 GB) |
| **g++-16 `gnu++26`** | **compiles, 151 s, 7.1 GB** |

The version alone is not a sufficient test: g++-16 in C++23 mode still selects pfr and still dies. Hence the guard checks `CXX_VERSION_FLAG` too.

### Resulting behaviour

Verified by evaluating the expression in CMake:

```
GNU 13.0 cxx_std_23 -> skip        GNU 16.1 cxx_std_23 -> skip
GNU 14.2 cxx_std_23 -> skip        GNU 16.1 cxx_std_26 -> BUILD
GNU 14.2 cxx_std_26 -> skip        Clang 23.0 cxx_std_23 -> BUILD
GNU 15.3 cxx_std_26 -> skip        AppleClang 17.0 cxx_std_23 -> BUILD
```

Net change: everything that built before still builds, plus g++-16 in C++26 mode gains these objects. The `EMSCRIPTEN` exclusion (binary size) is unchanged.

Related: celtera/avendish#190 (g++-15 currently selects a backend it cannot compile), ossia/score-addon-synthimi#10 (same guard for `kaboom`).