### PR TITLE
avnd: cap the inline threshold on the generated kabang TU

### DIFF
--- a/src/plugins/score-plugin-avnd/CMakeLists.txt
+++ b/src/plugins/score-plugin-avnd/CMakeLists.txt
@@ -1090,6 +1090,16 @@ avnd_make_score(
   NAMESPACE kbng
   OPTIMIZED
 )
+
+# Kabang's port count puts it in the range where clang's inliner turns the
+# generated walkers into functions the backend takes hours to lower. 40 is the
+# highest threshold that still compiles quickly. Only the generated TU is
+# touched, and -fno-lto keeps the inliner here instead of at link time.
+# Minibang is the reduced variant -- 4 ports against 45 -- and does not need it.
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
+  set_property(SOURCE "${CMAKE_BINARY_DIR}/kabang_avnd.cpp" APPEND PROPERTY
+    COMPILE_OPTIONS -fno-lto -mllvm -inline-threshold=40)
+endif()
 endif()
 
 avnd_make_score(


### PR DESCRIPTION
Kabang has 45 port members, which puts it in the range where clang's inliner flattens the generated avendish walkers into functions the backend takes a very long time to lower.

The equivalent object — Kaboom in `score-addon-synthimi`, same shape, ~336 fields — costs **3 h 31 m of link time** at the default threshold and about a minute at 40. Bisection there showed the cost is backend codegen of the `safe_node<Node>` construction subtree, spread across five generated functions of 40-60 KB each, so no single-site source fix exists; only reducing inlining pressure works. Full write-up and measurements: ossia/score-addon-synthimi#11.

The threshold has a sharp edge (measured on that TU): 30 → 57 s, **40 → 86 s**, 45 and above → still running after 20 minutes. 40 is the highest usable value.

### Scope

`set_property(SOURCE ...)` on the generated TU only, so no other object in the plugin changes. `-fno-lto` goes with it because under LTO the inlining happens at link time, where a compile-time `-mllvm` option would not apply. Guarded to clang, since `-mllvm` is clang-only.

`minibang` is deliberately left alone — it is the reduced variant, 4 port members against 45.

Note these objects are currently not built on GCC at all, and are excluded from wasm for binary size, so this affects native clang builds.