### PR TITLE
wasm: run the release-bundle step under bash

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -60,6 +60,9 @@ jobs:
       # other platforms. This is what tools/create-app-wasm.sh downloads for
       # `--platform wasm --release <tag>` (custom web apps).
       - name: Package release bundle
+        # This job runs in a container, where the default shell is sh, not bash.
+        # The script below uses [[ ]], which sh does not have.
+        shell: bash
         run: |
           export GITTAGNOV=$(echo "$GITHUB_REF" | sed "s/.*\///;s/^v//")
           mkdir -p staging


### PR DESCRIPTION
The `wasm` job runs in a `container:`, where the default shell is `sh` — every inline step in that job gets `shell: sh -e {0}`. The "Package release bundle" step uses `[[ ]]`.

### Why it did not fail where you would expect

`sh` reports `[[: not found`, but that line is an `if` **condition**, and conditions are exempt from `errexit`. So the script did not stop: the test evaluated false, took the `else` branch, and continued — failing several lines later on `zip` with exit 127, which is what the log shows and which hides the actual cause.

```
.sh: 3: [[: not found          <- silently took the else branch
.sh: 10: zip: not found
##[error]Process completed with exit code 127
```

### The part that matters more

The same test picks the artifact name on a tag build:

| shell | `GITHUB_REF` | resulting name |
|---|---|---|
| `sh` | `refs/tags/v3.5.0` | `ossia.score-master-wasm.zip` ❌ |
| `bash` | `refs/tags/v3.5.0` | `ossia.score-3.5.0-wasm.zip` ✅ |
| either | `refs/heads/master` | `ossia.score-master-wasm.zip` ✅ |

So a tagged release would publish a bundle that does not carry its version, silently — `tools/create-app-wasm.sh --platform wasm --release <tag>` looks that name up.

### Scope

I parsed every workflow in `.github/workflows` and checked each inline `run:` block that does not declare `shell:` against constructs `sh` lacks (`[[ ]]`, `pipefail`, arrays, process substitution, `source`, brace ranges, `declare`, …).

The only other hits are `source` in `custom.yml` and `mac-builds.yaml`, all in `runs-on: macos-26` jobs with no `container:` — the default shell there is already bash, so they are unaffected. **This step was the only one in a container**, and is the only change here.

(Separately, `zip` was genuinely missing from the image; that is fixed on our side.)