### PR TITLE
library: fix the library scan finding nothing on Windows

### DIFF
--- a/src/lib/score/tools/RecursiveWatch.cpp
+++ b/src/lib/score/tools/RecursiveWatch.cpp
@@ -2,6 +2,7 @@
 #include <score/tools/ThreadPool.hpp>
 
 #include <QCoreApplication>
+#include <QDebug>
 #include <QMetaObject>
 #include <QPointer>
 #include <Qt>
@@ -78,7 +79,14 @@ void for_all_files(std::string_view root, std::function<void(std::string_view)> 
   vis.contents_include_symlinks = true;
   try
   {
-    if(auto res = algorithm::contents(pp.value()))
+    // permit_racy_reads: on Windows NtQueryDirectoryFile() returns at most ~64Kb of
+    // entries per call however large a buffer it is given, so a directory holding more
+    // than that (~600 files with short names) cannot be enumerated as an atomic
+    // snapshot, and the strict default fails the whole traversal rather than returning
+    // the entries. The library is user content: it routinely has such directories, and
+    // a best-effort listing of one is worth far more to us than a snapshot of nothing.
+    if(auto res = algorithm::contents(
+           pp.value(), &vis, 0, false, directory_handle::flags::permit_racy_reads))
     {
       try
       {
@@ -135,6 +143,11 @@ void for_all_files(std::string_view root, std::function<void(std::string_view)> 
     }
     else
     {
+      // A failure here yields no files at all, which is indistinguishable from an empty
+      // library unless we say so.
+      qWarning() << "for_all_files: could not enumerate"
+                 << QString::fromUtf8(root.data(), root.size()) << ':'
+                 << QString::fromStdString(make_error_code(res.error()).message());
     }
   }
   catch(const std::exception& e)


### PR DESCRIPTION
Windows builds have been scanning **no library at all** since llfio was enabled there in 7789e60aa (after v3.8.2). Not just presets — no devices, cues, Faust or JSFX effects either. A default install scans zero of its 6041 library files.

## Cause

`NtQueryDirectoryFile()` returns at most ~64Kb of entries per call however large a buffer it is given ([ned14/llfio#137](https://github.com/ned14/llfio/issues/137)). llfio sizes its buffer correctly from its own first pass, but the kernel truncates anyway — traced on a 1513-entry directory:

```
call 0 returned 65426 bytes (buffer was 197536)
call 1 returned 65460 bytes
call 2 returned 53496 bytes
NO_MORE_FILES at count=3
```

`directory_handle::read()` treats needing a second call as a lost atomic snapshot and returns `errc::operation_would_block` rather than the entries. That propagates out of `algorithm::contents()` for the **whole tree**, so one oversized directory anywhere under `packages/` makes `for_all_files()` walk nothing.

The stock user library has three such directories:

| entries | path under `packages/` |
|--:|---|
| 1513 | `default/Presets/GLSL_shaders/grigm` |
| 1120 | `default/Presets/Vertex Shader Art/audioreactive` |
| 959 | `default/Presets/Vertex Shader Art/basic` |

Roughly 600 files with short names is enough to trip it.

This reads as "the library downloaded but score sees no presets", because the System Library panel is a `QFileSystemModel` and keeps listing the files regardless — only the `RecursiveWatch`-driven side is empty.

v3.8.2 was fine: it used `std::filesystem::recursive_directory_iterator` on Windows, which handles all 6041 entries. Linux is unaffected, llfio's POSIX `read()` loops over `getdents` properly. macOS still uses `std::filesystem`.

## Fix

Pass llfio's `permit_racy_reads`, which returns the entries when a snapshot is not possible. It is best-effort, not always-racy: an enumeration that fits in one call is still an atomic snapshot and reports `is_snapshot()` true. For scanning user content that is the only workable contract — a recursive walk does not get to pick the directories it meets.

Also report a failed enumeration. A `contents()` that errors and a genuinely empty library were indistinguishable, which is why this needed a standalone repro program to find rather than being obvious from the logs.

## llfio bump

`traverse()` and `contents()` had no way to pass read flags, so the submodule bump carries two commits: propagating `_snapshot` through `buffers_type` moves (it was being dropped, so `is_snapshot()` always answered true), and an `enumeration_flags` parameter defaulted to `flags::none`. Both are pending upstream; the submodule points at `jcelerier/llfio@traverse-enumeration-flags` until they merge, and should be repointed afterwards.

## Verification

`contents()` on Windows 11 26200, NTFS, clang 22.1.8 / libc++ / llvm-mingw:

| tree | before | after |
|---|---|---|
| 32 entries, no large directory | 32 entries | 32 entries |
| one 959-entry directory | `operation_would_block` | 959 entries |
| one 1513-entry directory plus subdirectories | `operation_would_block` | 1564 entries |
| the full `packages/` tree | `operation_would_block` | 6048 entries, 130 `.scp` |

130 `.scp` matches what `std::filesystem` finds on the same tree.
