### PR TITLE
ci: install zip in the wasm container

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install git
         run: |
           apt-get update -qq
-          apt-get install -y -qq git ca-certificates
+          apt-get install -y -qq git ca-certificates zip
 
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Follow-up to 7a92f320c: the release-bundle step now runs under bash but still dies with exit 127 — `zip` is not installed in the bare ubuntu:24.04 container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)