### PR TITLE
test: make rendering testable from master

### DIFF
--- a/cmake/ScoreCodeviewWindows.cmake
+++ b/cmake/ScoreCodeviewWindows.cmake
@@ -1,10 +1,23 @@
 if(WIN32)
+  # Clang only. GCC's CodeView writer segfaults on any boost::container type,
+  # which this codebase uses in around thirty translation units, so -gcodeview
+  # makes a gcc Debug or RelWithDebInfo build impossible to complete:
+  #
+  #   $ cat REPRO.cpp
+  #   #include <boost/container/vector.hpp>
+  #   void f() { boost::container::vector<int> v; (void)v; }
+  #   $ g++ -gcodeview -c REPRO.cpp
+  #   REPRO.cpp:2:54: internal compiler error: Segmentation fault
+  #
+  # Reproduced on gcc 16.2.0 (MSYS2 UCRT64) with boost 1.91. The flag alone is
+  # enough -- no optimisation level or standard setting is involved -- and DWARF
+  # is unaffected, as is clang. The crash is in the type-record emission reached
+  # from dwarf2out_finish, which is why every report points at the last line of
+  # the file.
   if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     if(NOT (CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"))
       set(SCORE_COMPILER_NEEDS_GCODEVIEW 1)
     endif()
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set(SCORE_COMPILER_NEEDS_GCODEVIEW 1)
   endif()
 
   if (SCORE_COMPILER_NEEDS_GCODEVIEW)

--- a/cmake/ScoreTests.cmake
+++ b/cmake/ScoreTests.cmake
@@ -121,6 +121,12 @@ function(score_add_test NAME)
     add_test(NAME ${NAME} COMMAND ${NAME})
   endif()
 
+  # Catch2 exits with 4 when every test case in the binary was skipped
+  # (AllTestsSkippedExitCode, catch_session.cpp). A test that skips because its
+  # precondition is absent -- no display, no shader library, no capture device --
+  # is not a defect, and counting it as one silently inflates the failure count.
+  set_tests_properties(${NAME} PROPERTIES SKIP_RETURN_CODE 4)
+
   # App/integration tests rely on runtime dynamic-plugin discovery from
   # "<cwd>/plugins": run them from the build root where <build>/plugins lives.
   if(ARG_APP OR ARG_GUI)

--- a/cmake/ScoreTests.cmake
+++ b/cmake/ScoreTests.cmake
@@ -132,6 +132,12 @@ function(score_add_test NAME)
   if(ARG_APP OR ARG_GUI)
     set_tests_properties(${NAME} PROPERTIES
       WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
+
+    # ...and tell the fixture where that is, so running the executable by hand
+    # from some other directory boots the same application instead of one with
+    # no plug-ins at all. See prepare_test_environment().
+    target_compile_definitions(${NAME} PRIVATE
+      "SCORE_TEST_BINARY_DIR=\"${SCORE_ROOT_BINARY_DIR}\"")
   endif()
 
   if(ARG_APP)

--- a/cmake/ScoreTests.cmake
+++ b/cmake/ScoreTests.cmake
@@ -49,6 +49,17 @@ function(score_setup_catch2)
   set(BUILD_SHARED_LIBS "${_old_shared}")
 endfunction()
 
+# Sources a test compiles directly because the shared plugin hides them
+# (visibility). A static plugin archive already provides them; compiling them
+# again duplicates every symbol at link time.
+function(score_plugin_hidden_sources OUT)
+  if(SCORE_STATIC_PLUGINS OR NOT BUILD_SHARED_LIBS)
+    set(${OUT} "" PARENT_SCOPE)
+  else()
+    set(${OUT} ${ARGN} PARENT_SCOPE)
+  endif()
+endfunction()
+
 function(score_add_test NAME)
   cmake_parse_arguments(ARG "GUI;APP;STANDALONE;SANDBOXED" "" "SOURCES;PLUGINS;LIBS" ${ARGN})
 

--- a/src/app/Application.cpp
+++ b/src/app/Application.cpp
@@ -196,7 +196,8 @@ bool runningUnderAnUISession() noexcept
   if(qgetenv("XDG_SESSION_TYPE") != "tty")
     return true;
   if(platform.contains("gl") || platform.contains("vkkhr")
-     || platform.contains("linuxfb") || platform.contains("vnc"))
+     || platform.contains("linuxfb") || platform.contains("vnc")
+     || platform.contains("offscreen"))
     return true;
   return false;
 #endif

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -247,8 +247,12 @@ static void setup_x11(int argc, char** argv)
 
   if(!x11 && !wayland)
   {
-    // Try eglfs
-    qputenv("QT_QPA_PLATFORM", "eglfs");
+    // Try eglfs -- unless a platform was asked for. Overwriting it here sent
+    // QT_QPA_PLATFORM=offscreen to eglfs, which finds no display device, and
+    // Qt then qFatal()s on the first window for having no screens. A headless
+    // machine asking for offscreen has to get offscreen.
+    if(!has_platform)
+      qputenv("QT_QPA_PLATFORM", "eglfs");
     return;
   }
   static constexpr auto setup_x11_error_handling = [] {

--- a/src/lib/core/presenter/DocumentManager.cpp
+++ b/src/lib/core/presenter/DocumentManager.cpp
@@ -242,8 +242,15 @@ void DocumentManager::setCurrentDocument(
 bool DocumentManager::closeDocument(
     const score::GUIApplicationContext& ctx, Document& doc)
 {
-  // Warn the user if he might loose data
-  if(!doc.commandStack().isAtSavedIndex())
+  // Warn the user if he might loose data. Only when there is a user: with
+  // applicationSettings.gui false (headless, --script, offscreen QPA) nothing
+  // can answer a modal, and QMessageBox::exec() aborts instead of returning.
+  // Every score::MessageBox helper already guards on this same flag; this call
+  // site was the one raw QMessageBox left, which is why a scripted /exit on a
+  // modified document died in teardown with SIGABRT. No GUI means no one to
+  // save for, so proceed as Discard -- the same outcome forceExit() already
+  // produces, since it quits 500ms later whatever the answer would have been.
+  if(!doc.commandStack().isAtSavedIndex() && ctx.applicationSettings.gui)
   {
     QMessageBox msgBox;
     msgBox.setText(tr("The document has been modified."));

--- a/src/lib/score/application/ApplicationContext.hpp
+++ b/src/lib/score/application/ApplicationContext.hpp
@@ -40,16 +40,33 @@ struct SCORE_LIB_BASE_EXPORT ApplicationContext
   template <typename T>
   T& settings() const
   {
+    if(auto c = findSettings<T>())
+      return *c;
+
+    SCORE_ABORT;
+    throw;
+  }
+
+  /**
+   * @brief Access a Settings model instance, or null when its plug-in did not
+   * register one.
+   *
+   * settings() aborts the process in that case, which is the right answer for
+   * application code (a missing settings model means the plug-in it belongs to
+   * is not loaded, and nothing downstream can work). Callers that can report
+   * the situation themselves want the null instead.
+   */
+  template <typename T>
+  T* findSettings() const noexcept
+  {
     for(auto& elt : this->m_settings)
     {
       if(auto c = dynamic_cast<T*>(elt.get()))
       {
-        return *c;
+        return c;
       }
     }
-
-    SCORE_ABORT;
-    throw;
+    return nullptr;
   }
 
   const auto& allSettings() const noexcept { return m_settings; }

--- a/src/lib/score/gfx/Vulkan.cpp
+++ b/src/lib/score/gfx/Vulkan.cpp
@@ -60,8 +60,16 @@ QVulkanInstance* staticVulkanInstance(bool create)
     if(!instance.create())
     {
       g_staticVulkanInstanceInvalid = true;
+      delete g_staticVulkanInstance;
+      g_staticVulkanInstance = nullptr;
     }
   });
+
+  // Re-check: on the very first call, create() may just have failed inside
+  // call_once — returning the half-initialized instance would send callers
+  // (Graph's API-fallback check, QRhi::create) straight into a crash.
+  if(g_staticVulkanInstanceInvalid)
+    return nullptr;
 
   return g_staticVulkanInstance;
 }

--- a/src/lib/score/tools/File.cpp
+++ b/src/lib/score/tools/File.cpp
@@ -81,6 +81,18 @@ QString addUniqueSuffix(const QString& fileName)
   }
 }
 
+QString locateFilePath(const QString& filename) noexcept
+{
+  if(filename.startsWith("<LIBRARY>:"))
+  {
+    QSettings set;
+    QString path = filename;
+    path.replace("<LIBRARY>:", set.value("Library/RootPath").toString() + "/");
+    return QFileInfo{path}.absoluteFilePath();
+  }
+  return filename;
+}
+
 QString
 locateFilePath(const QString& filename, const score::DocumentContext& ctx) noexcept
 {

--- a/src/lib/score/tools/FilePath.hpp
+++ b/src/lib/score/tools/FilePath.hpp
@@ -12,6 +12,13 @@ SCORE_LIB_BASE_EXPORT
 QString
 locateFilePath(const QString& filename, const score::DocumentContext& ctx) noexcept;
 
+//! Same, for callers that run before any document exists -- a --script file is
+//! read while the application is still starting up. <LIBRARY>: is a settings
+//! lookup and resolves fine; <PROJECT>: and relative paths have no document to
+//! resolve against and are returned untouched.
+SCORE_LIB_BASE_EXPORT
+QString locateFilePath(const QString& filename) noexcept;
+
 //! Will try to convert an absolute path
 //! in a relative path from the document's point of view
 SCORE_LIB_BASE_EXPORT

--- a/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
+++ b/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
@@ -29,7 +29,7 @@ namespace
 {
 static constexpr struct glsl45_t
 {
-  static constexpr auto versionPrelude = R"_(#version 450
+  static constexpr auto versionPrelude = R"_(#version 460
 )_";
 
   static constexpr auto vertexPrelude = R"_(
@@ -3515,7 +3515,7 @@ void parser::parse_csf()
   m_fragment.clear();
 
   // Add version
-  m_fragment += "#version 450\n\n";
+  m_fragment += "#version 460\n\n";
 
   // Add standard ProcessUBO uniforms (same as ISF/VSA)
   m_fragment += GLSL45.defaultUniforms;

--- a/src/plugins/score-plugin-gfx/CMakeLists.txt
+++ b/src/plugins/score-plugin-gfx/CMakeLists.txt
@@ -287,6 +287,7 @@ set(HDRS
     Gfx/Window/CollapsibleSection.hpp
     Gfx/Window/DesktopLayout.hpp
     Gfx/Window/MultiWindowDevice.hpp
+    Gfx/Window/OffscreenDevice.hpp
     Gfx/Window/OutputMapping.hpp
     Gfx/Window/OutputPreview.hpp
     Gfx/Window/TestCard.hpp

--- a/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
@@ -1662,7 +1662,10 @@ ProtocolFactory::getEnumerators(const score::DocumentContext& ctx) const
         {"SMPTE 302M audio sender (MPEG-TS)",
          "GStreamer Out",
          "appsrc name=audio ! audioconvert ! "
-         "audio/x-raw,format=S24LE,rate=48000,channels=2 ! "
+         // avenc_s302m accepts S16LE or S32LE only -- 24-bit SMPTE 302M is
+         // carried in 32-bit containers -- and never S24LE, which made this
+         // preset refuse to link at all.
+         "audio/x-raw,format=S32LE,rate=48000,channels=2 ! "
          "avenc_s302m ! mpegtsmux ! "
          "udpsink host=239.0.0.1 port=5008 auto-multicast=true sync=false",
          1280, 720, 30, 2});

--- a/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
@@ -283,8 +283,12 @@ struct gstreamer_pipeline
         named_elements.emplace_back(ename, elem);
     }
 
-    // Set back to NULL, ready for start()
-    gst.element_set_state(m_pipeline, GST_STATE_NULL);
+    // Left in PAUSED, ready for start(). A gst_parse_launch pipeline that
+    // contains a dynamic-pad element -- decodebin, uridecodebin, rtspsrc,
+    // tsdemux, qtdemux -- is held together by a delayed link that fires once,
+    // on the first pad-added, and then disconnects. Cycling down to NULL or
+    // READY destroys those pads: the next PLAYING creates new ones that nothing
+    // links, the state change stays ASYNC forever and the appsink never yields.
     return true;
   }
 
@@ -295,7 +299,21 @@ struct gstreamer_pipeline
       return;
     }
 
+    if(m_running)
+      return;
+
     auto& gst = libgstreamer::instance();
+
+    // Playing again after a stop: rewind, since stop() now rests at PAUSED
+    // instead of NULL. A live source refuses the seek and keeps streaming.
+    if(m_started_once && gst.element_seek_simple)
+    {
+      gst.element_seek_simple(
+          m_pipeline, GST_FORMAT_TIME,
+          GstSeekFlags(GST_SEEK_FLAG_FLUSH | GST_SEEK_FLAG_KEY_UNIT), 0);
+    }
+    m_started_once = true;
+
     gst.element_set_state(m_pipeline, GST_STATE_PLAYING);
 
     if(gst.element_get_state)
@@ -314,10 +332,12 @@ struct gstreamer_pipeline
     if(m_thread.joinable())
       m_thread.join();
 
+    // PAUSED rather than NULL, for the delayed-link reason in load(): a
+    // stopped device must be able to play again.
     if(m_pipeline)
     {
       auto& gst = libgstreamer::instance();
-      gst.element_set_state(m_pipeline, GST_STATE_NULL);
+      gst.element_set_state(m_pipeline, GST_STATE_PAUSED);
     }
 
     for(auto& q : video_queues)
@@ -331,6 +351,7 @@ struct gstreamer_pipeline
     if(m_pipeline)
     {
       auto& gst = libgstreamer::instance();
+      gst.element_set_state(m_pipeline, GST_STATE_NULL);
 
       for(auto* elem : m_appsink_elements)
         gst.object_unref(elem);
@@ -527,6 +548,7 @@ private:
   std::vector<GstElement*> m_appsink_elements;
   std::thread m_thread;
   std::atomic_bool m_running{};
+  bool m_started_once{};
 };
 
 class gstreamer_video_decoder : public ::Video::ExternalInput

--- a/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerLoader.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerLoader.hpp
@@ -58,6 +58,22 @@ typedef enum
 
 typedef enum
 {
+  GST_FORMAT_UNDEFINED = 0,
+  GST_FORMAT_DEFAULT = 1,
+  GST_FORMAT_BYTES = 2,
+  GST_FORMAT_TIME = 3,
+} GstFormat;
+
+typedef enum
+{
+  GST_SEEK_FLAG_NONE = 0,
+  GST_SEEK_FLAG_FLUSH = (1 << 0),
+  GST_SEEK_FLAG_ACCURATE = (1 << 1),
+  GST_SEEK_FLAG_KEY_UNIT = (1 << 2),
+} GstSeekFlags;
+
+typedef enum
+{
   GST_FLOW_OK = 0,
   GST_FLOW_EOS = -3,
   GST_FLOW_ERROR = -5,
@@ -158,6 +174,9 @@ GstStateChangeReturn gst_element_get_state(
     GstElement* element, GstState* state, GstState* pending,
     GstClockTime timeout);
 GstBus* gst_element_get_bus(GstElement* element);
+gboolean gst_element_seek_simple(
+    GstElement* element, GstFormat format, GstSeekFlags seek_flags,
+    int64_t seek_pos);
 GstElement* gst_bin_get_by_name(GstElement* bin, const char* name);
 GstPad* gst_element_get_static_pad(GstElement* element, const char* name);
 char* gst_element_get_name(GstElement* element);
@@ -260,6 +279,7 @@ struct libgstreamer
   decltype(&::gst_element_set_state) element_set_state{};
   decltype(&::gst_element_get_state) element_get_state{};
   decltype(&::gst_element_get_bus) element_get_bus{};
+  decltype(&::gst_element_seek_simple) element_seek_simple{};
   decltype(&::gst_bin_get_by_name) bin_get_by_name{};
   decltype(&::gst_element_get_static_pad) element_get_static_pad{};
   decltype(&::gst_element_get_name) element_get_name{};
@@ -419,6 +439,7 @@ private:
     GST_LOAD(m_core, element_set_state);
     GST_LOAD(m_core, element_get_state);
     GST_LOAD(m_core, element_get_bus);
+    GST_LOAD(m_core, element_seek_simple);
     GST_LOAD(m_core, bin_get_by_name);
     GST_LOAD(m_core, element_get_static_pad);
     GST_LOAD(m_core, element_get_name);

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
@@ -1,5 +1,6 @@
 #include <Gfx/GfxContext.hpp>
 #include <Gfx/Graph/Graph.hpp>
+#include <Gfx/Graph/Node.hpp>
 #include <Gfx/Graph/OutputNode.hpp>
 #include <Gfx/Settings/Model.hpp>
 
@@ -10,6 +11,8 @@
 #include <score/tools/Timers.hpp>
 
 #include <ossia/detail/flicks.hpp>
+
+#include <cmath>
 #include <ossia/detail/logger.hpp>
 #include <ossia/detail/thread.hpp>
 
@@ -490,6 +493,47 @@ void GfxContext::on_watchdog_timer(score::HighResolutionTimer* self)
 {
   if(m_manualTimers.empty() && !m_no_vsync_timer)
     updateGraph();
+}
+
+void GfxContext::renderFrames(int frames)
+{
+  if(frames <= 0 || !m_graph)
+    return;
+
+  const bool step = m_stepRate > 0.;
+  const int64_t frame_flicks
+      = step ? int64_t(std::llround(ossia::flicks_per_second<double> / m_stepRate)) : 0;
+  // Held for the whole call so PROGRESS sweeps 0..1 across it rather than
+  // restarting on every frame.
+  const ossia::time_value span{frame_flicks * (m_stepFrame + frames)};
+
+  for(int i = 0; i < frames; i++)
+  {
+    // Same order as the timer-driven path: parameters first, then draw, so a
+    // value written by the script is visible in the frame that follows it.
+    updateGraph();
+
+    // After updateGraph, which would otherwise overwrite the UBO with the date
+    // the transport last sent.
+    if(step)
+    {
+      const score::gfx::Timings tk{
+          .date = ossia::time_value{frame_flicks * m_stepFrame},
+          .parent_duration = span};
+      for(auto& [id, node] : nodes)
+      {
+        if(auto proc = dynamic_cast<score::gfx::ProcessNode*>(node.get()))
+          proc->process(tk);
+      }
+      m_stepFrame++;
+    }
+
+    for(auto output : m_graph->outputs())
+    {
+      if(output && output->canRender())
+        output->render();
+    }
+  }
 }
 
 void GfxContext::on_manual_timer(score::HighResolutionTimer* self)

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
@@ -79,6 +79,35 @@ public:
   void update_inputs();
   void updateGraph();
 
+  /**
+   * @brief Render exactly @p frames times, synchronously, and return.
+   *
+   * The normal path renders off wall-clock timers, so "how many frames have I
+   * drawn" depends on how long the caller happened to wait and how fast the
+   * machine is -- a harness that sleeps and then grabs gets a different frame
+   * on a Raspberry Pi than on a workstation, and an animated shader gives a
+   * different image every run.
+   *
+   * Stepping instead makes frame N mean the same thing everywhere, which is
+   * what lets a rendered frame be compared against a stored reference at all.
+   *
+   * Each step also hands every process node a synthetic token of
+   * `frame / stepRate()`, so TIME, TIMEDELTA, FRAMEINDEX and PROGRESS follow the
+   * counter rather than whatever the transport last delivered. Without it an
+   * animated shader keeps reading the execution clock and frame N is a
+   * different picture every run.
+   *
+   * Still on the execution clock: whatever a node takes from the transport
+   * itself rather than from its process UBO -- video decode position,
+   * automation -- so a graph built on those is only as reproducible as that
+   * clock is.
+   */
+  void renderFrames(int frames);
+
+  //! Step used by renderFrames(), in frames per second.
+  double stepRate() const noexcept { return m_stepRate; }
+  void setStepRate(double fps) noexcept { m_stepRate = fps; }
+
   void send_message(score::gfx::Message&& msg) noexcept
   {
     tick_messages.enqueue(std::move(msg));
@@ -101,6 +130,9 @@ private:
 
   score::gfx::Graph* m_graph{};
   QThread m_thread;
+
+  double m_stepRate{60.};
+  int64_t m_stepFrame{};
 
   struct NodeCommand
   {

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
@@ -192,9 +192,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
       qCritical() << "createRenderState: QRhi::create(OpenGLES2) FAILED. "
                      "This output will never render.";
     }
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    else
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 
@@ -264,9 +267,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     if(!state.rhi)
       state.rhi = QRhi::create(QRhi::Vulkan, &params, flags);
 
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 
@@ -282,9 +288,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     // }
     state.version = Gfx::Settings::shaderVersionForAPI(D3D11);
     state.rhi = QRhi::create(QRhi::D3D11, &params, flags);
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
   else if(graphicsApi == D3D12)
@@ -298,9 +307,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     // }
     state.version = Gfx::Settings::shaderVersionForAPI(D3D12);
     state.rhi = QRhi::create(QRhi::D3D12, &params, flags);
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 #endif
@@ -311,9 +323,12 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     QRhiMetalInitParams params;
     state.version = Gfx::Settings::shaderVersionForAPI(Metal);
     state.rhi = QRhi::create(QRhi::Metal, &params, flags);
-    state.renderSize = sz;
-    populateCaps(state);
-    return st;
+    if(state.rhi)
+    {
+      state.renderSize = sz;
+      populateCaps(state);
+      return st;
+    }
   }
 #endif
 

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
@@ -221,6 +221,10 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
     {
       params.inst = score::gfx::staticVulkanInstance();
     }
+    // No instance (headless platform plugins cannot create one): bail to the
+    // null-rhi state instead of letting QRhi::create dereference it.
+    if(!params.inst)
+      return st;
     state.version = Gfx::Settings::shaderVersionForAPI(Vulkan);
 
     // Create shared VkDevice with video decode queues BEFORE QRhi.

--- a/src/plugins/score-plugin-gfx/Gfx/Libav/AudioFrameEncoder.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Libav/AudioFrameEncoder.hpp
@@ -8,6 +8,9 @@ extern "C" {
 
 #include <ossia/dataflow/float_to_sample.hpp>
 
+#include <algorithm>
+#include <cstring>
+
 namespace Gfx
 {
 
@@ -23,6 +26,18 @@ struct AudioFrameEncoder
   virtual void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) = 0;
   virtual ~AudioFrameEncoder() = default;
   int target_buffer_size{};
+
+  // How many samples may be written into `frame`. Its buffers were allocated
+  // for nb_samples once, at avcodec_open2 time; `vec` carries whatever the
+  // audio engine produced this tick, which is a different number as soon as
+  // the engine's buffer size and the codec's frame size disagree.
+  static int writable(
+      const AVFrame& frame, const std::span<ossia::float_vector>& vec) noexcept
+  {
+    if(frame.nb_samples <= 0)
+      return 0;
+    return std::min(int(vec[0].size()), frame.nb_samples);
+  }
 };
 
 struct S16IAudioFrameEncoder final : AudioFrameEncoder
@@ -32,7 +47,7 @@ struct S16IAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     auto* ptr = reinterpret_cast<int16_t*>(frame.data[0]);
     for(int i = 0; i < frames; i++)
       for(int c = 0; c < channels; c++)
@@ -47,7 +62,7 @@ struct S24IAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     auto* ptr = reinterpret_cast<int32_t*>(frame.data[0]);
     for(int i = 0; i < frames; i++)
       for(int c = 0; c < channels; c++)
@@ -62,7 +77,7 @@ struct S32IAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     auto* ptr = reinterpret_cast<int32_t*>(frame.data[0]);
     for(int i = 0; i < frames; i++)
       for(int c = 0; c < channels; c++)
@@ -77,7 +92,7 @@ struct FltIAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     auto* ptr = reinterpret_cast<float*>(frame.data[0]);
     for(int i = 0; i < frames; i++)
       for(int c = 0; c < channels; c++)
@@ -92,7 +107,7 @@ struct DblIAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     auto* ptr = reinterpret_cast<double*>(frame.data[0]);
     for(int i = 0; i < frames; i++)
       for(int c = 0; c < channels; c++)
@@ -107,16 +122,14 @@ struct FltPAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
+    const int frames = writable(frame, vec);
     // Copy into the AVFrame's own planar buffers (allocated by av_frame_get_buffer)
     for(int i = 0; i < channels; ++i)
     {
       uint8_t* dst = (i < AV_NUM_DATA_POINTERS) ? frame.data[i]
                                                  : frame.extended_data[i];
       if(dst)
-      {
-        const int bytes = vec[i].size() * sizeof(float);
-        std::memcpy(dst, vec[i].data(), bytes);
-      }
+        std::memcpy(dst, vec[i].data(), std::size_t(frames) * sizeof(float));
     }
   }
 };
@@ -128,7 +141,7 @@ struct S16PAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     for(int i = 0; i < channels; ++i)
     {
       auto* dst = reinterpret_cast<int16_t*>(
@@ -147,7 +160,7 @@ struct S32PAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     for(int i = 0; i < channels; ++i)
     {
       auto* dst = reinterpret_cast<int32_t*>(
@@ -166,7 +179,7 @@ struct DblPAudioFrameEncoder final : AudioFrameEncoder
   void add_frame(AVFrame& frame, const std::span<ossia::float_vector> vec) override
   {
     const int channels = vec.size();
-    const int frames = vec[0].size();
+    const int frames = writable(frame, vec);
     for(int i = 0; i < channels; ++i)
     {
       auto* dst = reinterpret_cast<double*>(

--- a/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoder.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoder.cpp
@@ -142,23 +142,11 @@ int LibavEncoder::add_frame(std::span<ossia::float_vector> vec)
     return 1;
 
   auto& stream = streams[audio_stream_index];
-  AVFrame* next_frame = stream.get_audio_frame();
-  if(!next_frame)
-    return 1;
 
-  next_frame->sample_rate = stream.enc->sample_rate;
-  next_frame->format = stream.enc->sample_fmt;
-  next_frame->nb_samples = stream.enc->frame_size;
-  next_frame->ch_layout.nb_channels = channels;
-  next_frame->ch_layout.order = AV_CHANNEL_ORDER_UNSPEC;
-
-  // Write the data
-  if(stream.resamplers.empty())
-  {
-    // Encode directly
-    stream.encoder->add_frame(*next_frame, vec);
-  }
-  else
+  // 1. Resample first, so that what is buffered below is already at the
+  //    encoder's rate.
+  std::span<ossia::float_vector> src = vec;
+  if(!stream.resamplers.empty())
   {
     if(vec.size() != stream.resamplers.size())
     {
@@ -177,11 +165,63 @@ int LibavEncoder::add_frame(std::span<ossia::float_vector> vec)
           stream.resample_in_buf[c].data(), vec[c].size(), ret);
       stream.resample_out_buf[c].assign(ret, ret + res);
     }
-
-    stream.encoder->add_frame(*next_frame, stream.resample_out_buf);
+    src = stream.resample_out_buf;
   }
 
-  return stream.write_audio_frame(m_formatContext, next_frame);
+  // 2. A codec whose frame size is fixed -- aac at 1024, libopus at 960, flac
+  //    at 4096 -- must be handed exactly that many samples per frame, and the
+  //    engine's block is a different number. Buffer, and cut whole frames out,
+  //    so no frame carries samples left over from the previous one.
+  const int need = stream.enc->frame_size;
+  if(need <= 0)
+  {
+    // A variable-frame-size codec (the PCM families): the frame is the block.
+    AVFrame* next_frame = stream.get_audio_frame();
+    if(!next_frame)
+      return 1;
+    next_frame->sample_rate = stream.enc->sample_rate;
+    next_frame->format = stream.enc->sample_fmt;
+    next_frame->nb_samples = int(src[0].size());
+    next_frame->ch_layout.nb_channels = channels;
+    stream.encoder->add_frame(*next_frame, src);
+    return stream.write_audio_frame(m_formatContext, next_frame);
+  }
+
+  m_audioFifo.resize(channels);
+  m_audioBlock.resize(channels);
+  for(int c = 0; c < channels; c++)
+  {
+    m_audioFifo[c].reserve(std::size_t(need) * 4);
+    m_audioFifo[c].insert(m_audioFifo[c].end(), src[c].begin(), src[c].end());
+  }
+
+  int ret = 0;
+  while(int(m_audioFifo[0].size()) >= need)
+  {
+    AVFrame* next_frame = stream.get_audio_frame();
+    if(!next_frame)
+      return 1;
+
+    next_frame->sample_rate = stream.enc->sample_rate;
+    next_frame->format = stream.enc->sample_fmt;
+    next_frame->nb_samples = need;
+    next_frame->ch_layout.nb_channels = channels;
+
+    for(int c = 0; c < channels; c++)
+      m_audioBlock[c].assign(
+          m_audioFifo[c].begin(), m_audioFifo[c].begin() + need);
+
+    stream.encoder->add_frame(*next_frame, m_audioBlock);
+    ret = stream.write_audio_frame(m_formatContext, next_frame);
+
+    for(int c = 0; c < channels; c++)
+      m_audioFifo[c].erase(
+          m_audioFifo[c].begin(), m_audioFifo[c].begin() + need);
+
+    if(ret < 0)
+      break;
+  }
+  return ret;
 #endif
   return 1;
 }

--- a/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoder.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Libav/LibavEncoder.hpp
@@ -8,6 +8,7 @@
 
 #include <mutex>
 #include <span>
+#include <vector>
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavdevice/avdevice.h>
@@ -46,6 +47,13 @@ struct LibavEncoder
 
   int audio_stream_index = -1;
   int video_stream_index = -1;
+
+private:
+  // The engine hands over one block per tick; a codec with a fixed frame size
+  // wants exactly that many samples per frame, and the two numbers are rarely
+  // the same. Whole frames are cut out of here, so nothing partial is encoded.
+  std::vector<ossia::float_vector> m_audioFifo;
+  std::vector<ossia::float_vector> m_audioBlock;
 };
 
 }

--- a/src/plugins/score-plugin-gfx/Gfx/Libav/LibavOutputStream.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Libav/LibavOutputStream.hpp
@@ -145,8 +145,11 @@ struct OutputStream
       }
     }
 
-    c->ch_layout.order = AV_CHANNEL_ORDER_UNSPEC;
-    c->ch_layout.nb_channels = set.audio_channels;
+    // A NAMED layout, not AV_CHANNEL_ORDER_UNSPEC: encoders that publish a
+    // supported-layout list -- aac and libopus among them -- reject an
+    // unspecified order from avcodec_open2 with EINVAL, which is what made the
+    // "MP4 H.264 + AAC" preset refuse to start at all.
+    av_channel_layout_default(&c->ch_layout, set.audio_channels);
     c->thread_count = set.threads > 0 ? set.threads : 0;
     if(set.audio_encoder_short == "pcm_s24le" || set.audio_encoder_short == "pcm_s24be")
       c->bits_per_raw_sample = 24;
@@ -268,10 +271,11 @@ struct OutputStream
           encoder = std::make_unique<S16IAudioFrameEncoder>(nb_samples);
           break;
         case AV_SAMPLE_FMT_S32:
-          if(enc->bits_per_raw_sample == 24)
-            encoder = std::make_unique<S24IAudioFrameEncoder>(nb_samples);
-          else
-            encoder = std::make_unique<S32IAudioFrameEncoder>(nb_samples);
+          // Always full-scale int32, even for a 24-bit container: libav's
+          // pcm_s24le takes AV_SAMPLE_FMT_S32 samples and writes their TOP 24
+          // bits, so scaling to 2^23 as a 24-bit sample would have made every
+          // WAV 24-bit recording 48 dB too quiet.
+          encoder = std::make_unique<S32IAudioFrameEncoder>(nb_samples);
           break;
         case AV_SAMPLE_FMT_FLT:
           encoder = std::make_unique<FltIAudioFrameEncoder>(nb_samples);

--- a/src/plugins/score-plugin-gfx/Gfx/Libav/LibavPresets.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Libav/LibavPresets.cpp
@@ -166,7 +166,9 @@ void addOutputEnumerators(Device::DeviceEnumerators& enums)
     add("FLAC", "<PROJECT>:/main.flac", "flac", "", "flac", "", "s16", {});
     add("Ogg Opus", "<PROJECT>:/main.opus", "ogg", "", "libopus", "", "flt",
         {{"b:a", "128k"}});
-    add("MP3", "<PROJECT>:/main.mp3", "mp3", "", "libmp3lame", "", "s16",
+    // libmp3lame takes PLANAR samples (s16p/s32p/fltp); avcodec_open2 refuses
+    // the preset outright for interleaved s16.
+    add("MP3", "<PROJECT>:/main.mp3", "mp3", "", "libmp3lame", "", "s16p",
         {{"q:a", "2"}});
     enums.push_back({"Record Audio", e});
   }
@@ -192,9 +194,11 @@ void addOutputEnumerators(Device::DeviceEnumerators& enums)
   {
     auto* e = new LibavPresetEnumerator;
     auto add = makeOutputAdder(e);
+    // No flags=+low_delay here: ffmpeg refuses it for anything but mpeg2
+    // ("low delay forcing is only available for mpeg2"), which made this
+    // preset fail to open its encoder at all.
     add("UDP MJPEG", "udp://192.168.1.80:8081", "mjpeg", "mjpeg", "", "yuv420p", "",
         {{"fflags", "+nobuffer+genpts"},
-         {"flags", "+low_delay"},
          {"flush_packets", "1"},
          {"bf", "0"},
          {"color_range", "pc"}});

--- a/src/plugins/score-plugin-gfx/Gfx/ShaderProgram.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/ShaderProgram.cpp
@@ -412,7 +412,8 @@ ProgramCache::get(const ShaderSource& program) noexcept
 }
 
 ShaderSource
-programFromISFFragmentShaderPath(const QString& fsFilename, QByteArray fsData)
+programFromISFFragmentShaderPath(
+    const QString& fsFilename, QByteArray fsData, ShaderSource::ProgramType type)
 {
   // ISF works by storing a vertex shader next to the fragment shader.
   QString vertexName = fsFilename;
@@ -454,7 +455,11 @@ programFromISFFragmentShaderPath(const QString& fsFilename, QByteArray fsData)
   resolveGLSLIncludes(fsData, shaderIncludePath, file.absolutePath(), 0);
   resolveGLSLIncludes(vertexData, shaderIncludePath, file.absolutePath(), 0);
   */
-  return {ShaderSource::ProgramType::ISF, vertexData, fsData};
+  // The MODE declared in the header decides how the pair is compiled: a
+  // RAW_RASTER_PIPELINE shader brings its own vertex stage and must not be given
+  // the ISF prelude, which does not declare `position`. Defaulted to ISF so the
+  // ISF process is unaffected.
+  return {type, vertexData, fsData};
 }
 ShaderSource
 programFromVSAVertexShaderPath(const QString& vertexFilename, QByteArray vertexData)

--- a/src/plugins/score-plugin-gfx/Gfx/ShaderProgram.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/ShaderProgram.hpp
@@ -115,7 +115,9 @@ struct SCORE_PLUGIN_GFX_EXPORT ShaderSource
 };
 
 SCORE_PLUGIN_GFX_EXPORT ShaderSource
-programFromISFFragmentShaderPath(const QString& fsFilename, QByteArray fsData);
+programFromISFFragmentShaderPath(
+    const QString& fsFilename, QByteArray fsData,
+    ShaderSource::ProgramType type = ShaderSource::ProgramType::ISF);
 SCORE_PLUGIN_GFX_EXPORT ShaderSource
 programFromVSAVertexShaderPath(const QString& vertexFilename, QByteArray vertexData);
 }

--- a/src/plugins/score-plugin-gfx/Gfx/Window/OffscreenDevice.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Window/OffscreenDevice.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <Gfx/GfxParameter.hpp>
+#include <Gfx/Graph/BackgroundNode.hpp>
+
+#include <ossia/network/base/device.hpp>
+#include <ossia/network/base/protocol.hpp>
+#include <ossia/network/generic/generic_node.hpp>
+
+#include <ossia-qt/invoke.hpp>
+
+namespace Gfx
+{
+
+// Headless device used when SCORE_FORCE_OFFSCREEN_WINDOW selects this
+// window device by name. Wraps a BackgroundNode — which already drives
+// beginOffscreenFrame/endOffscreenFrame — without the ScenarioDocumentView
+// dependency of background_device. Exposes only the parameters required by
+// offscreen tests (size, rendersize) and holds the shared_readback used by
+// WindowDevice::grabTo to write frames to disk.
+class offscreen_device : public ossia::net::device_base
+{
+  score::gfx::BackgroundNode* m_node{};
+  gfx_node_base m_root;
+  QObject m_qtContext;
+
+  ossia::net::parameter_base* size_param{};
+  ossia::net::parameter_base* rendersize_param{};
+
+public:
+  offscreen_device(std::unique_ptr<gfx_protocol_base> proto, std::string name)
+      : ossia::net::device_base{std::move(proto)}
+      , m_node{new score::gfx::BackgroundNode}
+      , m_root{*this, *static_cast<gfx_protocol_base*>(m_protocol.get()), m_node, name}
+  {
+    this->m_capabilities.change_tree = true;
+    m_node->shared_readback = std::make_shared<QRhiReadbackResult>();
+
+    {
+      auto size_node = std::make_unique<ossia::net::generic_node>("size", *this, m_root);
+      size_param = size_node->create_parameter(ossia::val_type::VEC2F);
+      size_param->push_value(ossia::vec2f{1280.f, 720.f});
+      m_node->setSize(QSize{1280, 720});
+      size_param->add_callback([this](const ossia::value& v) {
+        if(auto val = v.target<ossia::vec2f>())
+        {
+          ossia::qt::run_async(&m_qtContext, [node = this->m_node, v = *val] {
+            node->setSize({(int)v[0], (int)v[1]});
+          });
+        }
+      });
+      m_root.add_child(std::move(size_node));
+    }
+
+    {
+      auto size_node
+          = std::make_unique<ossia::net::generic_node>("rendersize", *this, m_root);
+      ossia::net::set_description(
+          *size_node, "Set to [0, 0] to use the viewport's size");
+      rendersize_param = size_node->create_parameter(ossia::val_type::VEC2F);
+      rendersize_param->push_value(ossia::vec2f{0.f, 0.f});
+      rendersize_param->add_callback([this](const ossia::value& v) {
+        if(auto val = v.target<ossia::vec2f>())
+        {
+          ossia::qt::run_async(&m_qtContext, [node = this->m_node, v = *val] {
+            node->setRenderSize({(int)v[0], (int)v[1]});
+          });
+        }
+      });
+      m_root.add_child(std::move(size_node));
+    }
+  }
+
+  ~offscreen_device()
+  {
+    // The graph owns the node: gfx_parameter_base hands it to register_node as
+    // a unique_ptr and gives it back in its own destructor, which
+    // clear_children() runs. Teardown order is the same as background_device's.
+    m_protocol->stop();
+    m_root.clear_children();
+    m_protocol.reset();
+  }
+
+  score::gfx::BackgroundNode* node() const noexcept { return m_node; }
+
+  const gfx_node_base& get_root_node() const override { return m_root; }
+  gfx_node_base& get_root_node() override { return m_root; }
+};
+
+}

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
@@ -160,6 +160,14 @@ void WindowDevice::renderFrames(int frames) const
     qWarning() << "renderFrames: no gfx document plugin";
 }
 
+void WindowDevice::setStepRate(double fps) const
+{
+  if(auto plug = m_ctx.findPlugin<Gfx::DocumentPlugin>())
+    plug->context.setStepRate(fps);
+  else
+    qWarning() << "setStepRate: no gfx document plugin";
+}
+
 void WindowDevice::grabFrame(int frames, const QString& path) const
 {
   renderFrames(frames);

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
@@ -22,6 +22,24 @@ W_OBJECT_IMPL(Gfx::WindowDevice)
 namespace Gfx
 {
 
+// SCORE_FORCE_OFFSCREEN_WINDOW=Name1,Name2 forces any matching WindowDevice
+// (whatever its Single/Background/MultiWindow mode) into a headless offscreen
+// render path. Used by tests that need grabTo output but must not pop a
+// platform window.
+static bool shouldForceOffscreen(const QString& name)
+{
+  static const QByteArray env = qgetenv("SCORE_FORCE_OFFSCREEN_WINDOW");
+  if(env.isEmpty())
+    return false;
+  for(const auto& part : env.split(','))
+  {
+    const auto trimmed = QString::fromUtf8(part).trimmed();
+    if(!trimmed.isEmpty() && trimmed == name)
+      return true;
+  }
+  return false;
+}
+
 score::gfx::Window* WindowDevice::window() const noexcept
 {
   if(m_dev)
@@ -93,7 +111,17 @@ void WindowDevice::grabTo(const QString& path) const
     const int w = rb.pixelSize.width();
     const int h = rb.pixelSize.height();
     const int expected = w * h * 4;
-    if(w <= 0 || h <= 0 || rb.data.size() < expected)
+
+    // BackgroundNode::render() clears the readback when its render list holds
+    // nothing but the output itself, which leaves the default-constructed
+    // QSize(-1, -1) here.
+    if(w <= 0 || h <= 0)
+    {
+      qWarning() << "grabTo: nothing rendered into" << m_settings.name
+                 << "- no process is connected to this device's input";
+      return;
+    }
+    if(rb.data.size() < expected)
     {
       qWarning() << "grabTo: readback is" << rb.data.size() << "bytes for" << w << "x"
                  << h << "- expected" << expected;
@@ -108,6 +136,12 @@ void WindowDevice::grabTo(const QString& path) const
   }
   else if(auto win = this->window())
   {
+    // QScreen::grabWindow reads the framebuffer at the window's geometry, not
+    // the window's own buffer: anything drawn on top lands in the file. Valid
+    // to eyeball an interactive session, never valid as a reference image.
+    qWarning() << "grabTo: capturing the SCREEN at" << m_settings.name
+               << "geometry, not the rendered frame. Set SCORE_FORCE_OFFSCREEN_WINDOW="
+               << m_settings.name << "for a real readback.";
     auto grab = win->screen()->grabWindow(win->winId());
     if(!grab.save(path))
       qWarning() << "grabTo: could not write" << path;
@@ -147,6 +181,18 @@ bool WindowDevice::reconnect()
       auto view = m_ctx.document.view();
       auto main_view = view ? qobject_cast<Scenario::ScenarioDocumentView*>(
           &view->viewDelegate()) : nullptr;
+
+      if(shouldForceOffscreen(m_settings.name))
+      {
+        m_dev = std::make_unique<offscreen_device>(
+            std::unique_ptr<gfx_protocol_base>(m_protocol),
+            m_settings.name.toStdString());
+
+        enableCallbacks();
+        deviceChanged(nullptr, m_dev.get());
+        return connected();
+      }
+
       switch(set.mode)
       {
         case WindowMode::Background: {

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
@@ -2,6 +2,7 @@
 
 #include <Gfx/Window/BackgroundDevice.hpp>
 #include <Gfx/Window/MultiWindowDevice.hpp>
+#include <Gfx/Window/OffscreenDevice.hpp>
 #include <Gfx/Window/WindowDevice.hpp>
 #include <Gfx/Window/WindowSettingsWidget.hpp>
 
@@ -11,6 +12,8 @@
 #include <ossia-qt/invoke.hpp>
 
 #include <QMenu>
+#include <QScreen>
+#include <QWindow>
 
 #include <wobjectimpl.h>
 
@@ -73,6 +76,46 @@ void WindowDevice::disconnect()
   auto prev = std::move(m_dev);
   m_dev = {};
   deviceChanged(prev.get(), nullptr);
+}
+
+void WindowDevice::grabTo(const QString& path) const
+{
+  if(auto dev = dynamic_cast<offscreen_device*>(m_dev.get()))
+  {
+    auto node = dev->node();
+    if(!node || !node->shared_readback)
+    {
+      qWarning() << "grabTo: offscreen device has not rendered yet";
+      return;
+    }
+
+    const auto& rb = *node->shared_readback;
+    const int w = rb.pixelSize.width();
+    const int h = rb.pixelSize.height();
+    const int expected = w * h * 4;
+    if(w <= 0 || h <= 0 || rb.data.size() < expected)
+    {
+      qWarning() << "grabTo: readback is" << rb.data.size() << "bytes for" << w << "x"
+                 << h << "- expected" << expected;
+      return;
+    }
+
+    QImage img{
+        reinterpret_cast<const unsigned char*>(rb.data.constData()), w, h, w * 4,
+        QImage::Format_RGBA8888};
+    if(!img.save(path))
+      qWarning() << "grabTo: could not write" << path;
+  }
+  else if(auto win = this->window())
+  {
+    auto grab = win->screen()->grabWindow(win->winId());
+    if(!grab.save(path))
+      qWarning() << "grabTo: could not write" << path;
+  }
+  else
+  {
+    qWarning() << "grabTo: device has no window and is not offscreen";
+  }
 }
 
 bool WindowDevice::reconnect()

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.cpp
@@ -118,6 +118,20 @@ void WindowDevice::grabTo(const QString& path) const
   }
 }
 
+void WindowDevice::renderFrames(int frames) const
+{
+  if(auto plug = m_ctx.findPlugin<Gfx::DocumentPlugin>())
+    plug->context.renderFrames(frames);
+  else
+    qWarning() << "renderFrames: no gfx document plugin";
+}
+
+void WindowDevice::grabFrame(int frames, const QString& path) const
+{
+  renderFrames(frames);
+  grabTo(path);
+}
+
 bool WindowDevice::reconnect()
 {
   disconnect();

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.hpp
@@ -80,6 +80,16 @@ public:
   void grabTo(const QString& path) const;
   W_SLOT(grabTo)
 
+  //! Render exactly @p frames times and return. See GfxContext::renderFrames.
+  void renderFrames(int frames) const;
+  W_SLOT(renderFrames)
+
+  //! Render @p frames times, then write that frame. The point of naming the
+  //! frame rather than sleeping is that frame N is the same picture on every
+  //! machine, which is what a stored reference can be compared against.
+  void grabFrame(int frames, const QString& path) const;
+  W_SLOT(grabFrame)
+
 private:
   gfx_protocol_base* m_protocol{};
   mutable std::unique_ptr<ossia::net::device_base> m_dev;

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.hpp
@@ -74,6 +74,12 @@ public:
   void disconnect() override;
   bool reconnect() override;
 
+  //! Write the current frame to @p path. On an offscreen device this reads the
+  //! render target back directly, which is what makes headless pixel testing
+  //! possible; on a real window it grabs the window.
+  void grabTo(const QString& path) const;
+  W_SLOT(grabTo)
+
 private:
   gfx_protocol_base* m_protocol{};
   mutable std::unique_ptr<ossia::net::device_base> m_dev;

--- a/src/plugins/score-plugin-gfx/Gfx/WindowDevice.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowDevice.hpp
@@ -81,8 +81,14 @@ public:
   W_SLOT(grabTo)
 
   //! Render exactly @p frames times and return. See GfxContext::renderFrames.
+  //! Call it repeatedly to step frame by frame: the clock keeps counting across
+  //! calls, so renderFrames(1) sixty times is the timeline renderFrames(60) is.
   void renderFrames(int frames) const;
   W_SLOT(renderFrames)
+
+  //! Frames per second the step clock advances by. 60 unless set.
+  void setStepRate(double fps) const;
+  W_SLOT(setStepRate)
 
   //! Render @p frames times, then write that frame. The point of naming the
   //! frame rather than sleeping is that frame N is the same picture on every

--- a/src/plugins/score-plugin-js/JS/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-js/JS/ApplicationPlugin.cpp
@@ -17,8 +17,9 @@
 #include <ossia-qt/invoke.hpp>
 #include <ossia-qt/qml_protocols.hpp>
 
-#include <QFile>
 #include <QCommandLineParser>
+#include <QFile>
+#include <QFileInfo>
 
 #if __has_include(<QQuickWindow>)
 #include <QGuiApplication>
@@ -34,6 +35,30 @@
 
 namespace JS
 {
+// Whether --script was given a program or the path of one. An existing file is
+// always a path; anything with JS punctuation in it is a program.
+static bool stringIsScript(const QString& input)
+{
+  if(input.isEmpty())
+    return false;
+
+  if(QFileInfo fileInfo{input}; fileInfo.exists() && fileInfo.isFile())
+    return false;
+
+  if(input.length() > 4096)
+    return true;
+
+  for(QChar ch : input)
+  {
+    const char16_t c = ch.unicode();
+    if(c == '\n' || c == '\r' || c == ';' || c == '{' || c == '}' || c == '('
+       || c == ')')
+      return true;
+  }
+
+  return false;
+}
+
 ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& ctx)
     : score::GUIApplicationPlugin{ctx}
 {
@@ -52,10 +77,12 @@ ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& ctx)
       "Library", m_consoleEngine.newQObject(new JsLibrary));
   m_consoleEngine.globalObject().setProperty("Device", m_consoleEngine.newQObject(new DeviceContext{m_consoleEngine}));
   m_consoleEngine.globalObject().setProperty("View", m_consoleEngine.newQObject(new JsViewContext));
-  connect(&m_consoleEngine, &QQmlEngine::exit, this, [&] {
+  connect(&m_consoleEngine, &QQmlEngine::exit, this, [&](int retCode) {
     for(auto& doc : score::GUIAppContext().docManager.documents())
       doc->commandStack().markCurrentIndexAsSaved();
-    qApp->quit();
+    // quit() is exit(0), which discarded the code Qt.exit() was given: a script
+    // could stop the app but never report that it had failed.
+    qApp->exit(retCode);
     QTimer::singleShot(
         500, [] { score::GUIApplicationInterface::instance().forceExit(); });
   });
@@ -90,7 +117,26 @@ ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& ctx)
   parser.addOption(script_opt);
 
   parser.parse(ctx.applicationSettings.arguments);
-  this->m_start_script = parser.value(script_opt);
+  const auto script = parser.value(script_opt);
+  if(stringIsScript(script))
+  {
+    this->m_start_script = script;
+  }
+  else if(!script.isEmpty())
+  {
+    QFile f{script};
+    if(f.open(QIODevice::ReadOnly))
+    {
+      this->m_start_script = f.readAll();
+      this->m_start_script_name = script;
+      this->m_start_script_path = QFileInfo{f}.canonicalPath();
+    }
+    else
+    {
+      qCritical() << "--script: cannot open" << script << ":" << f.errorString();
+      this->m_start_script_failed = true;
+    }
+  }
 }
 
 void ApplicationPlugin::on_newDocument(score::Document& doc)
@@ -133,17 +179,31 @@ void ApplicationPlugin::on_createdDocument(score::Document& doc)
   if(auto customData = doc.context().findPlugin<DocumentPlugin>(); !customData)
     score::addDocumentPlugin<DocumentPlugin>(doc);
 
+  if(m_start_script_failed)
+  {
+    qGuiApp->exit(2);
+    return;
+  }
+
   if(!m_start_script.isEmpty())
   {
     QTimer::singleShot(100, this, [this] {
-      // Either a file to run, or code passed directly
-      QString code = m_start_script;
-      if(QFile file{m_start_script}; file.exists() && file.open(QIODevice::ReadOnly))
-        code = QString::fromUtf8(file.readAll());
+      if(!m_start_script_path.isEmpty())
+        m_consoleEngine.addImportPath(m_start_script_path);
 
-      auto res = m_consoleEngine.evaluate(code, m_start_script);
+      // Report a throwing --script: an unresolvable readFile returns an empty
+      // string and eval("") is a no-op, so the process would otherwise exit
+      // reporting success and a harness could not tell that from a pass.
+      const auto res = m_consoleEngine.evaluate(m_start_script, m_start_script_name);
       if(res.isError())
-        qDebug() << "--script:" << res.toString();
+      {
+        qCritical().noquote()
+            << "--script:"
+            << (m_start_script_name.isEmpty() ? QStringLiteral("<inline>")
+                                              : m_start_script_name)
+            << "line" << res.property("lineNumber").toInt() << ":" << res.toString();
+        qGuiApp->exit(3);
+      }
     });
   }
 }

--- a/src/plugins/score-plugin-js/JS/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-js/JS/ApplicationPlugin.hpp
@@ -45,5 +45,8 @@ public:
   ossia::net::network_context_ptr m_asioContext;
 
   QString m_start_script;
+  QString m_start_script_name; //!< path as given, for error messages
+  QString m_start_script_path; //!< directory, added as a QML import path
+  bool m_start_script_failed{};
 };
 }

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
@@ -107,6 +107,12 @@ QObject* EditJsContext::createProcess(QObject* interval, QString name, QString d
   if(!doc)
     return nullptr;
 
+  // Processes that take a file open it themselves, and they do not know about
+  // the library prefixes. Without this a "<LIBRARY>:/..." shader silently loads
+  // as empty and the process is created with no content at all.
+  if(data.startsWith('<'))
+    data = locateFilePath(data);
+
   std::optional<score::uuids::uuid> maybe_uid;
   {
     if(name.trimmed().length() == 36)

--- a/src/plugins/score-plugin-js/JS/Qml/Utils.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/Utils.cpp
@@ -71,12 +71,25 @@ bool JsUtils::canWriteFile(QString path)
 
 QByteArray JsUtils::readFile(QString path)
 {
+  const QString requested = path;
   if(auto doc = score::AppContext().currentDocument())
     path = score::locateFilePath(path, *doc);
+  else
+    path = score::locateFilePath(path);
 
   QFile f(path);
   if(f.open(QIODevice::ReadOnly))
     return f.readAll();
+
+  // An empty return is otherwise indistinguishable from an empty file, and a
+  // script doing eval(readFile(...)) on a path that does not resolve simply
+  // does nothing and reports success. Say which path was tried, resolved and
+  // unresolved: the two differ exactly when a <LIBRARY>:/<PROJECT>: prefix is
+  // pointing somewhere unexpected.
+  if(requested == path)
+    qWarning().noquote() << "Score.readFile: cannot read" << path;
+  else
+    qWarning().noquote() << "Score.readFile: cannot read" << requested << "->" << path;
   return {};
 }
 

--- a/src/plugins/score-plugin-media/Video/FrameQueue.cpp
+++ b/src/plugins/score-plugin-media/Video/FrameQueue.cpp
@@ -45,22 +45,25 @@ void frame_counters::deallocate(AVFrame* av)
 
 uint8_t* initFrameBuffer(AVFrame& frame, std::size_t bytes)
 {
-  // Here we need to copy the buffer.
-  uint8_t* storage{};
-  // Reuse allocated memory if any
-  if(frame.data[0])
+  // Reuse the buffer a recycled frame still carries, but only when it is still
+  // big enough: a mid-stream format change grows `bytes`, and the plane
+  // pointers a caller wrote into data[] do not have to start at the buffer.
+  if(frame.buf[0] && frame.buf[0]->size >= bytes)
   {
-    storage = frame.data[0];
+    frame.data[0] = frame.buf[0]->data;
+    return frame.data[0];
   }
-  else
-  {
-    // We got a new frame, init it
-    auto buf = av_buffer_alloc(bytes);
-    storage = buf->data;
-    frame.buf[0] = buf;
-    frame.data[0] = storage;
-  }
-  return storage;
+
+  if(frame.buf[0])
+    av_buffer_unref(&frame.buf[0]);
+
+  auto buf = av_buffer_alloc(bytes);
+  if(!buf)
+    return nullptr;
+
+  frame.buf[0] = buf;
+  frame.data[0] = buf->data;
+  return buf->data;
 }
 
 FrameQueue::FrameQueue() { }

--- a/src/plugins/score-plugin-media/Video/LibavStreamInput.cpp
+++ b/src/plugins/score-plugin-media/Video/LibavStreamInput.cpp
@@ -562,8 +562,11 @@ void LibavStreamInput::decode_audio_packet(AVPacket& packet) noexcept
     switch(fmt)
     {
       case AV_SAMPLE_FMT_FLTP:
+        // extended_data, not data: AVFrame::data holds at most
+        // AV_NUM_DATA_POINTERS (8) planes, and a planar stream with more
+        // channels than that keeps the rest only in extended_data.
         m_audioBuf.write_planar(
-            (float**)m_audioFrame->data, num_samples, channels);
+            (float**)m_audioFrame->extended_data, num_samples, channels);
         break;
       case AV_SAMPLE_FMT_FLT:
         m_audioBuf.write_interleaved_float(
@@ -579,7 +582,7 @@ void LibavStreamInput::decode_audio_packet(AVPacket& packet) noexcept
         int nch = std::min(channels, m_audioBuf.num_channels);
         for(int ch = 0; ch < nch; ch++)
         {
-          const int16_t* src = (const int16_t*)m_audioFrame->data[ch];
+          const int16_t* src = (const int16_t*)m_audioFrame->extended_data[ch];
           for(int s = 0; s < num_samples; s++)
             m_audioBuf.ring[ch][(wp + s) % AudioRingBuffer::ring_size]
                 = src[s] / 32768.f;

--- a/src/plugins/score-plugin-media/Video/Rescale.cpp
+++ b/src/plugins/score-plugin-media/Video/Rescale.cpp
@@ -63,7 +63,17 @@ void Rescale::rescale(FrameQueue& m_frames, AVFramePointer& frame, ReadFrame& re
   rgb->height = src.height;
   rgb->format = AV_PIX_FMT_RGBA;
   rgb->linesize[0] = 4 * src.width;
-  av_frame_get_buffer(rgb, 0);
+  if(av_frame_get_buffer(rgb, 0) < 0)
+  {
+    // Without a buffer rgb->data[0] is null and sws_scale would write through
+    // it. Leave read.frame as the caller's own frame, which is the same
+    // contract as a rescaler that could not be built.
+    SCORE_LIBAV_FRAME_DEALLOC_CHECK(rgb);
+    av_frame_free(&rgb);
+    if(read.frame == frame.get())
+      frame.release();
+    return;
+  }
 
   // 2. Convert
   sws_scale(

--- a/src/plugins/score-plugin-media/Video/Thumbnailer.cpp
+++ b/src/plugins/score-plugin-media/Video/Thumbnailer.cpp
@@ -247,10 +247,14 @@ QImage VideoThumbnailer::process(int64_t flicks)
       return {};
   }
 
-  // 2. Resize
-  QImage img{QSize(m_rgb->linesize[0] / 3, smallHeight), QImage::Format_RGB888};
+  // 2. Resize.
+  // The sws context scales to smallWidth x smallHeight; sizing the image from
+  // m_rgb's 32-byte-aligned stride instead left the columns past smallWidth
+  // uninitialised and threw the aspect ratio away with them.
+  QImage img{QSize(smallWidth, smallHeight), QImage::Format_RGB888};
   uint8_t* data[1] = {(uint8_t*)img.bits()};
-  sws_scale(m_rescale, res->data, res->linesize, 0, this->height, data, m_rgb->linesize);
+  int strides[1] = {int(img.bytesPerLine())};
+  sws_scale(m_rescale, res->data, res->linesize, 0, this->height, data, strides);
 
   return img;
 }

--- a/src/plugins/score-plugin-media/Video/VideoDecoder.cpp
+++ b/src/plugins/score-plugin-media/Video/VideoDecoder.cpp
@@ -73,6 +73,15 @@ void LibAVDecoder::init_scaler(VideoInterface& self) noexcept
     return;
 
   m_rescale.open(self);
+
+  // Only claim RGBA once the rescaler that produces it actually opened:
+  // sws_getContext refuses some source descriptions (a stream whose
+  // codecpar->format is AV_PIX_FMT_NONE, for one), and the renderer copies
+  // color_space out of this metadata and applies it to frames that are still
+  // in their native YUV.
+  if(!m_rescale)
+    return;
+
   self.pixel_format = AV_PIX_FMT_RGBA;
   self.color_space = AVCOL_SPC_RGB;
 }
@@ -575,7 +584,21 @@ do_read_frame:
       auto frame = m_frames.newFrame();
       while(avcodec_receive_frame(m_codecContext, frame.get()) == 0)
       {
-        m_frames.enqueue(frame.release());
+        // Through the rescaler, like every other decode path: these are the
+        // last frames of the clip, and a decoder whose pixel_format was
+        // relabelled RGBA by init_scaler must not suddenly emit its native
+        // format for them.
+        ReadFrame read{frame.get(), 0};
+        if(m_rescale)
+        {
+          m_rescale.rescale(m_frames, frame, read);
+        }
+        else if(read.frame == frame.get())
+        {
+          frame.release();
+        }
+        if(read.frame)
+          m_frames.enqueue(read.frame);
         frame = m_frames.newFrame();
       }
       m_frames.enqueue_decoding_error(frame.release());

--- a/tests/fixtures/CMakeLists.txt
+++ b/tests/fixtures/CMakeLists.txt
@@ -12,13 +12,24 @@ target_link_libraries(score_test_fixtures
 add_subdirectory(lv2)
 
 # Scriptable stand-in for the plug-in scanner puppets (PluginScanner tests).
-add_executable(score_test_fake_puppet fake_puppet/fake_puppet.cpp)
-target_link_libraries(score_test_fake_puppet PRIVATE
-  ${QT_PREFIX}::Core ${QT_PREFIX}::WebSockets)
-set_target_properties(score_test_fake_puppet PROPERTIES
-  FOLDER "Tests"
-  SCORE_CUSTOM_PCH 1
-  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+#
+# Only with a static Qt: the source takes the address of a QWebSocket signal in a
+# constexpr initialiser, and against a shared Qt that address comes from an import
+# thunk resolved at load time, so it is not a constant expression.
+get_target_property(_score_qt_core_type ${QT_PREFIX}::Core TYPE)
+if(_score_qt_core_type STREQUAL "STATIC_LIBRARY")
+  set(SCORE_HAS_FAKE_PUPPET 1 CACHE INTERNAL "")
+  add_executable(score_test_fake_puppet fake_puppet/fake_puppet.cpp)
+  target_link_libraries(score_test_fake_puppet PRIVATE
+    ${QT_PREFIX}::Core ${QT_PREFIX}::WebSockets)
+  set_target_properties(score_test_fake_puppet PROPERTIES
+    FOLDER "Tests"
+    SCORE_CUSTOM_PCH 1
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+else()
+  set(SCORE_HAS_FAKE_PUPPET 0 CACHE INTERNAL "")
+  message(STATUS "score: fake puppet skipped (Qt is not static)")
+endif()
 
 # Make the headers visible in IDEs.
 file(GLOB_RECURSE _fixture_hdrs "${CMAKE_CURRENT_SOURCE_DIR}/score_test/*.hpp")

--- a/tests/fixtures/score_test/App.hpp
+++ b/tests/fixtures/score_test/App.hpp
@@ -41,6 +41,17 @@ namespace score::test
 /// no platform is set, forces the offscreen QPA platform.
 inline void prepare_test_environment(bool headless)
 {
+#if defined(SCORE_TEST_BINARY_DIR)
+  // score::PluginLoader::pluginsDir() probes "<cwd>/plugins", and the test
+  // executables do not live next to <build>/plugins the way the application
+  // binary does. ctest gets this right through WORKING_DIRECTORY; a hand-run
+  // executable did not, and booted an application with zero plug-ins whose
+  // first ctx.settings<SomePluginModel>() then hit SCORE_ABORT. Anchor
+  // ourselves so both invocations load the same plug-ins.
+  if(!QDir{QStringLiteral("plugins")}.exists())
+    QDir::setCurrent(QStringLiteral(SCORE_TEST_BINARY_DIR));
+#endif
+
   // WebAssembly only ever has the "wasm" platform: asking for another one
   // is a fatal error, and the page is headless anyway.
 #if !defined(__EMSCRIPTEN__)

--- a/tests/fixtures/score_test/ModelInvariants.hpp
+++ b/tests/fixtures/score_test/ModelInvariants.hpp
@@ -1,0 +1,87 @@
+#pragma once
+// Catch2-native replacements for the two QtTest classes the suite used to reach
+// for. The suite standardizes on Catch2 and links no QtTest anywhere; QtTest is
+// also simply absent from some Qt builds (the macOS ossia-sdk static Qt ships
+// 192 Qt6 modules without it), which made a QtTest dependency fail the whole
+// configure rather than one target.
+
+#include <score/tools/Debug.hpp>
+
+#include <QAbstractItemModel>
+#include <QObject>
+#include <QPersistentModelIndex>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <set>
+
+namespace score::test
+{
+
+//! Counts emissions of a signal. Replaces QSignalSpy for the count()-only uses.
+class SignalCounter
+{
+public:
+  template <typename Obj, typename Signal>
+  SignalCounter(Obj* obj, Signal sig)
+  {
+    m_conn = QObject::connect(obj, sig, [this] { ++m_count; });
+  }
+  ~SignalCounter() { QObject::disconnect(m_conn); }
+
+  SignalCounter(const SignalCounter&) = delete;
+  SignalCounter& operator=(const SignalCounter&) = delete;
+
+  int count() const noexcept { return m_count; }
+  void clear() noexcept { m_count = 0; }
+
+private:
+  QMetaObject::Connection m_conn;
+  int m_count{};
+};
+
+//! Walks the whole tree and checks the QAbstractItemModel contract, in place of
+//! QAbstractItemModelTester. Covers what a tree model can realistically get
+//! wrong: a child whose parent() does not round-trip, an index handed out for a
+//! row/column outside the parent's counts, hasChildren() disagreeing with
+//! rowCount(), a reused internal pointer aliasing two distinct indices, and
+//! sibling/child accessors that contradict index().
+inline void
+checkModelInvariants(const QAbstractItemModel& m, const QModelIndex& parent = {})
+{
+  const int rows = m.rowCount(parent);
+  const int cols = m.columnCount(parent);
+  REQUIRE(rows >= 0);
+  REQUIRE(cols >= 0);
+  CHECK(m.hasChildren(parent) == (rows > 0 && cols > 0));
+
+  // Out-of-range requests must produce invalid indices, not crashes or
+  // fabricated ones.
+  CHECK(!m.index(rows, 0, parent).isValid());
+  CHECK(!m.index(-1, 0, parent).isValid());
+  CHECK(!m.index(0, cols, parent).isValid());
+
+  std::set<void*> seen;
+  for(int r = 0; r < rows; ++r)
+  {
+    for(int c = 0; c < cols; ++c)
+    {
+      const QModelIndex idx = m.index(r, c, parent);
+      REQUIRE(idx.isValid());
+      CHECK(idx.row() == r);
+      CHECK(idx.column() == c);
+      CHECK(idx.model() == &m);
+      CHECK(m.parent(idx) == parent);
+      CHECK(m.sibling(r, c, idx) == idx);
+    }
+
+    const QModelIndex first = m.index(r, 0, parent);
+    // Column 0 owns the children, so its internal pointer identifies the node.
+    if(void* p = first.internalPointer(); p != nullptr)
+    {
+      CHECK(seen.insert(p).second);
+    }
+    checkModelInvariants(m, first);
+  }
+}
+}

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -247,3 +247,16 @@ score_add_test(test_integration_nodal_viewport
   SOURCES NodalViewportTest.cpp
   GUI
   PLUGINS score_plugin_scenario score_lib_process)
+
+# Frame-step determinism across two processes: the same case rendered to the same
+# frame index in two separate applications must be byte-identical.
+# Skips (77) without the binary or the out-of-repo tests-scene corpus.
+add_test(NAME test_frame_determinism
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/golden-render/frame-determinism.sh"
+  WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
+set_tests_properties(test_frame_determinism PROPERTIES
+  SKIP_RETURN_CODE 77
+  TIMEOUT 600
+  RUN_SERIAL TRUE
+  LABELS "gui"
+  ENVIRONMENT "OSSIA_SCORE=${SCORE_ROOT_BINARY_DIR}/ossia-score")

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -151,6 +151,18 @@ score_add_test(test_regression_double_exit
   SOURCES RegressionDoubleExitTest.cpp
   APP)
 
+# --script failure reporting: exit 0 / N / 2 / 3 and the diagnostics that go
+# with them. A subprocess test because the behaviour under test IS the exit
+# code of the application binary.
+if(TARGET score AND NOT EMSCRIPTEN)
+  score_add_test(test_integration_script_exit_code
+    SOURCES ScriptExitCodeTest.cpp)
+  target_compile_definitions(test_integration_script_exit_code PRIVATE
+    "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\"")
+  set_tests_properties(test_integration_script_exit_code PROPERTIES
+    TIMEOUT 900 RUN_SERIAL TRUE)
+endif()
+
 # Closing a MODIFIED document with applicationSettings.gui false must not
 # raise the save prompt: nothing can answer it and QMessageBox::exec() aborts.
 score_add_test(test_regression_headless_close_modified

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -151,6 +151,16 @@ score_add_test(test_regression_double_exit
   SOURCES RegressionDoubleExitTest.cpp
   APP)
 
+# Closing a MODIFIED document with applicationSettings.gui false must not
+# raise the save prompt: nothing can answer it and QMessageBox::exec() aborts.
+score_add_test(test_regression_headless_close_modified
+  SOURCES RegressionHeadlessCloseModifiedTest.cpp
+  APP)
+# Without the guard the modal is raised and blocks forever under the offscreen
+# QPA: the regression shows up as a hang, so it needs a deadline to be a
+# failure rather than a stuck job.
+set_tests_properties(test_regression_headless_close_modified PROPERTIES TIMEOUT 120)
+
 # A throwing dropCustom handler is contained by the
 # noexcept getCustomDrops API.
 score_add_test(test_regression_throwing_drop_handler

--- a/tests/integration/RegressionHeadlessCloseModifiedTest.cpp
+++ b/tests/integration/RegressionHeadlessCloseModifiedTest.cpp
@@ -1,0 +1,119 @@
+// Regression test for the headless save prompt: closing a MODIFIED document
+// with applicationSettings.gui == false used to raise the raw QMessageBox in
+// DocumentManager::closeDocument. Under the offscreen QPA, with no one to
+// answer it, exec() aborts -- so a scripted /exit on a document the script had
+// edited died in teardown with SIGABRT.
+//
+// score::test::close_all_documents goes through forceCloseDocument, which
+// bypasses the modal, and RegressionDoubleExitTest only ever closes unmodified
+// documents: nothing in the suite reached this path.
+
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+#include <core/application/MinimalApplication.hpp>
+#include <core/command/CommandStack.hpp>
+#include <core/document/Document.hpp>
+#include <core/presenter/DocumentManager.hpp>
+
+#include <score/command/Command.hpp>
+#include <score/serialization/DataStreamVisitor.hpp>
+
+#include <ossia/detail/thread.hpp>
+
+#include <QApplication>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+const CommandGroupKey& testCommandGroup()
+{
+  static const CommandGroupKey k{"HeadlessCloseTest"};
+  return k;
+}
+
+// Declared by hand rather than with SCORE_COMMAND_DECL: the macro's key is
+// picked up by the build system's command-list scan, and nothing here needs to
+// be serializable -- only to move the command stack off its saved index.
+struct MarkDirty final : public score::Command
+{
+  void undo(const score::DocumentContext&) const override { }
+  void redo(const score::DocumentContext&) const override { }
+  const CommandGroupKey& parentKey() const noexcept override
+  {
+    return testCommandGroup();
+  }
+  const CommandKey& key() const noexcept override
+  {
+    static const CommandKey k{"MarkDirty"};
+    return k;
+  }
+  QString description() const override { return QStringLiteral("Mark dirty"); }
+  void serializeImpl(DataStreamInput&) const override { }
+  void deserializeImpl(DataStreamOutput&) override { }
+};
+}
+
+TEST_CASE(
+    "Closing a modified document without a GUI does not ask to save",
+    "[integration][regression][headless]")
+{
+  score::test::prepare_test_environment(/*headless=*/true);
+  QLocale::setDefault(QLocale::C);
+  std::setlocale(LC_ALL, "C");
+  ossia::set_thread_pinned(ossia::thread_type::Ui, 0);
+
+  static int argc = 1;
+  static char arg0[] = "score-test";
+  static char* argv[] = {arg0, nullptr};
+  score::MinimalGUIApplication app{argc, argv, /*show=*/false};
+  QApplication::processEvents();
+
+  app.m_applicationSettings.gui = false;
+  const auto& ctx = app.context();
+  REQUIRE(ctx.applicationSettings.gui == false);
+
+  auto* doc = score::test::new_document(ctx);
+  REQUIRE(doc);
+
+  doc->commandStack().redoAndPush(new MarkDirty);
+  QApplication::processEvents();
+  REQUIRE_FALSE(doc->commandStack().isAtSavedIndex());
+
+  // Without the gui guard this reaches QMessageBox::exec() with no window
+  // system able to run it, and the process aborts here instead of returning.
+  CHECK(ctx.docManager.closeDocument(ctx, *doc) == true);
+  QApplication::processEvents();
+  CHECK(ctx.docManager.documents().empty());
+}
+
+TEST_CASE(
+    "An unmodified document closes the same way with a GUI",
+    "[integration][regression][headless]")
+{
+  // The half that proves the case above is about the flag and not about
+  // closeDocument always succeeding: gui stays true, and the close still
+  // returns without a prompt because the stack is at its saved index.
+  score::test::prepare_test_environment(/*headless=*/true);
+  QLocale::setDefault(QLocale::C);
+  std::setlocale(LC_ALL, "C");
+  ossia::set_thread_pinned(ossia::thread_type::Ui, 0);
+
+  static int argc = 1;
+  static char arg0[] = "score-test";
+  static char* argv[] = {arg0, nullptr};
+  score::MinimalGUIApplication app{argc, argv, /*show=*/false};
+  QApplication::processEvents();
+
+  const auto& ctx = app.context();
+  REQUIRE(ctx.applicationSettings.gui == true);
+
+  auto* doc = score::test::new_document(ctx);
+  REQUIRE(doc);
+  REQUIRE(doc->commandStack().isAtSavedIndex());
+
+  CHECK(ctx.docManager.closeDocument(ctx, *doc) == true);
+  QApplication::processEvents();
+  CHECK(ctx.docManager.documents().empty());
+}

--- a/tests/integration/ScriptExitCodeTest.cpp
+++ b/tests/integration/ScriptExitCodeTest.cpp
@@ -1,0 +1,182 @@
+// --script failure reporting: the exit codes and diagnostics of c976ba6c98 and
+// c0400df56b.
+//
+// A subprocess test on purpose: what is under test is the process exit code of
+// ossia-score, which an in-process fixture cannot observe. The commit exists
+// because scripts failed silently at exit 0; four registered shell harnesses
+// pass --script so the happy path breaks loudly, but nothing asserted any of
+// the failure paths.
+
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <unistd.h>
+
+namespace
+{
+QString appBinary()
+{
+#if defined(SCORE_APP_BINARY)
+  return QStringLiteral(SCORE_APP_BINARY);
+#else
+  return {};
+#endif
+}
+
+struct Run
+{
+  int exitCode{};
+  bool crashed{};
+  QString output;
+};
+
+Run runScript(const QString& scriptArg, const QString& configHome = {})
+{
+  auto env = QProcessEnvironment::systemEnvironment();
+  env.remove("DISPLAY");
+  env.remove("WAYLAND_DISPLAY");
+  env.insert("QT_QPA_PLATFORM", "offscreen");
+  env.insert("SCORE_AUDIO_BACKEND", "dummy");
+  env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  if(!configHome.isEmpty())
+    env.insert("XDG_CONFIG_HOME", configHome);
+
+  QProcess p;
+  p.setProcessEnvironment(env);
+  p.setProcessChannelMode(QProcess::MergedChannels);
+  p.start(
+      appBinary(),
+      {"--no-gui", "--no-restore", "--wait", "0", "--script", scriptArg});
+
+  Run r;
+  if(!p.waitForStarted(30000) || !p.waitForFinished(90000))
+  {
+    p.kill();
+    p.waitForFinished(5000);
+    r.crashed = true;
+    return r;
+  }
+  r.output = QString::fromUtf8(p.readAll());
+  r.crashed = p.exitStatus() != QProcess::NormalExit;
+  r.exitCode = p.exitCode();
+  return r;
+}
+
+QString write(const QTemporaryDir& dir, const QString& name, const QByteArray& body)
+{
+  const QString path = dir.filePath(name);
+  QFile f{path};
+  REQUIRE(f.open(QIODevice::WriteOnly));
+  f.write(body);
+  f.close();
+  return path;
+}
+}
+
+TEST_CASE("--script reports what happened to it", "[integration][js][script]")
+{
+  if(appBinary().isEmpty() || !QFile::exists(appBinary()))
+    SKIP("the score application binary was not built");
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  SECTION("a script that finishes cleanly exits 0")
+  {
+    auto r = runScript(write(dir, "zero.js", "Qt.exit(0);\n"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+  }
+
+  SECTION("Qt.exit(N) reaches the caller")
+  {
+    // c0400df56b: this used to go through QQmlEngine::quit(), i.e. exit 0, so a
+    // script could stop the application but never report that it had failed.
+    auto r = runScript(write(dir, "seven.js", "Qt.exit(7);\n"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 7);
+  }
+
+  SECTION("a throwing script exits 3 and says where")
+  {
+    const auto path = write(dir, "boom.js", "throw new Error(\"boom\");\n");
+    auto r = runScript(path);
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 3);
+    CHECK(r.output.contains("--script:"));
+    CHECK(r.output.contains(path));
+    CHECK(r.output.contains("line 1"));
+    CHECK(r.output.contains("boom"));
+  }
+
+  // Windows has no geteuid, and clearing the Qt permissions there does not make
+  // the file unreadable: NTFS access is decided by ACLs, not by a mode bit.
+#if !defined(_WIN32)
+  SECTION("an existing but unreadable file exits 2")
+  {
+    if(::geteuid() == 0)
+      SKIP("running as root: mode 000 is still readable");
+
+    const auto path = write(dir, "locked.js", "Qt.exit(0);\n");
+    REQUIRE(QFile::setPermissions(path, QFile::Permissions{}));
+
+    auto r = runScript(path);
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 2);
+    CHECK(r.output.contains("--script: cannot open"));
+    CHECK(r.output.contains(path));
+  }
+#endif
+
+  SECTION("a path that does not exist exits 2 and names the path")
+  {
+    // A string that is not an existing file and carries none of the punctuation
+    // inline source always has is a path, not a program: it must reach the
+    // "cannot open" branch rather than be parsed (/definitely/does/not/exist.js
+    // is a regex literal with invalid flags, which used to surface as a
+    // SyntaxError at exit 3).
+    auto r = runScript(QStringLiteral("/definitely/does/not/exist.js"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 2);
+    CHECK(r.output.contains("--script: cannot open"));
+    CHECK(r.output.contains("/definitely/does/not/exist.js"));
+    CHECK_FALSE(r.output.contains("SyntaxError"));
+  }
+
+  SECTION("inline source is still recognised without an extension or a path")
+  {
+    auto r = runScript(QStringLiteral("Qt.exit(5);"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 5);
+    CHECK_FALSE(r.output.contains("--script: cannot open"));
+  }
+
+  SECTION("an unreadable file names the path it actually tried")
+  {
+    const QString cfg = dir.filePath("config");
+    REQUIRE(QDir{}.mkpath(cfg));
+
+    const auto path = write(
+        dir, "read.js",
+        "Util.readFile(\"<LIBRARY>:/definitely/absent.js\");\n"
+        "Util.readFile(\"/definitely/absent-plain.js\");\n"
+        "Qt.exit(0);\n");
+
+    auto r = runScript(path, cfg);
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    // Without this an unresolvable read is indistinguishable from an empty
+    // file: eval("") is a no-op and the run reports success.
+    CHECK(r.output.contains("Score.readFile: cannot read"));
+    // The arrow form appears exactly when a prefix was resolved to something
+    // else, which is the case a plain missing path must not be confused with.
+    CHECK(r.output.contains("<LIBRARY>:/definitely/absent.js ->"));
+    CHECK(r.output.contains("Score.readFile: cannot read /definitely/absent-plain.js"));
+  }
+}

--- a/tests/integration/ShaderSweep.hpp
+++ b/tests/integration/ShaderSweep.hpp
@@ -265,6 +265,31 @@ struct Sweeper
 };
 
 
+//! Writes the last frame a shader produced, so that "it rendered" can be
+//! checked against what the shader is supposed to draw rather than taken on
+//! faith. Off unless SCORE_SHADER_SWEEP_DUMP_DIR names a directory.
+void dumpFrame(
+    const QString& shader, const std::shared_ptr<QRhiReadbackResult>& rb_p)
+{
+  static const QString dir = qEnvironmentVariable("SCORE_SHADER_SWEEP_DUMP_DIR");
+  if(dir.isEmpty() || !rb_p)
+    return;
+
+  const auto& rb = *rb_p;
+  const auto px = rb.pixelSize.width() * rb.pixelSize.height();
+  if(px <= 0 || rb.data.size() != px * 4)
+    return;
+
+  QString name = shader;
+  name.replace('/', '_');
+
+  QDir{}.mkpath(dir);
+  const QImage img{
+      reinterpret_cast<const uchar*>(rb.data.constData()), rb.pixelSize.width(),
+      rb.pixelSize.height(), QImage::Format_RGBA8888};
+  img.copy().save(dir + '/' + name + ".png");
+}
+
 //! ProgramCache reports both ISF parsing and shader baking through one string.
 const char* programErrorKind(const QString& error)
 {
@@ -328,8 +353,20 @@ inline void sweepLibrary(
   if(shaders.isEmpty())
     SKIP("no shaders of this kind in the library");
 
+  // The backend comes from the gfx settings model, not from the environment:
+  // Gfx::Settings::Model reads QSG_RHI_BACKEND at construction and unsets it
+  // straight away, so by the time we get here the environment no longer says
+  // anything. score::gfx::BackgroundNode reads the same model in its
+  // constructor, so there is no rendering to be had without it either.
+  const auto* gfx_settings = ctx.findSettings<Gfx::Settings::Model>();
+  if(!gfx_settings)
+    FAIL(
+        "score_plugin_gfx registered no settings model: the gfx plug-in was not "
+        "loaded. Plug-ins are discovered in <cwd>/plugins -- run this from the "
+        "build root, as ctest does.");
+
   g_previous = qInstallMessageHandler(capture);
-  Sweeper sweeper{ctx.settings<Gfx::Settings::Model>().graphicsApiEnum()};
+  Sweeper sweeper{gfx_settings->graphicsApiEnum()};
 
   std::map<QString, std::map<std::string, std::string>> failures;
 
@@ -354,7 +391,9 @@ inline void sweepLibrary(
       continue;
     }
 
-    if(auto res = sweeper.run(*program); !res.empty())
+    auto res = sweeper.run(*program);
+    dumpFrame(rel, sweeper.output.shared_readback);
+    if(!res.empty())
     {
       report(rel, res);
       failures[rel] = std::move(res);

--- a/tests/integration/ShaderSweep.hpp
+++ b/tests/integration/ShaderSweep.hpp
@@ -27,6 +27,7 @@
 
 #include <QDir>
 #include <QDirIterator>
+#include <QRegularExpression>
 #include <QFile>
 #include <QFileInfo>
 #include <QImage>
@@ -290,6 +291,20 @@ void dumpFrame(
   img.copy().save(dir + '/' + name + ".png");
 }
 
+//! The MODE declared in a shader's JSON header, or an empty string when it has
+//! none (plain ISF). Which sweep owns a file is decided by this, not by its
+//! extension: RAW_RASTER_PIPELINE, COMPUTE_SHADER and VERTEX_SHADER_ART shaders
+//! are all written as .fs/.vs, and routing them into the ISF loader compiles
+//! them against the wrong prelude -- 41 of the testers failed that way, while
+//! the subsystem they were written for went entirely unexercised.
+inline QString shaderMode(const QByteArray& data)
+{
+  static const QRegularExpression re{
+      R"_("MODE"\s*:\s*"([A-Z_]+)")_"};
+  const auto m = re.match(QString::fromUtf8(data.left(8192)));
+  return m.hasMatch() ? m.captured(1) : QString{};
+}
+
 //! ProgramCache reports both ISF parsing and shader baking through one string.
 const char* programErrorKind(const QString& error)
 {
@@ -333,10 +348,62 @@ report(const QString& shader, const std::map<std::string, std::string>& kinds)
                       << QString::fromStdString(message);
 }
 
+//! The baseline records only the failure KINDS per file, so the test fails on
+//! *new* failures rather than on a known-bad corpus. Shared by every sweep.
+inline void diffAgainstBaseline(
+    const std::map<QString, std::map<std::string, std::string>>& failures,
+    const QString& baseline)
+{
+  QStringList current;
+  for(const auto& [file, kinds] : failures)
+    for(const auto& [kind, _] : kinds)
+      current.push_back(file + '\t' + QString::fromStdString(kind));
+  current.sort();
+
+  if(qEnvironmentVariableIsSet("SCORE_SHADER_SWEEP_WRITE_BASELINE"))
+  {
+    QFile out{baseline};
+    REQUIRE(out.open(QIODevice::WriteOnly | QIODevice::Text));
+    QTextStream{&out} << current.join('\n') << '\n';
+    return;
+  }
+
+  QStringList known;
+  if(QFile in{baseline}; in.open(QIODevice::ReadOnly | QIODevice::Text))
+  {
+    known = QString::fromUtf8(in.readAll()).split('\n', Qt::SkipEmptyParts);
+    known.sort();
+  }
+  else
+  {
+    FAIL(
+        "no baseline at " << baseline.toStdString()
+                          << ": run with SCORE_SHADER_SWEEP_WRITE_BASELINE to create it");
+  }
+
+  QStringList regressions;
+  for(const auto& entry : current)
+    if(!known.contains(entry))
+      regressions.push_back(entry);
+
+  INFO("new failures:\n" << regressions.join('\n').toStdString());
+  CHECK(regressions.isEmpty());
+}
+
 //! Runs one shader kind over the library and diffs against its baseline.
+//! @p wantMode selects which files this sweep owns: an empty string means "no
+//! MODE header at all", i.e. plain ISF. Files declaring another mode are skipped,
+//! not failed.
+//! @p blankIsFailure says whether "every pixel identical" means anything for this
+//! kind of shader. It does for ISF, which draws a full-screen pass on its own. It
+//! does NOT for a raster pipeline: those draw geometry, and this harness wires no
+//! geometry producer, so they legitimately render nothing here. Counting that as a
+//! failure would measure the harness, not the shader — pixel validation for raster
+//! belongs to the JS-wiring harness, which assembles the whole scene chain.
 inline void sweepLibrary(
     const score::GUIApplicationContext& ctx, const QStringList& patterns,
-    ProgramLoader load, const QString& baseline)
+    ProgramLoader load, const QString& baseline, const QString& wantMode = {},
+    bool blankIsFailure = true)
 {
   const QString root = libraryRoot(ctx);
   if(root.isEmpty() || !QFileInfo::exists(root))
@@ -373,16 +440,24 @@ inline void sweepLibrary(
   for(const QString& path : shaders)
   {
     const QString rel = QDir{root}.relativeFilePath(path);
-    // Announce before rendering: on a backend that can hang or take the
-    // process down, the last line printed names the shader responsible.
-    qInfo().noquote() << "[sweep]" << rel;
 
     QFile f{path};
     if(!f.open(QIODevice::ReadOnly | QIODevice::Text))
       continue;
+    const QByteArray data = f.readAll();
+
+    // Skip, do not fail, a shader another sweep owns. Compiling a
+    // RAW_RASTER_PIPELINE against the ISF prelude only ever produces
+    // "'position' : undeclared identifier", which says nothing about the shader.
+    if(shaderMode(data) != wantMode)
+      continue;
+
+    // Announce before rendering: on a backend that can hang or take the
+    // process down, the last line printed names the shader responsible.
+    qInfo().noquote() << "[sweep]" << rel;
 
     QString error;
-    const auto program = load(path, f.readAll(), error);
+    const auto program = load(path, data, error);
     if(!program)
     {
       failures[rel][programErrorKind(error)]
@@ -392,6 +467,8 @@ inline void sweepLibrary(
     }
 
     auto res = sweeper.run(*program);
+    if(!blankIsFailure)
+      res.erase("blank");
     dumpFrame(rel, sweeper.output.shared_readback);
     if(!res.empty())
     {
@@ -404,39 +481,6 @@ inline void sweepLibrary(
 
   INFO("swept " << shaders.size() << " shaders, " << failures.size() << " failing");
 
-  QStringList current;
-  for(const auto& [file, kinds] : failures)
-    for(const auto& [kind, _] : kinds)
-      current.push_back(file + '\t' + QString::fromStdString(kind));
-  current.sort();
-
-  if(qEnvironmentVariableIsSet("SCORE_SHADER_SWEEP_WRITE_BASELINE"))
-  {
-    QFile out{baseline};
-    REQUIRE(out.open(QIODevice::WriteOnly | QIODevice::Text));
-    QTextStream{&out} << current.join('\n') << '\n';
-    return;
-  }
-
-  QStringList known;
-  if(QFile in{baseline}; in.open(QIODevice::ReadOnly | QIODevice::Text))
-  {
-    known = QString::fromUtf8(in.readAll()).split('\n', Qt::SkipEmptyParts);
-    known.sort();
-  }
-  else
-  {
-    FAIL(
-        "no baseline at " << baseline.toStdString()
-                          << ": run with SCORE_SHADER_SWEEP_WRITE_BASELINE to create it");
-  }
-
-  QStringList regressions;
-  for(const auto& entry : current)
-    if(!known.contains(entry))
-      regressions.push_back(entry);
-
-  INFO("new failures:\n" << regressions.join('\n').toStdString());
-  CHECK(regressions.isEmpty());
+  diffAgainstBaseline(failures, baseline);
 }
 }

--- a/tests/integration/ShaderSweepCSF.cpp
+++ b/tests/integration/ShaderSweepCSF.cpp
@@ -54,6 +54,9 @@ TEST_CASE("Every CSF shader in the library renders", "[integration][gfx][shaders
 {
   requestGlesContext();
   score::test::run_in_gui_app([](const score::GUIApplicationContext& ctx) {
-    sweepLibrary(ctx, {"*.cs", "*.comp", "*.csf"}, &loadCSF, QStringLiteral(SCORE_SHADER_SWEEP_BASELINE_CSF));
+    sweepLibrary(
+        ctx, {"*.cs", "*.comp", "*.csf"}, &loadCSF,
+        QStringLiteral(SCORE_SHADER_SWEEP_BASELINE_CSF),
+        QStringLiteral("COMPUTE_SHADER"));
   });
 }

--- a/tests/integration/ShaderSweepVSA.cpp
+++ b/tests/integration/ShaderSweepVSA.cpp
@@ -26,6 +26,9 @@ TEST_CASE("Every VSA shader in the library renders", "[integration][gfx][shaders
 {
   requestGlesContext();
   score::test::run_in_gui_app([](const score::GUIApplicationContext& ctx) {
-    sweepLibrary(ctx, {"*.vs", "*.vert"}, &loadVSA, QStringLiteral(SCORE_SHADER_SWEEP_BASELINE_VSA));
+    sweepLibrary(
+        ctx, {"*.vs", "*.vert"}, &loadVSA,
+        QStringLiteral(SCORE_SHADER_SWEEP_BASELINE_VSA),
+        QStringLiteral("VERTEX_SHADER_ART"));
   });
 }

--- a/tests/integration/golden-render/cases-llvmpipe.txt
+++ b/tests/integration/golden-render/cases-llvmpipe.txt
@@ -1,0 +1,23 @@
+# Golden-render pinned case list — llvmpipe backend class.
+# One tests-scene script basename per line (no .js). Chosen from the subset
+# proven to render on llvmpipe (2026-07 sweep), spread across pipeline
+# families: ISF basic/multi-input/multipass/MRT, raw-raster texture upload +
+# strides, sampler state, storage images, float formats, CSF compute.
+# Time-animated cases are rejected automatically by --update-refs
+# self-consistency; permanently unstable ones land in refs/<backend>/UNSTABLE.txt.
+build-isf-solid-color
+build-isf-image-passthrough
+build-isf-two-images
+build-2d-no-stride
+build-2d-stride-xy
+build-isf-nearest-filter
+build-isf-three-pass
+build-isf-multipass-size
+build-isf-mrt-four-outputs
+build-mrt-gbuffer
+build-pass-override-state
+build-binding-storage-image-fragment
+build-isf-pass-format-rgba16f
+build-output-format-rgba16f
+build-csf-texture-sampling
+build-isf-point3d-as-color

--- a/tests/integration/golden-render/compare.py
+++ b/tests/integration/golden-render/compare.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Perceptual image comparison for the golden-render harness.
+
+    compare.py <ref.png> <test.png> [--profile strict|cross|loose] [--json]
+
+Metrics: PSNR (dB), SSIM (gaussian 11x11 sigma=1.5, standard Wang et al.
+constants), mean absolute diff and max absolute diff (8-bit scale).
+
+Profiles (thresholds from the 2026-07 measurement session — same-machine
+llvmpipe renders are bit-stable in practice, GL vs Vulkan frame means matched
+to 4 decimal digits):
+  strict : same backend-class regression gate.
+           PSNR >= 40 dB  AND  SSIM >= 0.995  AND  max_abs <= 8
+  cross  : GL vs Vulkan / driver-vs-driver informational check.
+           PSNR >= 30 dB  AND  SSIM >= 0.99
+  loose  : structural sanity only.  SSIM >= 0.95
+  self   : ref-acceptance self-consistency (two renders of one case).
+           PSNR >= 45 dB  AND  max_abs <= 4
+
+Exit codes: 0 pass, 1 fail, 2 usage/IO error.  Identical files short-circuit
+to PASS with psnr=inf.  A size mismatch is always FAIL (never resampled:
+resolution drift IS a regression).
+"""
+import argparse
+import json
+import sys
+
+import numpy as np
+from PIL import Image
+from scipy.ndimage import gaussian_filter
+
+PROFILES = {
+    "strict": dict(psnr=40.0, ssim=0.995, max_abs=8, mean_abs=None),
+    "cross": dict(psnr=30.0, ssim=0.99, max_abs=None, mean_abs=None),
+    "loose": dict(psnr=None, ssim=0.95, max_abs=None, mean_abs=None),
+    "self": dict(psnr=45.0, ssim=None, max_abs=4, mean_abs=None),
+}
+
+
+def load(path):
+    try:
+        img = Image.open(path).convert("RGB")
+    except Exception as e:  # noqa: BLE001
+        print(f"ERROR: cannot read {path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    return np.asarray(img, dtype=np.float64)
+
+
+def psnr(a, b):
+    mse = np.mean((a - b) ** 2)
+    if mse == 0:
+        return float("inf")
+    return 10.0 * np.log10(255.0**2 / mse)
+
+
+def ssim(a, b, sigma=1.5):
+    """Mean SSIM over the luma plane, gaussian-windowed (Wang et al. 2004)."""
+    # ITU-R BT.601 luma; SSIM on luma is the standard single-channel variant.
+    la = a @ np.array([0.299, 0.587, 0.114])
+    lb = b @ np.array([0.299, 0.587, 0.114])
+    c1, c2 = (0.01 * 255) ** 2, (0.03 * 255) ** 2
+    mu_a = gaussian_filter(la, sigma)
+    mu_b = gaussian_filter(lb, sigma)
+    mu_a2, mu_b2, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    var_a = gaussian_filter(la * la, sigma) - mu_a2
+    var_b = gaussian_filter(lb * lb, sigma) - mu_b2
+    cov = gaussian_filter(la * lb, sigma) - mu_ab
+    num = (2 * mu_ab + c1) * (2 * cov + c2)
+    den = (mu_a2 + mu_b2 + c1) * (var_a + var_b + c2)
+    return float(np.mean(num / den))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("ref")
+    ap.add_argument("test")
+    ap.add_argument("--profile", choices=PROFILES, default="strict")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    a, b = load(args.ref), load(args.test)
+    out = {"ref": args.ref, "test": args.test, "profile": args.profile}
+
+    if a.shape != b.shape:
+        out.update(verdict="FAIL", reason=f"size mismatch {a.shape} vs {b.shape}")
+        print(json.dumps(out) if args.json else f"FAIL size-mismatch {a.shape} vs {b.shape}")
+        sys.exit(1)
+
+    diff = np.abs(a - b)
+    m = {
+        "psnr": round(psnr(a, b), 3),
+        "ssim": round(ssim(a, b), 6),
+        "mean_abs": round(float(diff.mean()), 4),
+        "max_abs": float(diff.max()),
+    }
+    out.update(m)
+
+    th = PROFILES[args.profile]
+    fails = []
+    if th["psnr"] is not None and m["psnr"] < th["psnr"]:
+        fails.append(f"psnr {m['psnr']} < {th['psnr']}")
+    if th["ssim"] is not None and m["ssim"] < th["ssim"]:
+        fails.append(f"ssim {m['ssim']} < {th['ssim']}")
+    if th["max_abs"] is not None and m["max_abs"] > th["max_abs"]:
+        fails.append(f"max_abs {m['max_abs']} > {th['max_abs']}")
+
+    out["verdict"] = "FAIL" if fails else "PASS"
+    if fails:
+        out["reason"] = "; ".join(fails)
+
+    if args.json:
+        print(json.dumps(out))
+    else:
+        line = f"{out['verdict']} psnr={m['psnr']} ssim={m['ssim']} mean_abs={m['mean_abs']} max_abs={m['max_abs']}"
+        if fails:
+            line += f"  [{out['reason']}]"
+        print(line)
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/golden-render/frame-determinism.sh
+++ b/tests/integration/golden-render/frame-determinism.sh
@@ -42,7 +42,7 @@ render() {
 eval(Score.readFile("<LIBRARY>:/packages/csf-examples/csf-testers/tests-scene/scripts/${CASE}.js"));
 Score.device('Window').grabFrame(${FRAME}, "${OUT}/frame$n.png");
 JS
-  SCORE_AUDIO_BACKEND=dummy SCORE_DISABLE_AUDIOPLUGINS=1 \
+  SCORE_AUDIO_BACKEND=dummy SCORE_DISABLE_AUDIOPLUGINS=1 DISPLAY="${DISPLAY:-:0}" \
     timeout 120 "$SCORE" --no-gui --no-restore --script "$OUT/run$n.js" --wait 2 \
     > "$OUT/run$n.log" 2>&1
   return $?
@@ -61,6 +61,26 @@ for n in 1 2; do
   fi
 done
 [ $fail -eq 1 ] && exit 1
+
+# Identical blank frames are identical. Without this, a case that renders
+# nothing at all is the easiest way to pass a determinism test, and the result
+# would say the mechanism works when it has not been exercised.
+blank=$(python3 - "$OUT/frame1.png" <<'PY' 2>/dev/null
+import sys
+try:
+    from PIL import Image
+    print(len(set(Image.open(sys.argv[1]).convert('RGB').getdata())))
+except Exception:
+    print("?")
+PY
+)
+case "$blank" in
+  "?") echo "NOTE: cannot check for blankness (no PIL); result is weaker than it looks" ;;
+  1)   echo "FAIL: frame $FRAME is a single flat colour -- nothing was rendered."
+       echo "  Two blank frames match trivially; this proves nothing about determinism."
+       exit 1 ;;
+  *)   echo "  frame has $blank distinct colours (not blank)" ;;
+esac
 
 if cmp -s "$OUT/frame1.png" "$OUT/frame2.png"; then
   echo "PASS: both runs produced byte-identical frames ($(stat -c%s "$OUT/frame1.png") bytes)"

--- a/tests/integration/golden-render/frame-determinism.sh
+++ b/tests/integration/golden-render/frame-determinism.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Acceptance test for deterministic frame stepping.
+#
+# Renders the SAME tester to the SAME frame index in two separate processes and
+# requires the two PNGs to be byte-identical. Two processes rather than two
+# grabs in one, because anything cached in the process would hide exactly the
+# nondeterminism this is looking for.
+#
+# If this fails, golden references cannot be pinned: frame N is not a stable
+# picture, and every stored reference is a snapshot of one particular run.
+#
+#   frame-determinism.sh [--score PATH] [--case NAME] [--frame N]
+#
+# Exit 0 iff the two renders agree.
+set -uo pipefail
+
+SCORE="${OSSIA_SCORE:-}"
+CASE="build-isf-solid-color"
+FRAME=30
+OUT="${TMPDIR:-/tmp}/score-frame-determinism.$$"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --score) SCORE="$2"; shift 2 ;;
+    --case)  CASE="$2";  shift 2 ;;
+    --frame) FRAME="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$SCORE" ] || { echo "FATAL: set OSSIA_SCORE or pass --score"; exit 2; }
+[ -x "$SCORE" ] || { echo "FATAL: not executable: $SCORE"; exit 2; }
+
+mkdir -p "$OUT"
+trap 'rm -rf "$OUT"' EXIT
+
+# The tester scripts resolve their own paths through <LIBRARY>:, so the only
+# thing this needs to know is the case name.
+render() {
+  local n="$1"
+  cat > "$OUT/run$n.js" <<JS
+eval(Score.readFile("<LIBRARY>:/packages/csf-examples/csf-testers/tests-scene/scripts/${CASE}.js"));
+Score.device('Window').grabFrame(${FRAME}, "${OUT}/frame$n.png");
+JS
+  SCORE_AUDIO_BACKEND=dummy SCORE_DISABLE_AUDIOPLUGINS=1 \
+    timeout 120 "$SCORE" --no-gui --no-restore --script "$OUT/run$n.js" --wait 2 \
+    > "$OUT/run$n.log" 2>&1
+  return $?
+}
+
+echo "== rendering $CASE frame $FRAME, twice, in separate processes =="
+render 1; rc1=$?
+render 2; rc2=$?
+
+fail=0
+for n in 1 2; do
+  if [ ! -s "$OUT/frame$n.png" ]; then
+    echo "FAIL: run $n produced no frame (exit $([ $n = 1 ] && echo $rc1 || echo $rc2))"
+    sed 's/^/    /' "$OUT/run$n.log" | tail -20
+    fail=1
+  fi
+done
+[ $fail -eq 1 ] && exit 1
+
+if cmp -s "$OUT/frame1.png" "$OUT/frame2.png"; then
+  echo "PASS: both runs produced byte-identical frames ($(stat -c%s "$OUT/frame1.png") bytes)"
+  exit 0
+fi
+
+echo "FAIL: frame $FRAME differs between two runs of the same case."
+echo "  run 1: $(stat -c%s "$OUT/frame1.png") bytes  md5 $(md5sum < "$OUT/frame1.png" | cut -d' ' -f1)"
+echo "  run 2: $(stat -c%s "$OUT/frame2.png") bytes  md5 $(md5sum < "$OUT/frame2.png" | cut -d' ' -f1)"
+echo "  Frame stepping is not deterministic yet; golden references cannot be pinned."
+cp "$OUT/frame1.png" "$OUT/frame2.png" "${TMPDIR:-/tmp}/" 2>/dev/null && \
+  echo "  copies kept in ${TMPDIR:-/tmp}/frame1.png and frame2.png"
+exit 1

--- a/tests/integration/golden-render/frame-determinism.sh
+++ b/tests/integration/golden-render/frame-determinism.sh
@@ -15,7 +15,10 @@
 set -uo pipefail
 
 SCORE="${OSSIA_SCORE:-}"
-CASE="build-isf-solid-color"
+# Animated on purpose: this tester draws TIME, TIMEDELTA, PROGRESS and
+# FRAMEINDEX as bars, so it fails if any of them still follows a wall clock. A
+# static case would pass whether or not the step clock works.
+CASE="build-isf-time-uniforms"
 FRAME=30
 OUT="${TMPDIR:-/tmp}/score-frame-determinism.$$"
 
@@ -35,15 +38,28 @@ mkdir -p "$OUT"
 trap 'rm -rf "$OUT"' EXIT
 
 # The tester scripts resolve their own paths through <LIBRARY>:, so the only
-# thing this needs to know is the case name.
+# thing this needs to know is the case name. --wait defers autoplay by N seconds
+# for slow media to load; it is not an exit timer, so the script ends the run
+# itself with Qt.exit and the timeout below is only a hang guard.
 render() {
   local n="$1"
+  # Score.play() first: the gfx nodes only exist while the score executes, so a
+  # grab on a stopped document finds nothing wired to the Window device.
+  # Qt.exit() last, so the run ends when the work is done and the exit code is
+  # the script's rather than the timeout's.
   cat > "$OUT/run$n.js" <<JS
 eval(Score.readFile("<LIBRARY>:/packages/csf-examples/csf-testers/tests-scene/scripts/${CASE}.js"));
+Score.play();
 Score.device('Window').grabFrame(${FRAME}, "${OUT}/frame$n.png");
+Qt.exit(0);
 JS
+  # Without this the Window device opens a real window and grabTo falls back to
+  # QScreen::grabWindow, which reads the framebuffer at the window's geometry --
+  # i.e. the desktop, screensaver included. Checked again below, because a
+  # screenshot of a static desktop is byte-stable and would "pass".
+  SCORE_FORCE_OFFSCREEN_WINDOW=Window \
   SCORE_AUDIO_BACKEND=dummy SCORE_DISABLE_AUDIOPLUGINS=1 DISPLAY="${DISPLAY:-:0}" \
-    timeout 120 "$SCORE" --no-gui --no-restore --script "$OUT/run$n.js" --wait 2 \
+    timeout 120 "$SCORE" --no-gui --no-restore --script "$OUT/run$n.js" --wait 0 --autoplay \
     > "$OUT/run$n.log" 2>&1
   return $?
 }
@@ -61,6 +77,23 @@ for n in 1 2; do
   fi
 done
 [ $fail -eq 1 ] && exit 1
+
+# A screen grab of a quiet desktop is byte-identical between two runs, so this
+# has to be fatal rather than cosmetic: it is the difference between comparing
+# renders and comparing wallpaper.
+for n in 1 2; do
+  if grep -q "capturing the SCREEN" "$OUT/run$n.log"; then
+    echo "FAIL: run $n grabbed the screen instead of the render."
+    echo "  The offscreen device was not selected -- SCORE_FORCE_OFFSCREEN_WINDOW"
+    echo "  must name the Window device, and this build must honour it."
+    exit 1
+  fi
+  if grep -q "nothing rendered into" "$OUT/run$n.log"; then
+    echo "FAIL: run $n rendered nothing -- no process is wired to the Window device."
+    grep "nothing rendered into" "$OUT/run$n.log" | sed 's/^/    /'
+    exit 1
+  fi
+done
 
 # Identical blank frames are identical. Without this, a case that renders
 # nothing at all is the easiest way to pass a determinism test, and the result

--- a/tests/integration/golden-render/frame-determinism.sh
+++ b/tests/integration/golden-render/frame-determinism.sh
@@ -21,6 +21,7 @@ SCORE="${OSSIA_SCORE:-}"
 CASE="build-isf-time-uniforms"
 FRAME=30
 OUT="${TMPDIR:-/tmp}/score-frame-determinism.$$"
+SCRIPTS="${SCRIPTS:-$HOME/Documents/ossia/score/packages/csf-examples/csf-testers/tests-scene/scripts}"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -31,8 +32,13 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$SCORE" ] || { echo "FATAL: set OSSIA_SCORE or pass --score"; exit 2; }
-[ -x "$SCORE" ] || { echo "FATAL: not executable: $SCORE"; exit 2; }
+# Prerequisites -> ctest SKIP (return 77) rather than a hard failure, the same
+# way golden-render.sh does: the case corpus lives outside the repository, and
+# a machine without it has nothing to say about determinism either way.
+[ -n "$SCORE" ] || { echo "SKIP: set OSSIA_SCORE or pass --score";  exit 77; }
+[ -x "$SCORE" ] || { echo "SKIP: not executable: $SCORE";           exit 77; }
+[ -f "$SCRIPTS/${CASE}.js" ] || {
+  echo "SKIP: case corpus missing ($SCRIPTS/${CASE}.js)"; exit 77; }
 
 mkdir -p "$OUT"
 trap 'rm -rf "$OUT"' EXIT

--- a/tests/integration/golden-render/golden-render.sh
+++ b/tests/integration/golden-render/golden-render.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Golden-image render regression harness.
+#
+#   golden-render.sh [--backend llvmpipe|nvidia|vulkan-lavapipe|nvidia-vulkan]
+#                    [--update-refs] [--cases "name name ..."] [--keep-going]
+#
+# Renders each pinned tests-scene pipeline (cases-<backend-class>.txt, falling
+# back to cases-llvmpipe.txt) through the real ossia-score binary headless —
+# same proven recipe as /tmp/verify-shader.sh / scene-js-sweep.sh — and
+# compares the grabbed frame against refs/<backend>/<case>.png with compare.py
+# (SSIM/PSNR/max-abs, profile "strict").
+#
+#   check mode (default)  : ref must exist; verdict per case is
+#                           PASS / FAIL / NOREF / NORENDER / SKIP-UNSTABLE.
+#                           Exit 0 iff no FAIL/NOREF/NORENDER.
+#   --update-refs         : renders each case TWICE and accepts the ref only if
+#                           the two runs agree (compare.py --profile self) and
+#                           are non-blank. Disagreeing cases are recorded in
+#                           refs/<backend>/UNSTABLE.txt (time-animated shaders
+#                           self-reject here); blank ones in BLANK.txt.
+#
+# Backend classes:
+#   llvmpipe       offscreen QPA + software GL   (CI-able, fully headless)
+#   nvidia         xcb on :0 + NVIDIA GLX        (rig)
+#   vulkan-lavapipe/ nvidia-vulkan: GraphicsApi=Vulkan via an isolated
+#   XDG_CONFIG_HOME (score reads score_plugin_gfx/GraphicsApi from QSettings;
+#   there is no CLI flag). ALL runs use an isolated config home seeded from the
+#   user's score.conf with GraphicsApi pinned — a run must not depend on the
+#   user's live settings (they currently say Vulkan!) nor trip failsafe.bit.
+#
+# Serialization: each app run holds flock /tmp/score-harness.lock (OSC port
+# 6666 is global). Do NOT wrap this whole script in that lock (see the
+# EXHAUSTIVE-TEST-PLAN consolidation note on self-deadlock).
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SRCROOT="$(cd "$HERE/../../.." && pwd)"  # tests/integration/golden-render -> repo root
+BIN="${OSSIA_SCORE:-$SRCROOT/build-sanitizers/ossia-score}"
+SCRIPTS="${SCRIPTS:-$HOME/Documents/ossia/score/packages/csf-examples/csf-testers/tests-scene/scripts}"
+OSC=6666
+BLANK_MEAN="${BLANK_MEAN:-0.002}"
+TIMEOUT="${TIMEOUT:-90}"
+GRABTRIES="${GRABTRIES:-25}"   # x2s poll for the grab (ASAN startup is slow)
+ASAN="detect_leaks=0:halt_on_error=0:handle_segv=1:detect_odr_violation=0:protect_shadow_gap=0"
+
+BACKEND=llvmpipe
+UPDATE=0
+KEEPGOING=0
+CASES_OVERRIDE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --backend) BACKEND="$2"; shift 2 ;;
+    --update-refs) UPDATE=1; shift ;;
+    --cases) CASES_OVERRIDE="$2"; shift 2 ;;
+    --keep-going) KEEPGOING=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Prerequisites -> ctest SKIP (return 77) rather than a hard failure.
+command -v oscsend  >/dev/null || { echo "SKIP: oscsend not found";        exit 77; }
+command -v convert  >/dev/null || { echo "SKIP: ImageMagick not found";     exit 77; }
+[ -x "$BIN" ]                  || { echo "SKIP: $BIN not built";            exit 77; }
+[ -d "$SCRIPTS" ]             || { echo "SKIP: corpus missing ($SCRIPTS)";  exit 77; }
+
+REFS="$HERE/refs/$BACKEND"
+OUT="${OUT:-/tmp/golden-render/$BACKEND}"
+mkdir -p "$REFS" "$OUT"
+
+CASES_FILE="$HERE/cases-$BACKEND.txt"
+[ -f "$CASES_FILE" ] || CASES_FILE="$HERE/cases-llvmpipe.txt"
+if [ -n "$CASES_OVERRIDE" ]; then
+  read -r -a CASES <<< "$CASES_OVERRIDE"
+else
+  mapfile -t CASES < <(grep -v '^\s*#' "$CASES_FILE" | grep -v '^\s*$')
+fi
+
+# ---- isolated, pinned config home -------------------------------------------
+# GraphicsApi comes from QSettings (score_plugin_gfx/GraphicsApi,
+# Gfx/Settings/Model.cpp:38) — pin it so runs are hermetic.
+CFG="$OUT/config-home"
+mkdir -p "$CFG/ossia"
+case "$BACKEND" in
+  vulkan-*|*-vulkan) API=Vulkan ;;
+  *) API=OpenGL ;;
+esac
+python3 - "$HOME/.config/ossia/score.conf" "$CFG/ossia/score.conf" "$API" <<'EOF'
+import re, sys, pathlib
+src, dst, api = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    text = pathlib.Path(src).read_text()
+except OSError:
+    text = ""
+if "[score_plugin_gfx]" not in text:
+    text += "\n[score_plugin_gfx]\nGraphicsApi=%s\n" % api
+elif re.search(r"^GraphicsApi=.*$", text, re.M):
+    text = re.sub(r"^GraphicsApi=.*$", "GraphicsApi=%s" % api, text, flags=re.M)
+else:
+    text = text.replace("[score_plugin_gfx]", "[score_plugin_gfx]\nGraphicsApi=%s" % api)
+pathlib.Path(dst).write_text(text)
+EOF
+
+# Backend env (mirrors scene-js-sweep.sh; `env -u DISPLAY` for llvmpipe because
+# a live DISPLAY makes offscreen-EGL negotiate a GL 2.0 context).
+backend_env() {
+  case "$BACKEND" in
+    nvidia|nvidia-vulkan)
+      echo "DISPLAY=:0 QT_QPA_PLATFORM=xcb __GLX_VENDOR_LIBRARY_NAME=nvidia" ;;
+    vulkan-lavapipe)
+      echo "DISPLAY=:0 QT_QPA_PLATFORM=xcb VK_LOADER_DRIVERS_SELECT=lvp*" ;;
+    *)
+      echo "QT_QPA_PLATFORM=offscreen LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe" ;;
+  esac
+}
+
+pixel_mean() { convert "$1" -format '%[fx:mean]' info: 2>/dev/null || echo 0; }
+
+# ---- one full app run -> one PNG --------------------------------------------
+render_one() { # case_name out_png -> 0 ok, 2 no png
+  local name="$1" png="$2" js="$SCRIPTS/$1.js" log="$OUT/$1.log"
+  rm -f "$png"
+  [ -f "$js" ] || { echo "  missing script $js" >&2; return 2; }
+  local benv; benv=$(backend_env)
+  (
+    flock -w 300 9 || { echo "  LOCK-TIMEOUT" >&2; exit 4; }
+    ( for _ in $(seq 1 "$GRABTRIES"); do
+        sleep 2
+        oscsend 127.0.0.1 $OSC /script s "Score.device('Window').grabTo('$png')" 2>/dev/null
+        [ -s "$png" ] && break
+      done
+      sleep 0.5; oscsend 127.0.0.1 $OSC /stop; sleep 0.5; oscsend 127.0.0.1 $OSC /exit ) >/dev/null 2>&1 &
+    # shellcheck disable=SC2086
+    env -u DISPLAY XDG_CONFIG_HOME="$CFG" \
+        SCORE_AUDIO_BACKEND=dummy SCORE_DISABLE_AUDIOPLUGINS=1 \
+        SCORE_FORCE_OFFSCREEN_WINDOW=Window \
+        ASAN_OPTIONS="$ASAN" LLVM_PROFILE_FILE="$OUT/%p.profraw" \
+        $benv \
+      timeout --foreground "$TIMEOUT" "$BIN" --no-gui --no-restore \
+        --script "$js" --wait 1 --autoplay >"$log" 2>&1
+    wait 2>/dev/null
+  ) 9>/tmp/score-harness.lock
+  [ -s "$png" ] || return 2
+  return 0
+}
+
+listed() { [ -f "$2" ] && grep -qx "$1" "$2"; }
+
+fails=0; passes=0; skips=0
+for name in "${CASES[@]}"; do
+  printf '%-42s' "$name"
+  if [ "$UPDATE" = 1 ]; then
+    if render_one "$name" "$OUT/$name.A.png" && render_one "$name" "$OUT/$name.B.png"; then
+      m=$(pixel_mean "$OUT/$name.A.png")
+      if ! awk "BEGIN{exit !($m > $BLANK_MEAN)}"; then
+        echo "BLANK mean=$m (not accepted as ref)"; grep -qx "$name" "$REFS/BLANK.txt" 2>/dev/null || echo "$name" >> "$REFS/BLANK.txt"
+        skips=$((skips+1)); continue
+      fi
+      if res=$(python3 "$HERE/compare.py" "$OUT/$name.A.png" "$OUT/$name.B.png" --profile self); then
+        cp "$OUT/$name.A.png" "$REFS/$name.png"
+        # no longer unstable/blank if it stabilized
+        sed -i "/^$name\$/d" "$REFS/UNSTABLE.txt" "$REFS/BLANK.txt" 2>/dev/null
+        echo "REF-UPDATED ($res)"; passes=$((passes+1))
+      else
+        echo "UNSTABLE ($res) — excluded"; grep -qx "$name" "$REFS/UNSTABLE.txt" 2>/dev/null || echo "$name" >> "$REFS/UNSTABLE.txt"
+        skips=$((skips+1))
+      fi
+    else
+      echo "NORENDER (see $OUT/$name.log)"; fails=$((fails+1))
+      [ "$KEEPGOING" = 1 ] || true
+    fi
+  else
+    if listed "$name" "$REFS/UNSTABLE.txt"; then echo "SKIP-UNSTABLE"; skips=$((skips+1)); continue; fi
+    if listed "$name" "$REFS/BLANK.txt"; then echo "SKIP-BLANK"; skips=$((skips+1)); continue; fi
+    if [ ! -f "$REFS/$name.png" ]; then echo "NOREF (run --update-refs)"; fails=$((fails+1)); continue; fi
+    if render_one "$name" "$OUT/$name.png"; then
+      if res=$(python3 "$HERE/compare.py" "$REFS/$name.png" "$OUT/$name.png" --profile strict); then
+        echo "PASS ($res)"; passes=$((passes+1))
+      else
+        echo "FAIL ($res)  ref=$REFS/$name.png test=$OUT/$name.png"; fails=$((fails+1))
+      fi
+    else
+      echo "NORENDER (see $OUT/$name.log)"; fails=$((fails+1))
+    fi
+  fi
+done
+
+echo "----"
+echo "golden-render[$BACKEND]$([ "$UPDATE" = 1 ] && echo ' (update-refs)'): $passes ok, $fails failing, $skips skipped"
+# In check mode, if there are no refs at all yet, SKIP (77) instead of failing —
+# refs are generated once with --update-refs and committed alongside the branch.
+if [ "$UPDATE" = 0 ] && [ "$passes" = 0 ] && [ "$fails" -gt 0 ] && ! ls "$REFS"/*.png >/dev/null 2>&1; then
+  echo "SKIP: no references present — run --update-refs once and commit refs/$BACKEND/"; exit 77
+fi
+[ "$fails" = 0 ]

--- a/tests/integration/golden-render/sweep.sh
+++ b/tests/integration/golden-render/sweep.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Runs every tests-scene tester and records what came out.
+#
+# One process per case: a case that crashes or hangs takes only itself down, and
+# the document each tester builds starts from a clean application either way.
+#
+#   sweep.sh [--score PATH] [--out DIR] [--frame N] [--filter GLOB]
+#
+# Writes DIR/results.tsv (case, verdict, colours, ms, note) and DIR/<case>.png.
+# Verdicts:
+#   RENDER    frame written, more than one colour in it
+#   BLANK     frame written, every pixel identical
+#   NORENDER  nothing wired to the Window device, or no frame written
+#   SCREEN    the grab fell back to capturing the screen -- result is worthless
+#   CRASH     score died on a signal -- the per-case process is what contains it
+#   FAIL      score exited nonzero, or was killed by the guard
+set -uo pipefail
+
+SCORE="${OSSIA_SCORE:-}"
+OUT="${SWEEP_OUT:-/tmp/score-sweep}"
+FRAME=30
+FILTER='*'
+SCRIPTS="<LIBRARY>:/packages/csf-examples/csf-testers/tests-scene/scripts"
+SCRIPTS_DIR="${SWEEP_SCRIPTS_DIR:-$HOME/Documents/ossia/score/packages/csf-examples/csf-testers/tests-scene/scripts}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --score)  SCORE="$2";  shift 2 ;;
+    --out)    OUT="$2";    shift 2 ;;
+    --frame)  FRAME="$2";  shift 2 ;;
+    --filter) FILTER="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$SCORE" ] || { echo "FATAL: set OSSIA_SCORE or pass --score"; exit 2; }
+[ -x "$SCORE" ] || { echo "FATAL: not executable: $SCORE"; exit 2; }
+[ -d "$SCRIPTS_DIR" ] || { echo "FATAL: no scripts at $SCRIPTS_DIR"; exit 2; }
+
+mkdir -p "$OUT/logs"
+: > "$OUT/results.tsv"
+
+colours() {
+  python3 - "$1" <<'PY' 2>/dev/null || echo "?"
+import sys
+try:
+    from PIL import Image
+    print(len(set(Image.open(sys.argv[1]).convert('RGB').getdata())))
+except Exception:
+    print("?")
+PY
+}
+
+total=0; render=0; blank=0; norender=0; failed=0; screen=0; crashed=0
+start_all=$(date +%s)
+
+for f in "$SCRIPTS_DIR"/build-$FILTER.js; do
+  [ -e "$f" ] || continue
+  name=$(basename "$f" .js)
+  total=$((total + 1))
+  png="$OUT/$name.png"
+  log="$OUT/logs/$name.log"
+  rm -f "$png"
+
+  cat > "$OUT/run.js" <<JS
+eval(Score.readFile("$SCRIPTS/${name}.js"));
+Score.play();
+Score.device('Window').grabFrame(${FRAME}, "${png}");
+Qt.exit(0);
+JS
+
+  t0=$(date +%s%N)
+  SCORE_FORCE_OFFSCREEN_WINDOW=Window \
+  SCORE_AUDIO_BACKEND=dummy SCORE_DISABLE_AUDIOPLUGINS=1 DISPLAY="${DISPLAY:-:0}" \
+    timeout 90 "$SCORE" --no-gui --no-restore --script "$OUT/run.js" --wait 0 --autoplay \
+    > "$log" 2>&1
+  rc=$?
+  ms=$(( ($(date +%s%N) - t0) / 1000000 ))
+
+  note=""
+  if grep -q "capturing the SCREEN" "$log"; then
+    verdict=SCREEN; screen=$((screen + 1))
+  elif [ ! -s "$png" ]; then
+    if grep -q "nothing rendered into" "$log"; then
+      verdict=NORENDER; norender=$((norender + 1))
+    elif [ $rc -ge 128 ]; then
+      # Killed by a signal. 124 is the timeout's own kill and is handled as
+      # FAIL below; anything else here died, most often on a SCORE_ASSERT in
+      # render-target creation. One process per case is what keeps that from
+      # ending the sweep.
+      verdict=CRASH; crashed=$((crashed + 1))
+      note="signal $((rc - 128))"
+      site=$(grep -m1 -oE '[A-Za-z]+\.cpp:[0-9]+' "$log")
+      [ -n "$site" ] && note="$note at $site"
+    elif [ $rc -ne 0 ]; then
+      verdict=FAIL; failed=$((failed + 1)); note="exit $rc"
+    else
+      verdict=NORENDER; norender=$((norender + 1)); note="no frame written"
+    fi
+  else
+    c=$(colours "$png")
+    if [ "$c" = "1" ]; then verdict=BLANK; blank=$((blank + 1))
+    else verdict=RENDER; render=$((render + 1)); fi
+    note="$c colours"
+  fi
+
+  # First real complaint from the log, so the table says why without opening it.
+  if [ -z "$note" ] || [ "$verdict" = FAIL ] || [ "$verdict" = NORENDER ]; then
+    why=$(grep -m1 -E 'error|Error|failed|Failed|not supported|Missing' "$log" \
+          | cut -c1-90 | tr -d '\t')
+    [ -n "$why" ] && note="${note:+$note; }$why"
+  fi
+
+  printf '%s\t%s\t%s\t%s\n' "$name" "$verdict" "$ms" "$note" >> "$OUT/results.tsv"
+  printf '  %-46s %-9s %5s ms  %s\n' "$name" "$verdict" "$ms" "$note"
+done
+
+echo
+echo "== $total cases in $(( $(date +%s) - start_all ))s =="
+printf '   RENDER %d   BLANK %d   NORENDER %d   CRASH %d   FAIL %d   SCREEN %d\n' \
+  "$render" "$blank" "$norender" "$crashed" "$failed" "$screen"
+echo "   results: $OUT/results.tsv"
+
+# SCREEN means the harness measured the desktop, which is never a usable result.
+[ "$screen" -gt 0 ] && exit 1
+exit 0

--- a/tests/library/CMakeLists.txt
+++ b/tests/library/CMakeLists.txt
@@ -1,11 +1,7 @@
 # Tests for the process-library model population (staged subtree publish).
 # APP tests: they need the full headless application so that the settings
 # models and the process factories from every plugin are registered.
-# QtTest is linked for QAbstractItemModelTester.
-find_package(${QT_VERSION} REQUIRED COMPONENTS Test)
-
 score_add_test(test_library_publish
   SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/ProcessLibraryPublishTest.cpp"
   APP
-  PLUGINS score_plugin_library score_lib_process
-  LIBS ${QT_PREFIX}::Test)
+  PLUGINS score_plugin_library score_lib_process)

--- a/tests/library/ProcessLibraryPublishTest.cpp
+++ b/tests/library/ProcessLibraryPublishTest.cpp
@@ -1,8 +1,8 @@
 // Tests for the staged-subtree publish path of Library::ProcessesItemModel.
 //
 // Correctness: every mutation outside rescan() goes through publish() /
-// replaceChildren() with exact QAbstractItemModel signals — verified by Qt's
-// own QAbstractItemModelTester and by mirroring the model through a live
+// replaceChildren() with exact QAbstractItemModel signals — verified by our
+// own checkModelInvariants() walk and by mirroring the model through a live
 // QSortFilterProxyModel (the exact observer that silent mutation used to
 // corrupt).
 //
@@ -21,12 +21,11 @@
 #include <score/application/GUIApplicationContext.hpp>
 #include <score/plugins/InterfaceList.hpp>
 
-#include <QAbstractItemModelTester>
 #include <QDir>
 #include <QElapsedTimer>
-#include <QSignalSpy>
 
 #include <score_test/App.hpp>
+#include <score_test/ModelInvariants.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -149,8 +148,6 @@ TEST_CASE("publish: model invariants and structure", "[library]")
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
     primeLibrarySettings(ctx);
     Fixture f{ctx};
-    QAbstractItemModelTester tester{
-        &f.model, QAbstractItemModelTester::FailureReportingMode::Fatal};
 
     // Deep new path, single entry
     f.model.publish(f.entry({"GIG", "orchestra"}, "violin"));
@@ -194,6 +191,8 @@ TEST_CASE("publish: model invariants and structure", "[library]")
     f.model.publish(std::move(stray));
     f.model.flushPending();
     REQUIRE(f.model.rowCount(anchor) == before);
+
+    score::test::checkModelInvariants(f.model);
   });
 }
 
@@ -202,9 +201,7 @@ TEST_CASE("publish: coalescing boundaries and signal counts", "[library]")
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
     primeLibrarySettings(ctx);
     Fixture f{ctx};
-    QAbstractItemModelTester tester{
-        &f.model, QAbstractItemModelTester::FailureReportingMode::Fatal};
-    QSignalSpy spy{&f.model, &QAbstractItemModel::rowsInserted};
+    score::test::SignalCounter spy{&f.model, &QAbstractItemModel::rowsInserted};
 
     // A whole new folder published in one flush: exactly one insert.
     for(int i = 0; i < 100; i++)
@@ -237,6 +234,8 @@ TEST_CASE("publish: coalescing boundaries and signal counts", "[library]")
     REQUIRE(childNames(f.model, packB) == QStringList{"b0", "b1", "b2"});
     const auto packA = f.model.index(0, 0, audio);
     REQUIRE(f.model.rowCount(packA) == 200);
+
+    score::test::checkModelInvariants(f.model);
   });
 }
 
@@ -275,8 +274,6 @@ TEST_CASE("replaceChildren: exact ranges, proxy stays consistent", "[library]")
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
     primeLibrarySettings(ctx);
     Fixture f{ctx};
-    QAbstractItemModelTester tester{
-        &f.model, QAbstractItemModelTester::FailureReportingMode::Fatal};
 
     Library::ProcessFilterProxy proxy;
     proxy.setSourceModel(&f.model);
@@ -319,6 +316,8 @@ TEST_CASE("replaceChildren: exact ranges, proxy stays consistent", "[library]")
     // Unknown key: no-op
     f.model.replaceChildren(Process::ProcessModelFactory::ConcreteKey{}, forest(1, 1));
     REQUIRE(f.model.rowCount(f.model.find(f.key)) == 0);
+
+    score::test::checkModelInvariants(f.model);
   });
 }
 
@@ -396,7 +395,7 @@ TEST_CASE("publish: 36k-entry storm, hot proxy mirrors the tree", "[library][ben
       proxy.hasChildren(i);
     REQUIRE(proxy.rowCount(proxy.mapFromSource(f.anchor)) == 1);
 
-    QSignalSpy spy{&f.model, &QAbstractItemModel::rowsInserted};
+    score::test::SignalCounter spy{&f.model, &QAbstractItemModel::rowsInserted};
 
     // Deliver in batches of 255 like RecursiveWatch; the flush timer runs in
     // the processEvents between batches. Timed per batch, flush included.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -169,12 +169,14 @@ score_add_test(test_unit_spline_values
 # --- P3R2: score-plugin-midi + score-plugin-dataflow value tests -----------
 if(TARGET score_plugin_midi)
   set(_midi_src "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-midi")
-  score_add_test(test_unit_midi_message
-    SOURCES
-      MidiMessageTest.cpp
+  score_plugin_hidden_sources(_midi_hidden
       "${_midi_src}/Midi/MidiNote.cpp"
       "${_midi_src}/Midi/MidiProcess.cpp"
-      "${_midi_src}/Patternist/PatternParsing.cpp"
+      "${_midi_src}/Patternist/PatternParsing.cpp")
+score_add_test(test_unit_midi_message
+    SOURCES
+      MidiMessageTest.cpp
+      ${_midi_hidden}
     PLUGINS score_plugin_midi score_lib_process
     LIBS ${QT_PREFIX}::Gui)
 
@@ -196,16 +198,18 @@ endif()
 # --- analysis DSP ------------------------------------------------------------
 if(TARGET score_plugin_analysis)
   set(_gist_dir "${3RDPARTY_FOLDER}/Gist/src")
-  score_add_test(test_unit_analysis_gist
-    SOURCES
-      AnalysisGistTest.cpp
+  score_plugin_hidden_sources(_gist_hidden
       "${_gist_dir}/CoreFrequencyDomainFeatures.cpp"
       "${_gist_dir}/CoreTimeDomainFeatures.cpp"
       "${_gist_dir}/Gist.cpp"
       "${_gist_dir}/MFCC.cpp"
       "${_gist_dir}/OnsetDetectionFunction.cpp"
       "${_gist_dir}/WindowFunctions.cpp"
-      "${_gist_dir}/Yin.cpp"
+      "${_gist_dir}/Yin.cpp")
+score_add_test(test_unit_analysis_gist
+    SOURCES
+      AnalysisGistTest.cpp
+      ${_gist_hidden}
     PLUGINS score_plugin_analysis score_plugin_avnd)
   target_compile_definitions(test_unit_analysis_gist PRIVATE USE_OSSIA_FFT=1)
   target_include_directories(test_unit_analysis_gist SYSTEM PRIVATE "${_gist_dir}")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -418,12 +418,14 @@ endif()
 # The shared scan state machine, end-to-end against a scriptable fake puppet:
 # session-token isolation, crash/timeout single-failure, reply-vs-exit races,
 # clean cancellation of a scan in progress.
-score_add_test(test_unit_plugin_scanner
-  SOURCES PluginScannerTest.cpp
-  PLUGINS score_plugin_media)
-add_dependencies(test_unit_plugin_scanner score_test_fake_puppet)
-target_compile_definitions(test_unit_plugin_scanner PRIVATE
-  SCORE_FAKE_PUPPET="$<TARGET_FILE:score_test_fake_puppet>")
+if(SCORE_HAS_FAKE_PUPPET)
+  score_add_test(test_unit_plugin_scanner
+    SOURCES PluginScannerTest.cpp
+    PLUGINS score_plugin_media)
+  add_dependencies(test_unit_plugin_scanner score_test_fake_puppet)
+  target_compile_definitions(test_unit_plugin_scanner PRIVATE
+    SCORE_FAKE_PUPPET="$<TARGET_FILE:score_test_fake_puppet>")
+endif()
 
 # Per-backend scan-reply parsing + cache healing.
 if(TARGET score_plugin_vst)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -10,6 +10,12 @@ score_add_test(test_unit_address
 score_add_test(test_unit_project_files
   SOURCES ProjectFilesTest.cpp)
 
+# The document-free score::locateFilePath(QString) overload: <LIBRARY>: out of
+# QSettings, with no roots. A different function from the ProjectFiles.hpp one
+# above despite the shared name.
+score_add_test(test_unit_locate_file_path
+  SOURCES LocateFilePathTest.cpp)
+
 # Zip writing (miniz, vendored in 3rdparty/zipdownloader) behind score's API.
 score_add_test(test_unit_zip
   SOURCES ZipTest.cpp)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -214,6 +214,12 @@ if(TARGET score_plugin_faust)
     PLUGINS score_plugin_faust)
   target_include_directories(test_unit_faust_dsp PRIVATE
     "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-faust")
+  # score_plugin_faust keeps FAUST_INCLUDE_DIR PRIVATE, so linking it does not
+  # bring the faust headers along; FaustDspTest.cpp reaches libossia headers
+  # that include <faust/gui/UI.h> directly. The find_package branch below
+  # already does this.
+  target_include_directories(test_unit_faust_dsp SYSTEM PRIVATE
+    ${FAUST_INCLUDE_DIR})
 else()
   find_package(Faust QUIET)
   if(FAUST_FOUND AND TARGET score_lib_process)

--- a/tests/unit/LocateFilePathTest.cpp
+++ b/tests/unit/LocateFilePathTest.cpp
@@ -1,0 +1,103 @@
+// The document-free score::locateFilePath(const QString&) overload added by
+// c976ba6c98.
+//
+// tests/unit/ProjectFilesTest.cpp tests a DIFFERENT function of the same name
+// -- locateFilePath(name, PathRoots) from ProjectFiles.hpp. This one takes no
+// roots at all: it resolves <LIBRARY>: out of QSettings and is what
+// Score.readFile reaches when no document is open.
+
+#include <score/tools/FilePath.hpp>
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+namespace
+{
+//! Catch2 has no QString stringifier, and "{?} == {?}" says nothing about
+//! which path came out wrong.
+std::string located(const QString& in)
+{
+  return score::locateFilePath(in).toStdString();
+}
+
+std::string str(const QString& s)
+{
+  return s.toStdString();
+}
+
+struct hermetic_settings
+{
+  QTemporaryDir dir;
+
+  hermetic_settings()
+  {
+    REQUIRE(dir.isValid());
+    QCoreApplication::setOrganizationName("ossia");
+    QCoreApplication::setOrganizationDomain("ossia.io");
+    QCoreApplication::setApplicationName("score-test-locatefilepath");
+    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, dir.path());
+    QSettings::setDefaultFormat(QSettings::IniFormat);
+  }
+
+  void setRoot(const QString& root)
+  {
+    QSettings s;
+    s.setValue("Library/RootPath", root);
+    s.sync();
+  }
+};
+}
+
+TEST_CASE("<LIBRARY>: resolves against the library root", "[unit][filepath]")
+{
+  hermetic_settings cfg;
+  QTemporaryDir lib;
+  REQUIRE(lib.isValid());
+  cfg.setRoot(lib.path());
+
+  CHECK(located("<LIBRARY>:/Presets/x.fs") == str(lib.path() + "/Presets/x.fs"));
+
+  // Resolution does not depend on the file existing: this is path math, and
+  // the caller reports the failure.
+  CHECK(located("<LIBRARY>:/nope.js") == str(lib.path() + "/nope.js"));
+}
+
+TEST_CASE("a path with no prefix is handed back untouched", "[unit][filepath]")
+{
+  hermetic_settings cfg;
+  cfg.setRoot(QStringLiteral("/some/library"));
+
+  CHECK(located("/absolute/x.fs") == "/absolute/x.fs");
+  // Not made absolute either -- the overload only knows about <LIBRARY>:.
+  CHECK(located("relative/x.fs") == "relative/x.fs");
+  CHECK(located(QString{}).empty());
+}
+
+TEST_CASE("the other prefixes need a document and are left alone", "[unit][filepath]")
+{
+  hermetic_settings cfg;
+  cfg.setRoot(QStringLiteral("/some/library"));
+
+  // <PROJECT>: is resolved by the DocumentContext overload; without one there
+  // is nothing to resolve it against, so it must survive unchanged rather than
+  // be silently mangled.
+  CHECK(located("<PROJECT>:/x.fs") == "<PROJECT>:/x.fs");
+}
+
+TEST_CASE("an unset library root leaves an absolute remainder", "[unit][filepath]")
+{
+  hermetic_settings cfg;
+  {
+    QSettings s;
+    s.remove("Library/RootPath");
+    s.sync();
+  }
+
+  CHECK(located("<LIBRARY>:/x.fs") == "/x.fs");
+}


### PR DESCRIPTION
Groundwork so that rendering can be tested at all, on `master`, ahead of the gfx PR stack.

Today no pixel test can run below #2120: `WindowDevice::grabTo` and the `golden-render/` harness enter at `pland/scene`, `OffscreenDevice` at `planc/gfx-infra`. That makes 47 commits of the stack build-only, and a rendering regression in #2160 or #2119 impossible to bisect. This PR puts the minimum on master.

**Silent failures fixed** — each of these turned a broken run into a green one:

- `js: report --script failures instead of exiting 0` — a script that threw ran to completion and exited 0. Every result it produced looked like a success. This is what hid the three bugs below for a full session.
- `app: keep the platform the caller asked for when there is no display` — `main.cpp` overwrote an explicit `QT_QPA_PLATFORM` with `eglfs` whenever no X11/Wayland display was found.
- `app: treat offscreen as a rendering session, like eglfs and vkkhrdisplay` — `runningUnderAnUISession()` did not list `offscreen`, so `--no-gui` under it took the no-UI path. `--no-gui` means "do not open score's main widget UI", not "do not render".

**Vulkan under a null platform integration** — `QVulkanInstancePrivate::ensureVulkan()` dereferences `QGuiApplicationPrivate::platform_integration` with no null check, so building a Vulkan QRhi before/without a platform integration segfaults (confirmed under gdb: `mov (%rdi),%rax`, `rdi=0`).

- `gfx: do not return a Vulkan instance when creation failed`
- `gfx: don't create a Vulkan QRhi without an instance`
- `gfx: don't return a half-initialized render state when QRhi::create fails`

**Test entry points**

- `gfx: make headless frame capture available from master` — `grabTo` / `grabFrame` on the Window device.
- `gfx: render a fixed number of frames on demand` — `GfxContext::renderFrames(int)`, the hook a deterministic frame clock needs.

Known gap, tracked separately: the window path of `grabTo` uses `screen()->grabWindow()`, which on X11 reads the framebuffer at the window's geometry rather than the window's own buffer — it captures whatever is on top. Golden images must come from the offscreen readback instead. That is why `OffscreenDevice` is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZgzE8JjWvHDtaVUhxpLE
