### PR TITLE
ci: make the FreeBSD job actually build, and fail when it does not

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -52,8 +52,10 @@ jobs:
           echo "=============== FreeBSD End install ====================="
 
         run: |
+          set -e
           echo "=============== FreeBSD Start Deps ====================="
           ./ci/common.deps.sh && echo "=============== FreeBSD Deps Success ====================="
           echo "=============== FreeBSD Start Build ====================="
-          ./ci/freebsd.build.sh && echo "=============== FreeBSD Build Success ====================="
+          ./ci/freebsd.build.sh
+          echo "=============== FreeBSD Build Success ====================="
           echo "=============== FreeBSD End Build ====================="

--- a/ci/freebsd.build.sh
+++ b/ci/freebsd.build.sh
@@ -1,4 +1,10 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+# The options have to be set here, not on the shebang line: env(1) does not
+# split its first operand, so "#!/usr/bin/env bash -e" looks for a program
+# literally named "bash -e" and exits 127 before running a single line.
+# Note that bash is /usr/local/bin/bash on FreeBSD, hence env rather than the
+# "#!/bin/bash -e" the other ci/*.build.sh use.
+set -e
 
 export SCORE_DIR=$PWD
 


### PR DESCRIPTION
The FreeBSD job has been green since it was added, and it has never compiled score even once.

## What is broken

`ci/freebsd.build.sh` started with:

```sh
#!/usr/bin/env bash -e
```

`env(1)` does not split its first operand, so this asks for a program literally named `bash -e`. On FreeBSD that is:

```
env: bash -e: No such file or directory
```

and the script exits 127 without running a single line. It is not a FreeBSD quirk either — GNU `env` says the same thing (`use -[v]S to pass options in shebang lines`). `#!/bin/bash -e`, which every other `ci/*.build.sh` uses, is not an option here: on FreeBSD bash is `/usr/local/bin/bash`.

Here is the whole build step of [run 31948475911](https://github.com/ossia/score/actions/runs/31948475911) on master:

```
13:06:10.1976660Z =============== FreeBSD Deps Success =====================
13:06:10.1977851Z =============== FreeBSD Start Build =====================
13:06:10.2000273Z env: bash -e: No such file or directory
13:06:10.2001486Z =============== FreeBSD End Build =====================
```

Two milliseconds, and a green checkmark.

## Why CI did not notice

`.github/workflows/bsd.yml` ran the script as:

```sh
./ci/freebsd.build.sh && echo "=============== FreeBSD Build Success ====================="
echo "=============== FreeBSD End Build ====================="
```

The `&&` turns the failure into a skipped `echo`, and the step's exit status is that of the *last* command in the block — the unconditional `End Build` echo, which always succeeds. So no matter what the script does, the step is green.

Adding `set -e` to the block is not enough on its own: errexit is specified to ignore any command of an AND-OR list other than the last one, so `false && echo hi` does not stop an errexit shell. The `&&` has to go.

## The change

- `ci/freebsd.build.sh`: keep `env` (bash is not in `/bin` there), move the option into the script as `set -e`, with a comment so it does not get folded back into the shebang.
- `.github/workflows/bsd.yml`: `set -e` in the run block, and run the build script as a plain command instead of the left-hand side of an `&&`.

The deps line is deliberately left alone — #2202 rewrites it along with `ci/common.deps.sh`, and its version of this hunk is a superset of this one, so the two converge.

## How it was verified

In a FreeBSD 15.0 VM built from the same `vmactions/freebsd-builder` image the CI uses, with the packages this workflow installs. The workflow's build block was replayed against a `cmake` stub that fails on `--build`:

| | script | step exit status |
| --- | --- | --- |
| master, build fails | `env: bash -e: No such file or directory` | **0** (green) |
| this PR, build fails | `FAKE CMAKE: build FAILED` | **1** (red) |
| this PR, build succeeds | `Build Success` | 0 (green) |

and running master's script by hand on FreeBSD gives exit status 127.

Then the real thing: `./ci/freebsd.build.sh` on a full checkout with all the add-ons, which now runs and reports what it finds.

## What it finds

Once the script actually runs, master does not compile on FreeBSD. One add-on is responsible: `score-addon-sysinfo` vendors [lfreist/hwinfo](https://github.com/lfreist/hwinfo), whose "unix" backend is really the Linux one — it needs `<netpacket/packet.h>` and `_SC_AVPHYS_PAGES`, neither of which FreeBSD has, and it reads `/proc` and `/sys` throughout. That is fixed in [ossia/score-addon-sysinfo#3](https://github.com/ossia/score-addon-sysinfo/pull/3), which skips the add-on on the BSDs and explains why a real BSD backend belongs upstream rather than in a shim.

**Merge that one first.** `ci/common.deps.sh` clones the add-on from its default branch, so as soon as it lands the FreeBSD job here goes green on its own — and with this PR, green will finally mean something. Merged the other way round, this PR turns the job red until the add-on fix follows.

With the add-on out of the way, the whole of master compiles and links on FreeBSD 15.0.
