### PR TITLE
Plugin scanning rework: token/ephemeral-port protocol, shared scanner, cache healing, per-format settings

### DIFF
--- a/src/clappuppet/clappuppet.cpp
+++ b/src/clappuppet/clappuppet.cpp
@@ -204,7 +204,7 @@ int main(int argc, char** argv)
   init_invisible_window();
 
   return score::puppet::puppet_main(
-      argc, argv, 37589, "clappuppet", true,
+      argc, argv, 37589, "clappuppet", true, 30,
       [](const std::string& path, int id, const std::string& token) {
     return load_clap(path, id, token);
       });

--- a/src/clappuppet/clappuppet.cpp
+++ b/src/clappuppet/clappuppet.cpp
@@ -1,5 +1,4 @@
-#include <ossia/detail/fmt.hpp>
-#include <ossia/network/sockets/websocket.hpp>
+#include <score/tools/PuppetClient.hpp>
 
 #include <clap/all.h>
 
@@ -43,15 +42,22 @@ void throw_exception(std::exception const& e, boost::source_location const& loc)
 #include <dlfcn.h>
 #endif
 
-std::string load_clap(const std::string& path, int id)
+std::string load_clap(const std::string& path, int id, const std::string& token)
 {
+  using score::puppet::json_escape;
+  auto error_json = [&](std::string err) {
+    return fmt::format(
+        R"_({{"Path":"{}","Request":{},"Token":"{}","Error":"{}"}})_",
+        json_escape(path), id, json_escape(token), json_escape(err));
+  };
+
   try
   {
     const bool isFile = std::filesystem::exists(path);
     if(!isFile)
     {
       std::cerr << "Invalid path: " << path << std::endl;
-      return {};
+      return error_json("Invalid path");
     }
 
     // Load the plugin library
@@ -60,16 +66,18 @@ std::string load_clap(const std::string& path, int id)
     if(!handle)
     {
       std::cerr << "Failed to load library: " << path << std::endl;
-      return {};
+      return error_json("Failed to load library");
     }
-    
+
     auto entry_fn = (const clap_plugin_entry_t*)GetProcAddress(handle, "clap_entry");
 #else
     void* handle = dlopen(path.c_str(), RTLD_LAZY);
     if(!handle)
     {
-      std::cerr << "Failed to load library: " << path << " - " << dlerror() << std::endl;
-      return {};
+      const char* err = dlerror();
+      std::cerr << "Failed to load library: " << path << " - " << (err ? err : "")
+                << std::endl;
+      return error_json(std::string{"Failed to load library: "} + (err ? err : ""));
     }
     
     auto entry_fn = (const clap_plugin_entry_t*)dlsym(handle, "clap_entry");
@@ -83,7 +91,7 @@ std::string load_clap(const std::string& path, int id)
 #else
       dlclose(handle);
 #endif
-      return {};
+      return error_json("No clap_entry found");
     }
 
     if(!entry_fn->init(path.c_str()))
@@ -94,7 +102,7 @@ std::string load_clap(const std::string& path, int id)
 #else
       dlclose(handle);
 #endif
-      return {};
+      return error_json("Failed to initialize CLAP plugin");
     }
 
     auto factory = (const clap_plugin_factory_t*)entry_fn->get_factory(CLAP_PLUGIN_FACTORY_ID);
@@ -107,18 +115,20 @@ std::string load_clap(const std::string& path, int id)
 #else
       dlclose(handle);
 #endif
-      return {};
+      return error_json("No plugin factory found");
     }
 
     std::string root = fmt::format(
         R"_({{
 "Path":"{}",
 "Request":{},
+"Token":"{}",
 "Plugins":[
 )_",
-        path, id);
+        json_escape(path), id, json_escape(token));
 
     uint32_t plugin_count = factory->get_plugin_count(factory);
+    bool first_plugin = true;
     for(uint32_t i = 0; i < plugin_count; ++i)
     {
       const clap_plugin_descriptor_t* desc = factory->get_plugin_descriptor(factory, i);
@@ -132,7 +142,7 @@ std::string load_clap(const std::string& path, int id)
         for(const char* const* feature = desc->features; *feature; ++feature)
         {
           if(!first) features_str += ",";
-          features_str += fmt::format("\"{}\"", *feature);
+          features_str += fmt::format("\"{}\"", json_escape(*feature));
           first = false;
         }
       }
@@ -150,19 +160,20 @@ std::string load_clap(const std::string& path, int id)
 "Description":"{}",
 "Features":{}
 }})_",
-          desc->id ? desc->id : "",
-          desc->name ? desc->name : "",
-          desc->vendor ? desc->vendor : "",
-          desc->version ? desc->version : "",
-          desc->url ? desc->url : "",
-          desc->manual_url ? desc->manual_url : "",
-          desc->support_url ? desc->support_url : "",
-          desc->description ? desc->description : "",
+          json_escape(desc->id ? desc->id : ""),
+          json_escape(desc->name ? desc->name : ""),
+          json_escape(desc->vendor ? desc->vendor : ""),
+          json_escape(desc->version ? desc->version : ""),
+          json_escape(desc->url ? desc->url : ""),
+          json_escape(desc->manual_url ? desc->manual_url : ""),
+          json_escape(desc->support_url ? desc->support_url : ""),
+          json_escape(desc->description ? desc->description : ""),
           features_str);
 
-      if(i > 0)
+      if(!first_plugin)
         root += ",\n";
       root += plugin_json;
+      first_plugin = false;
     }
 
     root += "]\n}";
@@ -179,86 +190,24 @@ std::string load_clap(const std::string& path, int id)
   catch(const std::exception& e)
   {
     std::cerr << "Exception: " << e.what() << std::endl;
+    return error_json(std::string{"Exception: "} + e.what());
   }
-  return {};
+  catch(...)
+  {
+    return error_json("Unknown exception");
+  }
 }
-
-struct app
-{
-
-  boost::asio::io_context ctx;
-  ossia::net::websocket_simple_client socket{{.url = "ws://127.0.0.1:37589"}, ctx};
-
-  bool socket_ready{}, clap_ready{};
-  std::string json_ret;
-
-  app()
-  {
-    socket.on_open.connect<&app::on_open>(*this);
-    socket.on_fail.connect<&app::on_error>(*this);
-    socket.on_close.connect<&app::on_error>(*this);
-
-    socket.websocket_client::connect("ws://127.0.0.1:37589");
-  }
-
-  void on_ready()
-  {
-    if(socket_ready && clap_ready)
-    {
-      socket.send_message(json_ret);
-      socket.close();
-      boost::asio::post(ctx, [&] { exit(json_ret.empty() ? 1 : 0); });
-    }
-  }
-
-  void on_error()
-  {
-    std::cerr << "Socket error\n";
-    exit(1);
-  }
-
-  void load(const std::string& clap, int id)
-  {
-    json_ret = load_clap(clap, id);
-    std::cout << json_ret << "\n";
-    clap_ready = true;
-    on_ready();
-  }
-
-  void on_open()
-  {
-    socket_ready = true;
-    on_ready();
-  }
-};
 
 void init_invisible_window();
 int main(int argc, char** argv)
 {
-  if(argc <= 1)
-    return 1;
-
   init_invisible_window();
 
-  int id = 0;
-  if(argc > 2)
-    id = std::atoi(argv[2]);
-
-  app a;
-
-  boost::asio::post(a.ctx, [&] { a.load(argv[1], id); });
-
-  boost::asio::steady_timer tm{a.ctx};
-  tm.expires_after(std::chrono::seconds(10));
-  tm.async_wait([](auto ec) {
-    std::cerr << "Timeout\n";
-    exit(1);
-  });
-
-  a.ctx.run();
-  a.ctx.restart();
-  a.ctx.run();
-  return a.json_ret.empty() ? 1 : 0;
+  return score::puppet::puppet_main(
+      argc, argv, 37589, "clappuppet", true,
+      [](const std::string& path, int id, const std::string& token) {
+    return load_clap(path, id, token);
+      });
 }
 
 #include <score/tools/WinMainToMain.hpp>

--- a/src/lib/score/tools/ElfInspector.hpp
+++ b/src/lib/score/tools/ElfInspector.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+// Minimal ELF reader: lists the DT_NEEDED sonames of a 64-bit ELF binary.
+// Header-only and dependency-free so that both the linuxcheck diagnostic
+// tool and the plug-in hosts (e.g. the LV2 UI loader, which must refuse
+// UIs linked against a different Qt major) can share it.
+//
+// Extracted from linuxcheck/diagnostics.hpp.
+
+#if defined(__linux__)
+
+#include <elf.h>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace score
+{
+class ElfInspector
+{
+public:
+  //! nullopt: not a readable / valid / 64-bit ELF file (as opposed to a
+  //! valid binary with an empty dependency list).
+  std::optional<std::vector<std::string>>
+  try_get_dt_needed(std::string_view filename)
+  {
+    std::vector<std::string> libraries;
+
+    m_file.open(std::string(filename), std::ios::binary);
+    if(!m_file)
+      return std::nullopt;
+
+    // Read ELF magic and class
+    unsigned char e_ident[EI_NIDENT];
+    m_file.read(reinterpret_cast<char*>(e_ident), EI_NIDENT);
+    if(!m_file)
+      return std::nullopt;
+
+    if(e_ident[EI_MAG0] != ELFMAG0 || e_ident[EI_MAG1] != ELFMAG1
+       || e_ident[EI_MAG2] != ELFMAG2 || e_ident[EI_MAG3] != ELFMAG3)
+      return std::nullopt;
+
+    if(e_ident[EI_CLASS] != ELFCLASS64)
+      return std::nullopt;
+
+    try
+    {
+      process_elf64(libraries);
+    }
+    catch(...)
+    {
+      // Truncated / corrupt file
+      return std::nullopt;
+    }
+
+    return libraries;
+  }
+
+  //! linuxcheck-compatible interface: failures print to stderr and yield an
+  //! empty list.
+  std::vector<std::string> get_dt_needed(std::string_view filename)
+  {
+    if(auto res = try_get_dt_needed(filename))
+      return *std::move(res);
+
+    std::cerr << filename << " is not a readable, valid 64-bit ELF file\n";
+    return {};
+  }
+
+private:
+  template <typename T>
+  T read_at(std::streampos pos)
+  {
+    T value;
+    m_file.seekg(pos);
+    m_file.read(reinterpret_cast<char*>(&value), sizeof(T));
+    if(!m_file)
+      throw std::runtime_error("Failed to read from file");
+    return value;
+  }
+
+  std::string read_string_at(std::streampos pos)
+  {
+    m_file.seekg(pos);
+    std::string result;
+    char c;
+    while(m_file.get(c) && c != '\0')
+      result += c;
+    return result;
+  }
+
+  void process_elf64(std::vector<std::string>& libraries)
+  {
+    // Read ELF64 header
+    Elf64_Ehdr ehdr = read_at<Elf64_Ehdr>(0);
+
+    // Read program headers
+    auto phdrs = std::unique_ptr<Elf64_Phdr[]>(new Elf64_Phdr[ehdr.e_phnum]);
+    m_file.seekg(ehdr.e_phoff);
+    m_file.read(reinterpret_cast<char*>(phdrs.get()), ehdr.e_phnum * sizeof(Elf64_Phdr));
+    if(!m_file)
+      throw std::runtime_error("Failed to read program headers");
+
+    Elf64_Phdr* dynamic_phdr = nullptr;
+    for(int i = 0; i < ehdr.e_phnum; ++i)
+    {
+      if(phdrs[i].p_type == PT_DYNAMIC)
+      {
+        dynamic_phdr = &phdrs[i];
+        break;
+      }
+    }
+
+    if(!dynamic_phdr)
+      return; // Statically linked or no dynamic section
+
+    // Read dynamic section
+    std::vector<Elf64_Dyn> dyns(dynamic_phdr->p_filesz / sizeof(Elf64_Dyn));
+    m_file.seekg(dynamic_phdr->p_offset);
+    m_file.read(reinterpret_cast<char*>(dyns.data()), dynamic_phdr->p_filesz);
+    if(!m_file)
+      throw std::runtime_error("Failed to read dynamic section");
+
+    // Find string table address
+    Elf64_Addr strtab_addr = 0;
+    for(const auto& dyn : dyns)
+    {
+      if(dyn.d_tag == DT_STRTAB)
+      {
+        strtab_addr = dyn.d_un.d_ptr;
+        break;
+      }
+    }
+
+    if(!strtab_addr)
+      return;
+
+    // Convert virtual address to file offset
+    Elf64_Off strtab_offset = 0;
+    for(int i = 0; i < ehdr.e_phnum; ++i)
+    {
+      if(phdrs[i].p_type == PT_LOAD && strtab_addr >= phdrs[i].p_vaddr
+         && strtab_addr < phdrs[i].p_vaddr + phdrs[i].p_filesz)
+      {
+        strtab_offset = strtab_addr - phdrs[i].p_vaddr + phdrs[i].p_offset;
+        break;
+      }
+    }
+
+    if(!strtab_offset)
+      return;
+
+    // Extract DT_NEEDED entries
+    for(const auto& dyn : dyns)
+    {
+      if(dyn.d_tag == DT_NEEDED)
+      {
+        libraries.push_back(read_string_at(strtab_offset + dyn.d_un.d_val));
+      }
+    }
+  }
+
+  std::ifstream m_file;
+};
+}
+
+#endif

--- a/src/lib/score/tools/PuppetClient.hpp
+++ b/src/lib/score/tools/PuppetClient.hpp
@@ -99,10 +99,21 @@ struct client
 //! Common main() implementation: parse args, run scan_fn(path, id, token),
 //! ship the resulting JSON. scan_fn returns the full reply object as a
 //! string; an empty string means the plug-in could not be scanned.
+//!
+//! echo_stdout only applies to manual runs (no session token): when spawned
+//! by a host the parent never drains our stdout pipe, and a large reply
+//! (lsp-plugins.clap: ~100KB for ~200 plug-ins) overflows the 64KB pipe
+//! buffer and can stall the scan.
+//!
+//! watchdog_seconds guards against a host that never becomes reachable; it
+//! should match the host-side scan timeout. It must never abort a scan that
+//! already produced a payload: the scan itself runs synchronously in a
+//! posted handler (the timer cannot fire mid-scan), and once the payload is
+//! on its way out only the 500ms flush timer remains.
 template <typename ScanFn>
 int puppet_main(
     int argc, char** argv, int default_port, const char* name, bool echo_stdout,
-    ScanFn&& scan_fn)
+    int watchdog_seconds, ScanFn&& scan_fn)
 {
   const auto args = parse_arguments(argc, argv, default_port);
   if(!args.valid)
@@ -110,16 +121,21 @@ int puppet_main(
 
   client c{args.port};
   c.log_name = name;
-  c.echo_stdout = echo_stdout;
+  c.echo_stdout = echo_stdout && args.token.empty();
 
   boost::asio::post(c.ctx, [&] {
     c.set_payload(scan_fn(args.path, args.request_id, args.token));
   });
 
   boost::asio::steady_timer watchdog{c.ctx};
-  watchdog.expires_after(std::chrono::seconds(10));
+  watchdog.expires_after(std::chrono::seconds(watchdog_seconds));
   watchdog.async_wait([&](auto ec) {
     if(ec)
+      return;
+    // The send is already in flight (a scan longer than the watchdog leaves
+    // both the expired timer and the socket ready; asio dispatches the
+    // socket first): let the flush timer finish the exit instead
+    if(c.socket_ready && c.payload_ready)
       return;
     std::fprintf(stderr, "[%s] timeout\n", name);
     std::_Exit(1);

--- a/src/lib/score/tools/PuppetClient.hpp
+++ b/src/lib/score/tools/PuppetClient.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+// Shared WebSocket client + main-loop boilerplate for the plug-in scanner
+// puppets. Header-only; must only be included from the puppet executables
+// (pulls in asio / ossia websockets).
+//
+// Behaviour (aligned on the battle-tested lv2puppet implementation):
+//  * connect to ws://127.0.0.1:<port>, send the payload once both the
+//    socket and the scan are ready;
+//  * wait 500ms before exiting so the (async) send actually flushes,
+//    then _Exit: websocketpp/asio destructors can throw from internals
+//    when the server closes the connection first, which would turn a
+//    perfectly successful scan into a non-zero exit;
+//  * a watchdog kills the process if the socket never becomes ready.
+
+#include <score/tools/PuppetJson.hpp>
+
+#include <ossia/detail/fmt.hpp>
+#include <ossia/network/sockets/websocket.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+namespace score::puppet
+{
+struct client
+{
+  boost::asio::io_context ctx;
+  ossia::net::websocket_simple_client socket;
+
+  bool socket_ready{}, payload_ready{};
+  std::string payload;
+  std::string log_name;
+  bool echo_stdout{};
+
+  explicit client(int port)
+      : socket{{.url = fmt::format("ws://127.0.0.1:{}", port)}, ctx}
+  {
+    socket.on_open.connect<&client::on_open>(*this);
+    socket.on_fail.connect<&client::on_error>(*this);
+    socket.on_close.connect<&client::on_error>(*this);
+
+    socket.websocket_client::connect(fmt::format("ws://127.0.0.1:{}", port));
+  }
+
+  void set_payload(std::string json)
+  {
+    payload = std::move(json);
+    if(echo_stdout && !payload.empty())
+    {
+      std::fwrite(payload.data(), 1, payload.size(), stdout);
+      std::fwrite("\n", 1, 1, stdout);
+      std::fflush(stdout);
+    }
+    payload_ready = true;
+    on_ready();
+  }
+
+  void on_ready()
+  {
+    if(socket_ready && payload_ready)
+    {
+      try
+      {
+        socket.send_message(payload);
+      }
+      catch(...)
+      {
+        on_error();
+        return;
+      }
+
+      // Flush delay: send_message is async; large payloads (~MB) need time
+      auto delay = std::make_shared<boost::asio::steady_timer>(ctx);
+      delay->expires_after(std::chrono::milliseconds(500));
+      delay->async_wait(
+          [this, delay](auto) { std::_Exit(payload.empty() ? 1 : 0); });
+    }
+  }
+
+  void on_error()
+  {
+    auto line = fmt::format("[{}] socket error\n", log_name);
+    std::fwrite(line.data(), 1, line.size(), stderr);
+    std::fflush(stderr);
+    std::_Exit(1);
+  }
+
+  void on_open()
+  {
+    socket_ready = true;
+    on_ready();
+  }
+};
+
+//! Common main() implementation: parse args, run scan_fn(path, id, token),
+//! ship the resulting JSON. scan_fn returns the full reply object as a
+//! string; an empty string means the plug-in could not be scanned.
+template <typename ScanFn>
+int puppet_main(
+    int argc, char** argv, int default_port, const char* name, bool echo_stdout,
+    ScanFn&& scan_fn)
+{
+  const auto args = parse_arguments(argc, argv, default_port);
+  if(!args.valid)
+    return 1;
+
+  client c{args.port};
+  c.log_name = name;
+  c.echo_stdout = echo_stdout;
+
+  boost::asio::post(c.ctx, [&] {
+    c.set_payload(scan_fn(args.path, args.request_id, args.token));
+  });
+
+  boost::asio::steady_timer watchdog{c.ctx};
+  watchdog.expires_after(std::chrono::seconds(10));
+  watchdog.async_wait([&](auto ec) {
+    if(ec)
+      return;
+    std::fprintf(stderr, "[%s] timeout\n", name);
+    std::_Exit(1);
+  });
+
+  c.ctx.run();
+  c.ctx.restart();
+  c.ctx.run();
+  return c.payload.empty() ? 1 : 0;
+}
+}

--- a/src/lib/score/tools/PuppetJson.hpp
+++ b/src/lib/score/tools/PuppetJson.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+// Shared helpers for the out-of-process plug-in scanners ("puppets"):
+// JSON string escaping and command-line parsing. Header-only, no Qt —
+// the puppets only link ossia + fmt.
+//
+// Scanner protocol: a puppet is spawned as
+//     ossia-score-xxxpuppet <plugin-path> [request-id] [port] [token]
+// and replies on ws://127.0.0.1:<port> with a single JSON object that
+// echoes back "Request": <id> and "Token": "<token>". The host drops
+// any reply whose token does not match the scan session, so replies
+// from another score instance's puppets (or stale puppets from a
+// previous scan) can never pollute the plug-in database.
+// [port]/[token] are optional so that a puppet can still be run by hand
+// against the legacy fixed port for debugging.
+
+#include <charconv>
+#include <string>
+#include <string_view>
+
+namespace score::puppet
+{
+//! Escape a string for inclusion inside a JSON string literal.
+//! Plug-in metadata (names, vendors, descriptions) routinely contains
+//! quotes; unescaped, one such plug-in silently breaks its whole reply.
+inline std::string json_escape(std::string_view s)
+{
+  static constexpr char hex[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(s.size() + 8);
+  for(unsigned char c : s)
+  {
+    switch(c)
+    {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\b':
+        out += "\\b";
+        break;
+      case '\f':
+        out += "\\f";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if(c < 0x20)
+        {
+          out += "\\u00";
+          out += hex[(c >> 4) & 0xf];
+          out += hex[c & 0xf];
+        }
+        else
+        {
+          out += (char)c;
+        }
+        break;
+    }
+  }
+  return out;
+}
+
+inline std::string json_escape(const char* s)
+{
+  return s ? json_escape(std::string_view{s}) : std::string{};
+}
+
+struct puppet_arguments
+{
+  std::string path;
+  int request_id{0};
+  int port{0};
+  std::string token;
+
+  bool valid{false};
+};
+
+//! Parse `puppet <path> [id] [port] [token]`.
+//! Missing id / port fall back to 0 / default_port; missing token stays
+//! empty (accepted by hand-run debugging, rejected by a token-checking host).
+inline puppet_arguments
+parse_arguments(int argc, char** argv, int default_port) noexcept
+{
+  puppet_arguments res;
+  res.port = default_port;
+  if(argc <= 1)
+    return res;
+
+  res.path = argv[1];
+  if(res.path.empty())
+    return res;
+
+  auto to_int = [](const char* str, int fallback) {
+    int value{};
+    std::string_view sv{str};
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), value);
+    if(ec != std::errc{} || ptr != sv.data() + sv.size())
+      return fallback;
+    return value;
+  };
+
+  if(argc > 2)
+    res.request_id = to_int(argv[2], 0);
+  if(argc > 3)
+  {
+    if(int p = to_int(argv[3], 0); p > 0 && p <= 65535)
+      res.port = p;
+  }
+  if(argc > 4)
+    res.token = argv[4];
+
+  res.valid = true;
+  return res;
+}
+}

--- a/src/lib/score/tools/PuppetJson.hpp
+++ b/src/lib/score/tools/PuppetJson.hpp
@@ -109,8 +109,10 @@ parse_arguments(int argc, char** argv, int default_port) noexcept
     return value;
   };
 
+  // -1 fallback: a malformed id must not masquerade as request 0 (the host
+  // drops replies for unknown ids)
   if(argc > 2)
-    res.request_id = to_int(argv[2], 0);
+    res.request_id = to_int(argv[2], -1);
   if(argc > 3)
   {
     if(int p = to_int(argv[3], 0); p > 0 && p <= 65535)

--- a/src/linuxcheck/CMakeLists.txt
+++ b/src/linuxcheck/CMakeLists.txt
@@ -23,6 +23,7 @@ target_compile_features(linuxcheck
 target_include_directories(linuxcheck
   PRIVATE
     "${X11_X11_INCLUDE_PATH}"
+    "${SCORE_SRC}/lib"
 )
 
 target_link_libraries(linuxcheck

--- a/src/linuxcheck/diagnostics.hpp
+++ b/src/linuxcheck/diagnostics.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <ossia/detail/fmt.hpp>
 
+#include <score/tools/ElfInspector.hpp>
+
 #include <boost/algorithm/string.hpp>
 
 #include <sys/types.h>
@@ -296,128 +298,9 @@ inline std::string_view suggest_package(std::string_view missing_item, Distro di
       return "";
   }
 }
-class ElfInspector
-{
-public:
-  std::vector<std::string> get_dt_needed(std::string_view filename)
-  {
-    std::vector<std::string> libraries;
-
-    m_file.open(filename.data(), std::ios::binary);
-    if(!m_file)
-    {
-      std::cerr << "Cannot open file: " << filename << "\n";
-      return libraries;
-    }
-
-    // Read ELF magic and class
-    unsigned char e_ident[EI_NIDENT];
-    m_file.read(reinterpret_cast<char*>(e_ident), EI_NIDENT);
-
-    if(e_ident[EI_MAG0] != ELFMAG0 || e_ident[EI_MAG1] != ELFMAG1
-       || e_ident[EI_MAG2] != ELFMAG2 || e_ident[EI_MAG3] != ELFMAG3)
-    {
-      std::cerr << filename << " is not a valid ELF file\n";
-      return libraries;
-    }
-
-    if(e_ident[EI_CLASS] != ELFCLASS64)
-    {
-      std::cerr << filename << " is not a valid 64-bit ELF file\n";
-      return libraries;
-    }
-
-    process_elf64(libraries);
-
-    return libraries;
-  }
-
-private:
-  template <typename T>
-  T read_at(std::streampos pos)
-  {
-    T value;
-    m_file.seekg(pos);
-    m_file.read(reinterpret_cast<char*>(&value), sizeof(T));
-    if(!m_file)
-      throw std::runtime_error("Failed to read from file");
-    return value;
-  }
-
-  std::string read_string_at(std::streampos pos)
-  {
-    m_file.seekg(pos);
-    std::string result;
-    char c;
-    while(m_file.get(c) && c != '\0')
-      result += c;
-    return result;
-  }
-
-  void process_elf64(std::vector<std::string>& libraries)
-  {
-    // Read ELF64 header
-    Elf64_Ehdr ehdr = read_at<Elf64_Ehdr>(0);
-
-    // Find dynamic section
-    auto phdrs = std::unique_ptr<Elf64_Phdr[]>(new Elf64_Phdr[ehdr.e_phnum]);
-    m_file.seekg(ehdr.e_phoff);
-    m_file.read(reinterpret_cast<char*>(phdrs.get()), ehdr.e_phnum * sizeof(Elf64_Phdr));
-
-    Elf64_Phdr* dynamic_phdr = nullptr;
-    for(int i = 0; i < ehdr.e_phnum; ++i)
-    {
-      if(phdrs[i].p_type == PT_DYNAMIC)
-      {
-        dynamic_phdr = &phdrs[i];
-        break;
-      }
-    }
-
-    if(!dynamic_phdr)
-      return;
-
-    // Read dynamic section
-    std::vector<Elf64_Dyn> dyns(dynamic_phdr->p_filesz / sizeof(Elf64_Dyn));
-    m_file.seekg(dynamic_phdr->p_offset);
-    m_file.read(reinterpret_cast<char*>(dyns.data()), dynamic_phdr->p_filesz);
-
-    // Find string table
-    Elf64_Addr strtab_addr = 0;
-    for(const auto& dyn : dyns)
-    {
-      if(dyn.d_tag == DT_STRTAB)
-      {
-        strtab_addr = dyn.d_un.d_ptr;
-        break;
-      }
-    }
-
-    // Convert virtual address to file offset
-    Elf64_Off strtab_offset = 0;
-    for(int i = 0; i < ehdr.e_phnum; ++i)
-    {
-      if(phdrs[i].p_type == PT_LOAD && strtab_addr >= phdrs[i].p_vaddr
-         && strtab_addr < phdrs[i].p_vaddr + phdrs[i].p_memsz)
-      {
-        strtab_offset = phdrs[i].p_offset + (strtab_addr - phdrs[i].p_vaddr);
-        break;
-      }
-    }
-
-    // Extract DT_NEEDED entries
-    for(const auto& dyn : dyns)
-    {
-      if(dyn.d_tag == DT_NEEDED)
-      {
-        std::string lib = read_string_at(strtab_offset + dyn.d_un.d_val);
-        libraries.push_back(lib);
-      }
-    }
-  }
-
-  std::ifstream m_file;
-};
+// ElfInspector moved to <score/tools/ElfInspector.hpp>, shared with the
+// plug-in hosts (LV2 UI Qt-major compatibility check).
+using score::ElfInspector;
 
 inline bool is_in_group(std::string_view group)
 {

--- a/src/lv2puppet/lv2puppet.cpp
+++ b/src/lv2puppet/lv2puppet.cpp
@@ -1,5 +1,4 @@
-#include <ossia/detail/fmt.hpp>
-#include <ossia/network/sockets/websocket.hpp>
+#include <score/tools/PuppetClient.hpp>
 
 #include <filesystem>
 #include <iostream>
@@ -47,48 +46,7 @@ void throw_exception(std::exception const& e, boost::source_location const& loc)
 
 namespace
 {
-std::string json_escape(const char* s)
-{
-  if(!s)
-    return {};
-  std::string out;
-  out.reserve(std::strlen(s) + 8);
-  for(const char* p = s; *p; ++p)
-  {
-    unsigned char c = static_cast<unsigned char>(*p);
-    switch(c)
-    {
-      case '"':
-        out += "\\\"";
-        break;
-      case '\\':
-        out += "\\\\";
-        break;
-      case '\b':
-        out += "\\b";
-        break;
-      case '\f':
-        out += "\\f";
-        break;
-      case '\n':
-        out += "\\n";
-        break;
-      case '\r':
-        out += "\\r";
-        break;
-      case '\t':
-        out += "\\t";
-        break;
-      default:
-        if(c < 0x20)
-          out += fmt::format("\\u{:04x}", (int)c);
-        else
-          out += (char)c;
-        break;
-    }
-  }
-  return out;
-}
+using score::puppet::json_escape;
 
 std::string node_string(const LilvNode* n)
 {
@@ -214,24 +172,27 @@ std::string make_bundle_uri(std::string path)
   return std::string{"file://"} + path + "/";
 }
 
-std::string scan_bundle(const std::string& bundle_path, int id)
+std::string
+scan_bundle(const std::string& bundle_path, int id, const std::string& token)
 {
+  auto error_json = [&](std::string_view err) {
+    return fmt::format(
+        R"_({{"Bundle":"{}","Request":{},"Token":"{}","Error":"{}","Plugins":[]}})_",
+        json_escape(bundle_path), id, json_escape(token), json_escape(err));
+  };
+
   try
   {
     if(!std::filesystem::exists(bundle_path))
     {
       std::cerr << "Invalid bundle path: " << bundle_path << std::endl;
-      return fmt::format(
-          R"_({{"Bundle":"{}","Request":{},"Error":"Bundle not found","Plugins":[]}})_",
-          json_escape(bundle_path.c_str()), id);
+      return error_json("Bundle not found");
     }
 
     LilvWorld* world = lilv_world_new();
     if(!world)
     {
-      return fmt::format(
-          R"_({{"Bundle":"{}","Request":{},"Error":"lilv_world_new failed","Plugins":[]}})_",
-          json_escape(bundle_path.c_str()), id);
+      return error_json("lilv_world_new failed");
     }
 
     const std::string bundle_uri_str = make_bundle_uri(bundle_path);
@@ -239,9 +200,7 @@ std::string scan_bundle(const std::string& bundle_path, int id)
     if(!bundle_uri)
     {
       lilv_world_free(world);
-      return fmt::format(
-          R"_({{"Bundle":"{}","Request":{},"Error":"Invalid bundle URI","Plugins":[]}})_",
-          json_escape(bundle_path.c_str()), id);
+      return error_json("Invalid bundle URI");
     }
 
     // Avoid lilv_world_load_all: one malformed manifest would crash this scan
@@ -432,122 +391,34 @@ std::string scan_bundle(const std::string& bundle_path, int id)
     lilv_world_free(world);
 
     return fmt::format(
-        R"_({{"Bundle":"{}","Request":{},"Plugins":[{}]}})_",
-        json_escape(bundle_path.c_str()), id, plugins_json);
+        R"_({{"Bundle":"{}","Request":{},"Token":"{}","Plugins":[{}]}})_",
+        json_escape(bundle_path), id, json_escape(token), plugins_json);
   }
   catch(const std::exception& e)
   {
     std::cerr << "Exception: " << e.what() << std::endl;
-    return fmt::format(
-        R"_({{"Bundle":"{}","Request":{},"Error":"Exception: {}","Plugins":[]}})_",
-        json_escape(bundle_path.c_str()), id, json_escape(e.what()));
+    return error_json(std::string{"Exception: "} + e.what());
   }
   catch(...)
   {
     std::cerr << "Unknown exception" << std::endl;
-    return fmt::format(
-        R"_({{"Bundle":"{}","Request":{},"Error":"Unknown exception","Plugins":[]}})_",
-        json_escape(bundle_path.c_str()), id);
+    return error_json("Unknown exception");
   }
 }
 
-struct app
-{
-  boost::asio::io_context ctx;
-  ossia::net::websocket_simple_client socket{
-      {.url = "ws://127.0.0.1:37590"}, ctx};
-
-  bool socket_ready{}, lv2_ready{};
-  std::string json_ret;
-
-  app()
-  {
-    socket.on_open.connect<&app::on_open>(*this);
-    socket.on_fail.connect<&app::on_error>(*this);
-    socket.on_close.connect<&app::on_error>(*this);
-
-    socket.websocket_client::connect("ws://127.0.0.1:37590");
-  }
-
-  std::string bundle_for_log;
-
-  // _Exit: websocketpp/asio destructors throw from internals past our handlers
-  void finish_success() { std::_Exit(json_ret.empty() ? 1 : 0); }
-
-  void on_ready()
-  {
-    if(socket_ready && lv2_ready)
-    {
-      try
-      {
-        socket.send_message(json_ret);
-      }
-      catch(...)
-      {
-        on_error();
-        return;
-      }
-
-      // Flush delay: send_message is async; large payloads (~MB) need time
-      auto delay = std::make_shared<boost::asio::steady_timer>(ctx);
-      delay->expires_after(std::chrono::milliseconds(500));
-      delay->async_wait([this, delay](auto) { finish_success(); });
-    }
-  }
-
-  void on_error()
-  {
-    auto line = fmt::format("[lv2puppet {}] socket error\n", bundle_for_log);
-    std::fwrite(line.data(), 1, line.size(), stderr);
-    std::fflush(stderr);
-    std::_Exit(1);
-  }
-
-  void load(const std::string& bundle, int id)
-  {
-    auto pos = bundle.find_last_of('/');
-    bundle_for_log = (pos == std::string::npos) ? bundle : bundle.substr(pos + 1);
-    json_ret = scan_bundle(bundle, id);
-    // No stdout echo: parent pipe is never drained; large JSON would block
-    lv2_ready = true;
-    on_ready();
-  }
-
-  void on_open()
-  {
-    socket_ready = true;
-    on_ready();
-  }
-};
 }
 
 void init_invisible_window();
 int main(int argc, char** argv)
 {
-  if(argc <= 1)
-    return 1;
-
   init_invisible_window();
 
-  int id = 0;
-  if(argc > 2)
-    id = std::atoi(argv[2]);
-
-  app a;
-
-  boost::asio::post(a.ctx, [&] { a.load(argv[1], id); });
-
-  boost::asio::steady_timer tm{a.ctx};
-  tm.expires_after(std::chrono::seconds(10));
-  tm.async_wait([](auto ec) {
-    std::cerr << "Timeout\n";
-    exit(1);
-  });
-
-  a.ctx.run();
-  a.ctx.restart();
-  a.ctx.run();
-  return a.json_ret.empty() ? 1 : 0;
+  // No stdout echo: parent pipe is never drained; large JSON would block
+  return score::puppet::puppet_main(
+      argc, argv, 37590, "lv2puppet", false,
+      [](const std::string& bundle, int id, const std::string& token) {
+    return scan_bundle(bundle, id, token);
+      });
 }
 
 #include <score/tools/WinMainToMain.hpp>

--- a/src/lv2puppet/lv2puppet.cpp
+++ b/src/lv2puppet/lv2puppet.cpp
@@ -415,7 +415,7 @@ int main(int argc, char** argv)
 
   // No stdout echo: parent pipe is never drained; large JSON would block
   return score::puppet::puppet_main(
-      argc, argv, 37590, "lv2puppet", false,
+      argc, argv, 37590, "lv2puppet", false, 60,
       [](const std::string& bundle, int id, const std::string& token) {
     return scan_bundle(bundle, id, token);
       });

--- a/src/plugins/score-plugin-clap/CMakeLists.txt
+++ b/src/plugins/score-plugin-clap/CMakeLists.txt
@@ -5,6 +5,7 @@ score_common_setup()
 # Files & main target
 set(HDRS
   Clap/ApplicationPlugin.hpp
+  Clap/Settings.hpp
   Clap/EffectModel.hpp
   Clap/Executor.hpp
   Clap/Library.hpp
@@ -15,6 +16,7 @@ set(HDRS
 
 set(SRCS
   Clap/ApplicationPlugin.cpp
+  Clap/Settings.cpp
   Clap/EffectModel.cpp
   Clap/Executor.cpp
   Clap/Library.cpp

--- a/src/plugins/score-plugin-clap/CMakeLists.txt
+++ b/src/plugins/score-plugin-clap/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HDRS
   Clap/ApplicationPlugin.hpp
   Clap/Settings.hpp
   Clap/EffectModel.hpp
+  Clap/Transport.hpp
   Clap/Executor.hpp
   Clap/Library.hpp
   Clap/Window.hpp

--- a/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
@@ -1,34 +1,28 @@
 #include "ApplicationPlugin.hpp"
 
+#include <Media/AudioPluginCache.hpp>
+#include <Media/Effect/Settings/Model.hpp>
+#include <Media/PluginScanner.hpp>
+
 #include <score/serialization/DataStreamVisitor.hpp>
 #include <score/tools/Bind.hpp>
+
+#include <ossia/detail/hash_map.hpp>
 
 #include <QApplication>
 #include <QDir>
 #include <QDirIterator>
+#include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QProcess>
 #include <QSettings>
 #include <QStandardPaths>
-#include <QThread>
 #include <QTimer>
-#include <QWebSocket>
 
 #include <clap/all.h>
 
 #include <wobjectimpl.h>
-
-#if defined(__APPLE__)
-#include <CoreFoundation/CoreFoundation.h>
-#endif
-
-#if defined(_WIN32)
-#include <windows.h>
-#else
-#include <dlfcn.h>
-#endif
 
 W_OBJECT_IMPL(Clap::ApplicationPlugin)
 
@@ -49,96 +43,17 @@ void DataStreamWriter::write(Clap::PluginInfo& p)
 }
 namespace Clap
 {
-
-ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& app)
-    : score::GUIApplicationPlugin{app}
-    , m_wsServer("clap-notification-server", QWebSocketServer::NonSecureMode)
+namespace
 {
-  qRegisterMetaType<PluginInfo>();
-  qRegisterMetaType<std::vector<PluginInfo>>();
+constexpr quint32 cache_format_version = 1;
+const QString cache_key = QStringLiteral("Effect/KnownCLAPCache");
+const QString legacy_cache_key = QStringLiteral("Effect/KnownCLAP");
 
-  m_wsServer.listen(QHostAddress::LocalHost, 37589);
-  con(m_wsServer, &QWebSocketServer::newConnection, this, [this] {
-    QWebSocket* ws = m_wsServer.nextPendingConnection();
-    if(!ws)
-      return;
-
-    connect(ws, &QWebSocket::textMessageReceived, this, [this, ws](const QString& txt) {
-      processIncomingMessage(txt);
-      ws->deleteLater();
-    });
-  });
-}
-
-ApplicationPlugin::~ApplicationPlugin()
+QStringList clapSearchPaths(const score::ApplicationContext& ctx)
 {
-  // waitForFinished delivers finished() synchronously: detach the map and
-  // drop our connections first or the handlers erase from it mid-iteration.
-  auto processes = std::move(m_processes);
-  for(auto& [id, proc] : processes)
-  {
-    if(proc)
-    {
-      QObject::disconnect(proc, nullptr, this, nullptr);
-      proc->terminate();
-      if(!proc->waitForFinished(100))
-      {
-        // Reap after kill: ~QProcess on a still-running process re-kills and
-        // blocks for up to 30s
-        proc->kill();
-        proc->waitForFinished(100);
-      }
-      delete proc;
-    }
-  }
-}
+  QStringList paths = ctx.settings<Media::Settings::Model>().getClapPaths();
 
-void ApplicationPlugin::initialize()
-{
-  // Load cached plugin database
-  QSettings s;
-  auto val = s.value("Effect/KnownCLAP");
-  if(val.canConvert<std::vector<PluginInfo>>())
-  {
-    m_plugins = val.value<std::vector<PluginInfo>>();
-  }
-
-  pluginsChanged();
-  
-  if(qEnvironmentVariableIsEmpty("SCORE_DISABLE_AUDIOPLUGINS"))
-    rescanPlugins();
-}
-
-void ApplicationPlugin::rescanPlugins()
-{
-  // Clear previous scan state
-  m_pluginQueue.clear();
-  m_processes.clear();
-  m_processCount = 0;
-  
-  // Collect all CLAP files to scan
-  std::vector<QString> pluginsToScan;
-  
-  // Standard CLAP plugin directories
-  QStringList paths;
-
-#if defined(__APPLE__)
-  paths << "/Library/Audio/Plug-Ins/CLAP"
-        << (QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-            + "/Library/Audio/Plug-Ins/CLAP");
-#elif defined(_WIN32)
-  paths << "C:/Program Files/Common Files/CLAP"
-        << "C:/Program Files/Common Files/Audio Plugins/CLAP"
-        << QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
-               + "/CLAP";
-#else
-  paths << QStringLiteral("/usr/lib/clap") << QStringLiteral("/usr/local/lib/clap")
-        << QStringLiteral("/usr/lib64/clap") << QStringLiteral("/usr/local/lib64/clap");
-#endif
-
-  paths << QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.clap";
-
-  // $CLAP_PATH (per CLAP entry.h), supplementing standard locations.
+  // $CLAP_PATH (per CLAP entry.h), supplementing the configured locations.
   if(qEnvironmentVariableIsSet("CLAP_PATH"))
   {
     const auto extra = qEnvironmentVariable("CLAP_PATH")
@@ -161,41 +76,62 @@ void ApplicationPlugin::rescanPlugins()
     }
   }
   paths.removeDuplicates();
-  ossia::hash_set<QString> known_plugins_paths;
-  for(auto& plug : this->m_plugins)
-    known_plugins_paths.insert(plug.path);
+  return paths;
+}
+}
 
-  for(const QString& searchPath : paths)
+QString resolveClapEntry(const QString& path)
+{
+  const QFileInfo fi{path};
+  if(fi.isDir())
   {
-    if(!QDir{searchPath}.isReadable())
+    // macOS bundle: the binary lives in Contents/MacOS
+    const QString inner = path + QString{"/Contents/MacOS/%1"}.arg(fi.baseName());
+    if(QFileInfo::exists(inner))
+      return inner;
+    // Linux bundle-style directory (Cardinal & other DPF plug-ins): the
+    // inner *.clap files are found by the recursive iteration themselves
+    return {};
+  }
+  return path;
+}
+
+std::vector<PluginInfo> parseClapReply(const QString& path, const QJsonObject& obj)
+{
+  std::vector<PluginInfo> res;
+
+  if(!obj.contains("Plugins") || !obj["Plugins"].isArray())
+    return res;
+
+  for(const auto& plugin : obj["Plugins"].toArray())
+  {
+    if(!plugin.isObject())
       continue;
+    const auto o = plugin.toObject();
 
-    QDirIterator it(
-        searchPath, QStringList{"*.clap"}, QDir::Files | QDir::Dirs,
-        QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
-    while(it.hasNext())
+    PluginInfo info;
+    info.path = path;
+    info.id = o["ID"].toString();
+    info.name = o["Name"].toString();
+    info.vendor = o["Vendor"].toString();
+    info.version = o["Version"].toString();
+    info.url = o["URL"].toString();
+    info.manual_url = o["ManualURL"].toString();
+    info.support_url = o["SupportURL"].toString();
+    info.description = o["Description"].toString();
+
+    if(o.contains("Features") && o["Features"].isArray())
     {
-      auto fileName = it.next();
-      if(known_plugins_paths.contains(fileName))
-        continue;
-
-#if defined(__APPLE__)
-      if(QFileInfo{fileName}.isDir())
-        fileName = fileName
-                   + QString{"/Contents/MacOS/%1"}.arg(QFileInfo{fileName}.baseName());
-#endif
-      pluginsToScan.push_back(fileName);
+      for(const auto& feature : o["Features"].toArray())
+      {
+        if(feature.isString())
+          info.features.push_back(feature.toString());
+      }
     }
+    info.valid = true;
+    res.push_back(std::move(info));
   }
-
-  // Queue all plugins for scanning
-  for(const auto& path : pluginsToScan)
-  {
-    m_pluginQueue.push_back(path);
-  }
-
-  // Start scanning processes
-  scanNextBatch();
+  return res;
 }
 
 static const QString& clapPuppetPath()
@@ -212,7 +148,7 @@ static const QString& clapPuppetPath()
     else if(QFile::exists(app + "/ossia-score-clappuppet"))
       return QString(app + "/ossia-score-clappuppet");
     else if(QFile::exists(app + "/../../ossia-score-clappuppet"))
-      return QString(path + "/../../ossia-score-clappuppet");
+      return QString(app + "/../../ossia-score-clappuppet");
     else if(QFile::exists(app + "/../../" + bundle_path))
       return QString(app + "/../../" + bundle_path);
     else
@@ -223,186 +159,161 @@ static const QString& clapPuppetPath()
   }();
   return path;
 }
-void ApplicationPlugin::scanNextBatch()
+
+ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& app)
+    : score::GUIApplicationPlugin{app}
 {
-  // Check if we're done
-  if(m_pluginQueue.empty() && m_processes.empty())
-  {
-    // Save to settings
-    QSettings{}.setValue("Effect/KnownCLAP", QVariant::fromValue(m_plugins));
+  qRegisterMetaType<PluginInfo>();
+  qRegisterMetaType<std::vector<PluginInfo>>();
+
+#if QT_CONFIG(process)
+  m_scanner = std::make_unique<Media::PluginScanner>("clap-scanner");
+  con(*m_scanner, &Media::PluginScanner::scanned, this, &ApplicationPlugin::onScanned);
+  con(*m_scanner, &Media::PluginScanner::scanFailed, this,
+      &ApplicationPlugin::onScanFailed);
+  con(*m_scanner, &Media::PluginScanner::done, this, [this] {
+    persistCache();
     pluginsChanged();
-    return;
-  }
+  });
+#endif
 
-  // Launch new processes up to max_in_flight
-  while(!m_pluginQueue.empty() && m_processes.size() < max_in_flight)
-  {
-    QString pluginPath = m_pluginQueue.back();
-    m_pluginQueue.pop_back();
-
-    int id = m_processCount++;
-    QPointer<QProcess> proc = new QProcess;
-    // proc->setProcessChannelMode(QProcess::ProcessChannelMode::ForwardedChannels);
-    m_processes[id] = proc;
-
-    connect(
-        proc, &QProcess::errorOccurred, this,
-        [this, id, pluginPath, proc](QProcess::ProcessError err) {
-      qDebug() << "CLAP scan error for:" << pluginPath << "error:" << err;
-      m_processes.erase(id);
-      proc->deleteLater();
-      addInvalidPlugin(pluginPath);
-      scanNextBatch();
-    });
-
-    // Set up timeout; parented to proc so teardown paths that never reach a
-    // deleteLater still reap it
-    auto timer = new QTimer{proc};
-    timer->setSingleShot(true);
-    timer->setInterval(10000); // 10 second timeout
-    connect(timer, &QTimer::timeout, proc, [this, id, proc, timer, pluginPath] {
-      if(m_processes.find(id) != m_processes.end())
-      {
-        qDebug() << "CLAP scan timeout for:" << pluginPath;
-        if(proc)
-        {
-          proc->terminate();
-          if(!proc->waitForFinished(100))
-            proc->kill();
-        }
-      }
-      timer->deleteLater();
-    });
-
-    connect(
-        proc, &QProcess::finished, this,
-        [this, id, pluginPath, proc, timer](int exitCode, QProcess::ExitStatus) {
-      m_processes.erase(id);
-      if(proc)
-        proc->deleteLater();
-
-      if(exitCode != 0)
-      {
-        qDebug() << "CLAP scan failed for:" << pluginPath;
-        addInvalidPlugin(pluginPath);
-      }
-
-      // Continue scanning
-      scanNextBatch();
-      timer->deleteLater();
-    });
-    timer->start();
-
-    // Launch the puppet process
-    proc->start(clapPuppetPath(), {pluginPath, QString::number(id)});
-  }
+  // Coalesce disk writes + UI updates: one per batch, not one per puppet
+  m_persistTimer = new QTimer{this};
+  m_persistTimer->setSingleShot(true);
+  m_persistTimer->setInterval(500);
+  connect(m_persistTimer, &QTimer::timeout, this, [this] {
+    persistCache();
+    pluginsChanged();
+  });
 }
 
-void ApplicationPlugin::processIncomingMessage(const QString& txt)
+ApplicationPlugin::~ApplicationPlugin() = default;
+
+void ApplicationPlugin::initialize()
 {
-  try
+  // Load, and heal caches damaged by the pre-token protocol: replies from
+  // other score instances used to be appended and persisted on every run
+  // (observed: every plug-in duplicated 200+ times)
+  m_plugins = Media::loadPluginCache<PluginInfo>(
+      cache_format_version, cache_key, legacy_cache_key);
+  Media::sanitizePluginCache(
+      m_plugins, [](const PluginInfo& i) { return i.path + "|" + i.id; },
+      [](const PluginInfo& i) { return i.path; },
+      [](const PluginInfo& i) { return i.valid; });
+  // Make the migration/healing durable even if no scan runs this session
+  persistCache();
+
+  pluginsChanged();
+
+  auto& set = context.settings<Media::Settings::Model>();
+  con(set, &Media::Settings::Model::ClapPathsChanged, this,
+      [this] { rescanPlugins(); });
+
+  if(qEnvironmentVariableIsEmpty("SCORE_DISABLE_AUDIOPLUGINS"))
+    rescanPlugins();
+}
+
+void ApplicationPlugin::forceRescan()
+{
+  m_plugins.clear();
+  rescanPlugins();
+}
+
+void ApplicationPlugin::rescanPlugins()
+{
+#if QT_CONFIG(process)
+  const QStringList paths = clapSearchPaths(context);
+
+  // 1. Discover the .clap files on disk
+  QSet<QString> onDisk;
+  for(const QString& searchPath : paths)
   {
-    auto json = QJsonDocument::fromJson(txt.toUtf8());
-    if(!json.isObject())
-      return;
+    if(!QDir{searchPath}.isReadable())
+      continue;
 
-    auto obj = json.object();
-    auto req = obj["Request"].toInt();
-
-    auto it = m_processes.find(req);
-    if(it != m_processes.end())
+    QDirIterator it(
+        searchPath, QStringList{"*.clap"}, QDir::Files | QDir::Dirs,
+        QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+    while(it.hasNext())
     {
-      if(auto proc = it->second)
-      {
-        QObject::disconnect(proc, nullptr, this, nullptr);
-        proc->terminate();
-        if(proc)
-        {
-          QTimer::singleShot(100000, this, [proc] {
-            if(proc)
-            {
-              if(proc->state() != QProcess::NotRunning)
-                proc->kill();
-
-              if(proc)
-                proc->deleteLater();
-            }
-          });
-        }
-      }
-      m_processes.erase(req);
+      if(QString entry = resolveClapEntry(it.next()); !entry.isEmpty())
+        onDisk.insert(entry);
     }
+  }
 
-    auto path = obj["Path"].toString();
-
-    if(path.isEmpty())
-      return;
-
-    // Check if this is a valid plugin response
-    if(obj.contains("Plugins") && obj["Plugins"].isArray())
+  // 2. Drop cache entries for plug-ins removed from disk, keep the known
+  // ones (the CLAP cache historically never pruned anything)
+  ossia::hash_set<QString> known_plugins_paths;
+  for(auto it = m_plugins.begin(); it != m_plugins.end();)
+  {
+    if(onDisk.contains(it->path))
     {
-      auto plugins = obj["Plugins"].toArray();
-      for(const auto& plugin : plugins)
-      {
-        if(plugin.isObject())
-        {
-          addPlugin(path, plugin.toObject());
-        }
-      }
+      known_plugins_paths.insert(it->path);
+      ++it;
     }
     else
     {
-      addInvalidPlugin(path);
+      it = m_plugins.erase(it);
     }
   }
-  catch(...)
-  {
-    qDebug() << "Failed to parse CLAP scan result";
-  }
-}
-
-void ApplicationPlugin::addPlugin(const QString& path, const QJsonObject& obj)
-{
-  PluginInfo info;
-  info.path = path;
-  info.id = obj["ID"].toString();
-  info.name = obj["Name"].toString();
-  info.vendor = obj["Vendor"].toString();
-  info.version = obj["Version"].toString();
-  info.url = obj["URL"].toString();
-  info.manual_url = obj["ManualURL"].toString();
-  info.support_url = obj["SupportURL"].toString();
-  info.description = obj["Description"].toString();
-
-  if(obj.contains("Features") && obj["Features"].isArray())
-  {
-    auto features = obj["Features"].toArray();
-    for(const auto& feature : features)
-    {
-      if(feature.isString())
-        info.features.push_back(feature.toString());
-    }
-  }
-  info.valid = true;
-
-  m_plugins.push_back(std::move(info));
-  // write in the database
-  QSettings{}.setValue("Effect/KnownCLAP", QVariant::fromValue(m_plugins));
 
   pluginsChanged();
-  scanNextBatch();
+
+  // 3. Scan the new ones out-of-process
+  QStringList toScan;
+  for(const QString& path : onDisk)
+    if(!known_plugins_paths.contains(path))
+      toScan.push_back(path);
+  toScan.sort();
+
+  m_scanner->setPuppet(clapPuppetPath());
+  m_scanner->scan(std::move(toScan));
+#endif
 }
 
-void ApplicationPlugin::addInvalidPlugin(const QString& path)
+void ApplicationPlugin::removeEntriesForPath(const QString& path)
 {
+  ossia::remove_erase_if(
+      m_plugins, [&](const PluginInfo& i) { return i.path == path; });
+}
+
+void ApplicationPlugin::onScanned(const QString& path, const QJsonObject& obj)
+{
+  auto infos = parseClapReply(path, obj);
+  if(infos.empty())
+  {
+    onScanFailed(path, QStringLiteral("no plug-ins in file"));
+    return;
+  }
+
+  removeEntriesForPath(path);
+  for(auto& info : infos)
+    m_plugins.push_back(std::move(info));
+
+  schedulePersist();
+}
+
+void ApplicationPlugin::onScanFailed(const QString& path, const QString& reason)
+{
+  qDebug() << "CLAP scan failed for" << path << ":" << reason;
+
   PluginInfo info;
   info.path = path;
   info.name = "<Invalid>";
   info.valid = false;
-  m_plugins.push_back(info);
-  QSettings{}.setValue("Effect/KnownCLAP", QVariant::fromValue(m_plugins));
 
-  pluginsChanged();
-  scanNextBatch();
+  removeEntriesForPath(path);
+  m_plugins.push_back(std::move(info));
+  schedulePersist();
+}
+
+void ApplicationPlugin::persistCache()
+{
+  Media::savePluginCache(cache_format_version, cache_key, m_plugins);
+}
+
+void ApplicationPlugin::schedulePersist()
+{
+  m_persistTimer->start();
 }
 }

--- a/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
@@ -168,6 +168,9 @@ ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& app)
 
 #if QT_CONFIG(process)
   m_scanner = std::make_unique<Media::PluginScanner>("clap-scanner");
+  // 30s: multi-plug-in files (lsp-plugins: ~200 in one .clap) and machine
+  // load during a 4-format startup scan need headroom over the old 10s
+  m_scanner->setProcessTimeout(30000);
   con(*m_scanner, &Media::PluginScanner::scanned, this, &ApplicationPlugin::onScanned);
   con(*m_scanner, &Media::PluginScanner::scanFailed, this,
       &ApplicationPlugin::onScanFailed);
@@ -187,7 +190,13 @@ ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& app)
   });
 }
 
-ApplicationPlugin::~ApplicationPlugin() = default;
+ApplicationPlugin::~ApplicationPlugin()
+{
+  // Results delivered so far would otherwise be lost when quitting mid-scan:
+  // the debounced m_persistTimer dies with us
+  if(m_scanRan)
+    persistCache();
+}
 
 void ApplicationPlugin::initialize()
 {
@@ -314,6 +323,11 @@ void ApplicationPlugin::persistCache()
 
 void ApplicationPlugin::schedulePersist()
 {
-  m_persistTimer->start();
+  m_scanRan = true;
+  // Don't restart a running timer: during a busy scan replies arrive more
+  // often than the interval and a restarting debounce would never fire,
+  // deferring both persistence and UI updates to the very end of the scan
+  if(!m_persistTimer->isActive())
+    m_persistTimer->start();
 }
 }

--- a/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.hpp
@@ -2,19 +2,25 @@
 #include <score/plugins/application/GUIApplicationPlugin.hpp>
 
 #include <QObject>
-#include <QWebSocketServer>
+#include <QtCore/qglobal.h>
+
+#include <score_plugin_clap_export.h>
 
 #include <memory>
 #include <vector>
-#include <map>
 #include <verdigris>
 
 namespace Library
 {
 class ProcessesItemModel;
 }
+namespace Media
+{
+class PluginScanner;
+}
 
-class QProcess;
+class QTimer;
+class QJsonObject;
 
 namespace Clap
 {
@@ -34,7 +40,19 @@ struct PluginInfo
   bool valid{};
 };
 
-class ApplicationPlugin
+//! The plug-ins contained in one .clap file, from a clappuppet scan reply.
+//! The path is the scanned file, not whatever the reply claims.
+SCORE_PLUGIN_CLAP_EXPORT
+std::vector<PluginInfo> parseClapReply(const QString& path, const QJsonObject& obj);
+
+//! On macOS a .clap can be a bundle directory; the actual binary to scan
+//! lives inside. Must be applied *before* comparing against known paths:
+//! resolving after the known-check made every startup rescan (and
+//! re-append) every bundle.
+SCORE_PLUGIN_CLAP_EXPORT
+QString resolveClapEntry(const QString& path);
+
+class SCORE_PLUGIN_CLAP_EXPORT ApplicationPlugin
     : public QObject
     , public score::GUIApplicationPlugin
 {
@@ -48,21 +66,24 @@ public:
 
   const std::vector<PluginInfo>& plugins() const noexcept { return m_plugins; }
 
+  void rescanPlugins();
+  //! Forget everything and scan the configured paths again (settings UI)
+  void forceRescan();
+
 public:
-  void pluginsChanged() W_SIGNAL(pluginsChanged);
+  void pluginsChanged() E_SIGNAL(SCORE_PLUGIN_CLAP_EXPORT, pluginsChanged);
 
 private:
-  void rescanPlugins();
-  void scanNextBatch();
-  void processIncomingMessage(const QString& txt);
-  void addPlugin(const QString& path, const QJsonObject& obj);
-  void addInvalidPlugin(const QString& path);
-  
-  QWebSocketServer m_wsServer;
-  std::map<int, QPointer<QProcess>> m_processes;
-  std::vector<QString> m_pluginQueue;
-  int m_processCount{0};
-  static constexpr int max_in_flight = 8;
+  void onScanned(const QString& path, const QJsonObject& obj);
+  void onScanFailed(const QString& path, const QString& reason);
+  void removeEntriesForPath(const QString& path);
+  void persistCache();
+  void schedulePersist();
+
+#if QT_CONFIG(process)
+  std::unique_ptr<Media::PluginScanner> m_scanner;
+#endif
+  QTimer* m_persistTimer{};
 
   std::vector<PluginInfo> m_plugins;
 };

--- a/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.hpp
@@ -84,6 +84,7 @@ private:
   std::unique_ptr<Media::PluginScanner> m_scanner;
 #endif
   QTimer* m_persistTimer{};
+  bool m_scanRan{};
 
   std::vector<PluginInfo> m_plugins;
 };

--- a/src/plugins/score-plugin-clap/Clap/Executor.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Executor.cpp
@@ -1,5 +1,7 @@
 #include "Executor.hpp"
 
+#include "Transport.hpp"
+
 #include <Process/Dataflow/Port.hpp>
 #include <Process/ExecutionContext.hpp>
 
@@ -356,43 +358,8 @@ public:
 
   auto make_transport(const ossia::token_request& tk, ossia::exec_state_facade st)
   {
-    const double song_pos_beats = tk.musical_start_position;
-    const double song_pos_seconds = tk.prev_date.impl * st.samplesToModel();
-    uint32_t transport_flags
-        = CLAP_TRANSPORT_HAS_TEMPO | CLAP_TRANSPORT_HAS_BEATS_TIMELINE
-          | CLAP_TRANSPORT_HAS_SECONDS_TIMELINE | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
-    if(tk.prev_date != tk.date)
-      transport_flags |= CLAP_TRANSPORT_IS_PLAYING;
-
-    // Bar information
-    const double bar_start = tk.musical_start_last_bar;
-    const int32_t bar_number = static_cast<int32_t>(
-        tk.musical_start_last_bar / (4.0 * tk.signature.upper / tk.signature.lower));
-
-    clap_event_transport_t transport{
-        .header = {
-            .size = sizeof(clap_event_transport_t),
-            .time = 0,
-            .space_id = CLAP_CORE_EVENT_SPACE_ID,
-            .type = CLAP_EVENT_TRANSPORT,
-            .flags = 0,
-        },
-        .flags = transport_flags,
-        .song_pos_beats = (clap_beattime)std::floor(song_pos_beats),
-        .song_pos_seconds = (clap_sectime)std::floor(song_pos_seconds),
-        .tempo = tk.tempo,
-        .tempo_inc = 0.0, // FIXME
-        .loop_start_beats = 0,
-        .loop_end_beats = 0,
-        .loop_start_seconds = 0,
-        .loop_end_seconds = 0,
-        .bar_start = (clap_beattime) std::floor(bar_start),
-        .bar_number = bar_number,
-        .tsig_num = static_cast<uint16_t>(tk.signature.upper),
-        .tsig_denom = static_cast<uint16_t>(tk.signature.lower)
-    };
-
-    return transport;
+    (void)st;
+    return Clap::make_transport(tk);
   }
   void process_controls(uint32_t samples)
   {

--- a/src/plugins/score-plugin-clap/Clap/Settings.cpp
+++ b/src/plugins/score-plugin-clap/Clap/Settings.cpp
@@ -1,48 +1,45 @@
+#include <Clap/ApplicationPlugin.hpp>
+#include <Clap/Settings.hpp>
 #include <Media/Effect/Settings/Model.hpp>
 #include <Media/Effect/Settings/PluginTab.hpp>
-#include <Vst/ApplicationPlugin.hpp>
-#include <Vst/Settings.hpp>
 
 #include <score/application/GUIApplicationContext.hpp>
 
-namespace vst
+namespace Clap
 {
 QString SettingsWidget::name() const noexcept
 {
-  return "VST";
+  return "CLAP";
 }
 
 QWidget* SettingsWidget::make(const score::ApplicationContext& ctx)
 {
   auto& model = ctx.settings<Media::Settings::Model>();
   auto& gctx = static_cast<const score::GUIApplicationContext&>(ctx);
-  auto& plug = gctx.applicationPlugin<vst::ApplicationPlugin>();
+  auto& plug = gctx.guiApplicationPlugin<Clap::ApplicationPlugin>();
 
   Media::Settings::PluginTabSpec spec;
-  spec.pathsLabel = QObject::tr("VST paths");
-  spec.getPaths = [&model] { return model.getVstPaths(); };
+  spec.pathsLabel = QObject::tr("CLAP paths");
+  spec.getPaths = [&model] { return model.getClapPaths(); };
   spec.commitPaths = [this, &model](QStringList paths) {
-    m_disp.submit<Media::Settings::SetModelVstPaths>(model, std::move(paths));
+    m_disp.submit<Media::Settings::SetModelClapPaths>(model, std::move(paths));
   };
   spec.onPathsChanged = [&model](QObject* c, std::function<void(QStringList)> f) {
     QObject::connect(
-        &model, &Media::Settings::Model::VstPathsChanged, c, std::move(f));
+        &model, &Media::Settings::Model::ClapPathsChanged, c, std::move(f));
   };
   spec.rows = [&plug] {
     std::vector<Media::Settings::PluginTabRow> rows;
-    rows.reserve(plug.vst_infos.size());
-    for(const auto& p : plug.vst_infos)
-      rows.push_back(
-          {p.prettyName.isEmpty() ? p.displayName : p.prettyName, p.path, p.isValid});
+    rows.reserve(plug.plugins().size());
+    for(const auto& p : plug.plugins())
+      rows.push_back({p.name, p.path, p.valid});
     return rows;
   };
   spec.onPluginsChanged = [&plug](QObject* c, std::function<void()> f) {
-    QObject::connect(&plug, &vst::ApplicationPlugin::vstChanged, c, std::move(f));
+    QObject::connect(
+        &plug, &Clap::ApplicationPlugin::pluginsChanged, c, std::move(f));
   };
-  spec.rescan = [&plug, &model] {
-    plug.clearVSTs();
-    plug.rescanVSTs(model.getVstPaths());
-  };
+  spec.rescan = [&plug] { plug.forceRescan(); };
 
   return Media::Settings::makePluginSettingsWidget(std::move(spec));
 }

--- a/src/plugins/score-plugin-clap/Clap/Settings.hpp
+++ b/src/plugins/score-plugin-clap/Clap/Settings.hpp
@@ -3,12 +3,12 @@
 
 #include <score/command/Dispatchers/SettingsCommandDispatcher.hpp>
 
-namespace vst
+namespace Clap
 {
-//! "VST" tab of the Effects settings page: search paths + scanned plug-ins.
+//! "CLAP" tab of the Effects settings page: search paths + scanned plug-ins.
 class SettingsWidget final : public Media::Settings::PluginSettingsTab
 {
-  SCORE_CONCRETE("849b6420-cdc9-47c3-9cac-74897336a77a")
+  SCORE_CONCRETE("4a1022f6-32f7-49ff-bcf1-42f115394340")
 public:
   QString name() const noexcept override;
   QWidget* make(const score::ApplicationContext& ctx) override;

--- a/src/plugins/score-plugin-clap/Clap/Transport.hpp
+++ b/src/plugins/score-plugin-clap/Clap/Transport.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+// Builds the clap_event_transport_t for a tick.
+//
+// CLAP song positions are *fixed-point*: clap_beattime / clap_sectime are
+// int64 scaled by CLAP_BEATTIME_FACTOR / CLAP_SECTIME_FACTOR (1 << 31, see
+// clap/fixedpoint.h). Passing raw beat counts makes every host-side position
+// read as ~0 (beats / 2^31): plug-ins that follow the transport - step
+// sequencers like Stochas, arpeggiators, tempo-synced delays - saw
+// isPlaying==true but a song position frozen at zero and never advanced.
+
+#include <ossia/dataflow/token_request.hpp>
+
+#include <clap/all.h>
+
+#include <cmath>
+
+namespace Clap
+{
+inline clap_event_transport_t make_transport(const ossia::token_request& tk) noexcept
+{
+  // Quarter notes, like VST2 ppqPos / VST3 projectTimeMusic
+  const double song_pos_beats = tk.musical_start_position;
+  const double song_pos_seconds
+      = tk.tempo > 0. ? song_pos_beats * (60. / tk.tempo) : 0.;
+
+  uint32_t transport_flags
+      = CLAP_TRANSPORT_HAS_TEMPO | CLAP_TRANSPORT_HAS_BEATS_TIMELINE
+        | CLAP_TRANSPORT_HAS_SECONDS_TIMELINE | CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
+  if(tk.prev_date != tk.date)
+    transport_flags |= CLAP_TRANSPORT_IS_PLAYING;
+
+  // Bar information
+  const double bar_start = tk.musical_start_last_bar;
+  const double quarters_per_bar = 4.0 * tk.signature.upper / tk.signature.lower;
+  const int32_t bar_number = quarters_per_bar > 0.
+                                 ? static_cast<int32_t>(bar_start / quarters_per_bar)
+                                 : 0;
+
+  return clap_event_transport_t{
+      .header = {
+          .size = sizeof(clap_event_transport_t),
+          .time = 0,
+          .space_id = CLAP_CORE_EVENT_SPACE_ID,
+          .type = CLAP_EVENT_TRANSPORT,
+          .flags = 0,
+      },
+      .flags = transport_flags,
+      .song_pos_beats
+      = (clap_beattime)std::round(song_pos_beats * CLAP_BEATTIME_FACTOR),
+      .song_pos_seconds
+      = (clap_sectime)std::round(song_pos_seconds * CLAP_SECTIME_FACTOR),
+      .tempo = tk.tempo,
+      .tempo_inc = 0.0,
+      .loop_start_beats = 0,
+      .loop_end_beats = 0,
+      .loop_start_seconds = 0,
+      .loop_end_seconds = 0,
+      .bar_start = (clap_beattime)std::round(bar_start * CLAP_BEATTIME_FACTOR),
+      .bar_number = bar_number,
+      .tsig_num = static_cast<uint16_t>(tk.signature.upper),
+      .tsig_denom = static_cast<uint16_t>(tk.signature.lower)};
+}
+}

--- a/src/plugins/score-plugin-clap/score_plugin_clap.cpp
+++ b/src/plugins/score-plugin-clap/score_plugin_clap.cpp
@@ -12,6 +12,7 @@
 #include <Clap/EffectModel.hpp>
 #include <Clap/Executor.hpp>
 #include <Clap/Library.hpp>
+#include <Clap/Settings.hpp>
 #include <Clap/Window.hpp>
 
 #include <score_plugin_engine.hpp>
@@ -30,11 +31,12 @@ std::vector<score::InterfaceBase*> score_plugin_clap::factories(
     const score::ApplicationContext& ctx, const score::InterfaceKey& key) const
 {
   return instantiate_factories<
-      score::ApplicationContext, 
+      score::ApplicationContext,
       FW<Process::ProcessModelFactory, Clap::ProcessFactory>,
       FW<Process::LayerFactory, Clap::EffectLayerFactory>,
       FW<Execution::ProcessComponentFactory, Clap::ExecutorFactory>,
-      FW<Library::LibraryInterface, Clap::LibraryHandler>>(ctx, key);
+      FW<Library::LibraryInterface, Clap::LibraryHandler>,
+      FW<Media::Settings::PluginSettingsTab, Clap::SettingsWidget>>(ctx, key);
 }
 
 std::vector<score::PluginKey> score_plugin_clap::required() const

--- a/src/plugins/score-plugin-lv2/CMakeLists.txt
+++ b/src/plugins/score-plugin-lv2/CMakeLists.txt
@@ -36,6 +36,7 @@ set(HDRS
     "${CMAKE_CURRENT_SOURCE_DIR}/LV2/Node.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/LV2/Window.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/LV2/Library.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/LV2/Settings.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score_plugin_lv2.hpp")
 
 set(SRCS
@@ -43,6 +44,7 @@ set(SRCS
     "${CMAKE_CURRENT_SOURCE_DIR}/LV2/EffectModel.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/LV2/Context.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/LV2/Window.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/LV2/Settings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/score_plugin_lv2.cpp")
 
 add_library(${PROJECT_NAME} ${SRCS} ${HDRS})

--- a/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.cpp
@@ -8,7 +8,9 @@
 #include <Audio/Settings/Model.hpp>
 #include <LV2/Context.hpp>
 #include <LV2/EffectModel.hpp>
+#include <Media/AudioPluginCache.hpp>
 #include <Media/Effect/Settings/Model.hpp>
+#include <Media/PluginScanner.hpp>
 
 #include <score/serialization/DataStreamVisitor.hpp>
 #include <score/tools/Bind.hpp>
@@ -25,12 +27,10 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QProcess>
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTimer>
 #include <QUrl>
-#include <QWebSocket>
 
 #include <wobjectimpl.h>
 W_OBJECT_IMPL(LV2::ApplicationPlugin)
@@ -101,12 +101,17 @@ uint32_t port_index(SuilController controller, const char* symbol)
 
 namespace LV2
 {
+namespace
+{
+constexpr quint32 cache_format_version = 1;
+const QString cache_key = QStringLiteral("Effect/KnownLV2Cache");
+const QString legacy_cache_key = QStringLiteral("Effect/KnownLV2");
+}
 
 ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& app)
     : score::ApplicationPlugin{app}
     , lv2_context{std::make_unique<LV2::GlobalContext>(64, lv2_host_context)}
     , lv2_host_context{lv2_context.get(), nullptr, lv2_context->features(), lilv}
-    , m_wsServer("lv2-notification-server", QWebSocketServer::NonSecureMode)
 {
   qRegisterMetaType<PluginInfo>();
   qRegisterMetaType<std::vector<PluginInfo>>();
@@ -144,28 +149,27 @@ ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& app)
     descriptorsChanged();
   });
 
-  if(!m_wsServer.listen(QHostAddress::LocalHost, 37590))
-  {
-    qWarning() << "LV2: failed to start scanner WebSocket on 127.0.0.1:37590 -"
-               << m_wsServer.errorString()
-               << "- bundle scanning will be unavailable";
-  }
-  con(m_wsServer, &QWebSocketServer::newConnection, this, [this] {
-    QWebSocket* ws = m_wsServer.nextPendingConnection();
-    if(!ws)
-      return;
-
-    // Default Qt limits reject the multi-MB payloads from large bundles (lsp-plugins, ...)
-    ws->setMaxAllowedIncomingFrameSize(64 * 1024 * 1024);
-    ws->setMaxAllowedIncomingMessageSize(64 * 1024 * 1024);
-
-    // Defer deleteLater so the puppet closes its side first; sync FIN -> spurious exit 1
-    connect(ws, &QWebSocket::textMessageReceived, this, [this, ws](const QString& txt) {
-      QObject::disconnect(ws, &QWebSocket::textMessageReceived, nullptr, nullptr);
-      processIncomingMessage(txt);
-      QTimer::singleShot(1000, ws, [ws] { ws->deleteLater(); });
-    });
+#if QT_CONFIG(process)
+  m_scanner = std::make_unique<Media::PluginScanner>("lv2-scanner");
+  // 60s: lsp-plugins (~197 plug-ins, ASan) can push past 10s
+  m_scanner->setProcessTimeout(60000);
+  con(*m_scanner, &Media::PluginScanner::scanned, this, &ApplicationPlugin::onScanned);
+  con(*m_scanner, &Media::PluginScanner::scanFailed, this,
+      [this](const QString& bundle, const QString& reason) {
+    qDebug() << "LV2 scan failed for" << bundle << ":" << reason;
+    markBundleInvalid(bundle);
+      });
+  con(*m_scanner, &Media::PluginScanner::done, this, [this] {
+    persistCache();
+    descriptorsChanged();
   });
+#endif
+}
+
+void ApplicationPlugin::forceRescan()
+{
+  m_plugins.clear();
+  rescanBundles();
 }
 
 void ApplicationPlugin::initialize()
@@ -177,46 +181,37 @@ void ApplicationPlugin::initialize()
   if(!qEnvironmentVariableIsEmpty("SCORE_DISABLE_LV2"))
     return;
 
-  {
-    QSettings s;
-    auto val = s.value("Effect/KnownLV2");
-    if(val.canConvert<std::vector<PluginInfo>>())
-      m_plugins = val.value<std::vector<PluginInfo>>();
-  }
+  // Load, and heal caches damaged by the pre-token protocol (duplicated
+  // entries, valid/invalid pairs for the same bundle)
+  m_plugins = Media::loadPluginCache<PluginInfo>(
+      cache_format_version, cache_key, legacy_cache_key);
+  Media::sanitizePluginCache(
+      m_plugins, [](const PluginInfo& i) { return i.bundle + "|" + i.uri; },
+      [](const PluginInfo& i) { return i.bundle; },
+      [](const PluginInfo& i) { return i.valid; });
+  // Make the migration/healing durable even if no scan runs this session
+  persistCache();
 
   descriptorsChanged();
+
+  auto& set = context.settings<Media::Settings::Model>();
+  con(set, &Media::Settings::Model::Lv2PathsChanged, this,
+      [this] { rescanBundles(); });
 
   rescanBundles();
 }
 
 ApplicationPlugin::~ApplicationPlugin()
 {
-  // waitForFinished delivers finished() synchronously: detach the map and
-  // drop our connections first or the handlers erase from it mid-iteration
-  // (and scanNextBatch would spawn new puppets during teardown).
-  m_bundleQueue.clear();
-  auto processes = std::move(m_processes);
-  for(auto& [id, proc] : processes)
-  {
-    if(proc)
-    {
-      QObject::disconnect(proc, nullptr, this, nullptr);
-      proc->terminate();
-      if(!proc->waitForFinished(100))
-      {
-        // Reap after kill: ~QProcess on a still-running process re-kills and
-        // blocks for up to 30s
-        proc->kill();
-        proc->waitForFinished(100);
-      }
-      delete proc;
-    }
-  }
+#if QT_CONFIG(process)
+  // Reaps any puppet still running
+  m_scanner.reset();
+#endif
 
   // Results delivered so far would otherwise be lost when quitting mid-scan:
   // the debounced m_persistTimer dies with us. Only when a scan actually ran —
   // in disabled mode m_plugins is empty and would wipe the on-disk cache.
-  if(m_processCount > 0)
+  if(m_scanRan)
     persistCache();
 
   // The plug_map memoizes LilvPlugin* into our world; another
@@ -326,30 +321,8 @@ void ApplicationPlugin::ensureBundleLoaded(const QString& uri_or_bundle)
 
 QStringList ApplicationPlugin::discoverLv2Search()
 {
-  // Linux multi-arch paths come from Context.cpp's ldconfig heuristic
-  QStringList paths;
-
-#if defined(__APPLE__)
-  paths << "/Library/Audio/Plug-Ins/LV2"
-        << (QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-            + "/Library/Audio/Plug-Ins/LV2")
-        << "/usr/local/lib/lv2"      // lilv default, Homebrew Intel
-        << "/opt/homebrew/lib/lv2"   // Homebrew Apple Silicon
-        << "/usr/lib/lv2";           // lilv default
-#elif defined(_WIN32)
-  paths << "C:/Program Files/Common Files/LV2"
-        // Roaming %APPDATA%\LV2 (lilv/Carla default)
-        << QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/LV2"
-        // Non-roaming %LOCALAPPDATA%\LV2 (legacy score path)
-        << QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
-               + "/LV2";
-#else
-  paths << QStringLiteral("/usr/lib/lv2") << QStringLiteral("/usr/local/lib/lv2")
-        << QStringLiteral("/usr/lib64/lv2") << QStringLiteral("/usr/local/lib64/lv2");
-#endif
-
-  // ~/.lv2/: Linux convention; Ardour also writes user presets here cross-platform
-  paths << QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.lv2";
+  // Configured search paths; defaults live in Media::Settings::Model
+  QStringList paths = context.settings<Media::Settings::Model>().getLv2Paths();
 
   if(qEnvironmentVariableIsSet("LV2_PATH"))
   {
@@ -442,12 +415,14 @@ QStringList ApplicationPlugin::discoverSpecBundles(const QStringList& bundles)
   return specs;
 }
 
+static const QString& lv2puppetPath();
+
 void ApplicationPlugin::rescanBundles()
 {
-  m_bundleQueue.clear();
-  m_processes.clear();
-  m_processCount = 0;
-  m_scanned_ok.clear();
+#if QT_CONFIG(process)
+  // Not created when LV2 support is disabled (settings UI can still call us)
+  if(!m_scanner)
+    return;
 
   const auto search = discoverLv2Search();
   const auto bundles = discoverBundles(search);
@@ -500,17 +475,27 @@ void ApplicationPlugin::rescanBundles()
     descriptorsChanged(); // stale cache entries may have been removed
   }
 
-  for(const auto& b : toScan)
-    m_bundleQueue.push_back(b);
-
-  if(m_bundleQueue.empty())
+  if(toScan.isEmpty())
   {
     persistCache();
     descriptorsChanged();
     return;
   }
 
-  scanNextBatch();
+  m_scanRan = true;
+  m_scanner->setPuppet(lv2puppetPath());
+  m_scanner->setEnvironmentProvider([specs = m_spec_bundles] {
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    // Disable LSan in the child: lilv leaks on shutdown; we'd see QProcess::Crashed
+    env.insert(
+        "ASAN_OPTIONS", env.value("ASAN_OPTIONS", "") + ":detect_leaks=0:exitcode=0");
+    env.insert("LSAN_OPTIONS", env.value("LSAN_OPTIONS", "") + ":exitcode=0");
+    if(!specs.isEmpty())
+      env.insert("LV2PUPPET_SPECS", specs.join(QDir::listSeparator()));
+    return env;
+  });
+  m_scanner->scan(toScan);
+#endif
 }
 
 static const QString& lv2puppetPath()
@@ -539,128 +524,14 @@ static const QString& lv2puppetPath()
   return path;
 }
 
-void ApplicationPlugin::scanNextBatch()
+void ApplicationPlugin::onScanned(const QString& bundlePath, const QJsonObject& obj)
 {
-  if(m_bundleQueue.empty() && m_processes.empty())
-  {
-    persistCache();
-    descriptorsChanged();
-    return;
-  }
-
-  while(!m_bundleQueue.empty() && (int)m_processes.size() < max_in_flight)
-  {
-    QString bundlePath = m_bundleQueue.back();
-    m_bundleQueue.pop_back();
-
-    int id = m_processCount++;
-    QPointer<QProcess> proc = new QProcess;
-    m_processes[id] = proc;
-
-    connect(
-        proc, &QProcess::errorOccurred, this,
-        [this, id, bundlePath, proc](QProcess::ProcessError err) {
-      qDebug() << "LV2 scan error for:" << bundlePath << "error:" << err;
-      m_processes.erase(id);
-          if(proc)
-        proc->deleteLater();
-      // websocketpp throws on close-after-server-closed even after the JSON was delivered
-      if(!m_scanned_ok.contains(bundlePath))
-        markBundleInvalid(bundlePath);
-      scanNextBatch();
-    });
-
-    // Parented to proc so teardown paths that never reach the deleteLater
-    // below still reap it
-    auto timer = new QTimer{proc};
-    timer->setSingleShot(true);
-    // 60s: lsp-plugins (~197 plug-ins, ASan) can push past 10s
-    timer->setInterval(60000);
-    connect(timer, &QTimer::timeout, proc, [this, id, proc, timer, bundlePath] {
-      if(m_processes.find(id) != m_processes.end())
-      {
-        qDebug() << "LV2 scan timeout for:" << bundlePath;
-        if(proc)
-        {
-          proc->terminate();
-          if(!proc->waitForFinished(100))
-            proc->kill();
-        }
-      }
-      timer->deleteLater();
-    });
-
-    connect(
-        proc, &QProcess::finished, this,
-        [this, id, bundlePath, proc, timer](int exitCode, QProcess::ExitStatus) {
-      m_processes.erase(id);
-          if(proc)
-        proc->deleteLater();
-
-      // Non-zero after a close-handshake race / timeout SIGTERM does not invalidate
-      if(exitCode != 0 && !m_scanned_ok.contains(bundlePath))
-      {
-        qDebug() << "LV2 scan failed for:" << bundlePath;
-        markBundleInvalid(bundlePath);
-      }
-
-      scanNextBatch();
-      timer->deleteLater();
-    });
-    timer->start();
-
-    // Disable LSan in the child: lilv leaks on shutdown; we'd see QProcess::Crashed
-    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-    env.insert(
-        "ASAN_OPTIONS",
-        env.value("ASAN_OPTIONS", "") + ":detect_leaks=0:exitcode=0");
-    env.insert("LSAN_OPTIONS", env.value("LSAN_OPTIONS", "") + ":exitcode=0");
-    if(!m_spec_bundles.isEmpty())
-      env.insert("LV2PUPPET_SPECS", m_spec_bundles.join(QDir::listSeparator()));
-    proc->setProcessEnvironment(env);
-    proc->setProcessChannelMode(QProcess::ForwardedErrorChannel);
-    proc->start(lv2puppetPath(), {bundlePath, QString::number(id)});
-  }
-}
-
-void ApplicationPlugin::processIncomingMessage(const QString& txt)
-{
-  try
-  {
-    QJsonParseError err;
-    auto json = QJsonDocument::fromJson(txt.toUtf8(), &err);
-    if(!json.isObject())
-    {
-      qWarning() << "LV2: malformed scan result (" << txt.size()
-                 << "bytes):" << err.errorString();
-      return;
-    }
-
-    auto obj = json.object();
-    [[maybe_unused]] const int req = obj["Request"].toInt();
-    auto bundle = obj["Bundle"].toString();
-
-    if(bundle.isEmpty())
-      return;
-
-    if(obj.contains("Error"))
-    {
-      qDebug() << "LV2 puppet error for" << bundle << ":"
-               << obj["Error"].toString();
-      markBundleInvalid(bundle);
-      return;
-    }
-
-    if(obj.contains("Plugins") && obj["Plugins"].isArray())
-    {
-      addPluginsFromJson(bundle, obj["Plugins"].toArray());
-      m_scanned_ok.insert(bundle);
-    }
-  }
-  catch(...)
-  {
-    qDebug() << "Failed to parse LV2 scan result";
-  }
+  // The reply's own "Bundle" field is informative only; the scan session
+  // knows which bundle this reply belongs to.
+  if(obj.contains("Plugins") && obj["Plugins"].isArray())
+    addPluginsFromJson(bundlePath, obj["Plugins"].toArray());
+  else
+    markBundleInvalid(bundlePath);
 }
 
 void ApplicationPlugin::addPluginsFromJson(
@@ -757,7 +628,7 @@ void ApplicationPlugin::markBundleInvalid(const QString& bundlePath)
 
 void ApplicationPlugin::persistCache()
 {
-  QSettings{}.setValue("Effect/KnownLV2", QVariant::fromValue(m_plugins));
+  Media::savePluginCache(cache_format_version, cache_key, m_plugins);
 }
 
 }

--- a/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.cpp
@@ -600,7 +600,8 @@ void ApplicationPlugin::addPluginsFromJson(
     m_plugins.push_back(std::move(marker));
   }
 
-  if(m_persistTimer)
+  // Don't restart a running timer: a busy scan would starve the debounce
+  if(m_persistTimer && !m_persistTimer->isActive())
     m_persistTimer->start();
 }
 
@@ -622,7 +623,8 @@ void ApplicationPlugin::markBundleInvalid(const QString& bundlePath)
   }
   m_plugins.push_back(std::move(info));
 
-  if(m_persistTimer)
+  // Don't restart a running timer: a busy scan would starve the debounce
+  if(m_persistTimer && !m_persistTimer->isActive())
     m_persistTimer->start();
 }
 

--- a/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.hpp
@@ -7,20 +7,23 @@
 
 #include <ossia/detail/hash_map.hpp>
 
-#include <QPointer>
-#include <QProcess>
 #include <QString>
 #include <QStringList>
 #include <QVector>
-#include <QWebSocketServer>
+#include <QtCore/qglobal.h>
 
 #include <lilv/lilvmm.hpp>
 
 #include <score_plugin_lv2_export.h>
 
-#include <map>
+#include <memory>
 #include <vector>
 #include <verdigris>
+
+namespace Media
+{
+class PluginScanner;
+}
 
 namespace LV2
 {
@@ -84,7 +87,7 @@ public:
   void setCachedDescriptors(std::vector<PluginInfo> descriptors);
 
 public:
-  void descriptorsChanged() W_SIGNAL(descriptorsChanged);
+  void descriptorsChanged() E_SIGNAL(SCORE_PLUGIN_LV2_EXPORT, descriptorsChanged);
 
 public:
   Lilv::World lilv;
@@ -93,27 +96,25 @@ public:
 
   const libsuil& suil = libsuil::instance();
 
+  //! Forget everything and scan the configured paths again (settings UI)
+  void forceRescan();
+
 private:
   void rescanBundles();
-  void scanNextBatch();
-  void processIncomingMessage(const QString& txt);
+  void onScanned(const QString& bundlePath, const class QJsonObject& obj);
   void addPluginsFromJson(const QString& bundlePath, const class QJsonArray& arr);
   void markBundleInvalid(const QString& bundlePath);
   void persistCache();
 
-  static QStringList discoverLv2Search();
+  QStringList discoverLv2Search();
   static QStringList discoverBundles(const QStringList& search);
   // Pick out LV2 spec bundles (atom, urid, ui, ...) so puppets can skip load_all
   static QStringList discoverSpecBundles(const QStringList& bundles);
 
-  QWebSocketServer m_wsServer;
-  std::map<int, QPointer<QProcess>> m_processes;
-  std::vector<QString> m_bundleQueue;
-  int m_processCount{0};
-  static constexpr int max_in_flight = 8;
-
-  // Suppresses markBundleInvalid on post-report puppet exit (close-handshake race)
-  ossia::hash_set<QString> m_scanned_ok;
+#if QT_CONFIG(process)
+  std::unique_ptr<Media::PluginScanner> m_scanner;
+#endif
+  bool m_scanRan{};
 
   std::vector<PluginInfo> m_plugins;
 

--- a/src/plugins/score-plugin-lv2/LV2/Settings.cpp
+++ b/src/plugins/score-plugin-lv2/LV2/Settings.cpp
@@ -1,48 +1,46 @@
+#include <LV2/ApplicationPlugin.hpp>
+#include <LV2/Settings.hpp>
 #include <Media/Effect/Settings/Model.hpp>
 #include <Media/Effect/Settings/PluginTab.hpp>
-#include <Vst/ApplicationPlugin.hpp>
-#include <Vst/Settings.hpp>
 
 #include <score/application/GUIApplicationContext.hpp>
 
-namespace vst
+namespace LV2
 {
 QString SettingsWidget::name() const noexcept
 {
-  return "VST";
+  return "LV2";
 }
 
 QWidget* SettingsWidget::make(const score::ApplicationContext& ctx)
 {
   auto& model = ctx.settings<Media::Settings::Model>();
   auto& gctx = static_cast<const score::GUIApplicationContext&>(ctx);
-  auto& plug = gctx.applicationPlugin<vst::ApplicationPlugin>();
+  auto& plug = gctx.applicationPlugin<LV2::ApplicationPlugin>();
 
   Media::Settings::PluginTabSpec spec;
-  spec.pathsLabel = QObject::tr("VST paths");
-  spec.getPaths = [&model] { return model.getVstPaths(); };
+  spec.pathsLabel = QObject::tr("LV2 paths");
+  spec.getPaths = [&model] { return model.getLv2Paths(); };
   spec.commitPaths = [this, &model](QStringList paths) {
-    m_disp.submit<Media::Settings::SetModelVstPaths>(model, std::move(paths));
+    m_disp.submit<Media::Settings::SetModelLv2Paths>(model, std::move(paths));
   };
   spec.onPathsChanged = [&model](QObject* c, std::function<void(QStringList)> f) {
     QObject::connect(
-        &model, &Media::Settings::Model::VstPathsChanged, c, std::move(f));
+        &model, &Media::Settings::Model::Lv2PathsChanged, c, std::move(f));
   };
   spec.rows = [&plug] {
     std::vector<Media::Settings::PluginTabRow> rows;
-    rows.reserve(plug.vst_infos.size());
-    for(const auto& p : plug.vst_infos)
-      rows.push_back(
-          {p.prettyName.isEmpty() ? p.displayName : p.prettyName, p.path, p.isValid});
+    const auto& descs = plug.cachedDescriptors();
+    rows.reserve(descs.size());
+    for(const auto& p : descs)
+      rows.push_back({p.name, p.bundle, p.valid});
     return rows;
   };
   spec.onPluginsChanged = [&plug](QObject* c, std::function<void()> f) {
-    QObject::connect(&plug, &vst::ApplicationPlugin::vstChanged, c, std::move(f));
+    QObject::connect(
+        &plug, &LV2::ApplicationPlugin::descriptorsChanged, c, std::move(f));
   };
-  spec.rescan = [&plug, &model] {
-    plug.clearVSTs();
-    plug.rescanVSTs(model.getVstPaths());
-  };
+  spec.rescan = [&plug] { plug.forceRescan(); };
 
   return Media::Settings::makePluginSettingsWidget(std::move(spec));
 }

--- a/src/plugins/score-plugin-lv2/LV2/Settings.hpp
+++ b/src/plugins/score-plugin-lv2/LV2/Settings.hpp
@@ -3,12 +3,12 @@
 
 #include <score/command/Dispatchers/SettingsCommandDispatcher.hpp>
 
-namespace vst
+namespace LV2
 {
-//! "VST" tab of the Effects settings page: search paths + scanned plug-ins.
+//! "LV2" tab of the Effects settings page: search paths + scanned plug-ins.
 class SettingsWidget final : public Media::Settings::PluginSettingsTab
 {
-  SCORE_CONCRETE("849b6420-cdc9-47c3-9cac-74897336a77a")
+  SCORE_CONCRETE("5c729f84-fa4b-4d14-9951-ecab29ec5886")
 public:
   QString name() const noexcept override;
   QWidget* make(const score::ApplicationContext& ctx) override;

--- a/src/plugins/score-plugin-lv2/LV2/Window.cpp
+++ b/src/plugins/score-plugin-lv2/LV2/Window.cpp
@@ -8,6 +8,8 @@
 
 #include <ossia/network/value/value_conversion.hpp>
 
+#include <QDebug>
+#include <QFile>
 #include <QHBoxLayout>
 #include <QTimer>
 
@@ -15,9 +17,40 @@
 
 #include <suil-0/suil/suil.h>
 
+#include <array>
+
 W_OBJECT_IMPL(LV2::Window)
 namespace LV2
 {
+//! An X11UI binary linked against another Qt major version cannot run in
+//! this process: Qt keeps the same mangled names across majors for the
+//! exported QString/QByteArray operators, so the other Qt's internal calls
+//! get resolved to *our* Qt's code operating on their objects - memory
+//! corruption before the UI even finishes creating its QApplication
+//! (observed with qmidiarp's Qt5 UI: Qt5's QFactoryLoader ends up in Qt6's
+//! operator<(QString, QString) and dies). GTK-based hosts load these UIs
+//! fine since no other Qt lives in their process; we must refuse.
+bool uiLinksIncompatibleQt(const QString& binary_path)
+{
+  QFile f{binary_path};
+  if(!f.open(QIODevice::ReadOnly))
+    return false;
+  // DT_NEEDED sonames appear verbatim in .dynstr; a substring scan is
+  // enough and spares us an ELF/Mach-O/PE parser
+  const QByteArray data = f.readAll();
+  static constexpr std::array others{4, 5, 6, 7};
+  for(int major : others)
+  {
+    if(major == QT_VERSION_MAJOR)
+      continue;
+    const QByteArray core = "libQt" + QByteArray::number(major) + "Core.so";
+    const QByteArray gui = "libQt" + QByteArray::number(major) + "Gui.so";
+    if(data.contains(core) || data.contains(gui))
+      return true;
+  }
+  return false;
+}
+
 Window::Window(const Model& fx, const score::DocumentContext& ctx, QWidget* parent)
     : PluginWindow{ctx.app.settings<Media::Settings::Model>().getVstAlwaysOnTop(), parent}
     , m_model{fx}
@@ -26,23 +59,56 @@ Window::Window(const Model& fx, const score::DocumentContext& ctx, QWidget* pare
     throw std::runtime_error("Cannot create UI");
 
   auto& p = score::GUIAppContext().applicationPlugin<LV2::ApplicationPlugin>();
+  // Not created when LV2 support is disabled (SCORE_DISABLE_AUDIOPLUGINS /
+  // SCORE_DISABLE_LV2); suil dereferences it without checking
+  if(!p.lv2_context->ui_host)
+    throw std::runtime_error("LV2 UI host not available");
   auto lay = new score::MarginLess<QHBoxLayout>;
   setLayout(lay);
 
-  // Find a relevant ui
+  // Find a relevant ui: among the ones suil can host, keep the
+  // best-supported (lowest wrapping quality, lilv semantics) whose binary
+  // actually exists on disk. A bundle may declare UIs that are not shipped -
+  // qmidiarp's ttl lists an OpenGL UI first whose .so is absent from the
+  // distribution package; picking it blindly made the whole UI fail with a
+  // missing-file error even though the X11 UI right after it works.
   const auto native_ui_type_uri = "http://lv2plug.in/ns/extensions/ui#Qt6UI";
   {
     auto the_uis = lilv_plugin_get_uis(fx.plugin);
     auto native_ui_type = lilv_new_uri(p.lilv.me, native_ui_type_uri);
+    unsigned best_quality = 0; // lilv: 0 = unsupported, 1 = native, 2+ = wrapped
     LILV_FOREACH(uis, u, the_uis)
     {
       const LilvUI* this_ui = lilv_uis_get(the_uis, u);
-      if(lilv_ui_is_supported(
-             this_ui, p.suil.ui_supported, native_ui_type, &fx.effectContext.ui_type))
+      const LilvNode* ui_type{};
+      const unsigned quality
+          = lilv_ui_is_supported(this_ui, p.suil.ui_supported, native_ui_type, &ui_type);
+      if(quality == 0 || (best_quality != 0 && quality >= best_quality))
+        continue;
+
+      if(const char* binary_uri
+         = lilv_node_as_uri(lilv_ui_get_binary_uri(this_ui)))
       {
-        fx.effectContext.ui = this_ui;
-        break;
+        char* binary_path = lilv_file_uri_parse(binary_uri, nullptr);
+        const QString path = QString::fromUtf8(binary_path ? binary_path : "");
+        lilv_free(binary_path);
+        if(path.isEmpty() || !QFile::exists(path))
+        {
+          qDebug() << "LV2: skipping UI with missing binary:" << binary_uri;
+          continue;
+        }
+        if(uiLinksIncompatibleQt(path))
+        {
+          qDebug() << "LV2: skipping UI linked against an incompatible Qt "
+                      "version (cannot be embedded in this process):"
+                   << binary_uri;
+          continue;
+        }
       }
+
+      best_quality = quality;
+      fx.effectContext.ui = this_ui;
+      fx.effectContext.ui_type = ui_type;
     }
   }
   if(!fx.effectContext.ui)

--- a/src/plugins/score-plugin-lv2/LV2/Window.cpp
+++ b/src/plugins/score-plugin-lv2/LV2/Window.cpp
@@ -4,6 +4,7 @@
 #include <LV2/Window.hpp>
 #include <Media/Effect/Settings/Model.hpp>
 
+#include <score/tools/ElfInspector.hpp>
 #include <score/widgets/MarginLess.hpp>
 
 #include <ossia/network/value/value_conversion.hpp>
@@ -30,23 +31,53 @@ namespace LV2
 //! (observed with qmidiarp's Qt5 UI: Qt5's QFactoryLoader ends up in Qt6's
 //! operator<(QString, QString) and dies). GTK-based hosts load these UIs
 //! fine since no other Qt lives in their process; we must refuse.
+//!
+//! On Linux this reads the actual DT_NEEDED entries; elsewhere (and for
+//! binaries the ELF reader cannot parse) it falls back to scanning for the
+//! dependency name patterns of every platform's Qt linkage.
 bool uiLinksIncompatibleQt(const QString& binary_path)
 {
+#if defined(__linux__)
+  if(const auto deps
+     = score::ElfInspector{}.try_get_dt_needed(binary_path.toStdString()))
+  {
+    for(const std::string& dep : *deps)
+    {
+      // libQt5Core.so.5, libQt5Gui.so.5, libQt5Widgets.so.5, ...
+      constexpr std::string_view prefix = "libQt";
+      if(dep.size() > prefix.size() && dep.starts_with(prefix))
+      {
+        const char c = dep[prefix.size()];
+        if(c >= '0' && c <= '9' && (c - '0') != QT_VERSION_MAJOR)
+          return true;
+      }
+    }
+    return false; // definitive answer
+  }
+#endif
+
   QFile f{binary_path};
   if(!f.open(QIODevice::ReadOnly))
     return false;
-  // DT_NEEDED sonames appear verbatim in .dynstr; a substring scan is
-  // enough and spares us an ELF/Mach-O/PE parser
+  // Dependency names appear verbatim in the binary (ELF .dynstr, Mach-O
+  // load commands, PE import table); a substring scan is enough
   const QByteArray data = f.readAll();
   static constexpr std::array others{4, 5, 6, 7};
   for(int major : others)
   {
     if(major == QT_VERSION_MAJOR)
       continue;
-    const QByteArray core = "libQt" + QByteArray::number(major) + "Core.so";
-    const QByteArray gui = "libQt" + QByteArray::number(major) + "Gui.so";
-    if(data.contains(core) || data.contains(gui))
-      return true;
+    const QByteArray n = QByteArray::number(major);
+    const QByteArray patterns[]{
+        "libQt" + n + "Core",                 // Linux .so / macOS .dylib
+        "libQt" + n + "Gui",
+        "Qt" + n + "Core.dll",                // Windows
+        "Qt" + n + "Gui.dll",
+        "QtCore.framework/Versions/" + n,     // macOS frameworks (Qt4/Qt5
+        "QtGui.framework/Versions/" + n};     // used the major as version)
+    for(const auto& pattern : patterns)
+      if(data.contains(pattern))
+        return true;
   }
   return false;
 }

--- a/src/plugins/score-plugin-lv2/LV2/Window.hpp
+++ b/src/plugins/score-plugin-lv2/LV2/Window.hpp
@@ -7,6 +7,11 @@
 
 namespace LV2
 {
+//! True if this UI binary links a Qt major version other than the one this
+//! process runs: such a UI cannot be loaded in-process (identical mangled
+//! symbol names across Qt majors get cross-resolved and corrupt memory).
+SCORE_PLUGIN_LV2_EXPORT
+bool uiLinksIncompatibleQt(const QString& binary_path);
 
 class Window final : public score::PluginWindow
 {

--- a/src/plugins/score-plugin-lv2/score_plugin_lv2.cpp
+++ b/src/plugins/score-plugin-lv2/score_plugin_lv2.cpp
@@ -2,6 +2,7 @@
 
 #include <LV2/EffectModel.hpp>
 #include <LV2/Library.hpp>
+#include <LV2/Settings.hpp>
 #include <LV2/Window.hpp>
 #include <Library/LibraryInterface.hpp>
 
@@ -51,7 +52,8 @@ std::vector<score::InterfaceBase*> score_plugin_lv2::factories(
       score::ApplicationContext, FW<Process::ProcessModelFactory, LV2::ProcessFactory>,
       FW<Process::LayerFactory, LV2::LayerFactory>,
       FW<Library::LibraryInterface, LV2::LibraryHandler>,
-      FW<Execution::ProcessComponentFactory, LV2::ExecutorFactory>>(ctx, key);
+      FW<Execution::ProcessComponentFactory, LV2::ExecutorFactory>,
+      FW<Media::Settings::PluginSettingsTab, LV2::SettingsWidget>>(ctx, key);
 }
 
 #include <score/plugins/PluginInstances.hpp>

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -40,6 +40,9 @@ set(HDRS ${HDRS}
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Effect/Settings/View.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Effect/Settings/Factory.hpp"
 
+    "${CMAKE_CURRENT_SOURCE_DIR}/Media/AudioPluginCache.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Media/PluginScanner.hpp"
+
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Commands.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Metadata.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Executor.hpp"
@@ -105,6 +108,8 @@ set(SRCS
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Effect/Settings/Presenter.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Effect/Settings/View.cpp"
 
+    "${CMAKE_CURRENT_SOURCE_DIR}/Media/PluginScanner.cpp"
+
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Executor.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Model.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Factory.cpp"
@@ -159,6 +164,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
                      ${QT_PREFIX}::Core ${QT_PREFIX}::Widgets
                      score_lib_base score_plugin_engine score_plugin_library score_plugin_audio score_plugin_dataflow
 )
+target_link_libraries(${PROJECT_NAME} PRIVATE ${QT_PREFIX}::WebSockets)
 
 ### FFMPEG ###
 if(EMSCRIPTEN)

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -42,6 +42,7 @@ set(HDRS ${HDRS}
 
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/AudioPluginCache.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/PluginScanner.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Media/Effect/Settings/PluginTab.hpp"
 
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Commands.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Metadata.hpp"
@@ -109,6 +110,7 @@ set(SRCS
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Effect/Settings/View.cpp"
 
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/PluginScanner.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Media/Effect/Settings/PluginTab.cpp"
 
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Executor.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Media/Step/Model.cpp"
@@ -164,7 +166,11 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
                      ${QT_PREFIX}::Core ${QT_PREFIX}::Widgets
                      score_lib_base score_plugin_engine score_plugin_library score_plugin_audio score_plugin_dataflow
 )
-target_link_libraries(${PROJECT_NAME} PRIVATE ${QT_PREFIX}::WebSockets)
+# PluginScanner: without WebSockets the scan machinery degrades to
+# "scanning unavailable" (see SCORE_PLUGIN_MEDIA_NO_WEBSOCKETS).
+if(TARGET ${QT_PREFIX}::WebSockets)
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${QT_PREFIX}::WebSockets)
+endif()
 
 ### FFMPEG ###
 if(EMSCRIPTEN)

--- a/src/plugins/score-plugin-media/Media/AudioPluginCache.hpp
+++ b/src/plugins/score-plugin-media/Media/AudioPluginCache.hpp
@@ -34,6 +34,20 @@ inline constexpr quint32 pluginCacheMagic = 0x53435043; // "SCPC"
 
 //! Serialize a scan cache with magic + version + count framing.
 //! T must provide QDataStream operator<< / operator>>.
+//!
+//! Each element is stored as its own length-prefixed byte blob. The score
+//! datastream operators route reads through an internal, separate
+//! QDataStream, so a read error is invisible on the stream the caller
+//! iterates with - a naive `str >> elt` loop happily returns garbage on
+//! truncation or on a layout drift (the failure mode the old VST2
+//! `vst_invalid_format` global used to catch). With the length prefix, the
+//! outer stream reads the raw bytes itself (so its status is meaningful),
+//! and each element decodes from an isolated buffer that it must consume
+//! exactly.
+//!
+//! NOTE: this cannot catch every un-versioned layout change - adding or
+//! reordering fields of a cached Info struct REQUIRES bumping that
+//! backend's cache_format_version.
 template <typename T>
 QByteArray serializePluginCache(quint32 version, const std::vector<T>& vec)
 {
@@ -42,13 +56,20 @@ QByteArray serializePluginCache(quint32 version, const std::vector<T>& vec)
     QDataStream str{&res, QIODevice::WriteOnly};
     str << pluginCacheMagic << version << (quint32)vec.size();
     for(const auto& elt : vec)
-      str << elt;
+    {
+      QByteArray blob;
+      {
+        QDataStream es{&blob, QIODevice::WriteOnly};
+        es << elt;
+      }
+      str << blob;
+    }
   }
   return res;
 }
 
 //! Returns nullopt (instead of garbage) on: wrong magic, wrong version,
-//! truncation, or trailing bytes.
+//! truncation, trailing bytes, or an element not consuming its blob exactly.
 template <typename T>
 std::optional<std::vector<T>>
 deserializePluginCache(quint32 version, const QByteArray& data)
@@ -62,18 +83,26 @@ deserializePluginCache(quint32 version, const QByteArray& data)
   if(str.status() != QDataStream::Ok || magic != pluginCacheMagic || ver != version)
     return std::nullopt;
 
-  // Each element is at least a couple of bytes; a count beyond that is a
-  // corrupt header, not a plausible plug-in collection.
-  if(count > (quint32)data.size())
+  // Each element blob costs at least its 4-byte length prefix; a larger
+  // count is a corrupt header, not a plausible plug-in collection.
+  if(count > (quint32)data.size() / 4)
     return std::nullopt;
 
   std::vector<T> res;
   res.reserve(count);
   for(quint32 i = 0; i < count; i++)
   {
-    T elt;
-    str >> elt;
+    QByteArray blob;
+    str >> blob;
     if(str.status() != QDataStream::Ok)
+      return std::nullopt;
+
+    QDataStream es{blob};
+    T elt;
+    es >> elt;
+    // An element that does not consume its blob exactly decoded with a
+    // different layout than it was written with
+    if(es.status() != QDataStream::Ok || !es.atEnd())
       return std::nullopt;
     res.push_back(std::move(elt));
   }
@@ -93,20 +122,25 @@ std::vector<T> loadPluginCache(
 {
   QSettings set;
 
+  std::optional<std::vector<T>> versioned;
   if(const auto val = set.value(key); val.canConvert<QByteArray>())
-  {
-    if(auto res = deserializePluginCache<T>(version, val.toByteArray()))
-      return *std::move(res);
-  }
+    versioned = deserializePluginCache<T>(version, val.toByteArray());
 
   std::vector<T> legacy;
   if(!legacyKey.isEmpty())
   {
-    if(const auto val = set.value(legacyKey); val.canConvert<std::vector<T>>())
-      legacy = val.value<std::vector<T>>();
+    if(!versioned)
+    {
+      if(const auto val = set.value(legacyKey); val.canConvert<std::vector<T>>())
+        legacy = val.value<std::vector<T>>();
+    }
+    // Removed even when the versioned cache won: an older score run may have
+    // rewritten it since the migration, and it must not resurrect stale
+    // entries after a future format-version bump.
     set.remove(legacyKey);
   }
-  return legacy;
+
+  return versioned ? *std::move(versioned) : legacy;
 }
 
 template <typename T>

--- a/src/plugins/score-plugin-media/Media/AudioPluginCache.hpp
+++ b/src/plugins/score-plugin-media/Media/AudioPluginCache.hpp
@@ -1,0 +1,160 @@
+#pragma once
+
+// Versioned persistence for the audio plug-in scan caches (VST2 / VST3 /
+// CLAP / LV2), replacing the raw QVariant metatype blobs in QSettings.
+//
+// The old scheme stored `QVariant::fromValue(std::vector<Info>)`: any change
+// to the Info datastream layout made old blobs decode as garbage that
+// `QVariant::canConvert` happily accepted (the "vst_invalid_format" global
+// hack in the VST2 plug-in was a workaround for exactly this). The new blob
+// is explicit: magic, format version, element count, elements — and
+// deserialization fails cleanly instead of producing garbage when anything
+// does not line up.
+//
+// deduplicated() / dropShadowedInvalidEntries() heal caches that already
+// accumulated duplicates (each plug-in could end up multiplied by hundreds:
+// scan replies from *other* score instances used to be appended to whichever
+// instance owned the fixed notification port, and nothing ever pruned them).
+
+#include <ossia/detail/algorithms.hpp>
+
+#include <QByteArray>
+#include <QDataStream>
+#include <QIODevice>
+#include <QSet>
+#include <QSettings>
+#include <QString>
+
+#include <optional>
+#include <vector>
+
+namespace Media
+{
+inline constexpr quint32 pluginCacheMagic = 0x53435043; // "SCPC"
+
+//! Serialize a scan cache with magic + version + count framing.
+//! T must provide QDataStream operator<< / operator>>.
+template <typename T>
+QByteArray serializePluginCache(quint32 version, const std::vector<T>& vec)
+{
+  QByteArray res;
+  {
+    QDataStream str{&res, QIODevice::WriteOnly};
+    str << pluginCacheMagic << version << (quint32)vec.size();
+    for(const auto& elt : vec)
+      str << elt;
+  }
+  return res;
+}
+
+//! Returns nullopt (instead of garbage) on: wrong magic, wrong version,
+//! truncation, or trailing bytes.
+template <typename T>
+std::optional<std::vector<T>>
+deserializePluginCache(quint32 version, const QByteArray& data)
+{
+  if(data.isEmpty())
+    return std::nullopt;
+
+  QDataStream str{data};
+  quint32 magic{}, ver{}, count{};
+  str >> magic >> ver >> count;
+  if(str.status() != QDataStream::Ok || magic != pluginCacheMagic || ver != version)
+    return std::nullopt;
+
+  // Each element is at least a couple of bytes; a count beyond that is a
+  // corrupt header, not a plausible plug-in collection.
+  if(count > (quint32)data.size())
+    return std::nullopt;
+
+  std::vector<T> res;
+  res.reserve(count);
+  for(quint32 i = 0; i < count; i++)
+  {
+    T elt;
+    str >> elt;
+    if(str.status() != QDataStream::Ok)
+      return std::nullopt;
+    res.push_back(std::move(elt));
+  }
+
+  if(!str.atEnd())
+    return std::nullopt;
+
+  return res;
+}
+
+//! Load a scan cache from QSettings. Tries the versioned key first; on
+//! failure falls back to the legacy QVariant blob (pre-rework caches), which
+//! is removed either way so it cannot resurrect stale entries later.
+template <typename T>
+std::vector<T> loadPluginCache(
+    quint32 version, const QString& key, const QString& legacyKey)
+{
+  QSettings set;
+
+  if(const auto val = set.value(key); val.canConvert<QByteArray>())
+  {
+    if(auto res = deserializePluginCache<T>(version, val.toByteArray()))
+      return *std::move(res);
+  }
+
+  std::vector<T> legacy;
+  if(!legacyKey.isEmpty())
+  {
+    if(const auto val = set.value(legacyKey); val.canConvert<std::vector<T>>())
+      legacy = val.value<std::vector<T>>();
+    set.remove(legacyKey);
+  }
+  return legacy;
+}
+
+template <typename T>
+void savePluginCache(quint32 version, const QString& key, const std::vector<T>& vec)
+{
+  QSettings{}.setValue(key, serializePluginCache(version, vec));
+}
+
+//! Keep only the first entry for each key. Heals caches that accumulated
+//! duplicate entries.
+template <typename T, typename KeyFn>
+void deduplicate(std::vector<T>& vec, KeyFn&& key_of)
+{
+  QSet<QString> seen;
+  ossia::remove_erase_if(vec, [&](const T& elt) {
+    const QString k = key_of(elt);
+    if(seen.contains(k))
+      return true;
+    seen.insert(k);
+    return false;
+  });
+}
+
+//! Drop "invalid plug-in" markers that share a path with a valid entry:
+//! scan races used to record both (e.g. a reply arriving after the reaper
+//! had already declared a timeout).
+template <typename T, typename PathFn, typename ValidFn>
+void dropShadowedInvalidEntries(std::vector<T>& vec, PathFn&& path_of, ValidFn&& is_valid)
+{
+  QSet<QString> valid_paths;
+  for(const auto& elt : vec)
+    if(is_valid(elt))
+      valid_paths.insert(path_of(elt));
+
+  ossia::remove_erase_if(vec, [&](const T& elt) {
+    return !is_valid(elt) && valid_paths.contains(path_of(elt));
+  });
+}
+
+//! Standard cache sanitization on load: no empty paths, valid entries win
+//! over invalid markers for the same path, one entry per identity key.
+template <typename T, typename KeyFn, typename PathFn, typename ValidFn>
+void sanitizePluginCache(
+    std::vector<T>& vec, KeyFn&& key_of, PathFn&& path_of, ValidFn&& is_valid)
+{
+  ossia::remove_erase_if(
+      vec, [&](const T& elt) { return path_of(elt).isEmpty(); });
+  dropShadowedInvalidEntries(vec, path_of, is_valid);
+  deduplicate(vec, key_of);
+}
+}

--- a/src/plugins/score-plugin-media/Media/Effect/Settings/Model.cpp
+++ b/src/plugins/score-plugin-media/Media/Effect/Settings/Model.cpp
@@ -51,7 +51,10 @@ SETTINGS_PARAMETER_IMPL(ClapPaths){
       + "/Library/Audio/Plug-Ins/CLAP"),
      QStringLiteral("/Library/Audio/Plug-Ins/CLAP")
 #elif defined(_WIN32)
-     (QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/CLAP"),
+     // Env vars, not QStandardPaths::App*Location: these defaults are
+     // evaluated in a static initializer where the application identity may
+     // not be set yet, and the CLAP convention is %LOCALAPPDATA%\CLAP anyway
+     (qEnvironmentVariable("LOCALAPPDATA") + "/CLAP"),
      QStringLiteral("C:/Program Files/Common Files/CLAP"),
      QStringLiteral("C:/Program Files/Common Files/Audio Plugins/CLAP")
 #else
@@ -73,10 +76,11 @@ SETTINGS_PARAMETER_IMPL(Lv2Paths){
      QStringLiteral("/usr/lib/lv2")           // lilv default
 #elif defined(_WIN32)
      QStringLiteral("C:/Program Files/Common Files/LV2"),
-     // Roaming %APPDATA%\LV2 (lilv/Carla default)
-     (QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/LV2"),
-     // Non-roaming %LOCALAPPDATA%\LV2 (legacy score path)
-     (QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/LV2")
+     // Env vars, not QStandardPaths::App*Location: these defaults are
+     // evaluated in a static initializer where the application identity may
+     // not be set yet - and %APPDATA%\LV2 is the lilv/Carla convention
+     (qEnvironmentVariable("APPDATA") + "/LV2"),
+     (qEnvironmentVariable("LOCALAPPDATA") + "/LV2")
 #else
      QStringLiteral("/usr/lib/lv2"), QStringLiteral("/usr/local/lib/lv2"),
      QStringLiteral("/usr/lib64/lv2"), QStringLiteral("/usr/local/lib64/lv2")

--- a/src/plugins/score-plugin-media/Media/Effect/Settings/Model.cpp
+++ b/src/plugins/score-plugin-media/Media/Effect/Settings/Model.cpp
@@ -28,15 +28,75 @@ SETTINGS_PARAMETER_IMPL(VstPaths){
 #endif
     }};
 
+SETTINGS_PARAMETER_IMPL(Vst3Paths){
+    QStringLiteral("Effect/Vst3Paths"),
+    {(QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.vst3"),
+#if defined(__APPLE__)
+     (QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+      + "/Library/Audio/Plug-Ins/VST3"),
+     QStringLiteral("/Library/Audio/Plug-Ins/VST3")
+#elif defined(_WIN32)
+     (qEnvironmentVariable("LOCALAPPDATA") + "/Programs/Common/VST3"),
+     QStringLiteral("C:\\Program Files\\Common Files\\VST3")
+#else
+     QStringLiteral("/usr/lib/vst3"), QStringLiteral("/usr/lib64/vst3")
+#endif
+    }};
+
+SETTINGS_PARAMETER_IMPL(ClapPaths){
+    QStringLiteral("Effect/ClapPaths"),
+    {(QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.clap"),
+#if defined(__APPLE__)
+     (QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+      + "/Library/Audio/Plug-Ins/CLAP"),
+     QStringLiteral("/Library/Audio/Plug-Ins/CLAP")
+#elif defined(_WIN32)
+     (QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/CLAP"),
+     QStringLiteral("C:/Program Files/Common Files/CLAP"),
+     QStringLiteral("C:/Program Files/Common Files/Audio Plugins/CLAP")
+#else
+     QStringLiteral("/usr/lib/clap"), QStringLiteral("/usr/local/lib/clap"),
+     QStringLiteral("/usr/lib64/clap"), QStringLiteral("/usr/local/lib64/clap")
+#endif
+    }};
+
+SETTINGS_PARAMETER_IMPL(Lv2Paths){
+    QStringLiteral("Effect/Lv2Paths"),
+    // ~/.lv2/: Linux convention; Ardour also writes user presets here cross-platform
+    {(QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/.lv2"),
+#if defined(__APPLE__)
+     (QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+      + "/Library/Audio/Plug-Ins/LV2"),
+     QStringLiteral("/Library/Audio/Plug-Ins/LV2"),
+     QStringLiteral("/usr/local/lib/lv2"),    // lilv default, Homebrew Intel
+     QStringLiteral("/opt/homebrew/lib/lv2"), // Homebrew Apple Silicon
+     QStringLiteral("/usr/lib/lv2")           // lilv default
+#elif defined(_WIN32)
+     QStringLiteral("C:/Program Files/Common Files/LV2"),
+     // Roaming %APPDATA%\LV2 (lilv/Carla default)
+     (QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/LV2"),
+     // Non-roaming %LOCALAPPDATA%\LV2 (legacy score path)
+     (QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/LV2")
+#else
+     QStringLiteral("/usr/lib/lv2"), QStringLiteral("/usr/local/lib/lv2"),
+     QStringLiteral("/usr/lib64/lv2"), QStringLiteral("/usr/local/lib64/lv2")
+#endif
+    }};
+
 SETTINGS_PARAMETER_IMPL(VstAlwaysOnTop){
     QStringLiteral("score_plugin_engine/VstAlwaysOnTop"), true};
 static auto list()
 {
-  return std::tie(VstPaths, VstAlwaysOnTop);
+  return std::tie(VstPaths, Vst3Paths, ClapPaths, Lv2Paths, VstAlwaysOnTop);
 }
 }
 
 auto VstPathsChanged_symbol_for_shlib_bug = &Media::Settings::Model::VstPathsChanged;
+auto Vst3PathsChanged_symbol_for_shlib_bug
+    = &Media::Settings::Model::Vst3PathsChanged;
+auto ClapPathsChanged_symbol_for_shlib_bug
+    = &Media::Settings::Model::ClapPathsChanged;
+auto Lv2PathsChanged_symbol_for_shlib_bug = &Media::Settings::Model::Lv2PathsChanged;
 Model::Model(
     const UuidKey<score::SettingsDelegateFactory>& k, QSettings& set,
     const score::ApplicationContext& ctx)
@@ -46,5 +106,8 @@ Model::Model(
 }
 
 SCORE_SETTINGS_PARAMETER_CPP(QStringList, Model, VstPaths)
+SCORE_SETTINGS_PARAMETER_CPP(QStringList, Model, Vst3Paths)
+SCORE_SETTINGS_PARAMETER_CPP(QStringList, Model, ClapPaths)
+SCORE_SETTINGS_PARAMETER_CPP(QStringList, Model, Lv2Paths)
 SCORE_SETTINGS_PARAMETER_CPP(bool, Model, VstAlwaysOnTop)
 }

--- a/src/plugins/score-plugin-media/Media/Effect/Settings/Model.hpp
+++ b/src/plugins/score-plugin-media/Media/Effect/Settings/Model.hpp
@@ -12,6 +12,9 @@ class SCORE_PLUGIN_MEDIA_EXPORT Model : public score::SettingsDelegateModel
   W_OBJECT(Model)
 
   QStringList m_VstPaths;
+  QStringList m_Vst3Paths;
+  QStringList m_ClapPaths;
+  QStringList m_Lv2Paths;
   bool m_VstAlwaysOnTop{};
 
 public:
@@ -20,8 +23,14 @@ public:
       const score::ApplicationContext& ctx);
 
   SCORE_SETTINGS_PARAMETER_HPP(SCORE_PLUGIN_MEDIA_EXPORT, QStringList, VstPaths)
+  SCORE_SETTINGS_PARAMETER_HPP(SCORE_PLUGIN_MEDIA_EXPORT, QStringList, Vst3Paths)
+  SCORE_SETTINGS_PARAMETER_HPP(SCORE_PLUGIN_MEDIA_EXPORT, QStringList, ClapPaths)
+  SCORE_SETTINGS_PARAMETER_HPP(SCORE_PLUGIN_MEDIA_EXPORT, QStringList, Lv2Paths)
   SCORE_SETTINGS_PARAMETER_HPP(SCORE_PLUGIN_MEDIA_EXPORT, bool, VstAlwaysOnTop)
 };
 
 SCORE_SETTINGS_PARAMETER(Model, VstPaths)
+SCORE_SETTINGS_PARAMETER(Model, Vst3Paths)
+SCORE_SETTINGS_PARAMETER(Model, ClapPaths)
+SCORE_SETTINGS_PARAMETER(Model, Lv2Paths)
 }

--- a/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.cpp
+++ b/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.cpp
@@ -1,0 +1,155 @@
+#include "PluginTab.hpp"
+
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QListWidget>
+#include <QMenu>
+#include <QPushButton>
+#include <QSplitter>
+#include <QTableWidget>
+
+namespace Media::Settings
+{
+namespace
+{
+QTableWidget* makePluginTable()
+{
+  auto table = new QTableWidget;
+  table->verticalHeader()->setVisible(false);
+  table->setColumnCount(2);
+  table->setColumnWidth(0, 120);
+  table->horizontalHeader()->setStretchLastSection(true);
+  table->setHorizontalHeaderLabels(
+      {QObject::tr("Name"), QObject::tr("Path")});
+  table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  return table;
+}
+
+void appendRow(QTableWidget* table, const PluginTabRow& row)
+{
+  const int r = table->rowCount();
+  table->setRowCount(r + 1);
+  table->setItem(r, 0, new QTableWidgetItem{row.name});
+  table->setItem(r, 1, new QTableWidgetItem{row.path});
+}
+}
+
+QWidget* makePluginSettingsWidget(PluginTabSpec spec)
+{
+  auto splitter = new QSplitter(Qt::Vertical);
+
+  // --- Search paths -------------------------------------------------------
+  auto pathWidget = new QWidget;
+  auto pathLayout = new QFormLayout;
+  pathWidget->setLayout(pathLayout);
+
+  auto pathList = new QListWidget;
+
+  auto buttons = new QHBoxLayout;
+  auto addPath = new QPushButton{QObject::tr("Add path")};
+  auto rescan = new QPushButton{QObject::tr("Rescan")};
+  buttons->addWidget(addPath);
+  buttons->addWidget(rescan);
+
+  // The current items live in a shared_ptr captured by the handlers: the
+  // widget is recreated every time the dialog opens.
+  auto items = std::make_shared<QStringList>(spec.getPaths());
+
+  auto setItems = [pathList, items](const QStringList& paths) {
+    if(*items == paths && pathList->count() == paths.size())
+      return;
+    *items = paths;
+    pathList->blockSignals(true);
+    pathList->clear();
+    pathList->addItems(paths);
+    pathList->blockSignals(false);
+    pathList->update();
+  };
+  setItems(*items);
+
+  pathList->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+  QObject::connect(
+      pathList, &QListWidget::customContextMenuRequested, pathList,
+      [pathList, items, commit = spec.commitPaths](const QPoint& p) {
+    auto menu = new QMenu;
+    auto act = menu->addAction(QObject::tr("Remove"));
+    QObject::connect(
+        act, &QAction::triggered, pathList, [pathList, items, commit] {
+      const int idx = pathList->currentRow();
+      if(idx >= 0 && idx < items->size())
+      {
+        delete pathList->takeItem(idx);
+        items->removeAt(idx);
+        commit(*items);
+      }
+        });
+    menu->exec(pathList->mapToGlobal(p));
+    menu->deleteLater();
+      });
+
+  QObject::connect(
+      addPath, &QPushButton::clicked, pathList,
+      [pathList, items, commit = spec.commitPaths, splitter] {
+    auto path
+        = QFileDialog::getExistingDirectory(splitter, QObject::tr("Plug-in path"));
+    if(!path.isEmpty())
+    {
+      pathList->addItem(path);
+      items->push_back(path);
+      commit(*items);
+    }
+      });
+
+  if(spec.onPathsChanged)
+    spec.onPathsChanged(pathList, setItems);
+
+  pathLayout->addRow(spec.pathsLabel, pathList);
+  pathLayout->addRow(buttons);
+
+  splitter->addWidget(pathWidget);
+  splitter->setStretchFactor(0, 1);
+  splitter->setCollapsible(0, false);
+
+  // --- Plug-in tables -----------------------------------------------------
+  auto ok_table = makePluginTable();
+  auto bad_table = makePluginTable();
+
+  auto reload = [ok_table, bad_table, rows = spec.rows] {
+    ok_table->clearContents();
+    ok_table->setRowCount(0);
+    bad_table->clearContents();
+    bad_table->setRowCount(0);
+
+    for(const auto& row : rows())
+      appendRow(row.valid ? ok_table : bad_table, row);
+  };
+  reload();
+
+  if(spec.onPluginsChanged)
+    spec.onPluginsChanged(ok_table, reload);
+
+  QObject::connect(
+      rescan, &QPushButton::clicked, ok_table, [do_rescan = spec.rescan] {
+    if(do_rescan)
+      do_rescan();
+      });
+
+  auto tables = new QWidget;
+  auto tables_lay = new QGridLayout;
+  tables->setLayout(tables_lay);
+  tables_lay->addWidget(new QLabel(QObject::tr("Working plug-ins")), 0, 0, 1, 1);
+  tables_lay->addWidget(new QLabel(QObject::tr("Faulty plug-ins")), 0, 1, 1, 1);
+  tables_lay->addWidget(ok_table, 1, 0, 1, 1);
+  tables_lay->addWidget(bad_table, 1, 1, 1, 1);
+
+  splitter->addWidget(tables);
+  splitter->setStretchFactor(1, 4);
+  splitter->setCollapsible(1, false);
+
+  return splitter;
+}
+}

--- a/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.hpp
+++ b/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.hpp
@@ -33,8 +33,9 @@ struct PluginTabSpec
 
   //! Current search paths from the settings model
   std::function<QStringList()> getPaths;
-  //! Commit an edited path list (through the settings command dispatcher so
-  //! the dialog's Cancel button reverts it)
+  //! Commit an edited path list. Note: applied (and rescanned) immediately;
+  //! the settings dialog's Cancel button does not revert it - same behavior
+  //! as the historical VST tab, whose dispatcher was never rolled back either.
   std::function<void(QStringList)> commitPaths;
   //! Called with (context, callback); must invoke callback(paths) whenever
   //! the settings model's path list changes

--- a/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.hpp
+++ b/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+// Reusable UI for the per-format plug-in settings tabs (VST / VST3 / CLAP /
+// LV2): an editable search-path list, a Rescan button and the two
+// working / faulty plug-in tables. Each format supplies its data source and
+// actions through PluginTabSpec and gets an identical tab in the "Effects"
+// settings page.
+
+#include <score_plugin_media_export.h>
+
+#include <QString>
+#include <QStringList>
+
+#include <functional>
+#include <vector>
+
+class QWidget;
+class QObject;
+
+namespace Media::Settings
+{
+struct PluginTabRow
+{
+  QString name;
+  QString path;
+  bool valid{};
+};
+
+struct PluginTabSpec
+{
+  //! Label of the paths editor, e.g. "VST3 paths"
+  QString pathsLabel;
+
+  //! Current search paths from the settings model
+  std::function<QStringList()> getPaths;
+  //! Commit an edited path list (through the settings command dispatcher so
+  //! the dialog's Cancel button reverts it)
+  std::function<void(QStringList)> commitPaths;
+  //! Called with (context, callback); must invoke callback(paths) whenever
+  //! the settings model's path list changes
+  std::function<void(QObject*, std::function<void(QStringList)>)> onPathsChanged;
+
+  //! Current plug-in list of the format's application plug-in
+  std::function<std::vector<PluginTabRow>()> rows;
+  //! Called with (context, callback); must invoke callback() whenever the
+  //! plug-in list changes
+  std::function<void(QObject*, std::function<void()>)> onPluginsChanged;
+
+  //! Forget everything and scan the current paths again
+  std::function<void()> rescan;
+};
+
+SCORE_PLUGIN_MEDIA_EXPORT
+QWidget* makePluginSettingsWidget(PluginTabSpec spec);
+}

--- a/src/plugins/score-plugin-media/Media/PluginScanner.cpp
+++ b/src/plugins/score-plugin-media/Media/PluginScanner.cpp
@@ -1,0 +1,389 @@
+#include "PluginScanner.hpp"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QTimer>
+#include <QUuid>
+#include <QWebSocket>
+#include <QWebSocketServer>
+
+#include <wobjectimpl.h>
+
+W_OBJECT_IMPL(Media::PluginScanner)
+
+namespace Media
+{
+namespace
+{
+//! Old puppets sent the request id as a JSON string ("Request":"3"); the
+//! current ones send a number. QJsonValue::toInt() on a string silently
+//! returns 0, which used to attribute every reply to scan slot 0.
+int readRequestId(const QJsonValue& v) noexcept
+{
+  if(v.isDouble())
+    return v.toInt(-1);
+  if(v.isString())
+  {
+    bool ok{};
+    const int res = v.toString().toInt(&ok);
+    return ok ? res : -1;
+  }
+  return -1;
+}
+}
+
+PluginScanner::PluginScanner(QString serverName, QObject* parent)
+    : QObject{parent}
+    , m_serverName{std::move(serverName)}
+    , m_token{QUuid::createUuid().toString(QUuid::WithoutBraces)}
+{
+}
+
+PluginScanner::~PluginScanner()
+{
+  cancelCurrentScan();
+}
+
+void PluginScanner::setPuppet(const QString& executable)
+{
+  m_puppet = executable;
+}
+
+void PluginScanner::setMaxInFlight(int n)
+{
+  m_maxInFlight = std::max(1, n);
+}
+
+void PluginScanner::setProcessTimeout(int ms)
+{
+  m_timeoutMs = ms;
+}
+
+void PluginScanner::setReplyGracePeriod(int ms)
+{
+  m_graceMs = ms;
+}
+
+void PluginScanner::setEnvironmentProvider(std::function<QProcessEnvironment()> f)
+{
+  m_env = std::move(f);
+}
+
+bool PluginScanner::scanning() const noexcept
+{
+  return m_scanRunning;
+}
+
+quint16 PluginScanner::port() const noexcept
+{
+  return m_server ? m_server->serverPort() : 0;
+}
+
+bool PluginScanner::ensureListening()
+{
+  if(m_server && m_server->isListening())
+    return true;
+
+  m_server = std::make_unique<QWebSocketServer>(
+      m_serverName, QWebSocketServer::NonSecureMode);
+
+  // Ephemeral port: several score-derived processes can scan concurrently
+  // without ever seeing each other's replies.
+  if(!m_server->listen(QHostAddress::LocalHost, 0))
+  {
+    qWarning() << m_serverName << ": failed to start scan server -"
+               << m_server->errorString() << "- plug-in scanning unavailable";
+    m_server.reset();
+    return false;
+  }
+
+  connect(m_server.get(), &QWebSocketServer::newConnection, this, [this] {
+    QWebSocket* ws = m_server->nextPendingConnection();
+    if(!ws)
+      return;
+
+    // Default Qt limits reject the multi-MB payloads of large bundles
+    // (lsp-plugins ships hundreds of plug-ins in one file)
+    ws->setMaxAllowedIncomingFrameSize(64 * 1024 * 1024);
+    ws->setMaxAllowedIncomingMessageSize(64 * 1024 * 1024);
+
+    connect(ws, &QWebSocket::textMessageReceived, this, [this, ws](const QString& txt) {
+      QObject::disconnect(ws, &QWebSocket::textMessageReceived, nullptr, nullptr);
+      processIncomingMessage(txt);
+      // Defer deleteLater so the puppet closes its side first; a synchronous
+      // FIN turns the puppet's teardown into a spurious non-zero exit
+      QTimer::singleShot(1000, ws, [ws] { ws->deleteLater(); });
+    });
+  });
+  return true;
+}
+
+void PluginScanner::scan(QStringList pluginPaths)
+{
+  cancelCurrentScan();
+  m_scanRunning = true;
+
+  if(pluginPaths.isEmpty())
+  {
+    checkDone();
+    return;
+  }
+
+  if(m_puppet.isEmpty() || !ensureListening())
+  {
+    // No way to run any puppet: resolve everything as failed so callers
+    // are not left waiting for a done() that never comes.
+    for(const auto& path : pluginPaths)
+      scanFailed(path, QStringLiteral("plug-in scanner unavailable"));
+    checkDone();
+    return;
+  }
+  m_queue.assign(pluginPaths.rbegin(), pluginPaths.rend()); // pop_back order
+  refill();
+}
+
+void PluginScanner::refill()
+{
+  while(!m_queue.empty() && m_live < m_maxInFlight)
+  {
+    QString path = std::move(m_queue.back());
+    m_queue.pop_back();
+    startOne(path);
+  }
+}
+
+void PluginScanner::startOne(const QString& path)
+{
+  const int id = m_nextId++;
+
+  auto proc = new QProcess;
+  auto& rec = m_records[id];
+  rec.path = path;
+  rec.process = proc;
+  rec.live = true;
+  m_live++;
+
+  if(m_env)
+    proc->setProcessEnvironment(m_env());
+
+  // stderr passes through for debugging; stdout stays piped (some puppets
+  // echo their JSON there) and is discarded with the process
+  proc->setProcessChannelMode(QProcess::ForwardedErrorChannel);
+
+  connect(
+      proc, &QProcess::errorOccurred, this, [this, id](QProcess::ProcessError err) {
+    auto it = m_records.find(id);
+    if(it == m_records.end() || !it->second.live)
+      return;
+
+    if(err == QProcess::FailedToStart)
+    {
+      // finished() will never fire; resolve here
+      qDebug() << m_serverName << ": puppet failed to start for"
+               << it->second.path;
+      resolveProcess(id);
+      failIfStillUnresolved(id, QStringLiteral("failed to start"));
+      refill();
+      checkDone();
+    }
+    // Crashed also triggers finished(): a single resolution happens there
+      });
+
+  // Parented to proc so it dies with it, but connected in our context so
+  // that destroying the scanner severs the connection
+  auto timer = new QTimer{proc};
+  timer->setSingleShot(true);
+  timer->setInterval(m_timeoutMs);
+  connect(timer, &QTimer::timeout, this, [this, id, proc] {
+    auto it = m_records.find(id);
+    if(it != m_records.end() && it->second.live)
+    {
+      qDebug() << m_serverName << ": scan timeout for" << it->second.path;
+      proc->terminate();
+      if(!proc->waitForFinished(100))
+        proc->kill();
+      // finished() fires next and resolves the record
+    }
+  });
+
+  connect(
+      proc, &QProcess::finished, this,
+      [this, id](int exitCode, QProcess::ExitStatus status) {
+    auto it = m_records.find(id);
+    if(it == m_records.end() || !it->second.live)
+      return;
+
+    resolveProcess(id);
+
+    if(it->second.replied)
+    {
+      m_records.erase(it);
+    }
+    else
+    {
+      // The reply races the process exit - even a non-zero exit code does
+      // not prove failure (close-handshake teardown). Give the WebSocket
+      // delivery a grace period before declaring the plug-in dead.
+      (void)exitCode;
+      (void)status;
+      beginGracePeriod(id);
+    }
+
+    refill();
+    checkDone();
+      });
+
+  timer->start();
+  proc->start(
+      m_puppet,
+      {path, QString::number(id), QString::number(port()), m_token},
+      QIODevice::ReadOnly);
+}
+
+//! Mark the process slot as free and schedule the QProcess for deletion.
+void PluginScanner::resolveProcess(int id)
+{
+  auto it = m_records.find(id);
+  if(it == m_records.end())
+    return;
+  auto& rec = it->second;
+  if(rec.live)
+  {
+    rec.live = false;
+    m_live--;
+  }
+  if(auto proc = rec.process.data())
+  {
+    rec.process.clear();
+    releaseProcess(proc);
+  }
+}
+
+void PluginScanner::releaseProcess(QProcess* proc)
+{
+  QObject::disconnect(proc, nullptr, this, nullptr);
+  if(proc->state() != QProcess::NotRunning)
+  {
+    proc->terminate();
+    // Reap after kill: ~QProcess on a still-running process re-kills and
+    // blocks for up to 30s
+    QTimer::singleShot(100, proc, [proc] {
+      if(proc->state() != QProcess::NotRunning)
+      {
+        proc->kill();
+        proc->waitForFinished(100);
+      }
+      proc->deleteLater();
+    });
+  }
+  else
+  {
+    proc->deleteLater();
+  }
+}
+
+void PluginScanner::beginGracePeriod(int id)
+{
+  QTimer::singleShot(m_graceMs, this, [this, id] {
+    failIfStillUnresolved(id, QStringLiteral("no reply from scanner process"));
+    checkDone();
+  });
+}
+
+void PluginScanner::failIfStillUnresolved(int id, const QString& reason)
+{
+  auto it = m_records.find(id);
+  if(it == m_records.end() || it->second.replied)
+    return;
+
+  const QString path = it->second.path;
+  m_records.erase(it);
+  scanFailed(path, reason);
+}
+
+void PluginScanner::checkDone()
+{
+  if(m_scanRunning && m_queue.empty() && m_records.empty())
+  {
+    m_scanRunning = false;
+    done();
+  }
+}
+
+void PluginScanner::processIncomingMessage(const QString& message)
+{
+  QJsonParseError err{};
+  const auto doc = QJsonDocument::fromJson(message.toUtf8(), &err);
+  if(!doc.isObject())
+  {
+    qWarning() << m_serverName << ": malformed scan reply (" << message.size()
+               << "chars):" << err.errorString();
+    return;
+  }
+
+  const auto obj = doc.object();
+
+  // The token check is what keeps other score instances' scans - and any
+  // other local process - out of our plug-in database.
+  if(obj[QStringLiteral("Token")].toString() != m_token)
+  {
+    qWarning() << m_serverName << ": dropping scan reply with wrong session token";
+    return;
+  }
+
+  const int id = readRequestId(obj[QStringLiteral("Request")]);
+  auto it = m_records.find(id);
+  if(it == m_records.end())
+  {
+    qWarning() << m_serverName << ": dropping scan reply for unknown request" << id;
+    return;
+  }
+
+  auto& rec = it->second;
+  if(rec.replied)
+    return;
+  rec.replied = true;
+
+  const QString path = rec.path;
+  const bool wasLive = rec.live;
+
+  if(wasLive)
+    resolveProcess(id);
+  m_records.erase(id);
+
+  if(obj.contains(QStringLiteral("Error")))
+    scanFailed(path, obj[QStringLiteral("Error")].toString());
+  else
+    scanned(path, obj);
+
+  refill();
+  checkDone();
+}
+
+void PluginScanner::cancelCurrentScan()
+{
+  m_queue.clear();
+
+  // waitForFinished delivers finished() synchronously: detach the map and
+  // drop our connections first or the handlers would mutate it mid-iteration.
+  auto records = std::move(m_records);
+  m_records.clear();
+  m_live = 0;
+  m_scanRunning = false;
+
+  for(auto& [id, rec] : records)
+  {
+    if(auto proc = rec.process.data())
+    {
+      QObject::disconnect(proc, nullptr, this, nullptr);
+      proc->terminate();
+      if(!proc->waitForFinished(100))
+      {
+        proc->kill();
+        proc->waitForFinished(100);
+      }
+      delete proc;
+    }
+  }
+}
+}

--- a/src/plugins/score-plugin-media/Media/PluginScanner.cpp
+++ b/src/plugins/score-plugin-media/Media/PluginScanner.cpp
@@ -1,11 +1,16 @@
 #include "PluginScanner.hpp"
 
+#if QT_CONFIG(process)
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QTimer>
 #include <QUuid>
+#if __has_include(<QWebSocketServer>)
 #include <QWebSocket>
 #include <QWebSocketServer>
+#else
+#define SCORE_PLUGIN_MEDIA_NO_WEBSOCKETS 1
+#endif
 
 #include <wobjectimpl.h>
 
@@ -42,6 +47,9 @@ PluginScanner::PluginScanner(QString serverName, QObject* parent)
 PluginScanner::~PluginScanner()
 {
   cancelCurrentScan();
+#if !defined(SCORE_PLUGIN_MEDIA_NO_WEBSOCKETS)
+  delete m_server;
+#endif
 }
 
 void PluginScanner::setPuppet(const QString& executable)
@@ -76,16 +84,22 @@ bool PluginScanner::scanning() const noexcept
 
 quint16 PluginScanner::port() const noexcept
 {
+#if defined(SCORE_PLUGIN_MEDIA_NO_WEBSOCKETS)
+  return 0;
+#else
   return m_server ? m_server->serverPort() : 0;
+#endif
 }
 
 bool PluginScanner::ensureListening()
 {
+#if defined(SCORE_PLUGIN_MEDIA_NO_WEBSOCKETS)
+  return false;
+#else
   if(m_server && m_server->isListening())
     return true;
 
-  m_server = std::make_unique<QWebSocketServer>(
-      m_serverName, QWebSocketServer::NonSecureMode);
+  m_server = new QWebSocketServer(m_serverName, QWebSocketServer::NonSecureMode);
 
   // Ephemeral port: several score-derived processes can scan concurrently
   // without ever seeing each other's replies.
@@ -93,11 +107,12 @@ bool PluginScanner::ensureListening()
   {
     qWarning() << m_serverName << ": failed to start scan server -"
                << m_server->errorString() << "- plug-in scanning unavailable";
-    m_server.reset();
+    delete m_server;
+    m_server = nullptr;
     return false;
   }
 
-  connect(m_server.get(), &QWebSocketServer::newConnection, this, [this] {
+  connect(m_server, &QWebSocketServer::newConnection, this, [this] {
     QWebSocket* ws = m_server->nextPendingConnection();
     if(!ws)
       return;
@@ -116,6 +131,7 @@ bool PluginScanner::ensureListening()
     });
   });
   return true;
+#endif
 }
 
 void PluginScanner::scan(QStringList pluginPaths)
@@ -387,3 +403,4 @@ void PluginScanner::cancelCurrentScan()
   }
 }
 }
+#endif

--- a/src/plugins/score-plugin-media/Media/PluginScanner.cpp
+++ b/src/plugins/score-plugin-media/Media/PluginScanner.cpp
@@ -122,11 +122,16 @@ bool PluginScanner::ensureListening()
     ws->setMaxAllowedIncomingFrameSize(64 * 1024 * 1024);
     ws->setMaxAllowedIncomingMessageSize(64 * 1024 * 1024);
 
+    // A puppet that connects but never replies (hang, crash, timeout kill)
+    // would otherwise keep its socket alive for the scanner's lifetime
+    connect(ws, &QWebSocket::disconnected, ws, &QObject::deleteLater);
+
     connect(ws, &QWebSocket::textMessageReceived, this, [this, ws](const QString& txt) {
       QObject::disconnect(ws, &QWebSocket::textMessageReceived, nullptr, nullptr);
       processIncomingMessage(txt);
-      // Defer deleteLater so the puppet closes its side first; a synchronous
-      // FIN turns the puppet's teardown into a spurious non-zero exit
+      // Defer deleteLater so the puppet gets a chance to finish its own
+      // teardown first (exit codes after a reply are ignored either way;
+      // the disconnected handler below usually reaps the socket earlier)
       QTimer::singleShot(1000, ws, [ws] { ws->deleteLater(); });
     });
   });
@@ -194,13 +199,19 @@ void PluginScanner::startOne(const QString& path)
 
     if(err == QProcess::FailedToStart)
     {
-      // finished() will never fire; resolve here
+      // finished() will never fire; resolve here. Deferred: FailedToStart is
+      // emitted synchronously from QProcess::start(), so resolving inline
+      // would recurse start -> errorOccurred -> refill -> start through the
+      // whole remaining queue on one stack (e.g. when the puppet binary is
+      // missing).
       qDebug() << m_serverName << ": puppet failed to start for"
                << it->second.path;
-      resolveProcess(id);
-      failIfStillUnresolved(id, QStringLiteral("failed to start"));
-      refill();
-      checkDone();
+      QTimer::singleShot(0, this, [this, id] {
+        resolveProcess(id);
+        failIfStillUnresolved(id, QStringLiteral("failed to start"));
+        refill();
+        checkDone();
+      });
     }
     // Crashed also triggers finished(): a single resolution happens there
       });
@@ -301,8 +312,16 @@ void PluginScanner::releaseProcess(QProcess* proc)
 void PluginScanner::beginGracePeriod(int id)
 {
   QTimer::singleShot(m_graceMs, this, [this, id] {
-    failIfStillUnresolved(id, QStringLiteral("no reply from scanner process"));
-    checkDone();
+    // One extra event-loop iteration before declaring failure: when the main
+    // thread was stalled past the grace period (startup GUI build, large
+    // QSettings rewrite), this timer and the WebSocket delivering the reply
+    // become ready in the *same* poll iteration, and glib does not order a
+    // timeout source before a socket source. Deferring by a 0ms timer lets a
+    // reply that is already sitting in the socket win the race.
+    QTimer::singleShot(0, this, [this, id] {
+      failIfStillUnresolved(id, QStringLiteral("no reply from scanner process"));
+      checkDone();
+    });
   });
 }
 

--- a/src/plugins/score-plugin-media/Media/PluginScanner.hpp
+++ b/src/plugins/score-plugin-media/Media/PluginScanner.hpp
@@ -1,0 +1,132 @@
+#pragma once
+
+// Shared out-of-process plug-in scan machinery for the VST2 / VST3 / CLAP /
+// LV2 application plug-ins. One puppet process is spawned per plug-in file
+// (a crashing plug-in must not take score down); the puppet reports back
+// over a local WebSocket.
+//
+// Design points, distilled from years of per-backend bugs:
+//
+//  * The server listens on an *ephemeral* port and every reply must echo a
+//    per-scanner random token. The old fixed ports (37587..37590) meant
+//    that when several score-derived processes ran at once, every scan
+//    reply landed in whichever instance owned the port: that instance
+//    appended (and persisted) duplicates of every plug-in on each run,
+//    while the scanning instance timed out and marked its plug-ins
+//    invalid. Replies with a wrong/missing token are dropped before they
+//    can touch any plug-in database.
+//  * Event-driven refill: a fixed pool of at most maxInFlight() live
+//    puppets, refilled whenever one resolves. (The previous VST2/VST3
+//    implementation polled on a 1s timer, kept the in-flight count in a
+//    translation-unit static that leaked on rescan, and only checked
+//    timeouts while saturated - hung puppets in the last batch leaked
+//    forever.)
+//  * A puppet's exit and the WebSocket delivery of its reply race each
+//    other: the process routinely finishes - sometimes with a non-zero
+//    exit code from the close-handshake - before the reply is dispatched.
+//    A finished-without-reply record is therefore kept in a short grace
+//    period instead of being declared failed on the spot; failure is only
+//    reported if the grace period elapses with no reply. This subsumes the
+//    LV2 m_scanned_ok workaround and fixes the CLAP double-invalid.
+//  * scanFailed() is emitted at most once per path, whatever combination
+//    of errorOccurred / finished / timeout fires.
+
+#include <score_plugin_media_export.h>
+
+#include <QObject>
+#include <QPointer>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QStringList>
+
+#include <verdigris>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <QJsonObject>
+
+class QWebSocketServer;
+
+namespace Media
+{
+class SCORE_PLUGIN_MEDIA_EXPORT PluginScanner : public QObject
+{
+  W_OBJECT(PluginScanner)
+public:
+  //! serverName is only a debugging label for the WebSocket server.
+  explicit PluginScanner(QString serverName, QObject* parent = nullptr);
+  ~PluginScanner();
+
+  void setPuppet(const QString& executable);
+  void setMaxInFlight(int n);
+  //! How long a puppet may run before it is killed.
+  void setProcessTimeout(int ms);
+  //! How long to keep waiting for the WebSocket reply of a process that
+  //! already exited (the reply delivery races the process exit).
+  void setReplyGracePeriod(int ms);
+  //! Extra environment for the puppets; system environment by default.
+  void setEnvironmentProvider(std::function<QProcessEnvironment()> f);
+
+  //! Start scanning the given plug-in files. A scan already in progress is
+  //! cancelled first: its puppets are reaped and emit nothing.
+  void scan(QStringList pluginPaths);
+
+  bool scanning() const noexcept;
+
+  //! The per-scanner secret that replies must echo. Exposed for tests.
+  const QString& token() const noexcept { return m_token; }
+  //! The port puppets are told to connect to; 0 until the first scan.
+  quint16 port() const noexcept;
+
+  //! Feed one reply as if it had arrived on the socket. Public so that the
+  //! protocol validation (token, request id form) is directly testable.
+  void processIncomingMessage(const QString& message);
+
+  //! A plug-in file was scanned; obj is the puppet's reply. The path is the
+  //! one the scanner was asked to scan - not whatever the reply claims.
+  void scanned(QString path, QJsonObject obj)
+      E_SIGNAL(SCORE_PLUGIN_MEDIA_EXPORT, scanned, path, obj);
+  //! The puppet crashed, timed out, errored out, or replied with "Error".
+  void scanFailed(QString path, QString reason)
+      E_SIGNAL(SCORE_PLUGIN_MEDIA_EXPORT, scanFailed, path, reason);
+  //! All requested paths have been resolved one way or the other.
+  void done() E_SIGNAL(SCORE_PLUGIN_MEDIA_EXPORT, done);
+
+private:
+  struct Record
+  {
+    QString path;
+    QPointer<QProcess> process;
+    bool live{};    // started and not yet finished/reaped
+    bool replied{}; // a token-valid reply was attributed to it
+  };
+
+  bool ensureListening();
+  void refill();
+  void startOne(const QString& path);
+  void resolveProcess(int id);
+  void releaseProcess(QProcess* proc);
+  void beginGracePeriod(int id);
+  void failIfStillUnresolved(int id, const QString& reason);
+  void checkDone();
+  void cancelCurrentScan();
+
+  std::unique_ptr<QWebSocketServer> m_server;
+  QString m_serverName;
+  QString m_token;
+  QString m_puppet;
+  std::function<QProcessEnvironment()> m_env;
+
+  std::map<int, Record> m_records;
+  std::vector<QString> m_queue;
+  int m_nextId{};
+  int m_live{};
+  int m_maxInFlight{8};
+  int m_timeoutMs{10000};
+  int m_graceMs{2000};
+  bool m_scanRunning{};
+};
+}

--- a/src/plugins/score-plugin-media/Media/PluginScanner.hpp
+++ b/src/plugins/score-plugin-media/Media/PluginScanner.hpp
@@ -35,8 +35,11 @@
 
 #include <QObject>
 #include <QPointer>
+#include <QtCore/qglobal.h>
+#if QT_CONFIG(process)
 #include <QProcess>
 #include <QProcessEnvironment>
+#endif
 #include <QStringList>
 
 #include <verdigris>
@@ -50,6 +53,7 @@
 
 class QWebSocketServer;
 
+#if QT_CONFIG(process)
 namespace Media
 {
 class SCORE_PLUGIN_MEDIA_EXPORT PluginScanner : public QObject
@@ -114,7 +118,7 @@ private:
   void checkDone();
   void cancelCurrentScan();
 
-  std::unique_ptr<QWebSocketServer> m_server;
+  QWebSocketServer* m_server{};
   QString m_serverName;
   QString m_token;
   QString m_puppet;
@@ -130,3 +134,4 @@ private:
   bool m_scanRunning{};
 };
 }
+#endif

--- a/src/plugins/score-plugin-vst/CMakeLists.txt
+++ b/src/plugins/score-plugin-vst/CMakeLists.txt
@@ -10,11 +10,6 @@ if(SCORE_FAST_DEV_BUILD)
   return()
 endif()
 
-# Packages
-if(NOT TARGET ${QT_PREFIX}::WebSockets)
-  # VST support requires websockets
-  return()
-endif()
 
 # Files & main target
 set(HDRS
@@ -73,7 +68,7 @@ add_library(${PROJECT_NAME}
 
 score_generate_command_list_file(${PROJECT_NAME} "${HDRS}")
 target_link_libraries(${PROJECT_NAME} PUBLIC
-                     ${QT_PREFIX}::Core ${QT_PREFIX}::Widgets ${QT_PREFIX}::WebSockets
+                     ${QT_PREFIX}::Core ${QT_PREFIX}::Widgets
                      ${CMAKE_DL_LIBS}
                      score_lib_base score_plugin_automation score_plugin_media
 )

--- a/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.cpp
@@ -4,7 +4,9 @@
 
 #include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
 
+#include <Media/AudioPluginCache.hpp>
 #include <Media/Effect/Settings/Model.hpp>
+#include <Media/PluginScanner.hpp>
 #include <Vst/EffectModel.hpp>
 #include <Vst/Loader.hpp>
 
@@ -15,17 +17,13 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QProcess>
 #include <QTimer>
-#include <QWebSocket>
 
 #include <wobjectimpl.h>
 W_OBJECT_IMPL(vst::ApplicationPlugin)
 
 SCORE_SERALIZE_DATASTREAM_DEFINE(vst::VSTInfo)
 SCORE_SERALIZE_DATASTREAM_DEFINE(std::vector<vst::VSTInfo>)
-// TODO remove me in a few versions
-static bool vst_invalid_format = false;
 template <>
 void DataStreamReader::read(const vst::VSTInfo& p)
 {
@@ -35,13 +33,8 @@ void DataStreamReader::read(const vst::VSTInfo& p)
 template <>
 void DataStreamWriter::write(vst::VSTInfo& p)
 {
-  if(!vst_invalid_format)
-    m_stream >> p.path >> p.prettyName >> p.displayName >> p.author >> p.uniqueID
-        >> p.controls >> p.isSynth >> p.isValid;
-  if(m_stream.stream.status() != QDataStream::Status::Ok)
-  {
-    vst_invalid_format = true;
-  }
+  m_stream >> p.path >> p.prettyName >> p.displayName >> p.author >> p.uniqueID
+      >> p.controls >> p.isSynth >> p.isValid;
 }
 
 Q_DECLARE_METATYPE(vst::VSTInfo)
@@ -51,77 +44,14 @@ W_REGISTER_ARGTYPE(std::vector<vst::VSTInfo>)
 
 namespace vst
 {
-
-ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& app)
-    : score::ApplicationPlugin{app}
-#if QT_CONFIG(process)
-    , m_wsServer("vst-notification-server", QWebSocketServer::NonSecureMode)
-#endif
+namespace
 {
-  qRegisterMetaType<VSTInfo>();
-  qRegisterMetaType<std::vector<VSTInfo>>();
-
-#if QT_CONFIG(process)
-  m_wsServer.listen(QHostAddress::LocalHost, 37587);
-  con(m_wsServer, &QWebSocketServer::newConnection, this, [this] {
-    QWebSocket* ws = m_wsServer.nextPendingConnection();
-    if(!ws)
-      return;
-
-    connect(ws, &QWebSocket::textMessageReceived, this, [this, ws](const QString& txt) {
-      processIncomingMessage(txt);
-      ws->deleteLater();
-    });
-  });
-#endif
-
-  // VST idle update
-  startTimer(10, Qt::PreciseTimer);
+constexpr quint32 cache_format_version = 1;
+const QString cache_key = QStringLiteral("Effect/KnownVST2Cache");
+const QString legacy_cache_key = QStringLiteral("Effect/KnownVST2");
 }
 
-void ApplicationPlugin::initialize()
-{
-  // init with the database
-  QSettings s;
-  auto val = s.value("Effect/KnownVST2");
-  if(val.canConvert<std::vector<VSTInfo>>())
-  {
-    vst_infos = val.value<std::vector<VSTInfo>>();
-  }
-
-  if(vst_invalid_format)
-  {
-    vst_infos.clear();
-    vst_invalid_format = false;
-  }
-
-  vstChanged();
-
-  auto& set = context.settings<Media::Settings::Model>();
-  con(set, &Media::Settings::Model::VstPathsChanged, this,
-      &ApplicationPlugin::rescanVSTs);
-
-  if(qEnvironmentVariableIsEmpty("SCORE_DISABLE_AUDIOPLUGINS"))
-    rescanVSTs(set.getVstPaths());
-}
-
-void ApplicationPlugin::addInvalidVST(const QString& path)
-{
-  VSTInfo i;
-  i.path = path;
-  i.prettyName = "invalid";
-  i.uniqueID = -1;
-  i.isSynth = false;
-  i.isValid = false;
-  vst_infos.push_back(i);
-
-  // write in the database
-  QSettings{}.setValue("Effect/KnownVST2", QVariant::fromValue(vst_infos));
-
-  vstChanged();
-}
-
-void ApplicationPlugin::addVST(const QString& path, const QJsonObject& obj)
+VSTInfo parseVstReply(const QString& path, const QJsonObject& obj)
 {
   VSTInfo i;
   i.path = path;
@@ -135,15 +65,60 @@ void ApplicationPlugin::addVST(const QString& path, const QJsonObject& obj)
   // Only way to get a separation between Kontakt 5 / Kontakt 5 (8
   // out) / Kontakt 5 (16 out),  etc...
   i.prettyName = QFileInfo(path).completeBaseName();
+  return i;
+}
 
-  vst_modules.insert({i.uniqueID, nullptr});
-  vst_infos.push_back(std::move(i));
+ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& app)
+    : score::ApplicationPlugin{app}
+{
+  qRegisterMetaType<VSTInfo>();
+  qRegisterMetaType<std::vector<VSTInfo>>();
 
-  // write in the database
-  QSettings{}.setValue("Effect/KnownVST2", QVariant::fromValue(vst_infos));
+#if QT_CONFIG(process)
+  m_scanner = std::make_unique<Media::PluginScanner>("vst-scanner");
+  con(*m_scanner, &Media::PluginScanner::scanned, this, &ApplicationPlugin::onScanned);
+  con(*m_scanner, &Media::PluginScanner::scanFailed, this,
+      &ApplicationPlugin::onScanFailed);
+  con(*m_scanner, &Media::PluginScanner::done, this, [this] {
+    persistCache();
+    vstChanged();
+  });
+#endif
 
-  qDebug() << "Loaded VST " << path << "successfully";
+  // Coalesce disk writes + UI updates: one per batch, not one per puppet
+  m_persistTimer = new QTimer{this};
+  m_persistTimer->setSingleShot(true);
+  m_persistTimer->setInterval(500);
+  connect(m_persistTimer, &QTimer::timeout, this, [this] {
+    persistCache();
+    vstChanged();
+  });
+
+  // VST idle update
+  startTimer(10, Qt::PreciseTimer);
+}
+
+void ApplicationPlugin::initialize()
+{
+  // Load, and heal caches damaged by the pre-token protocol (duplicated
+  // entries, valid/invalid pairs for the same path)
+  vst_infos = Media::loadPluginCache<VSTInfo>(
+      cache_format_version, cache_key, legacy_cache_key);
+  Media::sanitizePluginCache(
+      vst_infos, [](const VSTInfo& i) { return i.path; },
+      [](const VSTInfo& i) { return i.path; },
+      [](const VSTInfo& i) { return i.isValid; });
+  // Make the migration/healing durable even if no scan runs this session
+  persistCache();
+
   vstChanged();
+
+  auto& set = context.settings<Media::Settings::Model>();
+  con(set, &Media::Settings::Model::VstPathsChanged, this,
+      &ApplicationPlugin::rescanVSTs);
+
+  if(qEnvironmentVariableIsEmpty("SCORE_DISABLE_AUDIOPLUGINS"))
+    rescanVSTs(set.getVstPaths());
 }
 
 void ApplicationPlugin::registerRunningVST(Model* m)
@@ -174,7 +149,7 @@ static const QString& vstPuppetPath()
     else if(QFile::exists(app + "/ossia-score-vstpuppet"))
       return QString(app + "/ossia-score-vstpuppet");
     else if(QFile::exists(app + "/../../ossia-score-vstpuppet"))
-      return QString(path + "/../../ossia-score-vstpuppet");
+      return QString(app + "/../../ossia-score-vstpuppet");
     else if(QFile::exists(app + "/../../" + bundle_path))
       return QString(app + "/../../" + bundle_path);
     else
@@ -256,13 +231,13 @@ void ApplicationPlugin::rescanVSTs(QStringList paths)
 #endif
   }
 
-  // 2. Remove plug-ins not in these paths
+  // 2. Remove plug-ins not in these paths, keep the known ones
   for(auto it = vst_infos.begin(); it != vst_infos.end();)
   {
     auto new_it = newPlugins.find(it->path);
     if(new_it != newPlugins.end())
     {
-      // plug-in is in both set, we ignore it
+      // plug-in is in both sets, no need to rescan it
       newPlugins.erase(new_it);
       ++it;
     }
@@ -274,114 +249,64 @@ void ApplicationPlugin::rescanVSTs(QStringList paths)
 
   vstChanged();
 
-  // 3. Add remaining plug-ins
-  m_processes.clear();
-  m_processes.reserve(newPlugins.size());
-  int i = 0;
+  // 3. Scan the remaining ones out-of-process
+  QStringList toScan;
   for(const QString& path : newPlugins)
   {
     if(path.contains("linvst.so"))
       continue;
-
-    auto proc = std::make_unique<QProcess>();
-    connect(proc.get(), &QProcess::errorOccurred, this, [proc = proc.get(), path] {
-      qDebug() << " == VST: error => " << path;
-      qDebug() << " -- VST out: " << proc->readAllStandardOutput().constData();
-      qDebug() << " -- VST error: " << proc->readAllStandardError().constData();
-    });
-
-    proc->setProgram(vstPuppetPath());
-    proc->setArguments({path, QString::number(i)});
-    m_processes.push_back({path, std::move(proc), false, {}});
-    i++;
+    toScan.push_back(path);
   }
-  scanVSTsEvent();
+  toScan.sort();
+
+  m_scanner->setPuppet(vstPuppetPath());
+  m_scanner->scan(std::move(toScan));
 #endif
 }
 
-static int vst_in_flight = 0;
-void ApplicationPlugin::processIncomingMessage(const QString& txt)
+void ApplicationPlugin::removeEntriesForPath(const QString& path)
 {
-#if QT_CONFIG(process)
-  QJsonDocument doc = QJsonDocument::fromJson(txt.toUtf8());
-  if(doc.isObject())
-  {
-    auto obj = doc.object();
-    addVST(obj["Path"].toString(), obj);
-    int id = obj["Request"].toInt();
-
-    if(id >= 0 && id < std::ssize(m_processes))
-    {
-      if(m_processes[id].process)
-      {
-        m_processes[id].process->close();
-        if(m_processes[id].process->state() == QProcess::ProcessState::NotRunning)
-        {
-          vst_in_flight--;
-          m_processes[id] = {};
-        }
-        else
-        {
-          connect(
-              m_processes[id].process.get(),
-              qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this,
-              [this, id] {
-            vst_in_flight--;
-            m_processes[id] = {};
-          });
-        }
-      }
-    }
-    else
-    {
-      qDebug() << "Got invalid VST request ID" << id;
-    }
-  }
-#endif
+  ossia::remove_erase_if(
+      vst_infos, [&](const VSTInfo& i) { return i.path == path; });
 }
 
-void ApplicationPlugin::scanVSTsEvent()
+void ApplicationPlugin::onScanned(const QString& path, const QJsonObject& obj)
 {
-#if QT_CONFIG(process)
-  constexpr int max_in_flight = 8;
+  VSTInfo i = parseVstReply(path, obj);
 
-  for(auto& proc : m_processes)
-  {
-    // Already scanned processes
-    if(!proc.process)
-      continue;
+  removeEntriesForPath(path);
+  vst_modules.insert({i.uniqueID, nullptr});
+  vst_infos.push_back(std::move(i));
 
-    if(!proc.scanning)
-    {
-      if(vst_in_flight < max_in_flight)
-      {
-        proc.process->start(QProcess::ReadOnly);
-        proc.scanning = true;
-        proc.timer.start();
+  qDebug() << "Loaded VST " << path << "successfully";
+  schedulePersist();
+}
 
-        vst_in_flight++;
-      }
-    }
-    else
-    {
-      if(proc.timer.elapsed() > 10000)
-      {
-        addInvalidVST(proc.path);
-        proc.process->kill();
-        proc.process.reset();
+void ApplicationPlugin::onScanFailed(const QString& path, const QString& reason)
+{
+  qDebug() << "VST scan failed for" << path << ":" << reason;
 
-        vst_in_flight--;
-        continue;
-      }
-    }
+  VSTInfo i;
+  i.path = path;
+  i.prettyName = "invalid";
+  i.uniqueID = -1;
+  i.isSynth = false;
+  i.isValid = false;
 
-    if(vst_in_flight == max_in_flight)
-    {
-      QTimer::singleShot(1000, this, &ApplicationPlugin::scanVSTsEvent);
-      return;
-    }
-  }
-#endif
+  removeEntriesForPath(path);
+  vst_infos.push_back(std::move(i));
+
+  schedulePersist();
+}
+
+void ApplicationPlugin::persistCache()
+{
+  Media::savePluginCache(cache_format_version, cache_key, vst_infos);
+}
+
+void ApplicationPlugin::schedulePersist()
+{
+  m_persistTimer->start();
 }
 
 void ApplicationPlugin::timerEvent(QTimerEvent* event)

--- a/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.cpp
@@ -76,6 +76,9 @@ ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& app)
 
 #if QT_CONFIG(process)
   m_scanner = std::make_unique<Media::PluginScanner>("vst-scanner");
+  // 30s: bridged plug-ins (yabridge) may need a cold wineserver start, and
+  // up to 4 formats x 8 puppets share the machine during a startup scan
+  m_scanner->setProcessTimeout(30000);
   con(*m_scanner, &Media::PluginScanner::scanned, this, &ApplicationPlugin::onScanned);
   con(*m_scanner, &Media::PluginScanner::scanFailed, this,
       &ApplicationPlugin::onScanFailed);
@@ -306,7 +309,12 @@ void ApplicationPlugin::persistCache()
 
 void ApplicationPlugin::schedulePersist()
 {
-  m_persistTimer->start();
+  m_scanRan = true;
+  // Don't restart a running timer: during a busy scan replies arrive more
+  // often than the interval and a restarting debounce would never fire,
+  // deferring both persistence and UI updates to the very end of the scan
+  if(!m_persistTimer->isActive())
+    m_persistTimer->start();
 }
 
 void ApplicationPlugin::timerEvent(QTimerEvent* event)
@@ -322,6 +330,11 @@ void ApplicationPlugin::timerEvent(QTimerEvent* event)
 
 ApplicationPlugin::~ApplicationPlugin()
 {
+  // Results delivered so far would otherwise be lost when quitting mid-scan:
+  // the debounced m_persistTimer dies with us
+  if(m_scanRan)
+    persistCache();
+
   for(auto& e : vst_modules)
   {
     delete e.second;

--- a/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.hpp
@@ -5,14 +5,20 @@
 
 #include <ossia/detail/hash_map.hpp>
 
-#include <QElapsedTimer>
-#if QT_CONFIG(process)
-#include <QProcess>
-#endif
-#include <QWebSocketServer>
+#include <QtCore/qglobal.h>
+
+#include <score_plugin_vst_export.h>
 
 #include <thread>
 #include <verdigris>
+
+class QTimer;
+class QJsonObject;
+namespace Media
+{
+class PluginScanner;
+}
+
 namespace vst
 {
 struct VSTInfo
@@ -27,6 +33,11 @@ struct VSTInfo
   bool isValid{};
 };
 
+//! Build a VSTInfo from a vstpuppet scan reply. The path is the scanned
+//! file, not whatever the reply claims.
+SCORE_PLUGIN_VST_EXPORT
+VSTInfo parseVstReply(const QString& path, const QJsonObject& obj);
+
 class Model;
 class ApplicationPlugin
     : public QObject
@@ -40,17 +51,12 @@ public:
 
   void clearVSTs();
   void rescanVSTs(QStringList);
-  void processIncomingMessage(const QString& txt);
-  void addInvalidVST(const QString& path);
-  void addVST(const QString& path, const QJsonObject& json);
 
   // Used for idle timers
   void registerRunningVST(vst::Model*);
   void unregisterRunningVST(vst::Model*);
 
-  void scanVSTsEvent();
-
-  void vstChanged() W_SIGNAL(vstChanged)
+  void vstChanged() E_SIGNAL(SCORE_PLUGIN_VST_EXPORT, vstChanged);
 
   std::vector<VSTInfo> vst_infos;
   ossia::hash_map<int32_t, vst::Module*> vst_modules;
@@ -59,20 +65,17 @@ public:
   auto mainThreadId() const noexcept { return m_tid; }
   std::vector<vst::Model*> m_runningVSTs;
 
-#if QT_CONFIG(process)
-  struct ScanningProcess
-  {
-    QString path;
-    std::unique_ptr<QProcess> process;
-    bool scanning{};
-    QElapsedTimer timer;
-  };
-
-  std::vector<ScanningProcess> m_processes;
-
 private:
-  QWebSocketServer m_wsServer;
+  void onScanned(const QString& path, const QJsonObject& obj);
+  void onScanFailed(const QString& path, const QString& reason);
+  void removeEntriesForPath(const QString& path);
+  void persistCache();
+  void schedulePersist();
+
+#if QT_CONFIG(process)
+  std::unique_ptr<Media::PluginScanner> m_scanner;
 #endif
+  QTimer* m_persistTimer{};
 
   void timerEvent(QTimerEvent* event) override;
 };

--- a/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-vst/Vst/ApplicationPlugin.hpp
@@ -76,6 +76,7 @@ private:
   std::unique_ptr<Media::PluginScanner> m_scanner;
 #endif
   QTimer* m_persistTimer{};
+  bool m_scanRan{};
 
   void timerEvent(QTimerEvent* event) override;
 };

--- a/src/plugins/score-plugin-vst3/CMakeLists.txt
+++ b/src/plugins/score-plugin-vst3/CMakeLists.txt
@@ -11,12 +11,6 @@ if(SCORE_FAST_DEV_BUILD)
   return()
 endif()
 
-# Packages
-if(NOT TARGET "${QT_PREFIX}::WebSockets")
-  # VST3 support requires websockets
-  return()
-endif()
-
 include("${3RDPARTY_FOLDER}/vst3.cmake")
 
 # Source files
@@ -31,6 +25,7 @@ set(HDRS
   Vst3/Node.hpp
   Vst3/Plugin.hpp
   Vst3/Library.hpp
+  Vst3/Settings.hpp
   Vst3/Widgets.hpp
   Vst3/UI/Window.hpp
   Vst3/UI/PlugFrame.hpp
@@ -45,6 +40,7 @@ set(SRCS
   Vst3/EffectModel.cpp
   Vst3/Executor.cpp
   Vst3/Plugin.cpp
+  Vst3/Settings.cpp
   Vst3/Widgets.cpp
   Vst3/UI/WindowCommon.cpp
 
@@ -95,7 +91,6 @@ target_link_libraries(${PROJECT_NAME}
     score_plugin_dataflow
     score_plugin_media
     sdk_common sdk_hosting
-    ${QT_PREFIX}::WebSockets
 )
 
 if(APPLE)

--- a/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.cpp
@@ -1,4 +1,6 @@
+#include <Media/AudioPluginCache.hpp>
 #include <Media/Effect/Settings/Model.hpp>
+#include <Media/PluginScanner.hpp>
 #include <Vst3/ApplicationPlugin.hpp>
 
 #include <score/serialization/DataStreamVisitor.hpp>
@@ -17,8 +19,6 @@
 #include <QSettings>
 #include <QStandardPaths>
 #include <QTimer>
-#include <QWebSocket>
-#include <QWebSocketServer>
 
 #include <wobjectimpl.h>
 
@@ -70,67 +70,113 @@ namespace vst3
 {
 namespace
 {
-#if defined(__APPLE__)
-static const QStringList default_paths = {"/Library/Audio/Plug-Ins/VST3"};
+constexpr quint32 cache_format_version = 1;
+const QString cache_key = QStringLiteral("Effect/KnownVST3Cache");
+const QString legacy_cache_key = QStringLiteral("Effect/KnownVST3");
+
 static const constexpr auto default_filter = "*.vst3";
-static const constexpr auto default_format = QDir::Dirs;
-#elif defined(_WIN32)
-static const QStringList default_paths = {"C:\\Program Files\\Common Files\\VST3"};
-static const constexpr auto default_filter = "*.vst3";
+#if defined(_WIN32)
 static const constexpr auto default_format = QDir::Files;
-#elif defined(__linux__)
-static const QStringList default_paths
-    = {QStringLiteral("/usr/lib/vst3"), QStringLiteral("/usr/lib64/vst3")};
-static const constexpr auto default_filter = "*.vst3";
-static const constexpr auto default_format = QDir::Dirs;
 #else
-static const QStringList default_paths = {QStringLiteral("/usr/lib/vst3")};
-static const constexpr auto default_filter = "*.vst3";
 static const constexpr auto default_format = QDir::Dirs;
 #endif
 }
+
+VST3::Hosting::ClassInfo::SubCategories
+parseSubCategories(const std::string& str) noexcept
+{
+  std::vector<std::string> vec;
+  std::stringstream stream(str);
+  std::string item;
+  while(std::getline(stream, item, '|'))
+    vec.emplace_back(std::move(item));
+  return vec;
+}
+
+AvailablePlugin parseVst3Reply(const QString& path, const QJsonObject& obj)
+{
+  AvailablePlugin i;
+  i.path = path;
+  i.name = obj["Name"].toString();
+  i.url = obj["Url"].toString();
+
+  const auto& classes = obj["Classes"].toArray();
+  i.classInfo.reserve(classes.size());
+
+  for(const QJsonValue& v : classes)
+  {
+    const QJsonObject& obj = v.toObject();
+    const auto uid = VST3::UID::fromString(obj["UID"].toString().toStdString());
+    if(!uid)
+      continue;
+
+    i.classInfo.resize(i.classInfo.size() + 1);
+    VST3::Hosting::ClassInfo& cls = i.classInfo.back();
+
+    cls.get().classID = *uid;
+    cls.get().cardinality = obj["Cardinality"].toInt();
+    cls.get().category = obj["Category"].toString().toStdString();
+    cls.get().name = obj["Name"].toString().toStdString();
+    cls.get().vendor = obj["Vendor"].toString().toStdString();
+    cls.get().version = obj["Version"].toString().toStdString();
+    cls.get().sdkVersion = obj["SDKVersion"].toString().toStdString();
+    cls.get().subCategories
+        = parseSubCategories(obj["Subcategories"].toString().toStdString());
+    cls.get().classFlags = (uint32_t)obj["ClassFlags"].toDouble();
+  }
+
+  i.isValid = !i.classInfo.empty();
+  return i;
+}
+
 ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& ctx)
     : score::ApplicationPlugin{ctx}
-#if QT_CONFIG(process)
-    , m_wsServer("vst3-notification-server", QWebSocketServer::NonSecureMode)
-#endif
 {
   qRegisterMetaType<AvailablePlugin>();
   qRegisterMetaType<std::vector<AvailablePlugin>>();
 
 #if QT_CONFIG(process)
-  m_wsServer.listen(QHostAddress::LocalHost, 37588);
-  con(m_wsServer, &QWebSocketServer::newConnection, this, [this] {
-    QWebSocket* ws = m_wsServer.nextPendingConnection();
-    if(!ws)
-      return;
-
-    connect(ws, &QWebSocket::textMessageReceived, this, [this, ws](const QString& txt) {
-      processIncomingMessage(txt);
-      ws->deleteLater();
-    });
+  m_scanner = std::make_unique<Media::PluginScanner>("vst3-scanner");
+  con(*m_scanner, &Media::PluginScanner::scanned, this, &ApplicationPlugin::onScanned);
+  con(*m_scanner, &Media::PluginScanner::scanFailed, this,
+      &ApplicationPlugin::onScanFailed);
+  con(*m_scanner, &Media::PluginScanner::done, this, [this] {
+    persistCache();
+    vstChanged();
   });
 #endif
+
+  // Coalesce disk writes + UI updates: one per batch, not one per puppet
+  m_persistTimer = new QTimer{this};
+  m_persistTimer->setSingleShot(true);
+  m_persistTimer->setInterval(500);
+  connect(m_persistTimer, &QTimer::timeout, this, [this] {
+    persistCache();
+    vstChanged();
+  });
 }
+
+ApplicationPlugin::~ApplicationPlugin() = default;
 
 void ApplicationPlugin::initialize()
 {
-  // init with the database
-  QSettings s;
-  auto val = s.value("Effect/KnownVST3");
-  if(val.canConvert<std::vector<AvailablePlugin>>())
-  {
-    vst_infos = val.value<std::vector<AvailablePlugin>>();
-  }
+  // Load, and heal caches damaged by the pre-token protocol (duplicated
+  // entries, valid/invalid pairs for the same path)
+  vst_infos = Media::loadPluginCache<AvailablePlugin>(
+      cache_format_version, cache_key, legacy_cache_key);
+  Media::sanitizePluginCache(
+      vst_infos, [](const AvailablePlugin& i) { return i.path; },
+      [](const AvailablePlugin& i) { return i.path; },
+      [](const AvailablePlugin& i) { return i.isValid; });
+  // Make the migration/healing durable even if no scan runs this session
+  persistCache();
 
   vstChanged();
 
-  //! TODO
+  // Note: our own path list, not VST2's - editing the VST2 paths used to
+  // wipe and rescan the whole VST3 database
   auto& set = context.settings<Media::Settings::Model>();
-  con(set, &Media::Settings::Model::VstPathsChanged, this, [this] {
-    vst_infos.clear();
-    rescan();
-  });
+  con(set, &Media::Settings::Model::Vst3PathsChanged, this, [this] { rescan(); });
 
   if(qEnvironmentVariableIsEmpty("SCORE_DISABLE_AUDIOPLUGINS"))
   {
@@ -140,19 +186,7 @@ void ApplicationPlugin::initialize()
 
 void ApplicationPlugin::rescan()
 {
-  auto paths = default_paths;
-
-  // User folders
-#if defined(__APPLE__)
-  const QString user = qgetenv("USERNAME");
-  paths.prepend(QString("/Users/%1/Library/Audio/Plug-ins/VST3/").arg(user));
-#elif defined(_WIN32)
-  const QString local_app_data = qgetenv("LOCALAPPDATA");
-  paths.prepend(QString("%1/Programs/Common/VST3/").arg(local_app_data));
-#endif
-
-  const QString home = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
-  paths.prepend(QString("%1/.vst3/").arg(home));
+  auto paths = context.settings<Media::Settings::Model>().getVst3Paths();
 
   // VST3_PATH
   if(QFileInfo vst_env_path{QString(qgetenv("VST3_PATH"))}; vst_env_path.isDir())
@@ -192,7 +226,7 @@ static const QString& vst3PuppetPath()
     else if(QFile::exists(app + "/ossia-score-vst3puppet"))
       return QString(app + "/ossia-score-vst3puppet");
     else if(QFile::exists(app + "/../../ossia-score-vst3puppet"))
-      return QString(path + "/../../ossia-score-vst3puppet");
+      return QString(app + "/../../ossia-score-vst3puppet");
     else if(QFile::exists(app + "/../../" + bundle_path))
       return QString(app + "/../../" + bundle_path);
     else
@@ -228,13 +262,13 @@ void ApplicationPlugin::rescan(const QStringList& paths)
     }
   }
 
-  // 2. Remove plug-ins not in these paths
+  // 2. Remove plug-ins not in these paths, keep the known ones
   for(auto it = vst_infos.begin(); it != vst_infos.end();)
   {
     auto new_it = newPlugins.find(it->path);
     if(new_it != newPlugins.end())
     {
-      // plug-in is in both set, we ignore it
+      // plug-in is in both sets, no need to rescan it
       newPlugins.erase(new_it);
       ++it;
     }
@@ -246,160 +280,60 @@ void ApplicationPlugin::rescan(const QStringList& paths)
 
   vstChanged();
 
-  // 3. Add remaining plug-ins
-  m_processes.clear();
-  m_processes.reserve(newPlugins.size());
-  int i = 0;
-  for(const QString& path : newPlugins)
-  {
-    auto proc = std::make_unique<QProcess>();
-    connect(proc.get(), &QProcess::errorOccurred, this, [proc = proc.get(), path] {
-      qDebug() << " == VST3: error => " << path;
-      qDebug() << " -- VST3 out: " << proc->readAllStandardOutput().constData();
-      qDebug() << " -- VST3 error: " << proc->readAllStandardError().constData();
-    });
+  // 3. Scan the remaining ones out-of-process
+  QStringList toScan{newPlugins.begin(), newPlugins.end()};
+  toScan.sort();
 
-    proc->setProgram(vst3PuppetPath());
-    proc->setArguments({path, QString::number(i)});
-    m_processes.push_back({path, std::move(proc), false, {}});
-    i++;
-  }
-
-  scanVSTsEvent();
-  /*
-  for(const auto& vst : newPlugins)
-  {
-    try {
-      auto module = getModule(vst.toStdString());
-      auto& v = vst_infos.emplace_back(AvailablePlugin{vst});
-
-      const auto& factory = module->getFactory();
-      for (const auto& class_info : factory.classInfos())
-      {
-        if (class_info.category() == kVstAudioEffectClass)
-        {
-          v.classInfo.push_back(class_info);
-        }
-      }
-
-      v.isValid = v.classInfo.size() > 0;
-    } catch(std::exception& e) {
-      qDebug() << e.what();
-    }
-  }
-  */
+  m_scanner->setPuppet(vst3PuppetPath());
+  m_scanner->scan(std::move(toScan));
 #endif
 }
 
-static int vst3_in_flight = 0;
-void ApplicationPlugin::processIncomingMessage(const QString& txt)
+void ApplicationPlugin::removeEntriesForPath(const QString& path)
 {
-#if QT_CONFIG(process)
-  QJsonDocument doc = QJsonDocument::fromJson(txt.toUtf8());
-
-  if(doc.isObject())
-  {
-    auto obj = doc.object();
-    addVST(obj["Path"].toString(), obj);
-    int id = obj["Request"].toInt();
-
-    if(ossia::valid_index(id, m_processes))
-    {
-      if(m_processes[id].process)
-      {
-        m_processes[id].process->close();
-        if(m_processes[id].process->state() == QProcess::ProcessState::NotRunning)
-        {
-          vst3_in_flight--;
-          m_processes[id] = {};
-        }
-        else
-        {
-          connect(
-              m_processes[id].process.get(),
-              qOverload<int, QProcess::ExitStatus>(&QProcess::finished), this,
-              [this, id] {
-            m_processes[id] = {};
-            vst3_in_flight--;
-          });
-        }
-      }
-    }
-    else
-    {
-      qDebug() << "Got invalid VST3 request ID" << id;
-    }
-  }
-#endif
+  ossia::remove_erase_if(
+      vst_infos, [&](const AvailablePlugin& i) { return i.path == path; });
 }
 
-void ApplicationPlugin::addInvalidVST(const QString& path)
+void ApplicationPlugin::onScanned(const QString& path, const QJsonObject& obj)
 {
+  AvailablePlugin i = parseVst3Reply(path, obj);
+  if(!i.isValid)
+  {
+    // A reply without any audio-effect class: not an error, but nothing we
+    // can instantiate either. Record it so the file is not rescanned on
+    // every startup.
+    onScanFailed(path, QStringLiteral("no audio effect classes"));
+    return;
+  }
+
+  removeEntriesForPath(path);
+  vst_infos.push_back(std::move(i));
+  schedulePersist();
+}
+
+void ApplicationPlugin::onScanFailed(const QString& path, const QString& reason)
+{
+  qDebug() << "VST3 scan failed for" << path << ":" << reason;
+
   AvailablePlugin i;
   i.path = path;
   i.name = "invalid";
   i.isValid = false;
-  vst_infos.push_back(i);
 
-  // write in the database
-  QSettings{}.setValue("Effect/KnownVST3", QVariant::fromValue(vst_infos));
-
-  vstChanged();
-}
-
-VST3::Hosting::ClassInfo::SubCategories
-parseSubCategories(const std::string& str) noexcept
-{
-  std::vector<std::string> vec;
-  std::stringstream stream(str);
-  std::string item;
-  while(std::getline(stream, item, '|'))
-    vec.emplace_back(std::move(item));
-  return vec;
-}
-
-void ApplicationPlugin::addVST(const QString& path, const QJsonObject& obj)
-{
-  AvailablePlugin i;
-  i.path = path;
-  i.name = obj["Name"].toString();
-  i.url = obj["Url"].toString();
-  i.isValid = true;
-
-  const auto& classes = obj["Classes"].toArray();
-  i.classInfo.reserve(classes.size());
-
-  for(const QJsonValue& v : classes)
-  {
-    const QJsonObject& obj = v.toObject();
-    const auto uid = VST3::UID::fromString(obj["UID"].toString().toStdString());
-    if(!uid)
-      continue;
-
-    i.classInfo.resize(i.classInfo.size() + 1);
-    VST3::Hosting::ClassInfo& cls = i.classInfo.back();
-
-    cls.get().classID = *uid;
-    cls.get().cardinality = obj["Cardinality"].toInt();
-    cls.get().category = obj["Category"].toString().toStdString();
-    cls.get().name = obj["Name"].toString().toStdString();
-    cls.get().vendor = obj["Vendor"].toString().toStdString();
-    cls.get().version = obj["Version"].toString().toStdString();
-    cls.get().sdkVersion = obj["SDKVersion"].toString().toStdString();
-    cls.get().subCategories
-        = parseSubCategories(obj["Subcategories"].toString().toStdString());
-    cls.get().classFlags = obj["Version"].toDouble();
-  }
-
-  if(i.classInfo.empty())
-    return;
-
+  removeEntriesForPath(path);
   vst_infos.push_back(std::move(i));
+  schedulePersist();
+}
 
-  // write in the database
-  QSettings{}.setValue("Effect/KnownVST3", QVariant::fromValue(vst_infos));
+void ApplicationPlugin::persistCache()
+{
+  Media::savePluginCache(cache_format_version, cache_key, vst_infos);
+}
 
-  vstChanged();
+void ApplicationPlugin::schedulePersist()
+{
+  m_persistTimer->start();
 }
 
 VST3::Hosting::Module::Ptr ApplicationPlugin::getModule(const std::string& path)
@@ -420,49 +354,6 @@ VST3::Hosting::Module::Ptr ApplicationPlugin::getModule(const std::string& path)
     modules[path] = module;
     return module;
   }
-}
-
-void ApplicationPlugin::scanVSTsEvent()
-{
-#if QT_CONFIG(process)
-  constexpr int max_in_flight = 8;
-
-  for(auto& proc : m_processes)
-  {
-    // Already scanned processes
-    if(!proc.process)
-      continue;
-
-    if(!proc.scanning)
-    {
-      if(vst3_in_flight < max_in_flight)
-      {
-        proc.process->start(QProcess::ReadOnly);
-        proc.scanning = true;
-        proc.timer.start();
-        vst3_in_flight++;
-      }
-    }
-    else
-    {
-      if(proc.timer.elapsed() > 10000)
-      {
-        addInvalidVST(proc.path);
-        proc.process->kill();
-        proc.process.reset();
-
-        vst3_in_flight--;
-        continue;
-      }
-    }
-
-    if(vst3_in_flight == max_in_flight)
-    {
-      QTimer::singleShot(1000, this, &ApplicationPlugin::scanVSTsEvent);
-      return;
-    }
-  }
-#endif
 }
 
 std::pair<const AvailablePlugin*, const VST3::Hosting::ClassInfo*>

--- a/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.cpp
@@ -137,6 +137,9 @@ ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& ctx)
 
 #if QT_CONFIG(process)
   m_scanner = std::make_unique<Media::PluginScanner>("vst3-scanner");
+  // 30s: bridged plug-ins (yabridge) may need a cold wineserver start, and
+  // up to 4 formats x 8 puppets share the machine during a startup scan
+  m_scanner->setProcessTimeout(30000);
   con(*m_scanner, &Media::PluginScanner::scanned, this, &ApplicationPlugin::onScanned);
   con(*m_scanner, &Media::PluginScanner::scanFailed, this,
       &ApplicationPlugin::onScanFailed);
@@ -156,7 +159,13 @@ ApplicationPlugin::ApplicationPlugin(const score::ApplicationContext& ctx)
   });
 }
 
-ApplicationPlugin::~ApplicationPlugin() = default;
+ApplicationPlugin::~ApplicationPlugin()
+{
+  // Results delivered so far would otherwise be lost when quitting mid-scan:
+  // the debounced m_persistTimer dies with us
+  if(m_scanRan)
+    persistCache();
+}
 
 void ApplicationPlugin::initialize()
 {
@@ -300,10 +309,10 @@ void ApplicationPlugin::onScanned(const QString& path, const QJsonObject& obj)
   AvailablePlugin i = parseVst3Reply(path, obj);
   if(!i.isValid)
   {
-    // A reply without any audio-effect class: not an error, but nothing we
-    // can instantiate either. Record it so the file is not rescanned on
-    // every startup.
-    onScanFailed(path, QStringLiteral("no audio effect classes"));
+    // No usable class in the reply (the puppet only emits audio-effect
+    // classes, and classes with malformed UIDs are skipped): nothing we can
+    // instantiate. Record it so the file is not rescanned on every startup.
+    onScanFailed(path, QStringLiteral("no usable audio effect classes"));
     return;
   }
 
@@ -333,7 +342,12 @@ void ApplicationPlugin::persistCache()
 
 void ApplicationPlugin::schedulePersist()
 {
-  m_persistTimer->start();
+  m_scanRan = true;
+  // Don't restart a running timer: during a busy scan replies arrive more
+  // often than the interval and a restarting debounce would never fire,
+  // deferring both persistence and UI updates to the very end of the scan
+  if(!m_persistTimer->isActive())
+    m_persistTimer->start();
 }
 
 VST3::Hosting::Module::Ptr ApplicationPlugin::getModule(const std::string& path)

--- a/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.hpp
@@ -132,5 +132,6 @@ private:
   std::unique_ptr<Media::PluginScanner> m_scanner;
 #endif
   QTimer* m_persistTimer{};
+  bool m_scanRan{};
 };
 }

--- a/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/ApplicationPlugin.hpp
@@ -6,15 +6,23 @@
 #include <ossia/detail/fmt.hpp>
 #include <ossia/detail/string_map.hpp>
 
-#include <QElapsedTimer>
-#include <QProcess>
-#include <QWebSocketServer>
+#include <QtCore/qglobal.h>
+
+#include <score_plugin_vst3_export.h>
 
 #include <base/source/fstring.h>
 #include <pluginterfaces/vst/ivstmessage.h>
 
 #include <memory>
 #include <stdexcept>
+#include <verdigris>
+
+class QTimer;
+class QJsonObject;
+namespace Media
+{
+class PluginScanner;
+}
 
 namespace vst3
 {
@@ -27,6 +35,11 @@ struct AvailablePlugin
 
   bool isValid{};
 };
+
+//! Build an AvailablePlugin from a vst3puppet scan reply. The path is the
+//! scanned module, not whatever the reply claims.
+SCORE_PLUGIN_VST3_EXPORT
+AvailablePlugin parseVst3Reply(const QString& path, const QJsonObject& obj);
 
 struct HostApp final : public Steinberg::Vst::IHostApplication
 {
@@ -81,13 +94,14 @@ struct HostApp final : public Steinberg::Vst::IHostApplication
   Steinberg::uint32 PLUGIN_API release() override { return 1; }
 };
 
-class ApplicationPlugin
+class SCORE_PLUGIN_VST3_EXPORT ApplicationPlugin
     : public QObject
     , public score::ApplicationPlugin
 {
   W_OBJECT(ApplicationPlugin)
 public:
   ApplicationPlugin(const score::ApplicationContext& ctx);
+  ~ApplicationPlugin();
 
   void initialize() override;
 
@@ -95,13 +109,7 @@ public:
 
   void rescan();
   void rescan(const QStringList& paths);
-  void vstChanged() W_SIGNAL(vstChanged)
-
-  void processIncomingMessage(const QString& txt);
-  void addInvalidVST(const QString& path);
-  void addVST(const QString& path, const QJsonObject& json);
-
-  void scanVSTsEvent();
+  void vstChanged() E_SIGNAL(SCORE_PLUGIN_VST3_EXPORT, vstChanged);
 
   std::pair<const AvailablePlugin*, const VST3::Hosting::ClassInfo*>
   classInfo(const VST3::UID& uid) const noexcept;
@@ -109,21 +117,20 @@ public:
   std::optional<VST3::UID>
   uidForPathAndClassName(const QString& path, const QString& cls) const noexcept;
 
-#if QT_CONFIG(process)
-  struct ScanningProcess
-  {
-    QString path;
-    std::unique_ptr<QProcess> process;
-    bool scanning{};
-    QElapsedTimer timer;
-  };
-
-  std::vector<ScanningProcess> m_processes;
-  QWebSocketServer m_wsServer;
-#endif
-
   HostApp m_host;
   ossia::string_map<VST3::Hosting::Module::Ptr> modules;
   std::vector<AvailablePlugin> vst_infos;
+
+private:
+  void onScanned(const QString& path, const QJsonObject& obj);
+  void onScanFailed(const QString& path, const QString& reason);
+  void removeEntriesForPath(const QString& path);
+  void persistCache();
+  void schedulePersist();
+
+#if QT_CONFIG(process)
+  std::unique_ptr<Media::PluginScanner> m_scanner;
+#endif
+  QTimer* m_persistTimer{};
 };
 }

--- a/src/plugins/score-plugin-vst3/Vst3/Settings.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Settings.cpp
@@ -1,47 +1,46 @@
 #include <Media/Effect/Settings/Model.hpp>
 #include <Media/Effect/Settings/PluginTab.hpp>
-#include <Vst/ApplicationPlugin.hpp>
-#include <Vst/Settings.hpp>
+#include <Vst3/ApplicationPlugin.hpp>
+#include <Vst3/Settings.hpp>
 
 #include <score/application/GUIApplicationContext.hpp>
 
-namespace vst
+namespace vst3
 {
 QString SettingsWidget::name() const noexcept
 {
-  return "VST";
+  return "VST3";
 }
 
 QWidget* SettingsWidget::make(const score::ApplicationContext& ctx)
 {
   auto& model = ctx.settings<Media::Settings::Model>();
   auto& gctx = static_cast<const score::GUIApplicationContext&>(ctx);
-  auto& plug = gctx.applicationPlugin<vst::ApplicationPlugin>();
+  auto& plug = gctx.applicationPlugin<vst3::ApplicationPlugin>();
 
   Media::Settings::PluginTabSpec spec;
-  spec.pathsLabel = QObject::tr("VST paths");
-  spec.getPaths = [&model] { return model.getVstPaths(); };
+  spec.pathsLabel = QObject::tr("VST3 paths");
+  spec.getPaths = [&model] { return model.getVst3Paths(); };
   spec.commitPaths = [this, &model](QStringList paths) {
-    m_disp.submit<Media::Settings::SetModelVstPaths>(model, std::move(paths));
+    m_disp.submit<Media::Settings::SetModelVst3Paths>(model, std::move(paths));
   };
   spec.onPathsChanged = [&model](QObject* c, std::function<void(QStringList)> f) {
     QObject::connect(
-        &model, &Media::Settings::Model::VstPathsChanged, c, std::move(f));
+        &model, &Media::Settings::Model::Vst3PathsChanged, c, std::move(f));
   };
   spec.rows = [&plug] {
     std::vector<Media::Settings::PluginTabRow> rows;
     rows.reserve(plug.vst_infos.size());
     for(const auto& p : plug.vst_infos)
-      rows.push_back(
-          {p.prettyName.isEmpty() ? p.displayName : p.prettyName, p.path, p.isValid});
+      rows.push_back({p.name, p.path, p.isValid});
     return rows;
   };
   spec.onPluginsChanged = [&plug](QObject* c, std::function<void()> f) {
-    QObject::connect(&plug, &vst::ApplicationPlugin::vstChanged, c, std::move(f));
+    QObject::connect(&plug, &vst3::ApplicationPlugin::vstChanged, c, std::move(f));
   };
-  spec.rescan = [&plug, &model] {
-    plug.clearVSTs();
-    plug.rescanVSTs(model.getVstPaths());
+  spec.rescan = [&plug] {
+    plug.vst_infos.clear();
+    plug.rescan();
   };
 
   return Media::Settings::makePluginSettingsWidget(std::move(spec));

--- a/src/plugins/score-plugin-vst3/Vst3/Settings.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Settings.hpp
@@ -3,12 +3,12 @@
 
 #include <score/command/Dispatchers/SettingsCommandDispatcher.hpp>
 
-namespace vst
+namespace vst3
 {
-//! "VST" tab of the Effects settings page: search paths + scanned plug-ins.
+//! "VST3" tab of the Effects settings page: search paths + scanned plug-ins.
 class SettingsWidget final : public Media::Settings::PluginSettingsTab
 {
-  SCORE_CONCRETE("849b6420-cdc9-47c3-9cac-74897336a77a")
+  SCORE_CONCRETE("ac291b3b-b0ed-4a37-ab55-5092337b3e24")
 public:
   QString name() const noexcept override;
   QWidget* make(const score::ApplicationContext& ctx) override;

--- a/src/plugins/score-plugin-vst3/score_plugin_vst3.cpp
+++ b/src/plugins/score-plugin-vst3/score_plugin_vst3.cpp
@@ -6,6 +6,7 @@
 #include <Vst3/Executor.hpp>
 #include <Vst3/Library.hpp>
 #include <Vst3/Plugin.hpp>
+#include <Vst3/Settings.hpp>
 #include <Vst3/UI/Window.hpp>
 #include <Vst3/Widgets.hpp>
 
@@ -37,7 +38,8 @@ std::vector<score::InterfaceBase*> score_plugin_vst3::factories(
       FW<Execution::ProcessComponentFactory, vst3::ExecutorFactory>,
       FW<Library::LibraryInterface, vst3::LibraryHandler>,
       FW<Process::PortFactory, vst3::VSTControlPortFactory>,
-      FW<Process::LayerFactory, vst3::LayerFactory>>(ctx, key);
+      FW<Process::LayerFactory, vst3::LayerFactory>,
+      FW<Media::Settings::PluginSettingsTab, vst3::SettingsWidget>>(ctx, key);
 }
 
 std::pair<const CommandGroupKey, CommandGeneratorMap> score_plugin_vst3::make_commands()

--- a/src/vst3puppet/vst3puppet.cpp
+++ b/src/vst3puppet/vst3puppet.cpp
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
   init_invisible_window();
 
   return score::puppet::puppet_main(
-      argc, argv, 37588, "vst3puppet", true,
+      argc, argv, 37588, "vst3puppet", true, 30,
       [](const std::string& path, int id, const std::string& token) {
     return load_vst(path, id, token);
       });

--- a/src/vst3puppet/vst3puppet.cpp
+++ b/src/vst3puppet/vst3puppet.cpp
@@ -1,6 +1,5 @@
 
-#include <ossia/detail/fmt.hpp>
-#include <ossia/network/sockets/websocket.hpp>
+#include <score/tools/PuppetClient.hpp>
 
 #include <pluginterfaces/base/funknown.h>
 #include <pluginterfaces/vst/ivstaudioprocessor.h>
@@ -45,7 +44,17 @@ void throw_exception(std::exception const& e, boost::source_location const& loc)
 #endif
 
 using namespace Steinberg;
-std::string load_vst(const std::string& path, int id)
+using score::puppet::json_escape;
+
+static std::string
+error_json(const std::string& path, int id, const std::string& token, std::string err)
+{
+  return fmt::format(
+      R"_({{"Path":"{}","Request":{},"Token":"{}","Error":"{}"}})_", json_escape(path),
+      id, json_escape(token), json_escape(err));
+}
+
+std::string load_vst(const std::string& path, int id, const std::string& token)
 {
   try
   {
@@ -53,7 +62,7 @@ std::string load_vst(const std::string& path, int id)
     if(!isFile)
     {
       std::cerr << "Invalid path: " << path << std::endl;
-      return {};
+      return error_json(path, id, token, "Invalid path");
     }
 
     std::string err;
@@ -62,6 +71,7 @@ std::string load_vst(const std::string& path, int id)
     if(!module)
     {
       std::cerr << "Failed to load VST3 " << path << err << std::endl;
+      return error_json(path, id, token, "Failed to load: " + err);
     }
 
     std::string root;
@@ -85,9 +95,10 @@ std::string load_vst(const std::string& path, int id)
 "Subcategories":"{}",
 "ClassFlags":{}
 }})_",
-            cls.ID().toString(), cls.cardinality(), cls.category(), cls.name(),
-            cls.vendor(), cls.version(), cls.sdkVersion(), cls.subCategoriesString(),
-            (double)cls.classFlags());
+            cls.ID().toString(), cls.cardinality(), json_escape(cls.category()),
+            json_escape(cls.name()), json_escape(cls.vendor()),
+            json_escape(cls.version()), json_escape(cls.sdkVersion()),
+            json_escape(cls.subCategoriesString()), (uint32_t)cls.classFlags());
 
         arr.push_back(str);
       }
@@ -99,11 +110,13 @@ std::string load_vst(const std::string& path, int id)
 "Url":"{}",
 "Email":"{}",
 "Path":"{}",
-"Request":"{}",
+"Request":{},
+"Token":"{}",
 "Classes":[
 )_",
-        module->getName(), fi.url(), fi.email(), path, id);
-    for(int i = 0; i < arr.size(); i++)
+        json_escape(module->getName()), json_escape(fi.url()), json_escape(fi.email()),
+        json_escape(path), id, json_escape(token));
+    for(std::size_t i = 0; i < arr.size(); i++)
     {
       root += arr[i];
       if(i < arr.size() - 1)
@@ -116,86 +129,24 @@ std::string load_vst(const std::string& path, int id)
   catch(const std::runtime_error& e)
   {
     std::cerr << e.what() << std::endl;
+    return error_json(path, id, token, e.what());
   }
-  return {};
+  catch(...)
+  {
+    return error_json(path, id, token, "Unknown exception");
+  }
 }
-
-struct app
-{
-
-  boost::asio::io_context ctx;
-  ossia::net::websocket_simple_client socket{{.url = "ws://127.0.0.1:37588"}, ctx};
-
-  bool socket_ready{}, vst_ready{};
-  std::string json_ret;
-
-  app()
-  {
-    socket.on_open.connect<&app::on_open>(*this);
-    socket.on_fail.connect<&app::on_error>(*this);
-    socket.on_close.connect<&app::on_error>(*this);
-
-    socket.websocket_client::connect("ws://127.0.0.1:37588");
-  }
-
-  void on_ready()
-  {
-    if(socket_ready && vst_ready)
-    {
-      socket.send_message(json_ret);
-      socket.close();
-      boost::asio::post(ctx, [&] { exit(json_ret.empty() ? 1 : 0); });
-    }
-  }
-
-  void on_error()
-  {
-    std::cerr << "Socket error\n";
-    exit(1);
-  }
-
-  void load(const std::string& vst, int id)
-  {
-    json_ret = load_vst(vst, id);
-    std::cout << json_ret << "\n";
-    vst_ready = true;
-    on_ready();
-  }
-
-  void on_open()
-  {
-    socket_ready = true;
-    on_ready();
-  }
-};
 
 void init_invisible_window();
 int main(int argc, char** argv)
 {
-  if(argc <= 1)
-    return 1;
-
   init_invisible_window();
 
-  int id = 0;
-  if(argc > 2)
-    id = std::atoi(argv[2]);
-
-  app a;
-
-  boost::asio::post(a.ctx, [&] { a.load(argv[1], id); });
-
-  boost::asio::steady_timer tm{a.ctx};
-  tm.expires_after(std::chrono::seconds(10));
-  tm.async_wait([](auto ec) {
-    std::cerr << "Timeout\n";
-    exit(1);
-  });
-
-  a.ctx.run();
-  a.ctx.restart();
-  a.ctx.run();
-  return a.json_ret.empty() ? 1 : 0;
+  return score::puppet::puppet_main(
+      argc, argv, 37588, "vst3puppet", true,
+      [](const std::string& path, int id, const std::string& token) {
+    return load_vst(path, id, token);
+      });
 }
 
 #include <score/tools/WinMainToMain.hpp>

--- a/src/vstpuppet/vstpuppet.cpp
+++ b/src/vstpuppet/vstpuppet.cpp
@@ -1,7 +1,6 @@
 #include <Vst/Loader.hpp>
 
-#include <ossia/detail/fmt.hpp>
-#include <ossia/network/sockets/websocket.hpp>
+#include <score/tools/PuppetClient.hpp>
 
 #include <filesystem>
 #include <iostream>
@@ -147,15 +146,22 @@ static std::string getString(AEffect* fx, AEffectOpcodes op, int param)
   return paramName;
 }
 
-std::string load_vst(const std::string& path, int id)
+std::string load_vst(const std::string& path, int id, const std::string& token)
 {
+  using score::puppet::json_escape;
+  auto error_json = [&](std::string err) {
+    return fmt::format(
+        R"_({{"Path":"{}","Request":{},"Token":"{}","Error":"{}"}})_",
+        json_escape(path), id, json_escape(token), json_escape(err));
+  };
+
   try
   {
     const bool isFile = std::filesystem::exists(path);
     if(!isFile)
     {
       std::cerr << "Invalid path: " << path << std::endl;
-      return {};
+      return error_json("Invalid path");
     }
 
     vst::Module plugin{path};
@@ -173,100 +179,42 @@ std::string load_vst(const std::string& path, int id)
 "Version":"{}",
 "Synth":{},
 "Path":"{}",
-"Request":{}
+"Request":{},
+"Token":"{}"
 }})_",
-            p->uniqueID, p->numParams, getString(p, effGetVendorString, 0),
-            getString(p, effGetProductString, 0), getString(p, effGetVendorVersion, 0),
-            bool(p->flags & effFlagsIsSynth), path, id);
+            p->uniqueID, p->numParams, json_escape(getString(p, effGetVendorString, 0)),
+            json_escape(getString(p, effGetProductString, 0)),
+            json_escape(getString(p, effGetVendorVersion, 0)),
+            bool(p->flags & effFlagsIsSynth), json_escape(path), id,
+            json_escape(token));
 
         p->dispatcher(p, AEffectOpcodes::effClose, 0, 0, nullptr, 0.f);
         return str;
       }
     }
+    return error_json("No VST entry point");
   }
   catch(const std::runtime_error& e)
   {
     std::cerr << e.what() << std::endl;
+    return error_json(e.what());
   }
-  return {};
+  catch(...)
+  {
+    return error_json("Unknown exception");
+  }
 }
-
-struct app
-{
-
-  boost::asio::io_context ctx;
-  ossia::net::websocket_simple_client socket{{.url = "ws://127.0.0.1:37587"}, ctx};
-
-  bool socket_ready{}, vst_ready{};
-  std::string json_ret;
-
-  app()
-  {
-    socket.on_open.connect<&app::on_open>(*this);
-    socket.on_fail.connect<&app::on_error>(*this);
-    socket.on_close.connect<&app::on_error>(*this);
-
-    socket.websocket_client::connect("ws://127.0.0.1:37587");
-  }
-
-  void on_ready()
-  {
-    if(socket_ready && vst_ready)
-    {
-      socket.send_message(json_ret);
-      socket.close();
-      boost::asio::post(ctx, [&] { exit(json_ret.empty() ? 1 : 0); });
-    }
-  }
-
-  void on_error()
-  {
-    std::cerr << "Socket error\n";
-    exit(1);
-  }
-
-  void load(const std::string& vst, int id)
-  {
-    json_ret = load_vst(vst, id);
-    std::cout << json_ret << "\n";
-    vst_ready = true;
-    on_ready();
-  }
-
-  void on_open()
-  {
-    socket_ready = true;
-    on_ready();
-  }
-};
 
 void init_invisible_window();
 int main(int argc, char** argv)
 {
-  if(argc <= 1)
-    return 1;
-
   init_invisible_window();
 
-  int id = 0;
-  if(argc > 2)
-    id = std::atoi(argv[2]);
-
-  app a;
-
-  boost::asio::post(a.ctx, [&] { a.load(argv[1], id); });
-
-  boost::asio::steady_timer tm{a.ctx};
-  tm.expires_after(std::chrono::seconds(10));
-  tm.async_wait([](auto ec) {
-    std::cerr << "Timeout\n";
-    exit(1);
-  });
-
-  a.ctx.run();
-  a.ctx.restart();
-  a.ctx.run();
-  return a.json_ret.empty() ? 1 : 0;
+  return score::puppet::puppet_main(
+      argc, argv, 37587, "vstpuppet", true,
+      [](const std::string& path, int id, const std::string& token) {
+    return load_vst(path, id, token);
+      });
 }
 
 #include <score/tools/WinMainToMain.hpp>

--- a/src/vstpuppet/vstpuppet.cpp
+++ b/src/vstpuppet/vstpuppet.cpp
@@ -211,7 +211,7 @@ int main(int argc, char** argv)
   init_invisible_window();
 
   return score::puppet::puppet_main(
-      argc, argv, 37587, "vstpuppet", true,
+      argc, argv, 37587, "vstpuppet", true, 30,
       [](const std::string& path, int id, const std::string& token) {
     return load_vst(path, id, token);
       });

--- a/tests/fixtures/CMakeLists.txt
+++ b/tests/fixtures/CMakeLists.txt
@@ -11,6 +11,15 @@ target_link_libraries(score_test_fixtures
 # Test LV2 bundle (only when score_plugin_lv2 is built).
 add_subdirectory(lv2)
 
+# Scriptable stand-in for the plug-in scanner puppets (PluginScanner tests).
+add_executable(score_test_fake_puppet fake_puppet/fake_puppet.cpp)
+target_link_libraries(score_test_fake_puppet PRIVATE
+  ${QT_PREFIX}::Core ${QT_PREFIX}::WebSockets)
+set_target_properties(score_test_fake_puppet PROPERTIES
+  FOLDER "Tests"
+  SCORE_CUSTOM_PCH 1
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
 # Make the headers visible in IDEs.
 file(GLOB_RECURSE _fixture_hdrs "${CMAKE_CURRENT_SOURCE_DIR}/score_test/*.hpp")
 add_custom_target(score_test_fixtures_headers SOURCES ${_fixture_hdrs})

--- a/tests/fixtures/fake_puppet/fake_puppet.cpp
+++ b/tests/fixtures/fake_puppet/fake_puppet.cpp
@@ -1,0 +1,93 @@
+// A stand-in for the plug-in scanner puppets, driven by the
+// FAKE_PUPPET_BEHAVIOR environment variable. Speaks the same protocol:
+//   fake_puppet <path> <id> <port> <token>
+// and replies on ws://127.0.0.1:<port>.
+//
+// Behaviors:
+//   reply        (default) send a well-formed reply, exit 0
+//   reply_exit1  send a well-formed reply, then exit 1 (close-handshake race)
+//   badtoken     send a reply carrying the wrong session token
+//   stringid     send the request id as a JSON string (legacy puppets)
+//   error        send an {"Error": ...} reply
+//   garbage      send something that is not JSON
+//   hang         connect but never reply (must be reaped by the timeout)
+//   crash        abort() before replying
+//   exit1        exit(1) without replying
+
+#include <QCoreApplication>
+#include <QTimer>
+#include <QWebSocket>
+
+#include <cstdlib>
+#include <cstring>
+
+int main(int argc, char** argv)
+{
+  QCoreApplication app(argc, argv);
+
+  if(argc < 5)
+    return 2;
+
+  const QString path = argv[1];
+  const QString id = argv[2];
+  const int port = atoi(argv[3]);
+  const QString token = argv[4];
+
+  const char* behavior_env = getenv("FAKE_PUPPET_BEHAVIOR");
+  const QString behavior = behavior_env ? behavior_env : "reply";
+
+  if(behavior == "crash")
+    abort();
+  if(behavior == "exit1")
+    return 1;
+
+  auto ws = new QWebSocket;
+  QObject::connect(ws, &QWebSocket::connected, &app, [&] {
+    if(behavior == "hang")
+      return; // stay connected, never reply
+
+    QString msg;
+    if(behavior == "garbage")
+    {
+      msg = "this is not json {{{";
+    }
+    else
+    {
+      const QString tok = (behavior == "badtoken") ? "WRONG-TOKEN" : token;
+      const QString req
+          = (behavior == "stringid") ? ("\"" + id + "\"") : id;
+      if(behavior == "error")
+      {
+        msg = QString(R"({"Path":"%1","Request":%2,"Token":"%3","Error":"simulated failure"})")
+                  .arg(path, req, tok);
+      }
+      else
+      {
+        msg = QString(
+                  R"({"Path":"%1","Request":%2,"Token":"%3","Name":"Fake Plugin","Plugins":[{"ID":"org.fake.%4","Name":"Fake %4"}]})")
+                  .arg(path, req, tok, id);
+      }
+    }
+    ws->sendTextMessage(msg);
+    ws->flush();
+
+    QTimer::singleShot(100, &app, [&] {
+      if(behavior == "reply_exit1")
+        std::exit(1);
+      app.exit(0);
+    });
+  });
+
+  QObject::connect(
+      ws, &QWebSocket::errorOccurred, &app, [&](QAbstractSocket::SocketError) {
+    // No server: mirrors the real puppets' "socket error" exit
+    std::exit(1);
+      });
+
+  ws->open(QUrl(QString("ws://127.0.0.1:%1").arg(port)));
+
+  // Global watchdog so a stuck test cannot leak processes forever
+  QTimer::singleShot(30000, &app, [] { std::exit(3); });
+
+  return app.exec();
+}

--- a/tests/fixtures/fake_puppet/fake_puppet.cpp
+++ b/tests/fixtures/fake_puppet/fake_puppet.cpp
@@ -78,11 +78,18 @@ int main(int argc, char** argv)
     });
   });
 
-  QObject::connect(
-      ws, &QWebSocket::errorOccurred, &app, [&](QAbstractSocket::SocketError) {
+  // QWebSocket::errorOccurred only exists since Qt 6.5 (before that the
+  // signal is the overloaded `error`); Coverage CI builds with Qt 6.4
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+  constexpr auto error_signal = &QWebSocket::errorOccurred;
+#else
+  constexpr auto error_signal
+      = qOverload<QAbstractSocket::SocketError>(&QWebSocket::error);
+#endif
+  QObject::connect(ws, error_signal, &app, [&](QAbstractSocket::SocketError) {
     // No server: mirrors the real puppets' "socket error" exit
     std::exit(1);
-      });
+  });
 
   ws->open(QUrl(QString("ws://127.0.0.1:%1").arg(port)));
 

--- a/tests/unit/AudioPluginCacheTest.cpp
+++ b/tests/unit/AudioPluginCacheTest.cpp
@@ -1,0 +1,182 @@
+// Tests for Media/AudioPluginCache.hpp — the versioned scan-cache blob and
+// the cache-healing helpers.
+//
+// Regressions covered:
+//  * The old caches were raw QVariant metatype blobs: a datastream layout
+//    change made old blobs decode as garbage that canConvert() accepted
+//    (the VST2 "vst_invalid_format" global was a workaround). The new blob
+//    must fail *cleanly* on version bumps, truncation and corruption.
+//  * Scan replies from other score instances used to be appended to
+//    whichever instance owned the fixed notification port, duplicating
+//    every plug-in on each run (observed: 200+ copies per CLAP plug-in).
+//    deduplicate() heals such caches on load.
+//  * A reply arriving after the 10s reaper had already declared a timeout
+//    recorded a plug-in both as valid and as an "<Invalid>" marker;
+//    dropShadowedInvalidEntries() resolves those pairs in favour of valid.
+
+#include <Media/AudioPluginCache.hpp>
+
+#include <QDataStream>
+#include <QString>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+struct TestInfo
+{
+  QString path;
+  QString id;
+  bool valid{};
+
+  bool operator==(const TestInfo&) const = default;
+};
+
+QDataStream& operator<<(QDataStream& s, const TestInfo& i)
+{
+  return s << i.path << i.id << i.valid;
+}
+QDataStream& operator>>(QDataStream& s, TestInfo& i)
+{
+  return s >> i.path >> i.id >> i.valid;
+}
+
+TestInfo info(QString path, QString id, bool valid = true)
+{
+  return TestInfo{std::move(path), std::move(id), valid};
+}
+
+const auto key_of = [](const TestInfo& i) { return i.path + "|" + i.id; };
+const auto path_of = [](const TestInfo& i) { return i.path; };
+const auto is_valid = [](const TestInfo& i) { return i.valid; };
+}
+
+TEST_CASE("plugin cache roundtrip", "[pluginscan][cache]")
+{
+  const std::vector<TestInfo> src{
+      info("/usr/lib/clap/a.clap", "org.a"), info("/usr/lib/clap/b.clap", "org.b"),
+      info("/usr/lib/clap/broken.clap", "", false)};
+
+  const auto blob = Media::serializePluginCache(3, src);
+  const auto back = Media::deserializePluginCache<TestInfo>(3, blob);
+  REQUIRE(back.has_value());
+  REQUIRE(*back == src);
+}
+
+TEST_CASE("plugin cache: empty vector roundtrips", "[pluginscan][cache]")
+{
+  const auto blob = Media::serializePluginCache(1, std::vector<TestInfo>{});
+  const auto back = Media::deserializePluginCache<TestInfo>(1, blob);
+  REQUIRE(back.has_value());
+  REQUIRE(back->empty());
+}
+
+TEST_CASE("plugin cache rejects version mismatch", "[pluginscan][cache]")
+{
+  const std::vector<TestInfo> src{info("/p", "x")};
+  const auto blob = Media::serializePluginCache(3, src);
+  REQUIRE(!Media::deserializePluginCache<TestInfo>(4, blob).has_value());
+  REQUIRE(!Media::deserializePluginCache<TestInfo>(2, blob).has_value());
+}
+
+TEST_CASE("plugin cache rejects damage instead of returning garbage", "[pluginscan][cache]")
+{
+  const std::vector<TestInfo> src{info("/p1", "x"), info("/p2", "y")};
+  auto blob = Media::serializePluginCache(3, src);
+
+  SECTION("truncation")
+  {
+    blob.truncate(blob.size() / 2);
+    REQUIRE(!Media::deserializePluginCache<TestInfo>(3, blob).has_value());
+  }
+  SECTION("trailing bytes")
+  {
+    blob.append("garbage");
+    REQUIRE(!Media::deserializePluginCache<TestInfo>(3, blob).has_value());
+  }
+  SECTION("wrong magic")
+  {
+    blob[0] = 'X';
+    REQUIRE(!Media::deserializePluginCache<TestInfo>(3, blob).has_value());
+  }
+  SECTION("empty")
+  {
+    REQUIRE(!Media::deserializePluginCache<TestInfo>(3, QByteArray{}).has_value());
+  }
+  SECTION("corrupt count")
+  {
+    // Header is magic(4) + version(4) + count(4): blast the count field
+    blob[8] = (char)0xff;
+    blob[9] = (char)0xff;
+    blob[10] = (char)0xff;
+    blob[11] = (char)0xff;
+    REQUIRE(!Media::deserializePluginCache<TestInfo>(3, blob).has_value());
+  }
+}
+
+TEST_CASE("deduplicate heals a 200x-duplicated cache", "[pluginscan][heal]")
+{
+  std::vector<TestInfo> cache;
+  for(int run = 0; run < 200; run++)
+  {
+    cache.push_back(info("/usr/lib/clap/surge.clap", "org.surge"));
+    cache.push_back(info("/usr/lib/clap/dexed.clap", "org.dexed"));
+  }
+  REQUIRE(cache.size() == 400);
+
+  Media::deduplicate(cache, key_of);
+
+  REQUIRE(cache.size() == 2);
+  REQUIRE(cache[0].path == "/usr/lib/clap/surge.clap");
+  REQUIRE(cache[1].path == "/usr/lib/clap/dexed.clap");
+}
+
+TEST_CASE("deduplicate keeps distinct plug-ins from one file", "[pluginscan][heal]")
+{
+  // One .clap file can host many plug-ins: same path, distinct ids
+  std::vector<TestInfo> cache{
+      info("/lsp.clap", "lsp.compressor"), info("/lsp.clap", "lsp.limiter"),
+      info("/lsp.clap", "lsp.compressor")};
+
+  Media::deduplicate(cache, key_of);
+
+  REQUIRE(cache.size() == 2);
+}
+
+TEST_CASE("valid entries win over invalid markers for the same path", "[pluginscan][heal]")
+{
+  std::vector<TestInfo> cache{
+      info("/a.clap", "", false),      // false timeout marker, recorded first
+      info("/a.clap", "org.a", true),  // the real reply
+      info("/dead.clap", "", false)};  // genuinely broken plug-in
+
+  Media::dropShadowedInvalidEntries(cache, path_of, is_valid);
+
+  REQUIRE(cache.size() == 2);
+  REQUIRE(cache[0].id == "org.a");
+  REQUIRE(cache[1].path == "/dead.clap"); // real invalid marker preserved
+}
+
+TEST_CASE("sanitizePluginCache combines all healing steps", "[pluginscan][heal]")
+{
+  std::vector<TestInfo> cache;
+  // 50 runs' worth of cross-instance duplicates...
+  for(int run = 0; run < 50; run++)
+  {
+    cache.push_back(info("/a.clap", "org.a"));
+    cache.push_back(info("/b.clap", "org.b"));
+  }
+  // ...a timeout/reply double...
+  cache.push_back(info("/a.clap", "", false));
+  // ...an entry that decoded to an empty path...
+  cache.push_back(info("", "junk"));
+  // ...and a legitimately broken plug-in.
+  cache.push_back(info("/dead.clap", "", false));
+
+  Media::sanitizePluginCache(cache, key_of, path_of, is_valid);
+
+  REQUIRE(cache.size() == 3);
+  REQUIRE(cache[0] == info("/a.clap", "org.a"));
+  REQUIRE(cache[1] == info("/b.clap", "org.b"));
+  REQUIRE(cache[2] == info("/dead.clap", "", false));
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -238,7 +238,8 @@ if(TARGET score_plugin_lv2)
     LIBS Lilv)
   add_dependencies(test_unit_lv2_loading score_test_gain_lv2)
   target_compile_definitions(test_unit_lv2_loading PRIVATE
-    SCORE_TEST_LV2_BUNDLE="${SCORE_ROOT_BINARY_DIR}/tests/lv2/score-test-gain.lv2")
+    SCORE_TEST_LV2_BUNDLE="${SCORE_ROOT_BINARY_DIR}/tests/lv2/score-test-gain.lv2"
+    SCORE_TEST_QT6_ELF="$<TARGET_FILE:score_plugin_lv2>")
   target_include_directories(test_unit_lv2_loading PRIVATE
     "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-lv2"
     "${LV2_PATH}"

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -287,3 +287,13 @@ score_add_test(test_unit_puppet_json
 score_add_test(test_unit_audio_plugin_cache
   SOURCES AudioPluginCacheTest.cpp
   PLUGINS score_plugin_media)
+
+# The shared scan state machine, end-to-end against a scriptable fake puppet:
+# session-token isolation, crash/timeout single-failure, reply-vs-exit races,
+# clean cancellation of a scan in progress.
+score_add_test(test_unit_plugin_scanner
+  SOURCES PluginScannerTest.cpp
+  PLUGINS score_plugin_media)
+add_dependencies(test_unit_plugin_scanner score_test_fake_puppet)
+target_compile_definitions(test_unit_plugin_scanner PRIVATE
+  SCORE_FAKE_PUPPET="$<TARGET_FILE:score_test_fake_puppet>")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -275,3 +275,10 @@ if(TARGET pipewire::pipewire)
     target_include_directories(test_unit_pipewire_protocol_quantum SYSTEM PRIVATE ${_pw_includes})
   endif()
 endif()
+
+# --- Plug-in scanner ("puppet") protocol helpers ----------------------------
+# Unescaped plug-in metadata used to break entire scan replies; the request
+# id / port / token argv protocol routes replies to the right scan session.
+score_add_test(test_unit_puppet_json
+  SOURCES PuppetJsonTest.cpp)
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -326,6 +326,15 @@ if(TARGET score_plugin_clap)
     PLUGINS score_plugin_clap)
   target_include_directories(test_unit_clap_scan PRIVATE
     "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-clap")
+
+  # The tick -> clap_event_transport_t conversion (fixed-point song positions;
+  # transport-following plug-ins froze at position 0 when this was wrong).
+  score_add_test(test_unit_clap_transport
+    SOURCES ClapTransportTest.cpp
+    PLUGINS score_lib_process)
+  target_include_directories(test_unit_clap_transport PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-clap"
+    "${SCORE_ROOT_SOURCE_DIR}/3rdparty/clap/include")
 endif()
 
 # Per-format plug-in path settings; VST3 must react to Vst3Paths, not VstPaths.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -297,3 +297,45 @@ score_add_test(test_unit_plugin_scanner
 add_dependencies(test_unit_plugin_scanner score_test_fake_puppet)
 target_compile_definitions(test_unit_plugin_scanner PRIVATE
   SCORE_FAKE_PUPPET="$<TARGET_FILE:score_test_fake_puppet>")
+
+# Per-backend scan-reply parsing + cache healing.
+if(TARGET score_plugin_vst)
+  score_add_test(test_unit_vst_scan_reply
+    SOURCES VstScanReplyTest.cpp
+    PLUGINS score_plugin_vst)
+  target_include_directories(test_unit_vst_scan_reply PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-vst")
+endif()
+
+if(TARGET score_plugin_vst3)
+  score_add_test(test_unit_vst3_scan_reply
+    SOURCES Vst3ScanReplyTest.cpp
+    PLUGINS score_plugin_vst3
+    LIBS sdk_common sdk_hosting)
+  target_include_directories(test_unit_vst3_scan_reply PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-vst3")
+endif()
+
+if(TARGET score_plugin_clap)
+  # The healing case boots the app: a legacy cache polluted with hundreds of
+  # cross-instance duplicates must come out deduplicated and migrated to the
+  # versioned format.
+  score_add_test(test_unit_clap_scan
+    SOURCES ClapScanTest.cpp
+    APP
+    PLUGINS score_plugin_clap)
+  target_include_directories(test_unit_clap_scan PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-clap")
+endif()
+
+# Per-format plug-in path settings; VST3 must react to Vst3Paths, not VstPaths.
+if(TARGET score_plugin_vst3 AND TARGET score_plugin_clap)
+  score_add_test(test_unit_plugin_path_settings
+    SOURCES PluginPathSettingsTest.cpp
+    APP
+    PLUGINS score_plugin_vst3 score_plugin_clap
+    LIBS sdk_common sdk_hosting)
+  target_include_directories(test_unit_plugin_path_settings PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-vst3"
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-clap")
+endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -282,3 +282,8 @@ endif()
 score_add_test(test_unit_puppet_json
   SOURCES PuppetJsonTest.cpp)
 
+# Versioned scan-cache blob + healing of caches polluted by the fixed-port
+# cross-instance duplication bug (200+ copies per plug-in were observed).
+score_add_test(test_unit_audio_plugin_cache
+  SOURCES AudioPluginCacheTest.cpp
+  PLUGINS score_plugin_media)

--- a/tests/unit/ClapScanTest.cpp
+++ b/tests/unit/ClapScanTest.cpp
@@ -1,0 +1,161 @@
+// CLAP scan-cache tests:
+//
+//  * parseClapReply — one .clap file can host many plug-ins;
+//  * resolveClapEntry — the macOS-bundle resolution that must run *before*
+//    the known-paths check (it used to run after, so every startup rescanned
+//    and re-appended every bundle: +1 duplicate per plug-in per launch);
+//  * the end-to-end healing of a legacy cache polluted with hundreds of
+//    duplicates by the fixed-port cross-instance bug, exercised through a
+//    real application boot (legacy QVariant blob -> versioned cache).
+
+#include <Clap/ApplicationPlugin.hpp>
+
+#include <score_test/App.hpp>
+
+#include <QDir>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSettings>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+Clap::PluginInfo info(QString path, QString id, bool valid = true)
+{
+  Clap::PluginInfo i;
+  i.path = std::move(path);
+  i.id = std::move(id);
+  i.name = valid ? "Some Plugin" : "<Invalid>";
+  i.valid = valid;
+  return i;
+}
+}
+
+TEST_CASE("parseClapReply parses a multi-plugin file", "[pluginscan][clap]")
+{
+  const auto doc = QJsonDocument::fromJson(R"({
+    "Path": "/claimed/elsewhere.clap",
+    "Request": 1,
+    "Token": "tok",
+    "Plugins": [
+      {"ID": "org.acme.comp", "Name": "Compressor", "Vendor": "ACME",
+       "Features": ["audio-effect", "compressor"]},
+      {"ID": "org.acme.limit", "Name": "Limiter", "Vendor": "ACME",
+       "Features": ["audio-effect"]}
+    ]
+  })");
+  REQUIRE(doc.isObject());
+
+  const auto plugins = Clap::parseClapReply("/usr/lib/clap/acme.clap", doc.object());
+
+  REQUIRE(plugins.size() == 2);
+  CHECK(plugins[0].path == "/usr/lib/clap/acme.clap"); // scanned path wins
+  CHECK(plugins[0].id == "org.acme.comp");
+  CHECK(plugins[0].features == QList<QString>{"audio-effect", "compressor"});
+  CHECK(plugins[0].valid);
+  CHECK(plugins[1].id == "org.acme.limit");
+}
+
+TEST_CASE("parseClapReply: no Plugins array -> nothing", "[pluginscan][clap]")
+{
+  const auto doc
+      = QJsonDocument::fromJson(R"({"Path":"/x.clap","Request":0,"Token":"t"})");
+  CHECK(Clap::parseClapReply("/x.clap", doc.object()).empty());
+}
+
+TEST_CASE("resolveClapEntry resolves bundle directories to their binary", "[pluginscan][clap]")
+{
+  QTemporaryDir tmp;
+  REQUIRE(tmp.isValid());
+
+  SECTION("plain file stays as-is")
+  {
+    const QString file = tmp.path() + "/plain.clap";
+    { QFile f{file}; REQUIRE(f.open(QIODevice::WriteOnly)); }
+    CHECK(Clap::resolveClapEntry(file) == file);
+  }
+  SECTION("bundle directory resolves to Contents/MacOS/<name>")
+  {
+    const QString bundle = tmp.path() + "/Surge XT.clap";
+    REQUIRE(QDir{}.mkpath(bundle + "/Contents/MacOS"));
+    {
+      QFile f{bundle + "/Contents/MacOS/Surge XT"};
+      REQUIRE(f.open(QIODevice::WriteOnly));
+    }
+    CHECK(
+        Clap::resolveClapEntry(bundle) == bundle + "/Contents/MacOS/Surge XT");
+  }
+  SECTION("Linux bundle-style dir without a macOS binary is skipped")
+  {
+    // Cardinal.clap on Linux: a *directory* containing Cardinal.clap,
+    // CardinalFX.clap... which the recursive iteration finds by itself.
+    // Resolving the directory to a nonexistent Contents/MacOS path used to
+    // produce a spurious invalid-plug-in entry.
+    const QString bundle = tmp.path() + "/Cardinal.clap";
+    REQUIRE(QDir{}.mkpath(bundle));
+    { QFile f{bundle + "/Cardinal.clap"}; REQUIRE(f.open(QIODevice::WriteOnly)); }
+    CHECK(Clap::resolveClapEntry(bundle).isEmpty());
+  }
+}
+
+TEST_CASE("a duplicate-ridden legacy CLAP cache is healed on boot", "[pluginscan][clap][heal]")
+{
+  qputenv("SCORE_DISABLE_AUDIOPLUGINS", "1");
+
+  // Private settings location: ctest runs tests in parallel and QSettings
+  // rewrites whole files, so sharing score-test.conf across processes would
+  // be racy.
+  static QTemporaryDir settings_dir;
+  REQUIRE(settings_dir.isValid());
+  QSettings::setPath(
+      QSettings::NativeFormat, QSettings::UserScope, settings_dir.path());
+  QSettings::setPath(
+      QSettings::IniFormat, QSettings::UserScope, settings_dir.path());
+
+  // Boot 1: seed a legacy-format cache the way the fixed-port bug left it:
+  // every plug-in duplicated once per (cross-instance) run, plus a
+  // valid/invalid pair from the timeout race. Seeding needs a booted app so
+  // the QVariant stream operators are registered.
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    std::vector<Clap::PluginInfo> polluted;
+    for(int run = 0; run < 50; run++)
+    {
+      polluted.push_back(info("/fake/surge.clap", "org.surge"));
+      polluted.push_back(info("/fake/dexed.clap", "org.dexed"));
+    }
+    polluted.push_back(info("/fake/surge.clap", "", false)); // timeout marker
+    polluted.push_back(info("/fake/dead.clap", "", false));  // genuinely broken
+
+    QSettings s;
+    s.remove("Effect/KnownCLAPCache");
+    s.setValue("Effect/KnownCLAP", QVariant::fromValue(polluted));
+  });
+
+  // Boot 2: initialize() must migrate + heal.
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& plug = ctx.guiApplicationPlugin<Clap::ApplicationPlugin>();
+
+    const auto& plugins = plug.plugins();
+    REQUIRE(plugins.size() == 3);
+    CHECK(plugins[0].path == "/fake/surge.clap");
+    CHECK(plugins[0].valid);
+    CHECK(plugins[1].path == "/fake/dexed.clap");
+    CHECK(plugins[1].valid);
+    CHECK(plugins[2].path == "/fake/dead.clap");
+    CHECK(!plugins[2].valid);
+
+    // Migration completed: legacy blob gone, versioned cache written
+    QSettings s;
+    CHECK(!s.contains("Effect/KnownCLAP"));
+    CHECK(s.contains("Effect/KnownCLAPCache"));
+  });
+
+  // Boot 3: the healed cache survives a round-trip through the new format.
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& plug = ctx.guiApplicationPlugin<Clap::ApplicationPlugin>();
+    REQUIRE(plug.plugins().size() == 3);
+    CHECK(plug.plugins()[0].id == "org.surge");
+  });
+}

--- a/tests/unit/ClapScanTest.cpp
+++ b/tests/unit/ClapScanTest.cpp
@@ -158,4 +158,23 @@ TEST_CASE("a duplicate-ridden legacy CLAP cache is healed on boot", "[pluginscan
     REQUIRE(plug.plugins().size() == 3);
     CHECK(plug.plugins()[0].id == "org.surge");
   });
+
+  // Boot 4: a legacy blob rewritten by an *older* score after the migration
+  // must not survive next to the versioned cache - it would resurrect stale
+  // entries after a future format-version bump.
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QSettings s;
+    REQUIRE(s.contains("Effect/KnownCLAPCache"));
+    s.setValue(
+        "Effect/KnownCLAP",
+        QVariant::fromValue(std::vector<Clap::PluginInfo>{info("/stale.clap", "old")}));
+  });
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& plug = ctx.guiApplicationPlugin<Clap::ApplicationPlugin>();
+    // Versioned cache won; the stale legacy entry is not loaded...
+    REQUIRE(plug.plugins().size() == 3);
+    // ...and the legacy key is gone again.
+    QSettings s;
+    CHECK(!s.contains("Effect/KnownCLAP"));
+  });
 }

--- a/tests/unit/ClapTransportTest.cpp
+++ b/tests/unit/ClapTransportTest.cpp
@@ -1,0 +1,95 @@
+// Clap::make_transport — the tick -> clap_event_transport_t conversion.
+//
+// Regression: CLAP song positions are fixed-point (clap_beattime/clap_sectime
+// are int64 scaled by 1<<31, clap/fixedpoint.h). The old code cast raw beat
+// counts (and floored away the fractional beat), so hosts reading
+// song_pos_beats / CLAP_BEATTIME_FACTOR saw the transport frozen at ~0:
+// transport-following plug-ins (the Stochas step sequencer, arpeggiators,
+// synced delays) never advanced even though IS_PLAYING was set.
+
+#include <Clap/Transport.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+ossia::token_request tick(double beats_start, double beats_end, double tempo)
+{
+  ossia::token_request tk{};
+  tk.prev_date = ossia::time_value{0};
+  tk.date = ossia::time_value{1000};
+  tk.musical_start_position = beats_start;
+  tk.musical_end_position = beats_end;
+  tk.musical_start_last_bar = 4.0 * (int)(beats_start / 4.0);
+  tk.tempo = tempo;
+  tk.signature = {4, 4};
+  return tk;
+}
+
+double to_beats(clap_beattime t)
+{
+  return (double)t / CLAP_BEATTIME_FACTOR;
+}
+double to_seconds(clap_sectime t)
+{
+  return (double)t / CLAP_SECTIME_FACTOR;
+}
+}
+
+TEST_CASE("clap transport: song position is fixed-point beats", "[clap][transport]")
+{
+  // 6.5 quarter notes in: the fractional part must survive
+  const auto t = Clap::make_transport(tick(6.5, 6.6, 120.));
+
+  CHECK(to_beats(t.song_pos_beats) == Catch::Approx(6.5));
+  CHECK(to_beats(t.bar_start) == Catch::Approx(4.0));
+  CHECK(t.bar_number == 1);
+  CHECK(t.tempo == 120.);
+  CHECK(t.tsig_num == 4);
+  CHECK(t.tsig_denom == 4);
+
+  // 6.5 quarters at 120 BPM = 3.25 s
+  CHECK(to_seconds(t.song_pos_seconds) == Catch::Approx(3.25));
+
+  CHECK(t.flags & CLAP_TRANSPORT_IS_PLAYING);
+  CHECK(t.flags & CLAP_TRANSPORT_HAS_BEATS_TIMELINE);
+  CHECK(t.flags & CLAP_TRANSPORT_HAS_SECONDS_TIMELINE);
+  CHECK(t.flags & CLAP_TRANSPORT_HAS_TEMPO);
+  CHECK(t.flags & CLAP_TRANSPORT_HAS_TIME_SIGNATURE);
+}
+
+TEST_CASE("clap transport: position advances tick after tick", "[clap][transport]")
+{
+  // The actual Stochas symptom: consecutive ticks must yield strictly
+  // increasing song positions (the old cast-to-int64 made them all ~0)
+  clap_beattime prev = -1;
+  for(double b = 0.; b < 8.; b += 0.25)
+  {
+    const auto t = Clap::make_transport(tick(b, b + 0.25, 132.));
+    CHECK(t.song_pos_beats > prev);
+    prev = t.song_pos_beats;
+  }
+  // After 31 ticks of a quarter beat, we are at 7.75 beats, not at ~0
+  CHECK(to_beats(prev) == Catch::Approx(7.75));
+}
+
+TEST_CASE("clap transport: paused tick is not playing", "[clap][transport]")
+{
+  auto tk = tick(2.0, 2.0, 120.);
+  tk.date = tk.prev_date; // zero-length tick: transport paused
+  const auto t = Clap::make_transport(tk);
+  CHECK(!(t.flags & CLAP_TRANSPORT_IS_PLAYING));
+}
+
+TEST_CASE("clap transport: 6/8 bar math", "[clap][transport]")
+{
+  auto tk = tick(9.0, 9.1, 90.);
+  tk.signature = {6, 8};
+  tk.musical_start_last_bar = 6.0; // bars are 3 quarters long in 6/8
+  const auto t = Clap::make_transport(tk);
+  CHECK(to_beats(t.bar_start) == Catch::Approx(6.0));
+  CHECK(t.bar_number == 2);
+  CHECK(t.tsig_num == 6);
+  CHECK(t.tsig_denom == 8);
+}

--- a/tests/unit/LV2LoadingTest.cpp
+++ b/tests/unit/LV2LoadingTest.cpp
@@ -254,6 +254,24 @@ TEST_CASE("LV2 UI binaries linked against another Qt major are rejected", "[lv2]
   CHECK(!LV2::uiLinksIncompatibleQt(our_qt_ui));
   CHECK(!LV2::uiLinksIncompatibleQt(no_qt_ui));
   CHECK(!LV2::uiLinksIncompatibleQt(dir.path() + "/does_not_exist.so"));
+
+  // macOS / Windows dependency name shapes go through the generic scan
+  const auto dylib_ui = write("qt5_mac.so", "...libQt5Gui.5.dylib...");
+  const auto fw_ui = write(
+      "qt5_fw.so", "...@rpath/QtGui.framework/Versions/5/QtGui...");
+  const auto dll_ui = write("qt5_win.so", "...Qt5Gui.dll...");
+  CHECK(LV2::uiLinksIncompatibleQt(dylib_ui));
+  CHECK(LV2::uiLinksIncompatibleQt(fw_ui));
+  CHECK(LV2::uiLinksIncompatibleQt(dll_ui));
+
+#if defined(__linux__)
+  // The definitive DT_NEEDED path, against real ELFs: our own Qt6-linked
+  // plug-in must be accepted...
+  CHECK(!LV2::uiLinksIncompatibleQt(QStringLiteral(SCORE_TEST_QT6_ELF)));
+  // ...and a real Qt5-linked library rejected, when one is installed
+  if(QFile::exists("/usr/lib/libQt5Gui.so.5"))
+    CHECK(LV2::uiLinksIncompatibleQt("/usr/lib/libQt5Gui.so.5"));
+#endif
 }
 
 TEST_CASE("LV2 descriptor cache round-trips through the versioned blob", "[lv2]")

--- a/tests/unit/LV2LoadingTest.cpp
+++ b/tests/unit/LV2LoadingTest.cpp
@@ -17,6 +17,8 @@
 #include <LV2/EffectModel.hpp>
 #include <LV2/Node.hpp>
 
+#include <Media/AudioPluginCache.hpp>
+
 #include <Process/Dataflow/WidgetInlets.hpp>
 
 #include <score/model/EntitySerialization.hpp>
@@ -216,6 +218,26 @@ TEST_CASE("find_lv2_plugin loads the bundle on demand", "[lv2]")
       REQUIRE(res);
       CHECK(QString(res->get_uri().as_string()) == "urn:score:test:gain2");
     }
+  });
+}
+
+TEST_CASE("LV2 descriptor cache round-trips through the versioned blob", "[lv2]")
+{
+  prepare_lv2_test_environment();
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    const std::vector<LV2::PluginInfo> src{makeGainInfo()};
+
+    const auto blob = Media::serializePluginCache(1, src);
+    const auto back = Media::deserializePluginCache<LV2::PluginInfo>(1, blob);
+    REQUIRE(back.has_value());
+    REQUIRE(back->size() == 1);
+    CHECK((*back)[0].bundle == src[0].bundle);
+    CHECK((*back)[0].uri == src[0].uri);
+    CHECK((*back)[0].control_in == src[0].control_in);
+    CHECK((*back)[0].valid == src[0].valid);
+
+    // A format bump must invalidate cleanly, not decode garbage
+    CHECK(!Media::deserializePluginCache<LV2::PluginInfo>(2, blob).has_value());
   });
 }
 

--- a/tests/unit/LV2LoadingTest.cpp
+++ b/tests/unit/LV2LoadingTest.cpp
@@ -238,6 +238,19 @@ TEST_CASE("LV2 descriptor cache round-trips through the versioned blob", "[lv2]"
 
     // A format bump must invalidate cleanly, not decode garbage
     CHECK(!Media::deserializePluginCache<LV2::PluginInfo>(2, blob).has_value());
+
+    // Truncation must be rejected *for a real score-serialized type*: the
+    // score datastream operators route reads through an internal stream, so
+    // a naive status check on the outer stream never fires and truncated
+    // blobs used to decode as garbage (the failure mode the old VST2
+    // vst_invalid_format global caught).
+    for(int cut : {1, 8, 12, 20, (int)blob.size() / 2, (int)blob.size() - 1})
+    {
+      auto truncated = blob;
+      truncated.truncate(cut);
+      CHECK(
+          !Media::deserializePluginCache<LV2::PluginInfo>(1, truncated).has_value());
+    }
   });
 }
 

--- a/tests/unit/LV2LoadingTest.cpp
+++ b/tests/unit/LV2LoadingTest.cpp
@@ -16,6 +16,7 @@
 #include <LV2/Context.hpp>
 #include <LV2/EffectModel.hpp>
 #include <LV2/Node.hpp>
+#include <LV2/Window.hpp>
 
 #include <Media/AudioPluginCache.hpp>
 
@@ -219,6 +220,40 @@ TEST_CASE("find_lv2_plugin loads the bundle on demand", "[lv2]")
       CHECK(QString(res->get_uri().as_string()) == "urn:score:test:gain2");
     }
   });
+}
+
+TEST_CASE("LV2 UI binaries linked against another Qt major are rejected", "[lv2]")
+{
+  // Identical mangled symbol names across Qt majors get cross-resolved when
+  // such a UI is dlopened into this process, corrupting memory before the
+  // UI even finishes creating its QApplication (observed with qmidiarp's
+  // Qt5 X11UI: dev builds die on a QStringView assert, static-Qt release
+  // builds corrupt silently since the executable exports its Qt).
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  auto write = [&](const char* name, QByteArray content) {
+    const QString p = dir.path() + "/" + name;
+    QFile f{p};
+    REQUIRE(f.open(QIODevice::WriteOnly));
+    f.write(content);
+    return p;
+  };
+
+  const auto qt5_ui
+      = write("qt5_ui.so", "\x7f" "ELF...libQt5Core.so.5...libQt5Gui.so.5...");
+  const auto qt4_ui = write("qt4_ui.so", "...libQt4Gui.so.4...");
+  const auto our_qt_ui = write(
+      "qt6_ui.so",
+      QByteArray("...libQt") + QByteArray::number(QT_VERSION_MAJOR)
+          + "Core.so...");
+  const auto no_qt_ui = write("plain_ui.so", "...libgtk-3.so.0...libX11.so...");
+
+  CHECK(LV2::uiLinksIncompatibleQt(qt5_ui));
+  CHECK(LV2::uiLinksIncompatibleQt(qt4_ui));
+  CHECK(!LV2::uiLinksIncompatibleQt(our_qt_ui));
+  CHECK(!LV2::uiLinksIncompatibleQt(no_qt_ui));
+  CHECK(!LV2::uiLinksIncompatibleQt(dir.path() + "/does_not_exist.so"));
 }
 
 TEST_CASE("LV2 descriptor cache round-trips through the versioned blob", "[lv2]")

--- a/tests/unit/PluginPathSettingsTest.cpp
+++ b/tests/unit/PluginPathSettingsTest.cpp
@@ -1,0 +1,112 @@
+// Per-format plug-in path settings:
+//
+//  * Vst3Paths / ClapPaths / Lv2Paths round-trip through the settings model
+//    and notify;
+//  * each backend rescans on *its own* path setting;
+//  * regression: VST3 used to listen to the VST2 path setting (a `//! TODO`
+//    left from the unfinished settings refactor) and wiped its whole
+//    database whenever the VST2 paths changed.
+
+#include <Clap/ApplicationPlugin.hpp>
+#include <Media/Effect/Settings/Model.hpp>
+#include <Vst3/ApplicationPlugin.hpp>
+
+#include <score_test/App.hpp>
+
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("plug-in path settings round-trip and notify", "[pluginscan][settings]")
+{
+  qputenv("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& m = ctx.settings<Media::Settings::Model>();
+
+    // Baseline first: settings persist across test runs, and set() is a
+    // no-op (no notification) when the value does not change
+    m.setVst3Paths({"/baseline"});
+    m.setClapPaths({"/baseline"});
+    m.setLv2Paths({"/baseline"});
+
+    int vst3_notified{}, clap_notified{}, lv2_notified{};
+    QObject::connect(
+        &m, &Media::Settings::Model::Vst3PathsChanged, &m,
+        [&](const QStringList&) { vst3_notified++; });
+    QObject::connect(
+        &m, &Media::Settings::Model::ClapPathsChanged, &m,
+        [&](const QStringList&) { clap_notified++; });
+    QObject::connect(
+        &m, &Media::Settings::Model::Lv2PathsChanged, &m,
+        [&](const QStringList&) { lv2_notified++; });
+
+    m.setVst3Paths({"/some/vst3/dir"});
+    m.setClapPaths({"/some/clap/dir"});
+    m.setLv2Paths({"/some/lv2/dir"});
+
+    CHECK(m.getVst3Paths() == QStringList{"/some/vst3/dir"});
+    CHECK(m.getClapPaths() == QStringList{"/some/clap/dir"});
+    CHECK(m.getLv2Paths() == QStringList{"/some/lv2/dir"});
+    CHECK(vst3_notified == 1);
+    CHECK(clap_notified == 1);
+    CHECK(lv2_notified == 1);
+
+    // Same value again: no spurious notification (and no spurious rescan)
+    m.setVst3Paths({"/some/vst3/dir"});
+    CHECK(vst3_notified == 1);
+  });
+}
+
+TEST_CASE("VST3 rescans on its own path setting, not on VST2's", "[pluginscan][settings]")
+{
+  qputenv("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& m = ctx.settings<Media::Settings::Model>();
+    auto& vst3 = ctx.applicationPlugin<vst3::ApplicationPlugin>();
+
+    QTemporaryDir empty_dir;
+    REQUIRE(empty_dir.isValid());
+
+    // Fake cached VST3 so we can observe what a rescan does to it
+    vst3::AvailablePlugin fake;
+    fake.path = "/fake/plugin.vst3";
+    fake.name = "Fake";
+    fake.isValid = false;
+    vst3.vst_infos.push_back(fake);
+
+    // Changing the *VST2* paths must not touch the VST3 database.
+    // (It used to clear it and trigger a full rescan.)
+    m.setVstPaths({empty_dir.path()});
+    REQUIRE(vst3.vst_infos.size() == 1);
+
+    // Changing the VST3 paths does rescan: the fake entry does not exist on
+    // disk in the new paths, so it gets pruned.
+    m.setVst3Paths({empty_dir.path()});
+    CHECK(vst3.vst_infos.empty());
+  });
+}
+
+TEST_CASE("CLAP rescans on its path setting", "[pluginscan][settings]")
+{
+  qputenv("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& m = ctx.settings<Media::Settings::Model>();
+    auto& clap = ctx.guiApplicationPlugin<Clap::ApplicationPlugin>();
+
+    QTemporaryDir empty_dir;
+    REQUIRE(empty_dir.isValid());
+    m.setClapPaths({"/baseline"}); // ensure the next set is a real change
+
+    int changed{};
+    QObject::connect(
+        &clap, &Clap::ApplicationPlugin::pluginsChanged, &clap, [&] { changed++; });
+
+    // Sanity: direct emission is observable across the plug-in boundary
+    clap.pluginsChanged();
+    REQUIRE(changed == 1);
+
+    m.setClapPaths({empty_dir.path()});
+    // rescanPlugins() ran: it signals at least once after pruning
+    CHECK(changed >= 2);
+  });
+}

--- a/tests/unit/PluginPathSettingsTest.cpp
+++ b/tests/unit/PluginPathSettingsTest.cpp
@@ -9,6 +9,7 @@
 
 #include <Clap/ApplicationPlugin.hpp>
 #include <Media/Effect/Settings/Model.hpp>
+#include <Media/Effect/Settings/View.hpp>
 #include <Vst3/ApplicationPlugin.hpp>
 
 #include <score_test/App.hpp>
@@ -83,6 +84,29 @@ TEST_CASE("VST3 rescans on its own path setting, not on VST2's", "[pluginscan][s
     // disk in the new paths, so it gets pruned.
     m.setVst3Paths({empty_dir.path()});
     CHECK(vst3.vst_infos.empty());
+  });
+}
+
+TEST_CASE("every plug-in format has a settings tab that builds", "[pluginscan][settings]")
+{
+  // The tab interface existed for years with only the VST implementation:
+  // the Effects settings page showed a lone "VST" tab and the other formats
+  // had no path configuration or scan feedback at all.
+  qputenv("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& tabs = ctx.interfaces<Media::Settings::PluginSettingsFactoryList>();
+
+    QStringList names;
+    for(auto& tab : tabs)
+    {
+      names.push_back(tab.name());
+      auto widget = tab.make(ctx);
+      REQUIRE(widget);
+      delete widget;
+    }
+    names.sort();
+
+    CHECK(names == QStringList{"CLAP", "LV2", "VST", "VST3"});
   });
 }
 

--- a/tests/unit/PluginScannerTest.cpp
+++ b/tests/unit/PluginScannerTest.cpp
@@ -1,0 +1,334 @@
+// Tests for Media::PluginScanner, the shared out-of-process plug-in scan
+// machinery, driven end-to-end against the score_test_fake_puppet fixture.
+//
+// Regressions covered (each was a live bug in the per-backend scanners):
+//  * Cross-instance pollution: with the old fixed ports, scan replies from
+//    other score processes were appended to this instance's database. Now:
+//    replies carrying a wrong session token are dropped, two scanners run
+//    fully isolated, and each resolves exactly its own scan set.
+//  * Legacy string request ids ("Request":"3") parsed as 0 via
+//    QJsonValue::toInt(), attributing every reply to slot 0.
+//  * A crash fired both errorOccurred and finished -> two invalid entries.
+//  * A reply racing the puppet's exit (possibly with a non-zero exit code
+//    from the websocket close handshake) -> plug-in recorded both valid
+//    and invalid. The grace period resolves the race in favour of the reply.
+//  * Hung puppets in the last batch were only reaped while the scan was
+//    saturated -> they leaked forever. Timeouts now always fire.
+//  * Rescanning while a scan ran corrupted the bookkeeping (TU-static
+//    in-flight counters, index-reuse clobbering unrelated slots).
+
+#include <Media/PluginScanner.hpp>
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+
+namespace
+{
+QCoreApplication& app()
+{
+  static int argc = 1;
+  static char arg0[] = "plugin_scanner_test";
+  static char* argv[] = {arg0, nullptr};
+  static QCoreApplication app{argc, argv};
+  return app;
+}
+
+//! Pump the event loop until pred() holds or timeout_ms elapses.
+bool spinUntil(const std::function<bool()>& pred, int timeout_ms = 10000)
+{
+  QElapsedTimer timer;
+  timer.start();
+  while(!pred())
+  {
+    if(timer.elapsed() > timeout_ms)
+      return false;
+    app().processEvents(QEventLoop::AllEvents, 20);
+  }
+  return true;
+}
+
+struct ScanResult
+{
+  std::vector<QString> scanned;
+  std::vector<QJsonObject> replies;
+  std::vector<QString> failed;
+  std::vector<QString> reasons;
+  int done{};
+
+  explicit ScanResult(Media::PluginScanner& s)
+  {
+    QObject::connect(
+        &s, &Media::PluginScanner::scanned, &app(),
+        [this](const QString& path, const QJsonObject& obj) {
+      scanned.push_back(path);
+      replies.push_back(obj);
+        });
+    QObject::connect(
+        &s, &Media::PluginScanner::scanFailed, &app(),
+        [this](const QString& path, const QString& reason) {
+      failed.push_back(path);
+      reasons.push_back(reason);
+        });
+    QObject::connect(
+        &s, &Media::PluginScanner::done, &app(), [this] { done++; });
+  }
+};
+
+QProcessEnvironment behavior(const char* name)
+{
+  auto env = QProcessEnvironment::systemEnvironment();
+  env.insert("FAKE_PUPPET_BEHAVIOR", name);
+  return env;
+}
+
+std::unique_ptr<Media::PluginScanner> makeScanner(const char* behavior_name)
+{
+  app(); // ensure the application object exists first
+  auto s = std::make_unique<Media::PluginScanner>("test-scanner");
+  s->setPuppet(QStringLiteral(SCORE_FAKE_PUPPET));
+  s->setEnvironmentProvider([=] { return behavior(behavior_name); });
+  s->setProcessTimeout(3000);
+  s->setReplyGracePeriod(500);
+  return s;
+}
+
+QStringList somePaths(int n, const QString& prefix = "/fake/plugin")
+{
+  QStringList res;
+  for(int i = 0; i < n; i++)
+    res.push_back(QString("%1-%2.so").arg(prefix).arg(i));
+  return res;
+}
+}
+
+TEST_CASE("scan resolves every path and completes", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("reply");
+  ScanResult r{*s};
+
+  const auto paths = somePaths(5);
+  s->setMaxInFlight(2); // force several refill rounds
+  s->scan(paths);
+  REQUIRE(s->scanning());
+
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  REQUIRE(r.failed.empty());
+  REQUIRE(r.scanned.size() == 5);
+  REQUIRE(r.done == 1);
+  REQUIRE(!s->scanning());
+
+  // Every requested path resolved exactly once, and the reply payload is
+  // the puppet's object
+  auto sorted = r.scanned;
+  std::sort(sorted.begin(), sorted.end());
+  auto expected = std::vector<QString>(paths.begin(), paths.end());
+  std::sort(expected.begin(), expected.end());
+  REQUIRE(sorted == expected);
+  REQUIRE(r.replies[0]["Plugins"].isArray());
+}
+
+TEST_CASE("empty scan still completes", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("reply");
+  ScanResult r{*s};
+  s->scan({});
+  REQUIRE(spinUntil([&] { return r.done > 0; }, 1000));
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.empty());
+}
+
+TEST_CASE("replies with a wrong session token are dropped", "[pluginscan][scanner][token]")
+{
+  auto s = makeScanner("badtoken");
+  ScanResult r{*s};
+
+  s->scan(somePaths(2));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  // The impostor replies must not surface as scanned plug-ins; the paths
+  // resolve as failed once the grace period elapses.
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.size() == 2);
+}
+
+TEST_CASE("legacy string request ids are accepted", "[pluginscan][scanner][compat]")
+{
+  auto s = makeScanner("stringid");
+  ScanResult r{*s};
+
+  s->scan(somePaths(3));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  REQUIRE(r.failed.empty());
+  REQUIRE(r.scanned.size() == 3);
+}
+
+TEST_CASE("an Error reply fails the plug-in with its reason", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("error");
+  ScanResult r{*s};
+
+  s->scan(somePaths(1));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.size() == 1);
+  REQUIRE(r.reasons[0] == "simulated failure");
+}
+
+TEST_CASE("a crashing puppet fails its plug-in exactly once", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("crash");
+  ScanResult r{*s};
+
+  s->scan(somePaths(3));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  // Historically errorOccurred + finished both recorded an invalid entry
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.size() == 3);
+}
+
+TEST_CASE("a puppet exiting without a reply fails exactly once", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("exit1");
+  ScanResult r{*s};
+
+  s->scan(somePaths(2));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.size() == 2);
+}
+
+TEST_CASE("garbage replies do not resolve a scan as success", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("garbage");
+  ScanResult r{*s};
+
+  s->scan(somePaths(1));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.size() == 1);
+}
+
+TEST_CASE("hung puppets are reaped by the timeout", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("hang");
+  s->setProcessTimeout(700);
+  ScanResult r{*s};
+
+  // More paths than maxInFlight: the *tail* batch used to never time out
+  // because the reaper only ran while the scan was saturated
+  s->setMaxInFlight(2);
+  s->scan(somePaths(3));
+  REQUIRE(spinUntil([&] { return r.done > 0; }, 20000));
+
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.size() == 3);
+}
+
+TEST_CASE("a reply beating the process exit wins over the exit code", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("reply_exit1");
+  ScanResult r{*s};
+
+  s->scan(somePaths(2));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  // The old implementations recorded these as invalid (or as both valid
+  // and invalid) because exit(1) raced the websocket delivery
+  REQUIRE(r.failed.empty());
+  REQUIRE(r.scanned.size() == 2);
+}
+
+TEST_CASE("two concurrent scanners stay fully isolated", "[pluginscan][scanner][token]")
+{
+  // The original sin: fixed ports meant one instance received every other
+  // instance's replies and appended them to its database.
+  auto s1 = makeScanner("reply");
+  auto s2 = makeScanner("reply");
+  ScanResult r1{*s1};
+  ScanResult r2{*s2};
+
+  s1->scan(somePaths(3, "/instance-a/plug"));
+  s2->scan(somePaths(4, "/instance-b/plug"));
+
+  REQUIRE(spinUntil([&] { return r1.done > 0 && r2.done > 0; }));
+
+  REQUIRE(s1->port() != s2->port());
+  REQUIRE(s1->token() != s2->token());
+
+  REQUIRE(r1.scanned.size() == 3);
+  REQUIRE(r2.scanned.size() == 4);
+  REQUIRE(r1.failed.empty());
+  REQUIRE(r2.failed.empty());
+  for(const auto& p : r1.scanned)
+    REQUIRE(p.startsWith("/instance-a/"));
+  for(const auto& p : r2.scanned)
+    REQUIRE(p.startsWith("/instance-b/"));
+}
+
+TEST_CASE("rescanning mid-scan cancels cleanly", "[pluginscan][scanner]")
+{
+  auto s = makeScanner("hang");
+  ScanResult r{*s};
+  s->setMaxInFlight(2);
+
+  s->scan(somePaths(4, "/old/plug"));
+  REQUIRE(s->scanning());
+
+  // Switch behavior and rescan while the first scan's puppets hang.
+  // Historically this leaked the in-flight count (a TU-level static),
+  // permanently throttling or deadlocking every later scan.
+  s->setEnvironmentProvider([] { return behavior("reply"); });
+  s->scan(somePaths(3, "/new/plug"));
+
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  REQUIRE(r.done == 1);
+  REQUIRE(r.scanned.size() == 3);
+  for(const auto& p : r.scanned)
+    REQUIRE(p.startsWith("/new/"));
+  // The cancelled scan must not surface as failures either
+  REQUIRE(r.failed.empty());
+}
+
+TEST_CASE("processIncomingMessage validates before touching anything", "[pluginscan][scanner][token]")
+{
+  auto s = makeScanner("reply");
+  ScanResult r{*s};
+
+  SECTION("valid token, unknown request id")
+  {
+    s->processIncomingMessage(
+        QString(R"({"Token":"%1","Request":123,"Path":"/x"})").arg(s->token()));
+    REQUIRE(r.scanned.empty());
+    REQUIRE(r.failed.empty());
+  }
+  SECTION("wrong token")
+  {
+    s->processIncomingMessage(R"({"Token":"nope","Request":0,"Path":"/x"})");
+    REQUIRE(r.scanned.empty());
+  }
+  SECTION("not JSON")
+  {
+    s->processIncomingMessage("ceci n'est pas du json");
+    REQUIRE(r.scanned.empty());
+  }
+  SECTION("no token field at all")
+  {
+    s->processIncomingMessage(R"({"Request":0,"Path":"/x"})");
+    REQUIRE(r.scanned.empty());
+  }
+}

--- a/tests/unit/PluginScannerTest.cpp
+++ b/tests/unit/PluginScannerTest.cpp
@@ -252,6 +252,23 @@ TEST_CASE("a reply beating the process exit wins over the exit code", "[pluginsc
   REQUIRE(r.scanned.size() == 2);
 }
 
+TEST_CASE("a missing puppet binary fails every path, without recursion", "[pluginscan][scanner]")
+{
+  // FailedToStart is emitted synchronously from QProcess::start(); resolving
+  // it inline used to recurse start -> errorOccurred -> refill -> start
+  // through the whole queue on one stack.
+  auto s = makeScanner("reply");
+  s->setPuppet(QStringLiteral("/nonexistent/puppet-binary"));
+  ScanResult r{*s};
+
+  s->scan(somePaths(50));
+  REQUIRE(spinUntil([&] { return r.done > 0; }));
+
+  REQUIRE(r.scanned.empty());
+  REQUIRE(r.failed.size() == 50);
+  REQUIRE(r.done == 1);
+}
+
 TEST_CASE("two concurrent scanners stay fully isolated", "[pluginscan][scanner][token]")
 {
   // The original sin: fixed ports meant one instance received every other

--- a/tests/unit/PuppetJsonTest.cpp
+++ b/tests/unit/PuppetJsonTest.cpp
@@ -100,7 +100,9 @@ TEST_CASE("parse_arguments: garbage numbers do not misroute the reply", "[puppet
   const char* argv[] = {"puppet", "/plug.so", "banana", "0", "tok"};
   auto args = parse_arguments(5, const_cast<char**>(argv), 37587);
   REQUIRE(args.valid);
-  REQUIRE(args.request_id == 0); // not atoi-garbage
-  REQUIRE(args.port == 37587);   // port 0 rejected, default kept
+  // -1, not 0: a malformed id must not masquerade as scan slot 0 (the host
+  // drops replies for unknown request ids)
+  REQUIRE(args.request_id == -1);
+  REQUIRE(args.port == 37587); // port 0 rejected, default kept
   REQUIRE(args.token == "tok");
 }

--- a/tests/unit/PuppetJsonTest.cpp
+++ b/tests/unit/PuppetJsonTest.cpp
@@ -1,0 +1,106 @@
+// Tests for the shared puppet-side helpers (score/tools/PuppetJson.hpp):
+//
+//  * JSON string escaping: plug-in metadata (names, vendors, descriptions)
+//    routinely contains quotes and other JSON-hostile characters; before
+//    the escaping was introduced, a single such plug-in silently broke its
+//    whole scan reply (the host dropped the unparseable JSON, timed out,
+//    and marked the plug-in invalid).
+//  * Command-line parsing for the token/port scan protocol, including the
+//    legacy `puppet <path> <id>` form that must keep working.
+
+#include <score/tools/PuppetJson.hpp>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+
+#include <catch2/catch_test_macros.hpp>
+
+using score::puppet::json_escape;
+using score::puppet::parse_arguments;
+
+TEST_CASE("json_escape leaves plain text alone", "[puppet][json]")
+{
+  REQUIRE(json_escape("Diode Ladder Filter") == "Diode Ladder Filter");
+  REQUIRE(json_escape("") == "");
+  REQUIRE(json_escape((const char*)nullptr) == "");
+}
+
+TEST_CASE("json_escape escapes JSON-hostile characters", "[puppet][json]")
+{
+  REQUIRE(json_escape(R"(The "best" plugin)") == R"(The \"best\" plugin)");
+  REQUIRE(json_escape(R"(C:\Plugins\foo.dll)") == R"(C:\\Plugins\\foo.dll)");
+  REQUIRE(json_escape("line1\nline2") == R"(line1\nline2)");
+  REQUIRE(json_escape("a\tb") == R"(a\tb)");
+  REQUIRE(json_escape("a\rb") == R"(a\rb)");
+  REQUIRE(json_escape("a\bb") == R"(a\bb)");
+  REQUIRE(json_escape("a\fb") == R"(a\fb)");
+  REQUIRE(json_escape(std::string_view{"\x01\x1f", 2}) == R"(\u0001\u001f)");
+}
+
+TEST_CASE("json_escape passes UTF-8 through untouched", "[puppet][json]")
+{
+  REQUIRE(json_escape("Frédéric — 変調") == "Frédéric — 変調");
+}
+
+TEST_CASE("escaped strings survive a real JSON parser roundtrip", "[puppet][json]")
+{
+  // The actual regression: build a reply the way the puppets do, then parse
+  // it the way the ApplicationPlugins do.
+  const std::string hostile = "A \"plugin\" with\nnewlines & \\backslashes\\";
+  const std::string reply = "{\"Name\":\"" + json_escape(hostile) + "\"}";
+
+  QJsonParseError err{};
+  const auto doc
+      = QJsonDocument::fromJson(QByteArray::fromStdString(reply), &err);
+  REQUIRE(err.error == QJsonParseError::NoError);
+  REQUIRE(doc.isObject());
+  REQUIRE(doc.object()["Name"].toString().toStdString() == hostile);
+}
+
+TEST_CASE("parse_arguments: full protocol form", "[puppet][args]")
+{
+  const char* argv[] = {"puppet", "/usr/lib/vst3/Foo.vst3", "7", "43210", "s3cr3t"};
+  auto args = parse_arguments(5, const_cast<char**>(argv), 37588);
+  REQUIRE(args.valid);
+  REQUIRE(args.path == "/usr/lib/vst3/Foo.vst3");
+  REQUIRE(args.request_id == 7);
+  REQUIRE(args.port == 43210);
+  REQUIRE(args.token == "s3cr3t");
+}
+
+TEST_CASE("parse_arguments: legacy forms fall back to defaults", "[puppet][args]")
+{
+  SECTION("path + id (pre-token hosts)")
+  {
+    const char* argv[] = {"puppet", "/plug.so", "3"};
+    auto args = parse_arguments(3, const_cast<char**>(argv), 37587);
+    REQUIRE(args.valid);
+    REQUIRE(args.request_id == 3);
+    REQUIRE(args.port == 37587);
+    REQUIRE(args.token.empty());
+  }
+  SECTION("path only (manual debugging)")
+  {
+    const char* argv[] = {"puppet", "/plug.so"};
+    auto args = parse_arguments(2, const_cast<char**>(argv), 37587);
+    REQUIRE(args.valid);
+    REQUIRE(args.request_id == 0);
+    REQUIRE(args.port == 37587);
+  }
+  SECTION("no arguments is invalid")
+  {
+    const char* argv[] = {"puppet"};
+    REQUIRE(!parse_arguments(1, const_cast<char**>(argv), 37587).valid);
+  }
+}
+
+TEST_CASE("parse_arguments: garbage numbers do not misroute the reply", "[puppet][args]")
+{
+  const char* argv[] = {"puppet", "/plug.so", "banana", "0", "tok"};
+  auto args = parse_arguments(5, const_cast<char**>(argv), 37587);
+  REQUIRE(args.valid);
+  REQUIRE(args.request_id == 0); // not atoi-garbage
+  REQUIRE(args.port == 37587);   // port 0 rejected, default kept
+  REQUIRE(args.token == "tok");
+}

--- a/tests/unit/Vst3ScanReplyTest.cpp
+++ b/tests/unit/Vst3ScanReplyTest.cpp
@@ -1,0 +1,85 @@
+// vst3::parseVst3Reply — the VST3 half of the scan-reply parsing.
+//
+// Regression: classFlags used to be read from the "Version" key (a string,
+// so QJsonValue::toDouble() returned 0.0) — every cached VST3 class had
+// classFlags == 0 regardless of what the plug-in declared.
+
+#include <Vst3/ApplicationPlugin.hpp>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+QJsonObject parse(const char* json)
+{
+  const auto doc = QJsonDocument::fromJson(json);
+  REQUIRE(doc.isObject());
+  return doc.object();
+}
+}
+
+TEST_CASE("parseVst3Reply fills classes from a puppet reply", "[pluginscan][vst3]")
+{
+  const auto obj = parse(R"({
+    "Name": "MegaPlugin",
+    "Url": "https://example.com",
+    "Path": "/claimed/elsewhere.vst3",
+    "Request": 2,
+    "Token": "tok",
+    "Classes": [{
+      "UID": "5BC32507D06049EA865193447511E8A2",
+      "Cardinality": 2147483647,
+      "Category": "Audio Module Class",
+      "Name": "Mega Reverb",
+      "Vendor": "ACME",
+      "Version": "1.0.2",
+      "SDKVersion": "VST 3.7.0",
+      "Subcategories": "Fx|Reverb",
+      "ClassFlags": 17
+    }]
+  })");
+
+  const auto info = vst3::parseVst3Reply("/usr/lib/vst3/mega.vst3", obj);
+
+  REQUIRE(info.isValid);
+  CHECK(info.path == "/usr/lib/vst3/mega.vst3"); // scanned path wins
+  CHECK(info.name == "MegaPlugin");
+  REQUIRE(info.classInfo.size() == 1);
+
+  const auto& cls = info.classInfo[0];
+  CHECK(cls.name() == "Mega Reverb");
+  CHECK(cls.vendor() == "ACME");
+  CHECK(cls.version() == "1.0.2");
+  CHECK(cls.subCategories().size() == 2);
+  CHECK(cls.subCategories()[0] == "Fx");
+  CHECK(cls.subCategories()[1] == "Reverb");
+  // The regression: this was parsed from "Version" and always came out 0
+  CHECK(cls.classFlags() == 17);
+}
+
+TEST_CASE("parseVst3Reply: no classes means not loadable", "[pluginscan][vst3]")
+{
+  const auto info = vst3::parseVst3Reply(
+      "/usr/lib/vst3/empty.vst3",
+      parse(R"({"Name":"Empty","Request":0,"Token":"t","Classes":[]})"));
+  CHECK(!info.isValid);
+}
+
+TEST_CASE("parseVst3Reply skips malformed class UIDs", "[pluginscan][vst3]")
+{
+  const auto info = vst3::parseVst3Reply("/p.vst3", parse(R"({
+    "Name": "Broken", "Request": 0, "Token": "t",
+    "Classes": [
+      {"UID": "not-a-uid", "Name": "Bad"},
+      {"UID": "5BC32507D06049EA865193447511E8A2", "Name": "Good",
+       "ClassFlags": 1, "Subcategories": "Fx"}
+    ]
+  })"));
+
+  REQUIRE(info.isValid);
+  REQUIRE(info.classInfo.size() == 1);
+  CHECK(info.classInfo[0].name() == "Good");
+}

--- a/tests/unit/VstScanReplyTest.cpp
+++ b/tests/unit/VstScanReplyTest.cpp
@@ -1,0 +1,37 @@
+// vst::parseVstReply — the VST2 half of the scan-reply parsing.
+
+#include <Vst/ApplicationPlugin.hpp>
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("parseVstReply fills VSTInfo from a puppet reply", "[pluginscan][vst]")
+{
+  const auto doc = QJsonDocument::fromJson(R"({
+    "UniqueID": 1450406192,
+    "Controls": 12,
+    "Author": "The \"Best\" Vendor",
+    "PrettyName": "SuperSynth",
+    "Version": "1.2.3",
+    "Synth": true,
+    "Path": "/some/other/claimed/path.so",
+    "Request": 3,
+    "Token": "tok"
+  })");
+  REQUIRE(doc.isObject());
+
+  const auto info = vst::parseVstReply("/usr/lib/vst/supersynth.so", doc.object());
+
+  CHECK(info.uniqueID == 1450406192);
+  CHECK(info.controls == 12);
+  CHECK(info.author == "The \"Best\" Vendor");
+  CHECK(info.displayName == "SuperSynth");
+  CHECK(info.isSynth);
+  CHECK(info.isValid);
+  // The scanned path wins over whatever the reply claims
+  CHECK(info.path == "/usr/lib/vst/supersynth.so");
+  // Pretty name comes from the file name (multi-variant plug-ins)
+  CHECK(info.prettyName == "supersynth");
+}


### PR DESCRIPTION
## Summary

Reworks VST2/VST3/CLAP/LV2 plug-in scanning around one shared, tested state machine, fixing three long-standing issue clusters:

- **Duplicate accumulation** (observed: every CLAP plug-in duplicated 200+ times): the scanners listened on fixed ports (37587–90) with unchecked `listen()` and no session identity, so any concurrent score-derived process delivered its scan replies into whichever instance owned the port — which appended and persisted them, while the scanning instance timed out and marked everything invalid.
- **"Got invalid VST(3) request ID 0/1/2/3…" spam**: vst3puppet sent its request id as a JSON *string*, so `QJsonValue::toInt()` attributed every reply to scan slot 0 — killing an unrelated scan, leaking the in-flight counter, and re-recording successfully-scanned plug-ins as invalid via false 10s timeouts.
- **The unfinished settings refactor**: the `PluginSettingsTab` interface existed with only a VST2 implementation; VST3/CLAP/LV2 had no path configuration or scan feedback, and VST3 wiped its whole database whenever the *VST2* paths changed (`//! TODO`).

## What changed

- **`Media::PluginScanner`**: ephemeral WebSocket port + per-scanner session token validated before any reply touches a plug-in database; event-driven batch refill; per-process timeouts that also cover the tail batch; a reply-vs-process-exit grace period (one `scanFailed` per path, no double/false invalids); clean rescan-while-scanning.
- **Puppets**: shared client (`score/tools/PuppetJson.hpp` / `PuppetClient.hpp`), JSON escaping of all plug-in metadata (one quote used to silently break a whole reply), numeric `Request`, `Token` echo, explicit `Error` replies, per-format watchdogs that can't truncate a reply that is already in flight.
- **Caches**: versioned, length-prefixed blobs that fail cleanly on truncation/corruption/version drift (replaces the raw QVariant blobs and the `vst_invalid_format` global hack), with one-shot migration from the legacy keys and load-time healing — existing configs polluted with duplicates repair themselves on first launch.
- **Settings**: `Vst3Paths`/`ClapPaths`/`Lv2Paths` join `VstPaths` in `Media::Settings::Model` (defaults = the previously hardcoded per-platform lists; `VST3_PATH`/`CLAP_PATH`/`LV2_PATH` stay additive); each backend rescans on its own signal; all four formats get an Effects-page tab (paths editor + rescan + working/faulty tables) built on one shared widget.
- Assorted fixes found along the way: VST3 `classFlags` was parsed from the wrong key and always 0; CLAP's macOS bundle resolution ran after the known-paths check (one duplicate set per launch); Linux bundle-style `.clap` directories (Cardinal & other DPF plug-ins) produced spurious invalid entries; backend change-signals are now `E_SIGNAL` (with `-fvisibility-inlines-hidden`, cross-library connections to `W_SIGNAL` bodies silently never fire).

## Validation

- **41+ test cases across 8 suites** (`tests/unit/{PuppetJson,AudioPluginCache,PluginScanner,VstScanReply,Vst3ScanReply,ClapScan,PluginPathSettings,LV2Loading}Test.cpp`), incl. an end-to-end scriptable fake puppet: token isolation between concurrent scanners, crash/timeout/garbage single-failure semantics, reply-then-exit(1) races, 200×-duplicate healing through a real app boot, legacy-cache migration, per-format path signals.
- **Adversarial review pass** (independent reviewer over the full diff, old-vs-new feature-parity matrix): its two confirmed regressions — a per-element cache status check that could never fire, and mid-scan-quit discarding the batch (starved debounce, no destructor persist) — are fixed and regression-tested.
- **Real-collection validation** on a machine with ~1400 plug-ins: full rescan loads 318 VST2s + complete VST3/CLAP/LV2 sets, zero invalid-request messages, zero dropped replies; every one of the 12 remaining failures was individually diagnosed (8 Carla helper libraries + the lsp-plugins shared core = genuinely not plug-ins; 3 × missing `libprojectM.so.3`). A second run is a pure cache hit. Bridged plug-ins through yabridge/wine scan correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)