### PR TITLE
Unbreak CI: Kabang/Minibang moved to synthimi; FreeBSD NFS git ownership

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -53,8 +53,17 @@ jobs:
 
         run: |
           set -e
+          # The workspace is NFS-shared from the Linux host and the VM runs as
+          # root, so directories created by git clone are owned by a foreign
+          # uid; without this, the post-clone `git submodule update` for
+          # score-addon-airwindows (the one addon that reopens its repo in a
+          # second git process, see SKIP_SUBMODULE in ci/common.deps.sh) dies
+          # with "detected dubious ownership" and leaves airwin2rack empty,
+          # which then breaks the CMake configure.
+          git config --global --add safe.directory '*'
           echo "=============== FreeBSD Start Deps ====================="
-          ./ci/common.deps.sh && echo "=============== FreeBSD Deps Success ====================="
+          ./ci/common.deps.sh
+          echo "=============== FreeBSD Deps Success ====================="
           echo "=============== FreeBSD Start Build ====================="
           ./ci/freebsd.build.sh
           echo "=============== FreeBSD Build Success ====================="

--- a/src/plugins/score-plugin-avnd/CMakeLists.txt
+++ b/src/plugins/score-plugin-avnd/CMakeLists.txt
@@ -1075,47 +1075,6 @@ avnd_make_score(
   NAMESPACE ao
 )
 
-# Too much binary size for wasm. On GCC these land on the boost.pfr fallback,
-# whose instantiation exhausts the compiler's memory; GCC only leaves that
-# fallback with P1061 packs, which need g++ >= 16 in C++26 mode.
-if(NOT EMSCRIPTEN AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-                           AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16
-                                OR NOT CXX_VERSION_FLAG STREQUAL "cxx_std_26")))
-avnd_make_score(
-  SOURCES
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Kabang.hpp"
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Kabang.cpp"
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Sampler.hpp"
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Sampler.cpp"
-  TARGET kabang
-  MAIN_CLASS Kabang
-  NAMESPACE kbng
-  OPTIMIZED
-)
-
-avnd_make_score(
-  SOURCES
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Minibang.hpp"
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Kabang.cpp"
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Sampler.hpp"
-    "${AVND_FOLDER}/examples/Advanced/Kabang/Sampler.cpp"
-  TARGET minibang
-  MAIN_CLASS Minibang
-  NAMESPACE kbng
-  OPTIMIZED
-)
-
-# Kabang's port count puts it in the range where clang's inliner turns the
-# generated walkers into functions the backend takes hours to lower. 40 is the
-# highest threshold that still compiles quickly. Only the generated TU is
-# touched, and -fno-lto keeps the inliner here instead of at link time.
-# Minibang is the reduced variant -- 4 ports against 45 -- and does not need it.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
-  set_property(SOURCE "${CMAKE_BINARY_DIR}/kabang_avnd.cpp" APPEND PROPERTY
-    COMPILE_OPTIONS -fno-lto -mllvm -inline-threshold=40)
-endif()
-endif()
-
 avnd_make_score(
   SOURCES
     "${AVND_FOLDER}/examples/Advanced/UI/Widgets.hpp"


### PR DESCRIPTION
Two independent master CI breakages, both diagnosed on PR #2214's runs but reproducing on master:

1. **Every addon-building job is red since score-addon-synthimi@18ec263b7** ("Kabang and Minibang, moved here from avendish", pushed 18:41Z today): the addon registers avnd targets named `kabang`/`minibang`, and both the addon helper and score-plugin-avnd generate their TU at `${CMAKE_BINARY_DIR}/<target>_avnd.cpp` — whichever configures last wins. The addon's version (addon-relative `#include "Kabang/Kabang.hpp"`) clobbers the core one, and `score_plugin_avnd` fails to compile it. Timeline check: Coverage on master was green at 14:24Z on the same score commit and red from 18:57Z with no score change in between. Fix: remove the core registration — the processes live in the addon now. (Verified locally: configure succeeds, `kabang_avnd` disappears from the build graph, no other references to Kabang exist in `src/`.)

2. **FreeBSD has been failing on `airwin2rack` since the job started actually building** (30fe1d771 fixed the script's shebang; before that CMake never configured on FreeBSD). Root cause: the workspace is NFS-shared into the VM which runs as root, so git-cloned directories belong to a foreign uid; the airwindows addon is the only one whose checkout reopens its repo in a second git process (`SKIP_SUBMODULE` in ci/common.deps.sh) and that process died on "detected dubious ownership", silently leaving `3rdparty/airwin2rack` empty. Fix: trust the tree inside the VM (mirroring coverage.yml's existing workaround) and stop `&&`-chaining the deps step so such failures are visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)