### PR TITLE
ci: give the FreeBSD VM enough memory to finish the build

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -26,6 +26,11 @@ jobs:
         usesh: true
         sync: nfs
         copyback: false
+        # The default 6GB VM dies on the OOM killer ("Subprocess killed",
+        # no compiler diagnostic) near the end of the build, first seen on
+        # the VST3 SDK TUs around step 4039/4104 - the job had never
+        # compiled that far before 30fe1d771 fixed its shebang.
+        mem: 8192
         prepare: |
           echo "=============== FreeBSD Start update ====================="
           pkg update -f -q


### PR DESCRIPTION
Follow-up to #2215: with the airwindows checkout fixed, the FreeBSD job now configures and builds — and dies at step ~4039/4104 with `Subprocess killed` (OOM killer, no compiler diagnostic) on the VST3 SDK translation units. The vmactions default of 6GB isn't enough for the tail of the build; bump the VM to 8GB (the ubuntu-latest host has 16GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)