### PR TITLE
ci: give the FreeBSD VM swap for the build's memory peak

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -32,6 +32,16 @@ jobs:
         # compiled that far before 30fe1d771 fixed its shebang.
         mem: 8192
         prepare: |
+          # 8GB was still not enough for the tail of the build (the VM died
+          # mid-compile on the same VST3 SDK / puppet TU cluster, moving from
+          # step 4039 to 4042 of 4104): give the guest swap to absorb the
+          # peak instead of dying, at zero cost while unused.
+          echo "=============== FreeBSD Start swap ====================="
+          truncate -s 6g /swapfile
+          chmod 0600 /swapfile
+          mdconfig -a -t vnode -f /swapfile -u 9
+          swapon /dev/md9
+          swapinfo
           echo "=============== FreeBSD Start update ====================="
           pkg update -f -q
           echo "=============== FreeBSD Start upgrade ====================="


### PR DESCRIPTION
Follow-up to #2217: 8GB RAM moved the death from build step 4039 to 4042 of 4104 — the VM still dies mid-compile (ssh drops, no compiler diagnostic) on the VST3 SDK / puppet TU cluster. Add a 6GB swap file in the prepare step so the parallel-clang peak spills to swap instead of killing the guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)