### PR TITLE
ci: actually engage the FreeBSD swap, and cap build parallelism

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -36,12 +36,16 @@ jobs:
           # mid-compile on the same VST3 SDK / puppet TU cluster, moving from
           # step 4039 to 4042 of 4104): give the guest swap to absorb the
           # peak instead of dying, at zero cost while unused.
+          # dd, not truncate: FreeBSD swapon silently does not engage on a
+          # sparse vnode (the first attempt left only the image's 1GB
+          # partition in swapinfo).
           echo "=============== FreeBSD Start swap ====================="
-          truncate -s 6g /swapfile
+          dd if=/dev/zero of=/swapfile bs=1m count=6144
           chmod 0600 /swapfile
           mdconfig -a -t vnode -f /swapfile -u 9
           swapon /dev/md9
           swapinfo
+          swapinfo | grep -q md9 || echo "WARNING: swap file not engaged"
           echo "=============== FreeBSD Start update ====================="
           pkg update -f -q
           echo "=============== FreeBSD Start upgrade ====================="

--- a/ci/freebsd.build.sh
+++ b/ci/freebsd.build.sh
@@ -20,5 +20,8 @@ cmake $SCORE_DIR \
   -DCMAKE_CXX_FLAGS="-fexperimental-library" \
   -DSCORE_PCH=1
 
-cmake --build .
+# --parallel 2: the 2-core VM otherwise runs enough concurrent -O3
+# compiles + plugin links to exhaust guest memory in the last ~60 build
+# steps, killing the VM with no compiler diagnostic.
+cmake --build . --parallel 2
 cmake --build . --target install


### PR DESCRIPTION
Third round on the FreeBSD tail-of-build death (steps 4039 → 4042 → 4052 of ~4110 across 6GB / 8GB / 8GB+"swap"):

- The swap from the previous fix **never engaged**: `swapon` on a sparse (`truncate`-created) vnode silently does nothing on FreeBSD — `swapinfo` in the logs shows only the image's builtin 1GB partition. Use `dd` and verify with `swapinfo | grep md9`.
- Cap the build at `--parallel 2`: the 2-core VM's default ninja parallelism runs enough concurrent `-O3` compiles + plugin links in the final stretch to exhaust guest memory with no compiler diagnostic (the VM/ssh just dies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)