### PR TITLE
Fix file-port use-after-free, camera/stream stalls and the optional-library loader crash

### DIFF
--- a/src/lib/score/tools/DynamicLibrary.hpp
+++ b/src/lib/score/tools/DynamicLibrary.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <ossia/detail/dylib_loader.hpp>
+
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace score
+{
+
+/**
+ * @brief dlopen a library, reporting absence instead of throwing.
+ *
+ * ossia::dylib_loader only signals failure by throwing from its constructor,
+ * which makes it unusable as a direct member of the optional-dependency
+ * loaders: a function-try-block around a constructor rethrows when it falls
+ * off the end of the handler, so the "unavailable" flag those loaders check is
+ * never reached and the exception escapes their instance() accessor instead.
+ */
+[[nodiscard]] inline std::optional<ossia::dylib_loader>
+try_load_library(const char* name) noexcept
+{
+  try
+  {
+    return ossia::dylib_loader{name};
+  }
+  catch(...)
+  {
+    return std::nullopt;
+  }
+}
+
+//! Loads the first of @p names that can be found
+[[nodiscard]] inline std::optional<ossia::dylib_loader>
+try_load_library(std::vector<std::string_view> names) noexcept
+{
+  try
+  {
+    return ossia::dylib_loader{std::move(names)};
+  }
+  catch(...)
+  {
+    return std::nullopt;
+  }
+}
+
+}

--- a/src/plugins/score-plugin-avnd/Crousti/CpuAnalysisNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/CpuAnalysisNode.hpp
@@ -10,7 +10,9 @@ template <typename Node_T>
   requires(
       (avnd::texture_output_introspection<Node_T>::size + avnd::buffer_output_introspection<Node_T>::size + avnd::geometry_output_introspection<Node_T>::size) == 0
   )
-struct GfxRenderer<Node_T> final : score::gfx::OutputNodeRenderer
+struct GfxRenderer<Node_T> final
+    : score::gfx::OutputNodeRenderer
+    , GpuRendererFiles<Node_T>
 {
   std::shared_ptr<Node_T> state;
   score::gfx::Message m_last_message{};

--- a/src/plugins/score-plugin-avnd/Crousti/CpuFilterNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/CpuFilterNode.hpp
@@ -10,7 +10,9 @@ template <typename Node_T>
   requires(
     (avnd::texture_output_introspection<Node_T>::size + avnd::buffer_output_introspection<Node_T>::size + avnd::geometry_output_introspection<Node_T>::size) >= 1
   )
-struct GfxRenderer<Node_T> final : score::gfx::GenericNodeRenderer
+struct GfxRenderer<Node_T> final
+    : score::gfx::GenericNodeRenderer
+    , GpuRendererFiles<Node_T>
 {
   std::shared_ptr<Node_T> state;
   score::gfx::Message m_last_message{};

--- a/src/plugins/score-plugin-avnd/Crousti/Executor.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Executor.hpp
@@ -451,7 +451,7 @@ public:
                   [&]<std::size_t NField, std::size_t N>(
                       auto& field, avnd::predicate_index<N> p,
                       avnd::field_index<NField> f) {
-                eff_ptr->soundfile_loaded(sf, p, f);
+                sf = eff_ptr->soundfile_loaded(sf, p, f);
               });
             });
           });

--- a/src/plugins/score-plugin-avnd/Crousti/ExecutorPortSetup.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/ExecutorPortSetup.hpp
@@ -228,7 +228,7 @@ struct setup_control_for_exec<Node, Field, N, NField>
 
               // We store the sound file handle returned in this lambda so that it gets
               // GC'd in the main thread
-              n->soundfile_loaded(
+              f = n->soundfile_loaded(
                   f, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
             });
           }
@@ -272,7 +272,7 @@ struct setup_control_for_exec<Node, Field, N, NField>
 
             // We store the sound file handle returned in this lambda so that it gets
             // GC'd in the main thread
-            n->midifile_loaded(
+            f = n->midifile_loaded(
                 f, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
           });
         }
@@ -337,7 +337,8 @@ struct setup_control_for_exec<Node, Field, N, NField>
 
               // We store the sound file handle returned in this lambda so that it gets
               // GC'd in the main thread
-              n->file_loaded(f, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
+              f = n->file_loaded(
+                  f, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
               if(ff)
                 ff(n->impl.effect);
             });
@@ -351,7 +352,8 @@ struct setup_control_for_exec<Node, Field, N, NField>
 
               // We store the sound file handle returned in this lambda so that it gets
               // GC'd in the main thread
-              n->file_loaded(f, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
+              f = n->file_loaded(
+                  f, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
             });
           }
         }

--- a/src/plugins/score-plugin-avnd/Crousti/GpuNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuNode.hpp
@@ -14,7 +14,9 @@ namespace oscr
 {
 
 template <typename Node_T>
-struct CustomGpuRenderer final : score::gfx::NodeRenderer
+struct CustomGpuRenderer final
+    : score::gfx::NodeRenderer
+    , GpuRendererFiles<Node_T>
 {
   using texture_inputs = avnd::texture_input_introspection<Node_T>;
   using texture_outputs = avnd::texture_output_introspection<Node_T>;
@@ -341,6 +343,8 @@ struct CustomGpuRenderer final : score::gfx::NodeRenderer
       }
     }
     states.clear();
+
+    this->releaseFiles();
 
     // Release the allocated mesh buffers
     m_meshBuffer = {};

--- a/src/plugins/score-plugin-avnd/Crousti/GpuUtils.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuUtils.hpp
@@ -18,6 +18,7 @@
 
 #include <score/tools/ThreadPool.hpp>
 
+#include <ossia/detail/hash_map.hpp>
 #include <ossia/detail/small_flat_map.hpp>
 
 #include <ossia-qt/invoke.hpp>
@@ -81,6 +82,43 @@ struct GpuWorker
   }
 };
 
+#if defined(OSCR_HAS_MMAP_FILE_STORAGE)
+// The file ports keep string_views into the raw_file_data, and there is one
+// object instance per renderer (one renderer per RenderList, that is per
+// output) and per instance in CustomGpuRenderer. Storing the handles on the
+// node would thus free, on every load, the memory that the ports of all the
+// other instances still point to.
+template <typename T>
+struct GpuRendererFiles
+{
+  template <std::size_t N, std::size_t NField>
+  void file_loaded(
+      T& state, const std::shared_ptr<oscr::raw_file_data>& hdl,
+      avnd::predicate_index<N> pred, avnd::field_index<NField> field)
+  {
+    m_rawfiles[&state].load(state, hdl, pred, field);
+  }
+
+  void releaseFiles() noexcept { m_rawfiles.clear(); }
+
+private:
+  ossia::hash_map<const T*, oscr::raw_file_storage<T>> m_rawfiles;
+};
+
+template <typename T>
+  requires(avnd::raw_file_input_introspection<T>::size == 0)
+struct GpuRendererFiles<T>
+{
+  void releaseFiles() noexcept { }
+};
+#else
+template <typename T>
+struct GpuRendererFiles
+{
+  void releaseFiles() noexcept { }
+};
+#endif
+
 template <typename GpuNodeRenderer, typename Node>
 struct GpuProcessIns
 {
@@ -127,7 +165,6 @@ struct GpuProcessIns
   void operator()(Field& t, avnd::field_index<NField> field_index)
   {
     // FIXME we should be loading a file there
-    using node_type = std::remove_cvref_t<decltype(gpu.node())>;
     using file_ports = avnd::raw_file_input_introspection<Node>;
 
     if(!can_process_message(field_index))
@@ -149,17 +186,15 @@ struct GpuProcessIns
         // FIXME also do it when we get a run-time message from the exec engine,
         // OSC, etc
         auto func = executePortPreprocess<Field>(*hdl);
-        const_cast<node_type&>(gpu.node())
-            .file_loaded(
-                state, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
+        gpu.file_loaded(
+            state, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
         if(func)
           func(state);
       }
       else
       {
-        const_cast<node_type&>(gpu.node())
-            .file_loaded(
-                state, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
+        gpu.file_loaded(
+            state, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
       }
     }
   }
@@ -252,18 +287,7 @@ struct SCORE_PLUGIN_AVND_EXPORT GpuNodeElements
 
   [[no_unique_address]] oscr::midifile_storage<T> midifiles;
 
-#if defined(OSCR_HAS_MMAP_FILE_STORAGE)
-  [[no_unique_address]] oscr::raw_file_storage<T> rawfiles;
-#endif
-
-  template <std::size_t N, std::size_t NField>
-  void file_loaded(
-      auto& state, const std::shared_ptr<oscr::raw_file_data>& hdl,
-      avnd::predicate_index<N>, avnd::field_index<NField>)
-  {
-    this->rawfiles.load(
-        state, hdl, avnd::predicate_index<N>{}, avnd::field_index<NField>{});
-  }
+  // Raw file handles are stored per-state in the renderers, see GpuRendererFiles
 };
 
 struct SCORE_PLUGIN_AVND_EXPORT CustomGfxNodeBase : score::gfx::NodeModel

--- a/src/plugins/score-plugin-gfx/Gfx/GPhoto2/GPhoto2Device.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GPhoto2/GPhoto2Device.cpp
@@ -7,6 +7,7 @@
 #include <Gfx/Graph/VideoNode.hpp>
 
 #include <score/serialization/MimeVisitor.hpp>
+#include <score/tools/DynamicLibrary.hpp>
 
 #include <ossia-qt/name_utils.hpp>
 #include <ossia/detail/dylib_loader.hpp>
@@ -27,6 +28,7 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 }
 
+#include <optional>
 #include <thread>
 
 // Forward declarations of gphoto2 types (all opaque)
@@ -277,187 +279,183 @@ struct libgphoto2
 
   bool available{};
 
-  static const libgphoto2& instance()
+  static const libgphoto2& instance() noexcept
   {
     static const libgphoto2 self;
     return self;
   }
 
 private:
-  static ossia::dylib_loader load_port_library()
+  static std::optional<ossia::dylib_loader> load_port_library()
   {
 #if defined(_WIN32)
-    return ossia::dylib_loader{"libgphoto2_port.dll"};
+    return score::try_load_library("libgphoto2_port.dll");
 #elif defined(__APPLE__)
-    return ossia::dylib_loader{std::vector<std::string_view>{"libgphoto2_port.12.dylib", "libgphoto2_port.dylib"}};
+    return score::try_load_library({"libgphoto2_port.12.dylib", "libgphoto2_port.dylib"});
 #else
-    return ossia::dylib_loader{std::vector<std::string_view>{"libgphoto2_port.so.12", "libgphoto2_port.so"}};
+    return score::try_load_library({"libgphoto2_port.so.12", "libgphoto2_port.so"});
 #endif
   }
 
-  static ossia::dylib_loader load_library()
+  static std::optional<ossia::dylib_loader> load_library()
   {
 #if defined(_WIN32)
-    return ossia::dylib_loader{"libgphoto2.dll"};
+    return score::try_load_library("libgphoto2.dll");
 #elif defined(__APPLE__)
-    return ossia::dylib_loader{std::vector<std::string_view>{"libgphoto2.6.dylib", "libgphoto2.dylib"}};
+    return score::try_load_library({"libgphoto2.6.dylib", "libgphoto2.dylib"});
 #else
-    return ossia::dylib_loader{std::vector<std::string_view>{"libgphoto2.so.6", "libgphoto2.so"}};
+    return score::try_load_library({"libgphoto2.so.6", "libgphoto2.so"});
 #endif
   }
 
   libgphoto2()
-  try : m_port_library{load_port_library()}
-      , m_library{load_library()}
-      , available{true}
   {
+    m_port_library = load_port_library();
+    m_library = load_library();
+
+    // Not installed: available stays false and every entry point bails out
+    if(!m_port_library || !m_library)
+      return;
+
     // libgphoto2_port symbols
     port_info_list_new
-        = m_port_library.symbol<decltype(&::gp_port_info_list_new)>(
+        = m_port_library->symbol<decltype(&::gp_port_info_list_new)>(
             "gp_port_info_list_new");
     port_info_list_load
-        = m_port_library.symbol<decltype(&::gp_port_info_list_load)>(
+        = m_port_library->symbol<decltype(&::gp_port_info_list_load)>(
             "gp_port_info_list_load");
     port_info_list_free
-        = m_port_library.symbol<decltype(&::gp_port_info_list_free)>(
+        = m_port_library->symbol<decltype(&::gp_port_info_list_free)>(
             "gp_port_info_list_free");
     port_info_list_lookup_path
-        = m_port_library.symbol<decltype(&::gp_port_info_list_lookup_path)>(
+        = m_port_library->symbol<decltype(&::gp_port_info_list_lookup_path)>(
             "gp_port_info_list_lookup_path");
     port_info_list_get_info
-        = m_port_library.symbol<decltype(&::gp_port_info_list_get_info)>(
+        = m_port_library->symbol<decltype(&::gp_port_info_list_get_info)>(
             "gp_port_info_list_get_info");
 
     // libgphoto2 symbols
     context_new
-        = m_library.symbol<decltype(&::gp_context_new)>("gp_context_new");
+        = m_library->symbol<decltype(&::gp_context_new)>("gp_context_new");
     context_unref
-        = m_library.symbol<decltype(&::gp_context_unref)>("gp_context_unref");
+        = m_library->symbol<decltype(&::gp_context_unref)>("gp_context_unref");
 
-    camera_new = m_library.symbol<decltype(&::gp_camera_new)>("gp_camera_new");
+    camera_new = m_library->symbol<decltype(&::gp_camera_new)>("gp_camera_new");
     camera_init
-        = m_library.symbol<decltype(&::gp_camera_init)>("gp_camera_init");
+        = m_library->symbol<decltype(&::gp_camera_init)>("gp_camera_init");
     camera_exit
-        = m_library.symbol<decltype(&::gp_camera_exit)>("gp_camera_exit");
+        = m_library->symbol<decltype(&::gp_camera_exit)>("gp_camera_exit");
     camera_unref
-        = m_library.symbol<decltype(&::gp_camera_unref)>("gp_camera_unref");
+        = m_library->symbol<decltype(&::gp_camera_unref)>("gp_camera_unref");
     camera_set_abilities
-        = m_library.symbol<decltype(&::gp_camera_set_abilities)>(
+        = m_library->symbol<decltype(&::gp_camera_set_abilities)>(
             "gp_camera_set_abilities");
     camera_set_port_info
-        = m_library.symbol<decltype(&::gp_camera_set_port_info)>(
+        = m_library->symbol<decltype(&::gp_camera_set_port_info)>(
             "gp_camera_set_port_info");
     camera_autodetect
-        = m_library.symbol<decltype(&::gp_camera_autodetect)>(
+        = m_library->symbol<decltype(&::gp_camera_autodetect)>(
             "gp_camera_autodetect");
     camera_capture_preview
-        = m_library.symbol<decltype(&::gp_camera_capture_preview)>(
+        = m_library->symbol<decltype(&::gp_camera_capture_preview)>(
             "gp_camera_capture_preview");
     camera_get_config
-        = m_library.symbol<decltype(&::gp_camera_get_config)>(
+        = m_library->symbol<decltype(&::gp_camera_get_config)>(
             "gp_camera_get_config");
     camera_set_config
-        = m_library.symbol<decltype(&::gp_camera_set_config)>(
+        = m_library->symbol<decltype(&::gp_camera_set_config)>(
             "gp_camera_set_config");
     camera_get_single_config
-        = m_library.symbol<decltype(&::gp_camera_get_single_config)>(
+        = m_library->symbol<decltype(&::gp_camera_get_single_config)>(
             "gp_camera_get_single_config");
     camera_set_single_config
-        = m_library.symbol<decltype(&::gp_camera_set_single_config)>(
+        = m_library->symbol<decltype(&::gp_camera_set_single_config)>(
             "gp_camera_set_single_config");
 
     widget_get_type
-        = m_library.symbol<decltype(&::gp_widget_get_type)>(
+        = m_library->symbol<decltype(&::gp_widget_get_type)>(
             "gp_widget_get_type");
     widget_get_name
-        = m_library.symbol<decltype(&::gp_widget_get_name)>(
+        = m_library->symbol<decltype(&::gp_widget_get_name)>(
             "gp_widget_get_name");
     widget_get_label
-        = m_library.symbol<decltype(&::gp_widget_get_label)>(
+        = m_library->symbol<decltype(&::gp_widget_get_label)>(
             "gp_widget_get_label");
     widget_get_value
-        = m_library.symbol<decltype(&::gp_widget_get_value)>(
+        = m_library->symbol<decltype(&::gp_widget_get_value)>(
             "gp_widget_get_value");
     widget_set_value
-        = m_library.symbol<decltype(&::gp_widget_set_value)>(
+        = m_library->symbol<decltype(&::gp_widget_set_value)>(
             "gp_widget_set_value");
     widget_get_range
-        = m_library.symbol<decltype(&::gp_widget_get_range)>(
+        = m_library->symbol<decltype(&::gp_widget_get_range)>(
             "gp_widget_get_range");
     widget_count_children
-        = m_library.symbol<decltype(&::gp_widget_count_children)>(
+        = m_library->symbol<decltype(&::gp_widget_count_children)>(
             "gp_widget_count_children");
     widget_get_child
-        = m_library.symbol<decltype(&::gp_widget_get_child)>(
+        = m_library->symbol<decltype(&::gp_widget_get_child)>(
             "gp_widget_get_child");
     widget_count_choices
-        = m_library.symbol<decltype(&::gp_widget_count_choices)>(
+        = m_library->symbol<decltype(&::gp_widget_count_choices)>(
             "gp_widget_count_choices");
     widget_get_choice
-        = m_library.symbol<decltype(&::gp_widget_get_choice)>(
+        = m_library->symbol<decltype(&::gp_widget_get_choice)>(
             "gp_widget_get_choice");
     widget_free
-        = m_library.symbol<decltype(&::gp_widget_free)>("gp_widget_free");
+        = m_library->symbol<decltype(&::gp_widget_free)>("gp_widget_free");
 
-    file_new = m_library.symbol<decltype(&::gp_file_new)>("gp_file_new");
+    file_new = m_library->symbol<decltype(&::gp_file_new)>("gp_file_new");
     file_new_from_handler
-        = m_library.symbol<decltype(&::gp_file_new_from_handler)>(
+        = m_library->symbol<decltype(&::gp_file_new_from_handler)>(
             "gp_file_new_from_handler");
     file_unref
-        = m_library.symbol<decltype(&::gp_file_unref)>("gp_file_unref");
+        = m_library->symbol<decltype(&::gp_file_unref)>("gp_file_unref");
     file_clean
-        = m_library.symbol<decltype(&::gp_file_clean)>("gp_file_clean");
+        = m_library->symbol<decltype(&::gp_file_clean)>("gp_file_clean");
     file_get_data_and_size
-        = m_library.symbol<decltype(&::gp_file_get_data_and_size)>(
+        = m_library->symbol<decltype(&::gp_file_get_data_and_size)>(
             "gp_file_get_data_and_size");
 
-    list_new = m_library.symbol<decltype(&::gp_list_new)>("gp_list_new");
-    list_free = m_library.symbol<decltype(&::gp_list_free)>("gp_list_free");
+    list_new = m_library->symbol<decltype(&::gp_list_new)>("gp_list_new");
+    list_free = m_library->symbol<decltype(&::gp_list_free)>("gp_list_free");
     list_count
-        = m_library.symbol<decltype(&::gp_list_count)>("gp_list_count");
+        = m_library->symbol<decltype(&::gp_list_count)>("gp_list_count");
     list_get_name
-        = m_library.symbol<decltype(&::gp_list_get_name)>("gp_list_get_name");
+        = m_library->symbol<decltype(&::gp_list_get_name)>("gp_list_get_name");
     list_get_value
-        = m_library.symbol<decltype(&::gp_list_get_value)>(
+        = m_library->symbol<decltype(&::gp_list_get_value)>(
             "gp_list_get_value");
 
     abilities_list_new
-        = m_library.symbol<decltype(&::gp_abilities_list_new)>(
+        = m_library->symbol<decltype(&::gp_abilities_list_new)>(
             "gp_abilities_list_new");
     abilities_list_load
-        = m_library.symbol<decltype(&::gp_abilities_list_load)>(
+        = m_library->symbol<decltype(&::gp_abilities_list_load)>(
             "gp_abilities_list_load");
     abilities_list_free
-        = m_library.symbol<decltype(&::gp_abilities_list_free)>(
+        = m_library->symbol<decltype(&::gp_abilities_list_free)>(
             "gp_abilities_list_free");
     abilities_list_lookup_model
-        = m_library.symbol<decltype(&::gp_abilities_list_lookup_model)>(
+        = m_library->symbol<decltype(&::gp_abilities_list_lookup_model)>(
             "gp_abilities_list_lookup_model");
     abilities_list_get_abilities
-        = m_library.symbol<decltype(&::gp_abilities_list_get_abilities)>(
+        = m_library->symbol<decltype(&::gp_abilities_list_get_abilities)>(
             "gp_abilities_list_get_abilities");
 
     result_as_string
-        = m_library.symbol<decltype(&::gp_result_as_string)>(
+        = m_library->symbol<decltype(&::gp_result_as_string)>(
             "gp_result_as_string");
 
     // Verify critical symbols
-    if(!context_new || !camera_new || !camera_init || !camera_exit
-       || !camera_unref || !camera_capture_preview || !file_new
-       || !file_unref || !file_get_data_and_size || !list_new
-       || !list_free || !list_count || !camera_autodetect)
-    {
-      available = false;
-    }
-  }
-  catch(...)
-  {
-    // available is default-initialized to false;
-    // if we reach here, the library loading failed.
+    available = context_new && camera_new && camera_init && camera_exit
+                && camera_unref && camera_capture_preview && file_new && file_unref
+                && file_get_data_and_size && list_new && list_free && list_count
+                && camera_autodetect;
   }
 
-  ossia::dylib_loader m_port_library;
-  ossia::dylib_loader m_library;
+  std::optional<ossia::dylib_loader> m_port_library;
+  std::optional<ossia::dylib_loader> m_library;
 };
 
 // MJPEG decoder for preview frames

--- a/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerLoader.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerLoader.hpp
@@ -1,8 +1,11 @@
 #pragma once
+#include <score/tools/DynamicLibrary.hpp>
+
 #include <ossia/detail/dylib_loader.hpp>
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -337,79 +340,79 @@ struct libgstreamer
 
   bool available{};
 
-  static const libgstreamer& instance()
+  static const libgstreamer& instance() noexcept
   {
     static const libgstreamer self;
     return self;
   }
 
 private:
-  static ossia::dylib_loader load_core_library()
+  static std::optional<ossia::dylib_loader> load_core_library()
   {
 #if defined(_WIN32)
-    return ossia::dylib_loader{
-        std::vector<std::string_view>{"gstreamer-1.0-0.dll"}};
+    return score::try_load_library({"gstreamer-1.0-0.dll"});
 #elif defined(__APPLE__)
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libgstreamer-1.0.0.dylib", "libgstreamer-1.0.dylib"}};
+    return score::try_load_library({
+        "libgstreamer-1.0.0.dylib", "libgstreamer-1.0.dylib"});
 #else
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libgstreamer-1.0.so.0", "libgstreamer-1.0.so"}};
+    return score::try_load_library({
+        "libgstreamer-1.0.so.0", "libgstreamer-1.0.so"});
 #endif
   }
 
-  static ossia::dylib_loader load_app_library()
+  static std::optional<ossia::dylib_loader> load_app_library()
   {
 #if defined(_WIN32)
-    return ossia::dylib_loader{
-        std::vector<std::string_view>{"gstapp-1.0-0.dll"}};
+    return score::try_load_library({"gstapp-1.0-0.dll"});
 #elif defined(__APPLE__)
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libgstapp-1.0.0.dylib", "libgstapp-1.0.dylib"}};
+    return score::try_load_library({
+        "libgstapp-1.0.0.dylib", "libgstapp-1.0.dylib"});
 #else
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libgstapp-1.0.so.0", "libgstapp-1.0.so"}};
+    return score::try_load_library({
+        "libgstapp-1.0.so.0", "libgstapp-1.0.so"});
 #endif
   }
 
-  static ossia::dylib_loader load_gobject_library()
+  static std::optional<ossia::dylib_loader> load_gobject_library()
   {
 #if defined(_WIN32)
-    return ossia::dylib_loader{
-        std::vector<std::string_view>{"gobject-2.0-0.dll", "libgobject-2.0-0.dll"}};
+    return score::try_load_library({"gobject-2.0-0.dll", "libgobject-2.0-0.dll"});
 #elif defined(__APPLE__)
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libgobject-2.0.0.dylib", "libgobject-2.0.dylib"}};
+    return score::try_load_library({
+        "libgobject-2.0.0.dylib", "libgobject-2.0.dylib"});
 #else
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libgobject-2.0.so.0", "libgobject-2.0.so"}};
+    return score::try_load_library({
+        "libgobject-2.0.so.0", "libgobject-2.0.so"});
 #endif
   }
 
-  static ossia::dylib_loader load_glib_library()
+  static std::optional<ossia::dylib_loader> load_glib_library()
   {
 #if defined(_WIN32)
-    return ossia::dylib_loader{
-        std::vector<std::string_view>{"glib-2.0-0.dll", "libglib-2.0-0.dll"}};
+    return score::try_load_library({"glib-2.0-0.dll", "libglib-2.0-0.dll"});
 #elif defined(__APPLE__)
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libglib-2.0.0.dylib", "libglib-2.0.dylib"}};
+    return score::try_load_library({
+        "libglib-2.0.0.dylib", "libglib-2.0.dylib"});
 #else
-    return ossia::dylib_loader{std::vector<std::string_view>{
-        "libglib-2.0.so.0", "libglib-2.0.so"}};
+    return score::try_load_library({
+        "libglib-2.0.so.0", "libglib-2.0.so"});
 #endif
   }
 
 #define GST_LOAD(lib, name) \
-  name = lib.symbol<decltype(&::gst_##name)>("gst_" #name)
+  name = lib->symbol<decltype(&::gst_##name)>("gst_" #name)
 
   libgstreamer()
-  try : m_core{load_core_library()}
-      , m_app{load_app_library()}
-      , m_gobject{load_gobject_library()}
-      , m_glib{load_glib_library()}
-      , available{true}
   {
+    m_core = load_core_library();
+    m_app = load_app_library();
+    m_gobject = load_gobject_library();
+    m_glib = load_glib_library();
+
+    // Not installed: available stays false and every entry point bails out
+    if(!m_core || !m_app || !m_gobject || !m_glib)
+      return;
+
     // Core
     GST_LOAD(m_core, init_check);
     GST_LOAD(m_core, parse_launch);
@@ -442,8 +445,8 @@ private:
     GST_LOAD(m_core, object_unref);
     GST_LOAD(m_core, message_unref);
     GST_LOAD(m_core, mini_object_unref);
-    g_free = m_glib.symbol<decltype(&::g_free)>("g_free");
-    g_error_free = m_glib.symbol<decltype(&::g_error_free)>("g_error_free");
+    g_free = m_glib->symbol<decltype(&::g_free)>("g_free");
+    g_error_free = m_glib->symbol<decltype(&::g_error_free)>("g_error_free");
 
     // AppSink
     GST_LOAD(m_app, app_sink_try_pull_sample);
@@ -464,7 +467,7 @@ private:
 
     // GObject property introspection
 #define GOBJ_LOAD(name) \
-  name = m_gobject.symbol<decltype(&::g_##name)>("g_" #name)
+  name = m_gobject->symbol<decltype(&::g_##name)>("g_" #name)
 
     GOBJ_LOAD(object_class_list_properties);
     GOBJ_LOAD(type_class_ref);
@@ -500,23 +503,16 @@ private:
 #undef GOBJ_LOAD
 
     // Verify critical symbols
-    if(!init_check || !parse_launch || !element_set_state
-       || !element_get_state || !bin_get_by_name || !object_unref
-       || !buffer_map || !buffer_unmap)
-    {
-      available = false;
-    }
-  }
-  catch(...)
-  {
+    available = init_check && parse_launch && element_set_state && element_get_state
+                && bin_get_by_name && object_unref && buffer_map && buffer_unmap;
   }
 
 #undef GST_LOAD
 
-  ossia::dylib_loader m_core;
-  ossia::dylib_loader m_app;
-  ossia::dylib_loader m_gobject;
-  ossia::dylib_loader m_glib;
+  std::optional<ossia::dylib_loader> m_core;
+  std::optional<ossia::dylib_loader> m_app;
+  std::optional<ossia::dylib_loader> m_gobject;
+  std::optional<ossia::dylib_loader> m_glib;
 };
 
 // Call once from any code that needs GStreamer

--- a/src/plugins/score-plugin-gfx/Gfx/WindowCapture/WindowCapture_x11.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/WindowCapture/WindowCapture_x11.cpp
@@ -1,5 +1,7 @@
 #include <Gfx/WindowCapture/WindowCaptureBackend.hpp>
 
+#include <score/tools/DynamicLibrary.hpp>
+
 #include <ossia/detail/dylib_loader.hpp>
 
 #include <QDebug>
@@ -107,15 +109,15 @@ struct libx11
 
   bool available{};
 
-  static const libx11& instance()
+  static const libx11& instance() noexcept
   {
     static const libx11 self;
     return self;
   }
 
 private:
-  ossia::dylib_loader m_x11;
-  ossia::dylib_loader m_xext;
+  std::optional<ossia::dylib_loader> m_x11;
+  std::optional<ossia::dylib_loader> m_xext;
   std::optional<ossia::dylib_loader> m_xcomposite;
   std::optional<ossia::dylib_loader> m_xrandr;
 
@@ -126,33 +128,37 @@ private:
   }
 
   libx11()
-  try : m_x11{std::vector<std::string_view>{"libX11.so.6", "libX11.so"}}
-      , m_xext{std::vector<std::string_view>{"libXext.so.6", "libXext.so"}}
   {
-    OpenDisplay = sym<XOpenDisplay_t>(m_x11, "XOpenDisplay");
-    CloseDisplay = sym<XCloseDisplay_t>(m_x11, "XCloseDisplay");
-    DefaultRootWindow = sym<XDefaultRootWindow_t>(m_x11, "XDefaultRootWindow");
-    InternAtom = sym<XInternAtom_t>(m_x11, "XInternAtom");
-    GetWindowProperty = sym<XGetWindowProperty_t>(m_x11, "XGetWindowProperty");
-    Free = sym<XFree_t>(m_x11, "XFree");
-    FetchName = sym<XFetchName_t>(m_x11, "XFetchName");
-    GetWindowAttributes = sym<XGetWindowAttributes_t>(m_x11, "XGetWindowAttributes");
-    QueryTree = sym<XQueryTree_t>(m_x11, "XQueryTree");
-    DestroyImage = sym<XDestroyImage_t>(m_x11, "XDestroyImage");
-    FreePixmap = sym<XFreePixmap_t>(m_x11, "XFreePixmap");
-    Sync = sym<XSync_t>(m_x11, "XSync");
+    m_x11 = score::try_load_library({"libX11.so.6", "libX11.so"});
+    m_xext = score::try_load_library({"libXext.so.6", "libXext.so"});
 
-    ShmQueryExtension = sym<XShmQueryExtension_t>(m_xext, "XShmQueryExtension");
-    ShmCreateImage = sym<XShmCreateImage_t>(m_xext, "XShmCreateImage");
-    ShmAttach = sym<XShmAttach_t>(m_xext, "XShmAttach");
-    ShmDetach = sym<XShmDetach_t>(m_xext, "XShmDetach");
-    ShmGetImage = sym<XShmGetImage_t>(m_xext, "XShmGetImage");
+    // Not installed: available stays false and every entry point bails out
+    if(!m_x11 || !m_xext)
+      return;
+
+    OpenDisplay = sym<XOpenDisplay_t>(*m_x11, "XOpenDisplay");
+    CloseDisplay = sym<XCloseDisplay_t>(*m_x11, "XCloseDisplay");
+    DefaultRootWindow = sym<XDefaultRootWindow_t>(*m_x11, "XDefaultRootWindow");
+    InternAtom = sym<XInternAtom_t>(*m_x11, "XInternAtom");
+    GetWindowProperty = sym<XGetWindowProperty_t>(*m_x11, "XGetWindowProperty");
+    Free = sym<XFree_t>(*m_x11, "XFree");
+    FetchName = sym<XFetchName_t>(*m_x11, "XFetchName");
+    GetWindowAttributes = sym<XGetWindowAttributes_t>(*m_x11, "XGetWindowAttributes");
+    QueryTree = sym<XQueryTree_t>(*m_x11, "XQueryTree");
+    DestroyImage = sym<XDestroyImage_t>(*m_x11, "XDestroyImage");
+    FreePixmap = sym<XFreePixmap_t>(*m_x11, "XFreePixmap");
+    Sync = sym<XSync_t>(*m_x11, "XSync");
+
+    ShmQueryExtension = sym<XShmQueryExtension_t>(*m_xext, "XShmQueryExtension");
+    ShmCreateImage = sym<XShmCreateImage_t>(*m_xext, "XShmCreateImage");
+    ShmAttach = sym<XShmAttach_t>(*m_xext, "XShmAttach");
+    ShmDetach = sym<XShmDetach_t>(*m_xext, "XShmDetach");
+    ShmGetImage = sym<XShmGetImage_t>(*m_xext, "XShmGetImage");
 
     // XComposite is optional — graceful fallback if not available
-    try
+    m_xcomposite = score::try_load_library({"libXcomposite.so.1", "libXcomposite.so"});
+    if(m_xcomposite)
     {
-      m_xcomposite.emplace(
-          std::vector<std::string_view>{"libXcomposite.so.1", "libXcomposite.so"});
       CompositeQueryExtension
           = sym<XCompositeQueryExtension_t>(*m_xcomposite, "XCompositeQueryExtension");
       CompositeRedirectWindow
@@ -164,16 +170,11 @@ private:
       hasComposite = CompositeQueryExtension && CompositeRedirectWindow
                      && CompositeUnredirectWindow && CompositeNameWindowPixmap;
     }
-    catch(...)
-    {
-      hasComposite = false;
-    }
 
     // XRandR is optional — needed for screen enumeration
-    try
+    m_xrandr = score::try_load_library({"libXrandr.so.2", "libXrandr.so"});
+    if(m_xrandr)
     {
-      m_xrandr.emplace(
-          std::vector<std::string_view>{"libXrandr.so.2", "libXrandr.so"});
       RRGetScreenResourcesCurrent = sym<XRRGetScreenResourcesCurrent_t>(
           *m_xrandr, "XRRGetScreenResourcesCurrent");
       RRGetOutputInfo
@@ -188,18 +189,11 @@ private:
       hasRandR = RRGetScreenResourcesCurrent && RRGetOutputInfo && RRGetCrtcInfo
                  && RRFreeScreenResources && RRFreeOutputInfo && RRFreeCrtcInfo;
     }
-    catch(...)
-    {
-      hasRandR = false;
-    }
 
     available = OpenDisplay && CloseDisplay && DefaultRootWindow && InternAtom
                 && GetWindowProperty && Free && FetchName && GetWindowAttributes
                 && ShmQueryExtension && ShmCreateImage && ShmAttach && ShmDetach
                 && ShmGetImage && DestroyImage && QueryTree && FreePixmap && Sync;
-  }
-  catch(...)
-  {
   }
 };
 

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -86,6 +86,7 @@ set(HDRS ${HDRS}
     "${CMAKE_CURRENT_SOURCE_DIR}/Video/GpuFormats.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Video/Thumbnailer.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Video/FrameQueue.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Video/LibavInterrupt.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Video/Rescale.hpp"
 
     "${CMAKE_CURRENT_SOURCE_DIR}/score_plugin_media.hpp"

--- a/src/plugins/score-plugin-media/Video/CameraInput.cpp
+++ b/src/plugins/score-plugin-media/Video/CameraInput.cpp
@@ -57,6 +57,19 @@ bool CameraInput::load(
   return (bool)ifmt;
 }
 
+bool CameraInput::alloc_format_context() noexcept
+{
+  m_formatContext = avformat_alloc_context();
+  if(!m_formatContext)
+    return false;
+
+  m_formatContext->flags |= AVFMT_FLAG_NONBLOCK;
+  m_formatContext->flags |= AVFMT_FLAG_NOBUFFER;
+  m_formatContext->flags |= AVFMT_FLAG_FLUSH_PACKETS;
+  m_interrupt.install(*m_formatContext);
+  return true;
+}
+
 bool CameraInput::start() noexcept
 {
   if(m_running)
@@ -66,10 +79,10 @@ bool CameraInput::start() noexcept
   if(!ifmt)
     return false;
 
-  m_formatContext = avformat_alloc_context();
-  m_formatContext->flags |= AVFMT_FLAG_NONBLOCK;
-  m_formatContext->flags |= AVFMT_FLAG_NOBUFFER;
-  m_formatContext->flags |= AVFMT_FLAG_FLUSH_PACKETS;
+  m_interrupt.reset();
+
+  if(!alloc_format_context())
+    return false;
 
   AVDictionary* options = nullptr;
 
@@ -94,30 +107,47 @@ bool CameraInput::start() noexcept
 
   // FIXME color_range 0,1,2
 
-  int ret = avformat_open_input(&m_formatContext, m_inputDevice.c_str(), ifmt, &options);
-  av_dict_free(&options);
-
-  if(ret < 0)
+  int ret{};
   {
-    qDebug() << "avformat_open_input" << av_to_string(ret);
+    LibavTimeout timeout{m_interrupt, open_timeout};
 
-    // Let's try with the default settings if the requested settings did not work:
-    ret = avformat_open_input(&m_formatContext, m_inputDevice.c_str(), ifmt, nullptr);
+    ret = avformat_open_input(&m_formatContext, m_inputDevice.c_str(), ifmt, &options);
+    av_dict_free(&options);
+
     if(ret < 0)
     {
       qDebug() << "avformat_open_input" << av_to_string(ret);
 
-      close_file();
-      return false;
+      // avformat_open_input freed the context: the flags and the interrupt
+      // callback have to be installed again before retrying.
+      if(m_interrupt.expired() || !alloc_format_context())
+      {
+        close_file();
+        return false;
+      }
+
+      // Let's try with the default settings if the requested settings did not work:
+      ret = avformat_open_input(&m_formatContext, m_inputDevice.c_str(), ifmt, nullptr);
+      if(ret < 0)
+      {
+        qDebug() << "avformat_open_input" << av_to_string(ret);
+
+        close_file();
+        return false;
+      }
     }
   }
 
-  ret = avformat_find_stream_info(m_formatContext, nullptr);
-  if(ret < 0)
   {
-    qDebug() << "avformat_find_stream_info" << av_to_string(ret);
-    close_file();
-    return false;
+    LibavTimeout timeout{m_interrupt, open_timeout};
+
+    ret = avformat_find_stream_info(m_formatContext, nullptr);
+    if(ret < 0)
+    {
+      qDebug() << "avformat_find_stream_info" << av_to_string(ret);
+      close_file();
+      return false;
+    }
   }
 
   if(!open_stream())
@@ -156,6 +186,7 @@ void CameraInput::buffer_thread() noexcept
   {
     if(m_frames.size() < 4)
     {
+      LibavTimeout timeout{m_interrupt, read_timeout};
       if(auto f = read_frame_impl())
       {
         m_frames.enqueue(f);
@@ -172,6 +203,10 @@ void CameraInput::close_file() noexcept
 {
   // Stop the running status
   m_running.store(false, std::memory_order_release);
+
+  // The buffer thread may be blocked in av_read_frame: joining without
+  // unblocking it first would hang for as long as the device does.
+  m_interrupt.abort();
 
   if(m_thread.joinable())
     m_thread.join();

--- a/src/plugins/score-plugin-media/Video/CameraInput.hpp
+++ b/src/plugins/score-plugin-media/Video/CameraInput.hpp
@@ -4,6 +4,7 @@
 
 #include <Video/ExternalInput.hpp>
 #include <Video/FrameQueue.hpp>
+#include <Video/LibavInterrupt.hpp>
 #include <Video/Rescale.hpp>
 
 extern "C" {
@@ -45,9 +46,17 @@ private:
   AVFrame* read_frame_impl() noexcept;
   bool open_stream() noexcept;
   void close_stream() noexcept;
+  bool alloc_format_context() noexcept;
   ReadFrame read_one_frame(AVFramePointer frame, AVPacket& packet);
 
   static const constexpr int frames_to_buffer = 1;
+
+  //! Opening a device that never answers must not wedge the caller
+  static const constexpr auto open_timeout = std::chrono::milliseconds(2000);
+  //! A camera that stopped delivering must not wedge the buffer thread
+  static const constexpr auto read_timeout = std::chrono::milliseconds(5000);
+
+  LibavInterrupt m_interrupt;
 
   AVCodecID m_requestedCodec{AV_CODEC_ID_NONE};
   AVPixelFormat m_requestedPixfmt{AV_PIX_FMT_NONE};

--- a/src/plugins/score-plugin-media/Video/LibavInterrupt.hpp
+++ b/src/plugins/score-plugin-media/Video/LibavInterrupt.hpp
@@ -1,0 +1,98 @@
+#pragma once
+#include <Media/Libav.hpp>
+#if SCORE_HAS_LIBAV
+
+extern "C" {
+#include <libavformat/avformat.h>
+}
+
+#include <atomic>
+#include <chrono>
+
+namespace Video
+{
+
+/**
+ * @brief Deadline for the blocking libav I/O of one AVFormatContext.
+ *
+ * avformat_open_input, avformat_find_stream_info and av_read_frame have no
+ * timeout of their own: on a device that stops answering they block until the
+ * kernel gives up, which for some USB cameras never happens. The only way out
+ * is the interrupt callback, which libav polls from inside those calls.
+ *
+ * install() must be called on a freshly allocated context, before
+ * avformat_open_input: libav frees the context on failure, so a retry has to
+ * allocate and install again.
+ *
+ * Safe to arm from the thread doing the I/O and to abort from another one.
+ */
+class LibavInterrupt
+{
+public:
+  using clock = std::chrono::steady_clock;
+
+  void install(AVFormatContext& ctx) noexcept
+  {
+    ctx.interrupt_callback.callback = &LibavInterrupt::on_interrupt;
+    ctx.interrupt_callback.opaque = this;
+  }
+
+  void arm(std::chrono::milliseconds timeout) noexcept
+  {
+    m_deadline.store(
+        (clock::now() + timeout).time_since_epoch().count(), std::memory_order_release);
+  }
+
+  void disarm() noexcept { m_deadline.store(none, std::memory_order_release); }
+
+  //! Unblocks the pending call and every subsequent one until reset()
+  void abort() noexcept { m_aborted.store(true, std::memory_order_release); }
+
+  void reset() noexcept
+  {
+    m_aborted.store(false, std::memory_order_release);
+    disarm();
+  }
+
+  bool aborted() const noexcept { return m_aborted.load(std::memory_order_acquire); }
+
+  bool expired() const noexcept
+  {
+    if(aborted())
+      return true;
+
+    const auto deadline = m_deadline.load(std::memory_order_acquire);
+    return deadline != none && clock::now().time_since_epoch().count() >= deadline;
+  }
+
+private:
+  static constexpr int64_t none = 0;
+
+  static int on_interrupt(void* opaque) noexcept
+  {
+    return static_cast<const LibavInterrupt*>(opaque)->expired() ? 1 : 0;
+  }
+
+  std::atomic<int64_t> m_deadline{none};
+  std::atomic_bool m_aborted{};
+};
+
+//! Arms an interrupt for the duration of a scope
+struct LibavTimeout
+{
+  explicit LibavTimeout(LibavInterrupt& itr, std::chrono::milliseconds t) noexcept
+      : m_itr{itr}
+  {
+    m_itr.arm(t);
+  }
+  ~LibavTimeout() { m_itr.disarm(); }
+
+  LibavTimeout(const LibavTimeout&) = delete;
+  LibavTimeout& operator=(const LibavTimeout&) = delete;
+
+private:
+  LibavInterrupt& m_itr;
+};
+
+}
+#endif

--- a/src/plugins/score-plugin-media/Video/LibavStreamInput.cpp
+++ b/src/plugins/score-plugin-media/Video/LibavStreamInput.cpp
@@ -138,9 +138,12 @@ bool LibavStreamInput::probe() noexcept
   if(m_formatContext)
     return true; // Already probed
 
+  m_interrupt.reset();
+
   m_formatContext = avformat_alloc_context();
   if(!m_formatContext)
     return false;
+  m_interrupt.install(*m_formatContext);
 
   AVDictionary* options = nullptr;
   const AVInputFormat* input_fmt = nullptr;
@@ -180,25 +183,28 @@ bool LibavStreamInput::probe() noexcept
     }
   }
 
-  int ret = avformat_open_input(&m_formatContext, m_url.c_str(), input_fmt, &options);
-  av_dict_free(&options);
-
-  if(ret < 0)
+  int ret{};
   {
-    qDebug() << "FFmpeg input: avformat_open_input failed for"
-             << m_url.c_str() << av_to_string(ret);
-    m_formatContext = nullptr; // avformat_open_input frees on failure
-    return false;
-  }
+    LibavTimeout timeout{m_interrupt, probe_timeout};
+    ret = avformat_open_input(&m_formatContext, m_url.c_str(), input_fmt, &options);
+    av_dict_free(&options);
 
-  ret = avformat_find_stream_info(m_formatContext, nullptr);
-  if(ret < 0)
-  {
-    qDebug() << "FFmpeg input: avformat_find_stream_info failed:"
-             << av_to_string(ret);
-    avformat_close_input(&m_formatContext);
-    m_formatContext = nullptr;
-    return false;
+    if(ret < 0)
+    {
+      qDebug() << "FFmpeg input: avformat_open_input failed for" << m_url.c_str()
+               << av_to_string(ret);
+      m_formatContext = nullptr; // avformat_open_input frees on failure
+      return false;
+    }
+
+    ret = avformat_find_stream_info(m_formatContext, nullptr);
+    if(ret < 0)
+    {
+      qDebug() << "FFmpeg input: avformat_find_stream_info failed:" << av_to_string(ret);
+      avformat_close_input(&m_formatContext);
+      m_formatContext = nullptr;
+      return false;
+    }
   }
 
   if(!open_streams())
@@ -307,6 +313,9 @@ void LibavStreamInput::buffer_thread() noexcept
 
   while(m_running.load(std::memory_order_acquire))
   {
+    // No deadline here: a live stream may legitimately go quiet, and giving up
+    // on a read is fatal to the loop below. close_file() aborts the interrupt,
+    // which is what a blocked read has to be unblocked by.
     int ret = av_read_frame(m_formatContext, &packet);
     if(ret < 0)
     {
@@ -411,6 +420,10 @@ void LibavStreamInput::buffer_thread() noexcept
 void LibavStreamInput::close_file() noexcept
 {
   m_running.store(false, std::memory_order_release);
+
+  // The buffer thread may be blocked in av_read_frame: joining without
+  // unblocking it first would hang for as long as the stream does.
+  m_interrupt.abort();
 
   if(m_thread.joinable())
     m_thread.join();

--- a/src/plugins/score-plugin-media/Video/LibavStreamInput.hpp
+++ b/src/plugins/score-plugin-media/Video/LibavStreamInput.hpp
@@ -4,6 +4,7 @@
 
 #include <Video/ExternalInput.hpp>
 #include <Video/FrameQueue.hpp>
+#include <Video/LibavInterrupt.hpp>
 #include <Video/Rescale.hpp>
 
 extern "C" {
@@ -94,6 +95,11 @@ private:
   AVCodecContext* m_audioCodecContext{};
   AVFrame* m_audioFrame{};
   AudioRingBuffer m_audioBuf;
+
+  //! An unreachable stream must not wedge the caller
+  static const constexpr auto probe_timeout = std::chrono::milliseconds(10000);
+
+  LibavInterrupt m_interrupt;
 
   std::thread m_thread;
   std::atomic_bool m_running{};

--- a/src/plugins/score-plugin-vst3/Vst3/EffectModel.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/EffectModel.cpp
@@ -388,6 +388,9 @@ void Model::initFx()
   catch(std::exception& e)
   {
     qDebug() << e.what();
+    // load() may have thrown after having instantiated the plug-in: hand back
+    // whatever it managed to create instead of dropping the pointers
+    this->fx.stop();
     this->fx = {};
     return;
   }

--- a/src/plugins/score-plugin-vst3/Vst3/Node.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Node.hpp
@@ -112,9 +112,14 @@ public:
 
     ~PluginHandle()
     {
-      // qDebug() << processor->release();
-      // qDebug() << component->release();
+      processor->release();
+      component->release();
     }
+
+    PluginHandle(const PluginHandle&) = delete;
+    PluginHandle(PluginHandle&&) = delete;
+    PluginHandle& operator=(const PluginHandle&) = delete;
+    PluginHandle& operator=(PluginHandle&&) = delete;
 
     Steinberg::Vst::IComponent* component{};
     Steinberg::Vst::IAudioProcessor* processor{};

--- a/src/plugins/score-plugin-vst3/Vst3/Plugin.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Plugin.cpp
@@ -71,28 +71,15 @@ void Plugin::loadBuses()
 
 void Plugin::loadPresets()
 {
+  if(!controller)
+    return;
+
   Steinberg::Vst::IUnitInfo* unit_ptr = nullptr;
-  Steinberg::Vst::IProgramListData* pl_ptr = nullptr;
-  Steinberg::Vst::IUnitData* udata_ptr = nullptr;
   {
     auto res
         = controller->queryInterface(Steinberg::Vst::IUnitInfo::iid, (void**)&unit_ptr);
     if(res != Steinberg::kResultOk || !unit_ptr)
       return;
-  }
-
-  {
-    auto res = component->queryInterface(
-        Steinberg::Vst::IProgramListData::iid, (void**)&pl_ptr);
-    if(res != Steinberg::kResultOk || !pl_ptr)
-      pl_ptr = nullptr;
-  }
-
-  {
-    auto res
-        = component->queryInterface(Steinberg::Vst::IUnitData::iid, (void**)&udata_ptr);
-    if(res != Steinberg::kResultOk || !udata_ptr)
-      udata_ptr = nullptr;
   }
 
   this->units = unit_ptr;
@@ -123,10 +110,20 @@ void Plugin::loadProcessorStateToController()
 void Plugin::loadEditController(Model& model, ApplicationPlugin& ctx)
 {
   Steinberg::Vst::IEditController* controller{};
+
+  // Single-component effects implement IEditController on the component itself.
+  // The component has already been initialized in load(): initializing (and
+  // later terminating) it a second time through the controller interface
+  // corrupts the internal bookkeeping of such plug-ins.
   auto ctl_res = component->queryInterface(
       Steinberg::Vst::IEditController::iid, (void**)&controller);
-  if(ctl_res != Steinberg::kResultOk || !controller)
+  if(ctl_res == Steinberg::kResultOk && controller)
   {
+    this->controller_is_component = true;
+  }
+  else
+  {
+    controller = nullptr;
     Steinberg::TUID cid;
     if(component->getControllerClassId(cid) == Steinberg::kResultTrue)
     {
@@ -142,15 +139,23 @@ void Plugin::loadEditController(Model& model, ApplicationPlugin& ctx)
     return;
   }
 
-  controller->initialize(&ctx.m_host);
+  if(!this->controller_is_component)
+  {
+    if(controller->initialize(&ctx.m_host) == Steinberg::kResultOk)
+      this->controller_initialized = true;
+  }
   this->controller = controller;
 
-  // Connect the controller to the component... for... reasons
+  this->componentHandler = new ComponentHandler{model};
+  controller->setComponentHandler(this->componentHandler);
+
+  // Connect the controller to the component... for... reasons.
+  // Pointless when they are the same object, and stop() has to disconnect them
+  // before terminating the plug-in.
+  if(!this->controller_is_component)
   {
-    controller->setComponentHandler(new ComponentHandler{model});
     using namespace Steinberg;
     using namespace Steinberg::Vst;
-    // TODO need disconnection
 
     IConnectionPoint* compICP{};
     IConnectionPoint* contrICP{};
@@ -164,6 +169,15 @@ void Plugin::loadEditController(Model& model, ApplicationPlugin& ctx)
     {
       compICP->connect(contrICP);
       contrICP->connect(compICP);
+      this->componentCP = compICP;
+      this->controllerCP = contrICP;
+    }
+    else
+    {
+      if(compICP)
+        compICP->release();
+      if(contrICP)
+        contrICP->release();
     }
   }
 }
@@ -171,6 +185,8 @@ void Plugin::loadEditController(Model& model, ApplicationPlugin& ctx)
 void Plugin::loadView(Model& model)
 {
   if(model.fx.view)
+    return;
+  if(!controller)
     return;
 
   // Try to instantiate a view
@@ -188,7 +204,7 @@ void Plugin::loadView(Model& model)
           == Steinberg::kResultOk)
          && view)
       {
-        view->addRef();
+        // queryInterface() already handed us an owned reference
         this->ui_owned = true;
       }
     }
@@ -218,6 +234,7 @@ void Plugin::load(
   if(component->initialize(&ctx.m_host) != Steinberg::kResultOk)
     throw std::runtime_error(
         fmt::format("Couldn't initialize VST3 component ({})", path));
+  component_initialized = true;
 
   loadAudioProcessor(ctx);
 
@@ -266,28 +283,78 @@ void Plugin::stop()
 
   component->setActive(false);
 
+  // Note: when an editor window was open, it already released the view and
+  // reset it to nullptr - this only handles the view created by load()
   if(view)
   {
+    view->setFrame(nullptr);
+    view->release();
     view = nullptr;
+  }
+
+  // The handler points to the Model which is going away: the plug-in must not
+  // be able to call back into it anymore
+  if(controller)
+    controller->setComponentHandler(nullptr);
+
+  // VST3 requires the connection points to be disconnected before terminate(),
+  // otherwise component and controller keep referencing each other
+  if(componentCP && controllerCP)
+  {
+    componentCP->disconnect(controllerCP);
+    controllerCP->disconnect(componentCP);
+  }
+  if(controllerCP)
+  {
+    controllerCP->release();
+    controllerCP = nullptr;
+  }
+  if(componentCP)
+  {
+    componentCP->release();
+    componentCP = nullptr;
+  }
+
+  if(units)
+  {
+    units->release();
+    units = nullptr;
   }
 
   if(controller)
   {
-    controller->terminate();
+    // For a single-component effect the controller *is* the component: it gets
+    // terminated once, below
+    if(controller_initialized && !controller_is_component)
+      controller->terminate();
+    controller->release();
     controller = nullptr;
   }
 
   if(processor)
   {
+    processor->release();
     processor = nullptr;
   }
 
-  component->terminate();
+  if(component_initialized)
+    component->terminate();
+  component->release();
   component = nullptr;
+
+  component_initialized = false;
+  controller_initialized = false;
+  controller_is_component = false;
+  ui_available = false;
+  ui_owned = false;
+
+  delete componentHandler;
+  componentHandler = nullptr;
 
   if(plugFrame)
   {
     QTimer::singleShot(100, [ptr = plugFrame] { delete ptr; });
+    plugFrame = nullptr;
   }
 }
 

--- a/src/plugins/score-plugin-vst3/Vst3/Plugin.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/Plugin.hpp
@@ -9,6 +9,7 @@
 #include <pluginterfaces/gui/iplugview.h>
 #include <pluginterfaces/vst/ivstaudioprocessor.h>
 #include <pluginterfaces/vst/ivstcomponent.h>
+#include <pluginterfaces/vst/ivstmessage.h>
 #include <pluginterfaces/vst/ivstunits.h>
 
 #include <string_view>
@@ -39,6 +40,7 @@ inline QString fromString(const Steinberg::Vst::String128& str)
 
 using MIDIControls = ossia::flat_map<std::pair<int, int>, Steinberg::Vst::ParamID>;
 class PlugFrame;
+class ComponentHandler;
 struct Plugin
 {
   Plugin() = default;
@@ -63,6 +65,15 @@ struct Plugin
   Steinberg::IPlugView* view{};
   PlugFrame* plugFrame{};
 
+  // Connection points of the component and the controller, kept around because
+  // VST3 mandates disconnecting them before terminating the plug-in
+  Steinberg::Vst::IConnectionPoint* componentCP{};
+  Steinberg::Vst::IConnectionPoint* controllerCP{};
+
+  // Given to the controller: it points to the Model, so it has to be unset
+  // before the Model dies
+  ComponentHandler* componentHandler{};
+
   void loadAudioProcessor(ApplicationPlugin& ctx);
   void loadEditController(Model& model, ApplicationPlugin& ctx);
   void loadView(Model& model);
@@ -77,6 +88,14 @@ struct Plugin
   bool supports_double{};
   bool ui_available{};
   bool ui_owned{};
+
+  // initialize() succeeded and must be paired with exactly one terminate()
+  bool component_initialized{};
+  bool controller_initialized{};
+
+  // Single-component effect: the component *is* the edit controller, thus it
+  // must only be initialized and terminated once
+  bool controller_is_component{};
   int audio_ins = 0;
   int event_ins = 0;
   int audio_outs = 0;

--- a/src/plugins/score-plugin-vst3/Vst3/UI/Window.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/Window.cpp
@@ -27,6 +27,17 @@ WindowContainer createVstWindowContainer(
   }
   wc.frame = e.fx.plugFrame;
   view.setFrame(wc.frame);
+
+  // Hidpi-aware plug-ins cannot find the screen scale out by themselves on
+  // Windows and X11. A plug-in that handles it scales its view accordingly, so
+  // ask for the size again - the frame is already set, thus it may also just
+  // call us back through resizeView.
+  if(applyContentScaleFactor(view, parentWindow))
+  {
+    view.getSize(&r);
+    wc.setSizeFromQt(view, r, parentWindow);
+  }
+
   view.attached((void*)wc.qwindow->winId(), currentPlatform());
 
   QTimer::singleShot(16, &parentWindow, [&, wc]() mutable {
@@ -39,7 +50,29 @@ WindowContainer createVstWindowContainer(
       view.onSize(&r);
     }
   });
-  //parentWindow.show();
+
+  // Moving the window to a screen with another scale means going through the
+  // whole dance again
+  if(wc.qwindow)
+  {
+    QObject::connect(
+        wc.qwindow, &QWindow::screenChanged, &parentWindow,
+        [&parentWindow, &e, wc]() mutable {
+      auto* view = e.fx.view;
+      if(!view)
+        return;
+
+      applyContentScaleFactor(*view, parentWindow);
+
+      Steinberg::ViewRect r;
+      view->getSize(&r);
+      if(r.getWidth() != 0 && r.getHeight() != 0)
+      {
+        wc.setSizeFromQt(*view, r, parentWindow);
+        view->onSize(&r);
+      }
+    });
+  }
 
   return wc;
 }

--- a/src/plugins/score-plugin-vst3/Vst3/UI/WindowCommon.cpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/WindowCommon.cpp
@@ -29,8 +29,8 @@ Window::~Window()
   if(auto view = m_model.fx.view)
   {
     view->removed();
-    if(m_model.fx.ui_owned)
-      view->release();
+    // Both createView() and queryInterface() hand out an owned reference
+    view->release();
 
     const_cast<Plugin&>(m_model.fx).view = nullptr;
   }
@@ -58,8 +58,8 @@ void Window::closeEvent(QCloseEvent* event)
   if(auto view = m_model.fx.view)
   {
     view->removed();
-    if(m_model.fx.ui_owned)
-      view->release();
+    // Both createView() and queryInterface() hand out an owned reference
+    view->release();
 
     const_cast<Plugin&>(m_model.fx).view = nullptr;
   }

--- a/src/plugins/score-plugin-vst3/Vst3/UI/WindowContainer.hpp
+++ b/src/plugins/score-plugin-vst3/Vst3/UI/WindowContainer.hpp
@@ -5,6 +5,7 @@
 #include <QWindow>
 
 #include <pluginterfaces/gui/iplugview.h>
+#include <pluginterfaces/gui/iplugviewcontentscalesupport.h>
 
 namespace vst3
 {
@@ -22,32 +23,63 @@ inline const char* currentPlatform()
   return "";
 }
 
+//! Tell the plug-in about the scale of the screen its view is on.
+//! Returns true if the plug-in took it into account - it then has resized its
+//! view by that factor, so its size has to be queried again.
+inline bool applyContentScaleFactor(Steinberg::IPlugView& view, const QWidget& w)
+{
+#if defined(__APPLE__)
+  // NSViews are scaled by the system: there is nothing for the plug-in to do
+  return false;
+#else
+  // On Windows and X11 the plug-in has no way to find this out by itself
+  Steinberg::IPlugViewContentScaleSupport* scaling{};
+  if(view.queryInterface(Steinberg::IPlugViewContentScaleSupport::iid, (void**)&scaling)
+         != Steinberg::kResultOk
+     || !scaling)
+    return false;
+
+  const auto res = scaling->setContentScaleFactor(w.devicePixelRatioF());
+  scaling->release();
+  return res == Steinberg::kResultTrue;
+#endif
+}
+
 struct WindowContainer
 {
-  WId nativeId;
+  WId nativeId{};
   QWindow* qwindow{};
   QWidget* container{};
   vst3::PlugFrame* frame{};
 
-  double qtScaleFactor{1.};
-
-  WindowContainer()
+  //! Factor to go from the coordinates the plug-in gives us to the logical
+  //! pixels Qt lays out with
+  static double qtScaleFactor(const QWidget& w) noexcept
   {
-    double r = qEnvironmentVariable("QT_SCALE_FACTOR").toDouble();
-    if(r > 0.1)
-    {
-      qtScaleFactor = 1. / r;
-    }
+#if defined(__APPLE__)
+    // Cocoa view rects are in points, which is exactly Qt's logical pixel:
+    // only an explicit QT_SCALE_FACTOR breaks that 1:1 mapping
+    const double r = qEnvironmentVariable("QT_SCALE_FACTOR").toDouble();
+    return r > 0.1 ? 1. / r : 1.;
+#else
+    // Everywhere else the plug-in sizes its window in device pixels. Handing
+    // those numbers to Qt as-is makes the container devicePixelRatio times too
+    // big on a hidpi screen, with the actual UI sitting in a corner of it.
+    // Note: devicePixelRatioF() already accounts for QT_SCALE_FACTOR.
+    const double dpr = w.devicePixelRatioF();
+    return dpr > 0.1 ? 1. / dpr : 1.;
+#endif
   }
 
   auto setSizeFromQt(
       Steinberg::IPlugView& view, const Steinberg::ViewRect& r,
       QDialog& parentWindow) const
   {
+    const double scale = qtScaleFactor(parentWindow);
     int w = r.getWidth();
     int h = r.getHeight();
-    int qw = r.getWidth() * qtScaleFactor;
-    int qh = r.getHeight() * qtScaleFactor;
+    int qw = r.getWidth() * scale;
+    int qh = r.getHeight() * scale;
 
     if(w == 0 || h == 0)
     {
@@ -82,13 +114,14 @@ struct WindowContainer
       return;
     return;
 
+    const double scale = qtScaleFactor(parentWindow);
     int qw = sz.width();
     int qh = sz.height();
     Steinberg::ViewRect r;
     r.top = 0;
     r.left = 0;
-    r.right = sz.width() / qtScaleFactor;
-    r.bottom = sz.height() / qtScaleFactor;
+    r.right = sz.width() / scale;
+    r.bottom = sz.height() / scale;
     view.checkSizeConstraint(&r);
 
     parentWindow.resize(QSize(qw, qh));
@@ -110,10 +143,11 @@ struct WindowContainer
   auto setSizeFromVst(
       Steinberg::IPlugView& view, Steinberg::ViewRect& r, QDialog& parentWindow)
   {
+    const double scale = qtScaleFactor(parentWindow);
     int w = r.getWidth();
     int h = r.getHeight();
-    int qw = r.getWidth() * qtScaleFactor;
-    int qh = r.getHeight() * qtScaleFactor;
+    int qw = r.getWidth() * scale;
+    int qh = r.getHeight() * scale;
 
     if(w == 0 || h == 0)
     {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -304,6 +304,12 @@ score_add_test(test_unit_audio_plugin_cache
   SOURCES AudioPluginCacheTest.cpp
   PLUGINS score_plugin_media)
 
+# --- optional dynamic dependencies ------------------------------------------
+# A library that is not installed must leave its loader unavailable instead of
+# throwing out of instance().
+score_add_test(test_unit_dynamic_library
+  SOURCES DynamicLibraryTest.cpp)
+
 # --- video input timeouts ---------------------------------------------------
 # Blocking libav I/O on a device or stream that stops answering: the deadline
 # libav polls, and the abort that lets close_file() join its buffer thread.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -304,6 +304,20 @@ score_add_test(test_unit_audio_plugin_cache
   SOURCES AudioPluginCacheTest.cpp
   PLUGINS score_plugin_media)
 
+# --- video input timeouts ---------------------------------------------------
+# Blocking libav I/O on a device or stream that stops answering: the deadline
+# libav polls, and the abort that lets close_file() join its buffer thread.
+# The two end-to-end cases drive CameraInput / LibavStreamInput against a local
+# server that accepts and then stays silent, which used to block forever.
+if(TARGET score_plugin_media)
+  score_add_test(test_unit_libav_interrupt
+    SOURCES LibavInterruptTest.cpp
+    PLUGINS score_plugin_media
+    LIBS ${QT_PREFIX}::Network)
+  target_include_directories(test_unit_libav_interrupt PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-media")
+endif()
+
 # The shared scan state machine, end-to-end against a scriptable fake puppet:
 # session-token isolation, crash/timeout single-failure, reply-vs-exit races,
 # clean cancellation of a scan in progress.

--- a/tests/unit/DynamicLibraryTest.cpp
+++ b/tests/unit/DynamicLibraryTest.cpp
@@ -1,0 +1,80 @@
+// score::try_load_library and the optional-dependency loaders built on it.
+//
+// ossia::dylib_loader reports a missing library by throwing from its
+// constructor. The loaders for gphoto2, GStreamer and X11 wrapped that in a
+// function-try-block on their own constructor, which rethrows when the handler
+// falls off its end: instead of leaving their `available` flag false, they
+// threw out of instance() and took the application down whenever the library
+// was not installed.
+
+#include <score/tools/DynamicLibrary.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+// A library name no system can resolve.
+constexpr auto missing = "libscore-definitely-not-installed.so.999";
+
+//! The shape the optional-dependency loaders use.
+struct loader
+{
+  bool available{};
+
+  static const loader& instance() noexcept
+  {
+    static const loader self;
+    return self;
+  }
+
+private:
+  loader()
+  {
+    m_lib = score::try_load_library(missing);
+    if(!m_lib)
+      return;
+
+    available = true;
+  }
+
+  std::optional<ossia::dylib_loader> m_lib;
+};
+}
+
+TEST_CASE("A missing library is reported, not thrown", "[dylib]")
+{
+  REQUIRE(!score::try_load_library(missing).has_value());
+  REQUIRE(!score::try_load_library({missing, "libscore-not-there-either.so"})
+               .has_value());
+  REQUIRE(!score::try_load_library(std::vector<std::string_view>{}).has_value());
+}
+
+TEST_CASE("An installed library is loaded and its symbols resolve", "[dylib]")
+{
+#if defined(_WIN32)
+  auto lib = score::try_load_library("kernel32.dll");
+  const char* symbol = "GetTickCount";
+#elif defined(__APPLE__)
+  auto lib = score::try_load_library({"libSystem.B.dylib", "libSystem.dylib"});
+  const char* symbol = "getpid";
+#else
+  auto lib = score::try_load_library({"libm.so.6", "libm.so"});
+  const char* symbol = "floor";
+#endif
+
+  REQUIRE(lib.has_value());
+  REQUIRE(lib->symbol<void*>(symbol) != nullptr);
+  REQUIRE(lib->symbol<void*>("score_no_such_symbol_here") == nullptr);
+}
+
+// The regression: instance() must hand back an unavailable loader rather than
+// propagate the failure to load.
+TEST_CASE("A loader whose library is absent stays unavailable", "[dylib]")
+{
+  const loader* l{};
+  REQUIRE_NOTHROW(l = &loader::instance());
+  REQUIRE(!l->available);
+
+  // The failure is cached with the singleton: asking again must not throw either
+  REQUIRE_NOTHROW(loader::instance());
+}

--- a/tests/unit/LibavInterruptTest.cpp
+++ b/tests/unit/LibavInterruptTest.cpp
@@ -1,0 +1,239 @@
+// Timeouts for the blocking libav I/O of the video inputs.
+//
+// A camera that stops answering, or a stream that accepts the connection and
+// then goes silent, blocks avformat_open_input / av_read_frame indefinitely.
+// Video::LibavInterrupt is the deadline libav polls to give up, and the escape
+// hatch close_file() uses so that joining the buffer thread terminates.
+
+#include <Media/Libav.hpp>
+
+#if SCORE_HAS_LIBAV
+#include <Video/CameraInput.hpp>
+#include <Video/LibavInterrupt.hpp>
+#include <Video/LibavStreamInput.hpp>
+
+#include <QTcpServer>
+#include <QTcpSocket>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace std::literals;
+using clock_type = std::chrono::steady_clock;
+
+namespace
+{
+bool has_tcp_protocol()
+{
+  void* opaque = nullptr;
+  while(const char* name = avio_enum_protocols(&opaque, 0))
+  {
+    if(std::string_view{name} == "tcp")
+      return true;
+  }
+  return false;
+}
+
+//! Accepts connections and then never sends anything, like a wedged device.
+struct SilentServer
+{
+  SilentServer()
+  {
+    REQUIRE(server.listen(QHostAddress::LocalHost, 0));
+    QObject::connect(&server, &QTcpServer::newConnection, &server, [this] {
+      clients.push_back(server.nextPendingConnection());
+    });
+  }
+
+  ~SilentServer()
+  {
+    for(auto* c : clients)
+      c->abort();
+  }
+
+  std::string url() const
+  {
+    return "tcp://127.0.0.1:" + std::to_string(server.serverPort());
+  }
+
+  QTcpServer server;
+  std::vector<QTcpSocket*> clients;
+};
+
+//! Everything the call under test touches, kept in one heap block
+template <typename Input>
+struct RunState
+{
+  Input input;
+  bool result{true};
+  std::atomic_bool done{};
+};
+
+//! Runs f(state) on a thread and reports whether it returned within the delay.
+//!
+//! A blocked libav call cannot be cancelled: when it does not return, the
+//! thread is detached and the state it keeps writing to is leaked on purpose,
+//! so that a failing run reports the timeout instead of a use-after-free.
+template <typename Input, typename F>
+bool completes_within(
+    std::chrono::milliseconds delay, std::unique_ptr<RunState<Input>>& state, F f)
+{
+  auto* st = state.get();
+  std::thread th{[st, f] {
+    st->result = f(st->input);
+    st->done.store(true, std::memory_order_release);
+  }};
+
+  const auto deadline = clock_type::now() + delay;
+  while(!st->done.load(std::memory_order_acquire) && clock_type::now() < deadline)
+    std::this_thread::sleep_for(5ms);
+
+  if(!st->done.load(std::memory_order_acquire))
+  {
+    th.detach();
+    (void)state.release();
+    return false;
+  }
+
+  th.join();
+  return true;
+}
+}
+
+TEST_CASE("A fresh interrupt lets libav run", "[libav][interrupt]")
+{
+  Video::LibavInterrupt itr;
+  REQUIRE(!itr.expired());
+  REQUIRE(!itr.aborted());
+
+  AVFormatContext ctx{};
+  itr.install(ctx);
+  REQUIRE(ctx.interrupt_callback.callback != nullptr);
+  REQUIRE(ctx.interrupt_callback.opaque == &itr);
+  REQUIRE(ctx.interrupt_callback.callback(ctx.interrupt_callback.opaque) == 0);
+}
+
+TEST_CASE("An armed interrupt fires once its deadline passes", "[libav][interrupt]")
+{
+  Video::LibavInterrupt itr;
+  AVFormatContext ctx{};
+  itr.install(ctx);
+
+  itr.arm(60s);
+  REQUIRE(!itr.expired());
+  REQUIRE(ctx.interrupt_callback.callback(ctx.interrupt_callback.opaque) == 0);
+
+  itr.arm(1ms);
+  std::this_thread::sleep_for(20ms);
+  REQUIRE(itr.expired());
+  REQUIRE(ctx.interrupt_callback.callback(ctx.interrupt_callback.opaque) == 1);
+
+  itr.disarm();
+  REQUIRE(!itr.expired());
+}
+
+// close_file() aborts, then joins. The buffer thread it is waiting for owns a
+// scoped timeout whose destructor disarms: if that cleared the abort, the next
+// read would block again and the join would never return.
+TEST_CASE("Aborting outlives the scoped timeouts", "[libav][interrupt]")
+{
+  Video::LibavInterrupt itr;
+
+  {
+    Video::LibavTimeout timeout{itr, 60s};
+    REQUIRE(!itr.expired());
+
+    itr.abort();
+    REQUIRE(itr.expired());
+  }
+
+  REQUIRE(itr.aborted());
+  REQUIRE(itr.expired());
+
+  Video::LibavTimeout timeout{itr, 60s};
+  REQUIRE(itr.expired());
+}
+
+TEST_CASE("Only reset clears an abort", "[libav][interrupt]")
+{
+  Video::LibavInterrupt itr;
+  itr.abort();
+  REQUIRE(itr.expired());
+
+  itr.reset();
+  REQUIRE(!itr.aborted());
+  REQUIRE(!itr.expired());
+}
+
+// What unblocks a buffer thread sitting in av_read_frame: libav polls the
+// callback from the reading thread while another one aborts.
+TEST_CASE("Aborting unblocks a polling reader", "[libav][interrupt]")
+{
+  Video::LibavInterrupt itr;
+  AVFormatContext ctx{};
+  itr.install(ctx);
+
+  std::atomic_bool interrupted{};
+  std::thread reader{[&] {
+    while(ctx.interrupt_callback.callback(ctx.interrupt_callback.opaque) == 0)
+      std::this_thread::sleep_for(1ms);
+    interrupted.store(true, std::memory_order_release);
+  }};
+
+  std::this_thread::sleep_for(20ms);
+  REQUIRE(!interrupted.load(std::memory_order_acquire));
+
+  itr.abort();
+  reader.join();
+  REQUIRE(interrupted.load(std::memory_order_acquire));
+}
+
+TEST_CASE("Opening a device that never answers gives up", "[libav][camera]")
+{
+  if(!has_tcp_protocol())
+    SKIP("this libavformat has no tcp protocol");
+
+  SilentServer server;
+
+  auto state = std::make_unique<RunState<Video::CameraInput>>();
+  REQUIRE(
+      state->input.load("mpegts", server.url(), 640, 480, 30., AV_CODEC_ID_NONE, -1));
+
+  const auto start = clock_type::now();
+  const bool finished = completes_within(
+      30s, state, [](Video::CameraInput& camera) { return camera.start(); });
+  const auto elapsed = clock_type::now() - start;
+
+  REQUIRE(finished);
+  REQUIRE(!state->result);
+  REQUIRE(elapsed < 20s);
+  // Anything faster means it failed before ever reaching the device, which
+  // would make this test pass without exercising the timeout at all.
+  REQUIRE(elapsed > 500ms);
+}
+
+TEST_CASE("Probing a stream that never answers gives up", "[libav][stream]")
+{
+  if(!has_tcp_protocol())
+    SKIP("this libavformat has no tcp protocol");
+
+  SilentServer server;
+
+  auto state = std::make_unique<RunState<Video::LibavStreamInput>>();
+  REQUIRE(state->input.load(server.url(), {{"format", "mpegts"}}));
+
+  const auto start = clock_type::now();
+  const bool finished = completes_within(
+      60s, state, [](Video::LibavStreamInput& stream) { return stream.probe(); });
+  const auto elapsed = clock_type::now() - start;
+
+  REQUIRE(finished);
+  REQUIRE(!state->result);
+  REQUIRE(elapsed < 40s);
+  REQUIRE(elapsed > 500ms);
+}
+#endif


### PR DESCRIPTION
Three unrelated-looking failures that all come down to a resource outliving, or not outliving, the thing that uses it.

## File ports: use-after-free on the raw file handles

`halp::file_port` keeps `string_view`s into the `oscr::raw_file_data` owned by `raw_file_storage`. `load()` released the previous handle through a discarded `std::exchange` *before* comparing the port's view of its filename against the new one, and only repointed the port when the two differed — so a reload of the same path left the port pointing into freed memory.

The deeper half: those handles lived on the node, but a node has one object instance **per renderer** (one renderer per `RenderList`, i.e. per output) and `CustomGpuRenderer` creates one per instance. Loading a file for one of them freed the memory every other one's ports still referenced, which is what the reported ASan trace caught — the free came from a `ScreenNode` render pass and the read from a different `RenderList` one frame later. The handles now live in the renderer, keyed per state, so they are released with the states that reference them.

## Camera and stream inputs: blocking libav I/O with no way out

`avformat_open_input`, `avformat_find_stream_info` and `av_read_frame` have no timeout of their own. A USB camera that stops answering blocks them indefinitely: starting the capture froze the caller, and `close_file()` then joined a buffer thread that was itself blocked in a read.

`Video::LibavInterrupt` is the deadline libav polls through the context's interrupt callback, plus an abort that `close_file()` raises before joining. Arming and aborting are separate so that the buffer thread's scoped deadlines cannot clear a pending abort.

`CameraInput` also lost its flags and its interrupt callback when retrying with default settings — `avformat_open_input` frees the context on failure, so the retry must allocate and install again.

No deadline is armed around `av_read_frame` in `LibavStreamInput`: a live stream may legitimately go quiet, and giving up there would kill the read loop.

## Optional library loaders: a crash when the library is not installed

`libgphoto2`, `libgstreamer` and `libx11` each held their `ossia::dylib_loader` members directly and wrapped the constructor in a function-try-block. **A handler of a constructor's function-try-block rethrows when it falls off its end**, so a missing library never reached the `available = false` that every entry point checks: `instance()` threw, and the exception escaped through device enumeration into the Qt event dispatch. In a developer build, where `SafeQApplication::notify` does not catch, that took the application down.

`score::try_load_library` reports absence instead of throwing. `libgphoto2` additionally had `available{true}` in a mem-init list ordered after the loaders but declared before them, so the flag was set before any loading happened.

## Tests

`tests/unit/LibavInterruptTest.cpp` — deadline/abort semantics against the real C callback, including the property `close_file()` depends on (an abort outlives the scoped deadlines), plus two end-to-end cases driving `CameraInput::start()` and `LibavStreamInput::probe()` against a local server that accepts and then stays silent. Both were verified to hang without their fix.

`tests/unit/DynamicLibraryTest.cpp` — a missing library is reported rather than thrown, and a loader built on it stays unavailable instead of propagating out of `instance()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)