### PR TITLE
score: do not cache ApplicationContext members in function-local statics

### DIFF
--- a/src/lib/score/widgets/SetIcons.cpp
+++ b/src/lib/score/widgets/SetIcons.cpp
@@ -263,7 +263,7 @@ QPixmap get_pixmap(QString str, QString svg)
   init_svgmap();
 
   QPixmap img;
-  static const auto& appSettings = score::AppContext().applicationSettings;
+  const auto& appSettings = score::AppContext().applicationSettings;
   if(!appSettings.gui)
     return img;
 
@@ -305,7 +305,7 @@ QPixmap get_pixmap(QString str, QString svg)
 QCursor get_cursor(QString str, double hotspot_x, double hotspot_y)
 {
   QCursor cur;
-  static const auto& appSettings = score::AppContext().applicationSettings;
+  const auto& appSettings = score::AppContext().applicationSettings;
   if(!appSettings.gui)
     return cur;
 
@@ -344,7 +344,7 @@ QImage get_image(QString str, QString svg)
   init_svgmap();
 
   QImage img;
-  static const auto& appSettings = score::AppContext().applicationSettings;
+  const auto& appSettings = score::AppContext().applicationSettings;
   if(!appSettings.gui)
     return img;
 


### PR DESCRIPTION
## Problem

`get_pixmap`, `get_cursor` and `get_image` in `src/lib/score/widgets/SetIcons.cpp`
each do:

```cpp
static const auto& appSettings = score::AppContext().applicationSettings;
```

`AppContext()` returns a reference, so this reads as safe. But a function-local
`static` is initialised exactly once, binding to whichever `ApplicationContext`
happened to exist at the first call. Every later application instance leaves the
reference dangling.

The test suite constructs and destroys an application per test, so it hits this
directly.

## Evidence

AddressSanitizer, on the full suite (clang, `-fsanitize=address,undefined`):

```
ERROR: AddressSanitizer: stack-use-after-return
READ of size 1
    #0 score::get_pixmap(QString, QString) src/lib/score/widgets/SetIcons.cpp:267:19
    #1 setIcons(QAction*, ...)             src/lib/score/widgets/SetIcons.cpp:100:18
    #2 Engine::ApplicationPlugin::makeGUIElements()::$_0::operator()(bool)
       src/plugins/score-plugin-engine/Engine/ApplicationPlugin.cpp:225:11
   ...
    #9 QAction::setChecked(bool)
   #10 tests/integration/NodalPlacementTest.cpp:234:16
```

4 occurrences of `stack-use-after-return` in one run; this is the reported site.

## Fix

Drop the `static` at all three sites. The lookup is a reference return, so there
is nothing to cache.

## Validation

- Builds clean.
- `test_integration_nodal_placement` — the test whose teardown/rebuild sequence
  exposes it — passes (2.69 s).
- Same class of defect as the earlier static factory-list lifetime work; that
  sweep did not reach these three call sites.