### PR TITLE
Three pre-existing defects found while validating the gfx stack

### DIFF
--- a/src/plugins/score-plugin-engine/Execution/ExecutionController.cpp
+++ b/src/plugins/score-plugin-engine/Execution/ExecutionController.cpp
@@ -155,7 +155,8 @@ ExecutionController::ExecutionController(const score::GUIApplicationContext& ctx
 
 ExecutionController::~ExecutionController()
 {
-  m_transport->teardown();
+  if(m_transport)
+    m_transport->teardown();
 }
 
 TransportInterface& ExecutionController::transport() const noexcept

--- a/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GStreamer/GStreamerDevice.cpp
@@ -616,8 +616,12 @@ public:
   gstreamer_protocol(const std::string& pipeline_string)
       : ossia::net::protocol_base{flags{}}
   {
-    pipeline.load(pipeline_string);
+    m_loaded = pipeline.load(pipeline_string);
   }
+
+  // load() fails on an unavailable gstreamer, a parse error, or a pipeline
+  // with no appsink. Callers must not present the device as connected then.
+  bool loaded() const noexcept { return m_loaded; }
 
   bool pull(ossia::net::parameter_base&) override { return false; }
   bool push(const ossia::net::parameter_base&, const ossia::value&) override
@@ -640,6 +644,9 @@ public:
       buf->read_into_output(buffer_size);
     }
   }
+
+private:
+  bool m_loaded{};
 };
 
 class gstreamer_device : public ossia::net::device_base
@@ -1010,6 +1017,12 @@ bool InputDevice::reconnect()
     {
       auto proto = std::make_unique<gstreamer_protocol>(
           set.pipeline.toStdString());
+      if(!proto->loaded())
+      {
+        qDebug() << "GStreamer: pipeline unusable, not creating the device:"
+                 << set.pipeline;
+        return connected();
+      }
       m_protocol = proto.get();
       m_dev = std::make_unique<gstreamer_device>(
           plug->exec, std::move(proto), this->settings().name.toStdString());

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
@@ -48,6 +48,24 @@
 
 namespace score::gfx
 {
+namespace
+{
+// The D3D debug layer and the RHI debug markers were gated on NDEBUG, which
+// puts them out of reach in Release -- the configuration release testing and
+// the GPU validation matrix actually build. Keep the Debug behaviour and let a
+// Release binary opt in at run time.
+bool gpuDebugRequested() noexcept
+{
+#if !defined(NDEBUG)
+  return true;
+#else
+  static const bool requested
+      = qEnvironmentVariableIntValue("SCORE_GPU_VALIDATION") != 0;
+  return requested;
+#endif
+}
+}
+
 std::shared_ptr<RenderState>
 createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
 {
@@ -106,9 +124,8 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
   };
 
   QRhi::Flags flags{};
-#ifndef NDEBUG
-  flags |= QRhi::EnableDebugMarkers;
-#endif
+  if(gpuDebugRequested())
+    flags |= QRhi::EnableDebugMarkers;
 
 #ifndef QT_NO_OPENGL
   if(graphicsApi == OpenGL)
@@ -253,9 +270,7 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
   if(graphicsApi == D3D11)
   {
     QRhiD3D11InitParams params;
-#if !defined(NDEBUG)
-    params.enableDebugLayer = true;
-#endif
+    params.enableDebugLayer = gpuDebugRequested();
     // if (framesUntilTdr > 0)
     // {
     //   params.framesUntilKillingDeviceViaTdr = framesUntilTdr;
@@ -271,9 +286,7 @@ createRenderState(GraphicsApi graphicsApi, QSize sz, QWindow* window)
   else if(graphicsApi == D3D12)
   {
     QRhiD3D12InitParams params;
-#if !defined(NDEBUG)
-    params.enableDebugLayer = true;
-#endif
+    params.enableDebugLayer = gpuDebugRequested();
     // if (framesUntilTdr > 0)
     // {
     //   params.framesUntilKillingDeviceViaTdr = framesUntilTdr;


### PR DESCRIPTION
Three unrelated defects found while validating the gfx/interop branch stack. All three are
**pre-existing on `master`** — none is introduced by that stack — so they are split out
here rather than folded into it. Each is a separate commit.

### 1. `~ExecutionController` dereferences a null transport

The destructor calls `m_transport->teardown()` unguarded, while `init_transport()` guards
the identical call with `if(m_transport)`. Any path that abandons construction before
`init_transport()` runs — application boot throwing — segfaults on the way out.

The practical cost is worse than the crash itself: the SIGSEGV replaces the exception that
was actually propagating, so the real failure never gets reported.

### 2. GStreamer device reports success for an unusable pipeline

`gstreamer_protocol`'s constructor called `pipeline.load()` and discarded the result.
`load()` returns false for an unavailable gstreamer, a `gst_parse_launch` error, or a
pipeline with no appsink — but the protocol and `gstreamer_device` were constructed anyway,
and `InputDevice::reconnect()` ends in `return connected()`, which only checks `m_dev`.

So a typo in a pipeline string produced a device that reported itself connected and
presented an empty tree. The diagnostics were logged; nothing acted on them.

### 3. The D3D debug layer is unreachable in Release

`params.enableDebugLayer` (D3D11 and D3D12) and `QRhi::EnableDebugMarkers` were gated on
`NDEBUG`. Release is the configuration that actually gets built for validation work — a
Debug build of this tree is impractical on Windows, where
`cmake/ScoreCodeviewWindows.cmake` adds `-gcodeview` unconditionally for non-MSVC clang —
so in practice the D3D validation layer never runs, and a "no D3D errors" result means the
layer was absent rather than quiet.

The three sites now go through one predicate: unchanged under Debug, and in Release honour
`SCORE_GPU_VALIDATION=1`. It can only enable validation, never disable it.

## Verification, and its limits

I would rather state these plainly than imply more than I measured.

| | evidence |
|---|---|
| builds | the two affected plugins compile against `master` (clang-22, Qt 6.12, Debug) |
| GStreamer | the 4 existing gstreamer tests still pass |
| ExecutionController | **not** negative-controlled — see below |
| D3D debug layer | **not** verified on Windows — see below |

- **`~ExecutionController` has no red-then-green evidence.** The reported trigger is app boot
  throwing out of `LV2::ApplicationPlugin::initialize()`, which does not reproduce on my
  machine: running test binaries with `SCORE_DISABLE_AUDIOPLUGINS` unset exits 0, so the LV2
  scan does not throw here. The defect is real by inspection — an unguarded dereference of a
  member the class itself treats as nullable 640 lines later — and the fix is a one-line
  guard matching existing code, but I could not make it fire.
- **The D3D change is unproven on Windows.** It builds on Linux and leaves the gfx suite
  unchanged, and it is low-risk by construction (Debug behaviour is byte-identical; Release
  can only gain validation). But the thing it exists to enable can only be demonstrated on
  Windows with `SCORE_GPU_VALIDATION=1` against a Release build.
- **OpenGL still has no validation path at all.** `GL_KHR_debug` /
  `glDebugMessageCallback` is not wired up, so every "0 errors on GL" result means *not
  measured*, not *clean*. Deliberately left for a separate change rather than bundled here.
