### PR TITLE
Fix CLAP/LV2 cache-key dangling QStringBuilder (startup crash) + filter error typo

### DIFF
--- a/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-clap/Clap/ApplicationPlugin.cpp
@@ -206,7 +206,10 @@ void ApplicationPlugin::initialize()
   m_plugins = Media::loadPluginCache<PluginInfo>(
       cache_format_version, cache_key, legacy_cache_key);
   Media::sanitizePluginCache(
-      m_plugins, [](const PluginInfo& i) { return i.path + "|" + i.id; },
+      m_plugins,
+      // -> QString: QT_USE_QSTRINGBUILDER makes operator+ return an expression
+      // template whose outer node references a dead temporary.
+      [](const PluginInfo& i) -> QString { return i.path + "|" + i.id; },
       [](const PluginInfo& i) { return i.path; },
       [](const PluginInfo& i) { return i.valid; });
   // Make the migration/healing durable even if no scan runs this session

--- a/src/plugins/score-plugin-gfx/Gfx/Filter/Process.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Filter/Process.cpp
@@ -132,7 +132,7 @@ Process::ScriptChangeResult Model::setProgram(const ShaderSource& f)
   }
   else
   {
-    qDebug() << "Erroe while processingp rogram: " << error;
+    qDebug() << "Error while processing program: " << error;
   }
   return {};
 }

--- a/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-lv2/LV2/ApplicationPlugin.cpp
@@ -186,7 +186,9 @@ void ApplicationPlugin::initialize()
   m_plugins = Media::loadPluginCache<PluginInfo>(
       cache_format_version, cache_key, legacy_cache_key);
   Media::sanitizePluginCache(
-      m_plugins, [](const PluginInfo& i) { return i.bundle + "|" + i.uri; },
+      m_plugins,
+      // -> QString: same QStringBuilder dangling-temporary trap as the CLAP key.
+      [](const PluginInfo& i) -> QString { return i.bundle + "|" + i.uri; },
       [](const PluginInfo& i) { return i.bundle; },
       [](const PluginInfo& i) { return i.valid; });
   // Make the migration/healing durable even if no scan runs this session


### PR DESCRIPTION
Two independent, self-contained fixes against `master`. Both were found while
working on the gfx test stack but neither depends on it.

### 1. CLAP/LV2 plug-in cache keys returned a dangling `QStringBuilder`

**This is a startup crash for any user whose CLAP plug-in cache is non-empty.**
score aborts with `std::bad_alloc`:

```
qTerminate
QStringBuilder<QStringBuilder<QString, char[2]>, QString>::convertTo<QString>()
Media::deduplicate<Clap::PluginInfo, ...>
Clap::ApplicationPlugin::initialize()
score::GUIApplicationInterface::loadPluginData
```

The cache key was:

```cpp
[](const PluginInfo& i) { return i.path + "|" + i.id; }
```

We compile with `QT_USE_QSTRINGBUILDER` (`ScoreTargetSetup.cmake:76`), so
`operator+` builds a lazy expression template instead of a `QString`. With a
deduced return type the lambda hands back
`QStringBuilder<QStringBuilder<QString, char[2]>, QString>`, whose outer node
holds a *reference* to the inner node — a temporary that dies at the end of the
return statement. `convertTo<QString>()` then reads a garbage length.

Fixed by giving both lambdas an explicit `-> QString` return type, which forces
the conversion while the operands are still alive. The LV2 cache key had the
same defect.

### 2. Transposed letters in the filter program error

`"Erroe while processingp rogram"` → `"Error while processing program"`. The
sibling call sites in VSA and Threedim already print it correctly. That line is
often the only thing that says what went wrong when a shader fails to compile
in a headless log.
