### PR TITLE
CAN device driven by a DBC database

### DIFF
--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
@@ -250,23 +250,12 @@ DeviceEditDialog::~DeviceEditDialog()
 
 void DeviceEditDialog::clearEnumerators()
 {
-  // The order here is load-bearing.
-  //
-  // The deviceAdded / deviceRemoved / sort lambdas installed by
-  // selectedProtocolChanged capture `cat`, a raw QTreeWidgetItem* owned by
-  // m_devices. Every one of those items dies in the m_devices->clear() that
-  // follows this call. An enumerator that emits deviceAdded from a worker
-  // thread (SimpleBLE's scan callback, for one) has its Qt::AutoConnection
-  // resolved to a queued one, which posts a QMetaCallEvent to the *context*
-  // object of the connection. Destroying the enumerator does not retract that
-  // event -- Qt only drops posted events when their **receiver** is destroyed
-  // (QObject::~QObject -> QCoreApplication::removePostedEvents(this)). So with
-  // `this` as the context the call was still delivered after the switch, and
-  // ran addItem() on a freed QTreeWidgetItem: the SIGSEGV in
-  // QTreeWidgetItem::setExpanded reported from the release build.
-  //
-  // Giving each selection its own context object and destroying it *before*
-  // the items it captured makes Qt discard whatever is still in flight.
+  // Order is load-bearing. The enumerator callbacks capture QTreeWidgetItem*s
+  // that the following m_devices->clear() deletes. An enumerator emitting from
+  // a worker thread makes the connection queued, and Qt retracts posted events
+  // only when their *receiver* dies - not the sender - so with `this` as the
+  // context they still ran, on freed items. Each selection therefore gets its
+  // own context object, destroyed here, before those items.
   delete m_enumeratorContext;
   m_enumeratorContext = nullptr;
 

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
@@ -525,8 +525,7 @@ void DeviceEditDialog::selectedProtocolChanged()
       cat->setFlags(Qt::ItemIsEnabled);
       m_devices->addTopLevelItem(cat);
 
-      auto addItem
-          = [cat](const QString& name, const Device::DeviceSettings& settings) {
+      auto addItem = [cat](const QString& name, const Device::DeviceSettings& settings) {
         auto item = new QTreeWidgetItem;
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setText(0, name);

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.cpp
@@ -243,7 +243,35 @@ static void setCategoryStyle(QTreeWidgetItem* catItem)
   catItem->setFont(0, font);
   catItem->setExpanded(true);
 }
-DeviceEditDialog::~DeviceEditDialog() { }
+DeviceEditDialog::~DeviceEditDialog()
+{
+  clearEnumerators();
+}
+
+void DeviceEditDialog::clearEnumerators()
+{
+  // The order here is load-bearing.
+  //
+  // The deviceAdded / deviceRemoved / sort lambdas installed by
+  // selectedProtocolChanged capture `cat`, a raw QTreeWidgetItem* owned by
+  // m_devices. Every one of those items dies in the m_devices->clear() that
+  // follows this call. An enumerator that emits deviceAdded from a worker
+  // thread (SimpleBLE's scan callback, for one) has its Qt::AutoConnection
+  // resolved to a queued one, which posts a QMetaCallEvent to the *context*
+  // object of the connection. Destroying the enumerator does not retract that
+  // event -- Qt only drops posted events when their **receiver** is destroyed
+  // (QObject::~QObject -> QCoreApplication::removePostedEvents(this)). So with
+  // `this` as the context the call was still delivered after the switch, and
+  // ran addItem() on a freed QTreeWidgetItem: the SIGSEGV in
+  // QTreeWidgetItem::setExpanded reported from the release build.
+  //
+  // Giving each selection its own context object and destroying it *before*
+  // the items it captured makes Qt discard whatever is still in flight.
+  delete m_enumeratorContext;
+  m_enumeratorContext = nullptr;
+
+  m_enumerators.clear();
+}
 
 void DeviceEditDialog::initAvailableProtocols()
 {
@@ -375,7 +403,7 @@ void DeviceEditDialog::selectedPresetChanged()
     return;
 
   // Clear previous state
-  m_enumerators.clear();
+  clearEnumerators();
   m_devices->clear();
   if(m_protocolWidget)
   {
@@ -459,8 +487,8 @@ void DeviceEditDialog::selectedProtocolChanged()
   // Clear preset state
   m_presetNode = Device::Node{};
 
-  // Clear listener
-  m_enumerators.clear();
+  // Clear listener (must happen before the tree items the callbacks captured)
+  clearEnumerators();
 
   // Clear devices
   m_devices->clear();
@@ -492,6 +520,14 @@ void DeviceEditDialog::selectedProtocolChanged()
       m_splitter->widget(0)->setMinimumWidth(200);
     }
 
+    // Context object for every connection made below. It is destroyed by
+    // clearEnumerators() before the QTreeWidgetItems these lambdas capture, so
+    // that Qt drops any queued deviceAdded/deviceRemoved/sort still in flight.
+    // See the comment in clearEnumerators().
+    SCORE_ASSERT(!m_enumeratorContext);
+    m_enumeratorContext = new QObject{this};
+    auto* ctx = m_enumeratorContext;
+
     for(auto& [name, e] : m_enumerators)
     {
       auto cat = new QTreeWidgetItem{};
@@ -501,7 +537,7 @@ void DeviceEditDialog::selectedProtocolChanged()
       m_devices->addTopLevelItem(cat);
 
       auto addItem
-          = [&, cat](const QString& name, const Device::DeviceSettings& settings) {
+          = [cat](const QString& name, const Device::DeviceSettings& settings) {
         auto item = new QTreeWidgetItem;
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setText(0, name);
@@ -509,7 +545,7 @@ void DeviceEditDialog::selectedProtocolChanged()
         cat->addChild(item);
         cat->setExpanded(true);
       };
-      auto rmItem = [&, cat](const QString& name) {
+      auto rmItem = [cat](const QString& name) {
         for(int i = 0; i < cat->childCount();)
         {
           auto cld = cat->child(i);
@@ -525,9 +561,9 @@ void DeviceEditDialog::selectedProtocolChanged()
         }
       };
 
-      connect(e.get(), &Device::DeviceEnumerator::deviceAdded, this, addItem);
-      connect(e.get(), &Device::DeviceEnumerator::deviceRemoved, this, rmItem);
-      connect(e.get(), &Device::DeviceEnumerator::sort, this, [cat] {
+      connect(e.get(), &Device::DeviceEnumerator::deviceAdded, ctx, addItem);
+      connect(e.get(), &Device::DeviceEnumerator::deviceRemoved, ctx, rmItem);
+      connect(e.get(), &Device::DeviceEnumerator::sort, ctx, [cat] {
         cat->sortChildren(0, Qt::SortOrder::AscendingOrder);
       });
       e->enumerate(addItem);
@@ -623,7 +659,7 @@ void DeviceEditDialog::setBrowserEnabled(bool st)
 {
   if(!st)
   {
-    m_enumerators.clear();
+    clearEnumerators();
 
     delete m_column1Stack;
     m_column1Stack = nullptr;

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.hpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/Widgets/DeviceEditDialog.hpp
@@ -66,12 +66,17 @@ private:
   void selectedPresetChanged();
   void initAvailableProtocols();
   void initPresets();
+  void clearEnumerators();
 
   const DeviceExplorerModel& m_model;
   const Device::ProtocolFactoryList& m_protocolList;
   Mode m_mode{};
   std::vector<std::pair<QString, std::unique_ptr<Device::DeviceEnumerator>>>
       m_enumerators;
+  // Receiver of every enumerator connection of the current selection: it is
+  // deleted before the QTreeWidgetItems those connections capture, which makes
+  // Qt discard the queued metacalls still posted to it.
+  QObject* m_enumeratorContext{};
 
   QSplitter* m_splitter{};
   QDialogButtonBox* m_buttonBox{};

--- a/src/plugins/score-plugin-protocols/CMakeLists.txt
+++ b/src/plugins/score-plugin-protocols/CMakeLists.txt
@@ -256,6 +256,22 @@ set(GPS_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/GPS/GPSSpecificSettingsSerialization.cpp"
 )
 
+set(CAN_HDRS
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANDevice.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolFactory.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolSettingsWidget.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANSpecificSettings.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/DBCParser.hpp"
+)
+
+set(CAN_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANDevice.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolFactory.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolSettingsWidget.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANSpecificSettingsSerialization.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/DBCParser.cpp"
+)
+
 set(EVDEV_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Evdev/EvdevDevice.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/Evdev/EvdevProtocolFactory.hpp"
@@ -409,6 +425,15 @@ if(LINUX)
   list(APPEND SCORE_FEATURES_LIST protocol_evdev)
 endif()
 
+# SocketCAN is Linux-only, and so is ossia::net::can_socket. The DBC parser
+# itself is portable and has no guard of its own, so that it stays unit-testable
+# everywhere; it is simply not compiled into the plugin elsewhere.
+if(LINUX)
+  target_sources(${PROJECT_NAME} PRIVATE ${CAN_HDRS} ${CAN_SRCS})
+  target_compile_definitions(${PROJECT_NAME} PRIVATE OSSIA_PROTOCOL_CAN)
+  list(APPEND SCORE_FEATURES_LIST protocol_can)
+endif()
+
 if(NOT EMSCRIPTEN)
   target_sources(${PROJECT_NAME} PRIVATE ${BITFOCUS_HDRS} ${BITFOCUS_SRCS})
   if(WIN32)
@@ -446,3 +471,7 @@ if(WIN32)
 endif()
 
 setup_score_plugin(${PROJECT_NAME})
+
+if(SCORE_TESTING)
+  add_subdirectory(Tests)
+endif()

--- a/src/plugins/score-plugin-protocols/CMakeLists.txt
+++ b/src/plugins/score-plugin-protocols/CMakeLists.txt
@@ -258,6 +258,7 @@ set(GPS_SRCS
 
 set(CAN_HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANDevice.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANInterfaces.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolFactory.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolSettingsWidget.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANSpecificSettings.hpp"
@@ -266,6 +267,7 @@ set(CAN_HDRS
 
 set(CAN_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANDevice.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANInterfaces.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolFactory.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANProtocolSettingsWidget.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Protocols/CAN/CANSpecificSettingsSerialization.cpp"

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
@@ -1,0 +1,466 @@
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include "CANDevice.hpp"
+
+#include "CANSpecificSettings.hpp"
+#include "DBCParser.hpp"
+
+#include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
+
+#include <score/document/DocumentContext.hpp>
+
+#include <ossia/detail/hash_map.hpp>
+#include <ossia/network/base/node_functions.hpp>
+#include <ossia/network/base/protocol.hpp>
+#include <ossia/network/context.hpp>
+#include <ossia/network/dataspace/dataspace_visitors.hpp>
+#include <ossia/network/domain/domain.hpp>
+#include <ossia/network/generic/generic_device.hpp>
+#include <ossia/network/sockets/can_socket.hpp>
+
+#include <QDebug>
+
+#include <wobjectimpl.h>
+
+#include <cmath>
+
+W_OBJECT_IMPL(Protocols::CANDevice)
+
+namespace ossia::net
+{
+namespace
+{
+using namespace Protocols::CAN;
+
+/**
+ * Key for the frame dispatch table.
+ *
+ * The identifier alone is *not* a key: an 11-bit standard frame and a 29-bit
+ * extended frame may carry the same numeric identifier and are different
+ * frames on the bus. The extended flag therefore goes into the key.
+ */
+constexpr uint64_t frameKey(uint32_t id, bool extended) noexcept
+{
+  return (uint64_t(extended) << 32) | uint64_t(id);
+}
+
+/**
+ * Map a DBC unit string onto an ossia unit.
+ *
+ * Deliberately tiny. DBC unit strings are free text with no vocabulary, and
+ * the vendor files in hand use "d" for degrees, plus "g", "d/s", "uT" and
+ * "kPa" -- none of which exist as ossia dataspaces. Inventing a mapping for
+ * those would attach a wrong unit (and therefore a wrong automatic conversion)
+ * to the parameter, which is worse than having none: a parameter with no unit
+ * is simply a number, which is exactly what those signals are.
+ *
+ * So: only units that are unambiguous *and* exist in ossia are mapped, and
+ * everything else stays a plain float.
+ */
+ossia::unit_t unitFromDBC(std::string_view u)
+{
+  // Angles: the only dataspace the vendor files actually touch.
+  if(u == "d" || u == "deg" || u == "degree" || u == "degrees" || u == "°")
+    return ossia::degree_u{};
+  if(u == "rad" || u == "radian" || u == "radians")
+    return ossia::radian_u{};
+
+  // Distances: unambiguous symbols only. Note that "m" is left out on purpose
+  // in favour of nothing -- it is just as often "minutes" or a scale prefix in
+  // an automotive database.
+  if(u == "km")
+    return ossia::kilometer_u{};
+  if(u == "cm")
+    return ossia::centimeter_u{};
+  if(u == "mm")
+    return ossia::millimeter_u{};
+
+  return {};
+}
+
+/**
+ * Choose the ossia value type for a signal.
+ *
+ * A signal whose scaling is the identity is an integer, and presenting it as a
+ * float would lose exactness on the wide ones; anything scaled is a float. A
+ * single bit with identity scaling is a boolean.
+ */
+ossia::val_type valueTypeFor(const Signal& sig) noexcept
+{
+  if(sig.valueType == ValueType::Float32 || sig.valueType == ValueType::Double64)
+    return ossia::val_type::FLOAT;
+
+  const bool identity = (sig.factor == 1. && sig.offset == 0.);
+  if(!identity)
+    return ossia::val_type::FLOAT;
+
+  if(!sig.valueTable.empty())
+    return ossia::val_type::INT;
+
+  if(sig.length == 1)
+    return ossia::val_type::BOOL;
+
+  // ossia's INT is a 32-bit signed integer: only widths that fit in it without
+  // wrapping may use it. An unsigned 32-bit signal does not.
+  const bool isSigned = (sig.valueType == ValueType::Signed);
+  if(isSigned ? (sig.length <= 32) : (sig.length <= 31))
+    return ossia::val_type::INT;
+
+  return ossia::val_type::FLOAT;
+}
+
+//! One signal, resolved to the parameter it feeds.
+struct signal_binding
+{
+  const Signal* sig{};
+  ossia::net::parameter_base* param{};
+  ossia::val_type type{};
+};
+
+//! One message, resolved to its signals' parameters.
+struct message_binding
+{
+  const Message* msg{};
+  std::vector<signal_binding> signals;
+
+  //! The `M` signal of the message, if it has one.
+  const Signal* multiplexer{};
+};
+
+/**
+ * A read-only CAN device driven by a DBC database.
+ *
+ * Incoming frames are dispatched through a hash map built once, when the node
+ * tree is created -- never by looking up a node by name per frame. A CAN bus
+ * at 1 Mbit/s delivers on the order of 8000 frames per second and every one of
+ * them lands on this path.
+ */
+struct can_protocol final : public ossia::net::protocol_base
+{
+  using settings = Protocols::CANSpecificSettings;
+
+  can_protocol(const settings& set, ossia::net::network_context_ptr ctx)
+      : protocol_base{flags{}}
+      , m_context{std::move(ctx)}
+      , m_db{loadDatabase(set)}
+      , m_socket{makeConfiguration(set, m_db), m_context->context}
+  {
+    // Throws std::system_error if the interface does not exist or cannot be
+    // bound; the device's reconnect() turns that into a message for the user.
+    m_socket.open();
+  }
+
+  ~can_protocol() { m_socket.close(); }
+
+  /**
+   * Read the database and apply the two settings that rewrite it.
+   *
+   * Order matters: the float override is about how a signal's *bits* are read
+   * and the offset is about *which frame* carries it, so they are independent,
+   * but both must happen before the dispatch table keys are computed.
+   */
+  static Database loadDatabase(const settings& set)
+  {
+    if(set.dbcPath.isEmpty())
+      throw std::runtime_error("no DBC file given");
+
+    auto db = parseDBCFile(set.dbcPath.toStdString());
+
+    // Diagnostics are never silent: a half-loaded database is worse than one
+    // that fails, so everything the parser could not make sense of is said out
+    // loud even though it is not fatal.
+    for(const auto& w : db.warnings)
+      qWarning() << "CAN: " << set.dbcPath << ":" << w.c_str();
+
+    if(db.messages.empty())
+      throw std::runtime_error(
+          "no message could be read from " + set.dbcPath.toStdString());
+
+    if(set.float32Override)
+      applyFloat32Override(db);
+
+    applyNodeIdOffset(db, set.nodeIdOffset);
+
+    // applyNodeIdOffset may itself complain about messages it could not move.
+    for(std::size_t k = db.warnings.size(); k-- > 0;)
+      if(db.warnings[k].rfind("node id offset", 0) == 0)
+        qWarning() << "CAN: " << db.warnings[k].c_str();
+
+    return db;
+  }
+
+  /**
+   * Build the socket configuration, including a kernel-side filter limited to
+   * the identifiers the database actually describes.
+   *
+   * Worth doing: on a shared bus this is what keeps a chain of devices cheap.
+   * SocketCAN applies filters per socket, so each score device wakes only for
+   * its own node's frames instead of for every frame on the wire.
+   */
+  static can_configuration makeConfiguration(const settings& set, const Database& db)
+  {
+    can_configuration conf;
+    conf.interface_name = set.interfaceName.toStdString();
+    conf.fd = set.fd;
+
+    if(set.filterToDatabase)
+    {
+      for(const auto& msg : db.messages)
+      {
+        can_filter_configuration f;
+        // The filter is matched against the raw identifier, flag bits and all,
+        // so the extended flag has to be put back and the mask has to cover it
+        // -- otherwise a standard frame would match an extended filter.
+        if(msg.extended)
+        {
+          f.id = (msg.id & CAN_EFF_MASK) | CAN_EFF_FLAG;
+          f.mask = CAN_EFF_MASK | CAN_EFF_FLAG;
+        }
+        else
+        {
+          f.id = msg.id & CAN_SFF_MASK;
+          f.mask = CAN_SFF_MASK | CAN_EFF_FLAG;
+        }
+        conf.filters.push_back(f);
+      }
+    }
+
+    return conf;
+  }
+
+  void set_device(ossia::net::device_base& dev) override
+  {
+    m_device = &dev;
+    buildTree(dev.get_root_node());
+
+    m_socket.receive([this](const can_message& msg) { onFrame(msg); });
+  }
+
+  void buildTree(ossia::net::node_base& root)
+  {
+    m_bindings.reserve(m_db.messages.size());
+
+    for(const auto& msg : m_db.messages)
+    {
+      // create_node rather than find_or_create_node: two messages may share a
+      // name (they are keyed by identifier, not by name), and merging them
+      // into one node would silently mix two frames' signals.
+      auto& msgNode = ossia::net::create_node(root, msg.name);
+      if(!msg.comment.empty())
+        ossia::net::set_description(msgNode, msg.comment);
+
+      message_binding binding;
+      binding.msg = &msg;
+      binding.signals.reserve(msg.signals.size());
+
+      for(const auto& sig : msg.signals)
+      {
+        const auto type = valueTypeFor(sig);
+
+        auto& sigNode = ossia::net::create_node(msgNode, sig.name);
+        auto* param = sigNode.create_parameter(type);
+        if(!param)
+          continue;
+
+        applyMetadata(sigNode, *param, sig, type);
+
+        binding.signals.push_back(signal_binding{&sig, param, type});
+
+        if(sig.isMultiplexer)
+          binding.multiplexer = &sig;
+      }
+
+      m_bindings.emplace(frameKey(msg.id, msg.extended), std::move(binding));
+    }
+  }
+
+  static void applyMetadata(
+      ossia::net::node_base& node, ossia::net::parameter_base& param, const Signal& sig,
+      ossia::val_type type)
+  {
+    // Receive-only: the value comes from the bus.
+    param.set_access(ossia::access_mode::GET);
+
+    const auto unit = unitFromDBC(sig.unit);
+    if(unit)
+      param.set_unit(unit);
+
+    if(!sig.valueTable.empty())
+    {
+      // A value table is an enumeration: the domain is the set of the values
+      // the signal is documented to take.
+      std::vector<ossia::value> accepted;
+      accepted.reserve(sig.valueTable.size());
+      for(const auto& vd : sig.valueTable)
+        accepted.push_back(int32_t(vd.value));
+      param.set_domain(ossia::make_domain(accepted));
+    }
+    else if(sig.hasRange && type != ossia::val_type::BOOL)
+    {
+      // `[0|0]` means "no range stated" and the parser reports it as such;
+      // pushing it as a domain would clamp every value to zero.
+      //
+      // The bounds must carry the parameter's own type: a float domain on an
+      // integer parameter is a type mismatch that ossia has to reconcile on
+      // every clamp.
+      if(type == ossia::val_type::INT)
+        param.set_domain(ossia::make_domain(int32_t(sig.min), int32_t(sig.max)));
+      else
+        param.set_domain(ossia::make_domain(float(sig.min), float(sig.max)));
+    }
+
+    // The description carries what has no structured place in ossia: the DBC
+    // comment, the unit when it could not be mapped, and the enumeration's
+    // names.
+    std::string desc = sig.comment;
+    if(!sig.unit.empty() && !unit)
+    {
+      if(!desc.empty())
+        desc += ' ';
+      desc += '[' + sig.unit + ']';
+    }
+    if(!sig.valueTable.empty())
+    {
+      if(!desc.empty())
+        desc += ' ';
+      desc += '{';
+      bool first = true;
+      for(const auto& vd : sig.valueTable)
+      {
+        if(!first)
+          desc += ", ";
+        first = false;
+        desc += std::to_string(vd.value) + '=' + vd.name;
+      }
+      desc += '}';
+    }
+    if(!desc.empty())
+      ossia::net::set_description(node, desc);
+  }
+
+  /**
+   * Decode one frame.
+   *
+   * The hot path: one hash lookup, then one pass over the message's signals.
+   */
+  void onFrame(const can_message& msg)
+  {
+    // Error frames are not bus traffic -- the identifier is a bitmask of error
+    // classes, not an identifier -- and an RTR frame carries no payload at all,
+    // so decoding either would produce numbers out of nothing.
+    if(msg.error || msg.remote)
+      return;
+
+    const auto it = m_bindings.find(frameKey(msg.id, msg.extended));
+    if(it == m_bindings.end())
+      return;
+
+    const auto& binding = it->second;
+    const int size = int(msg.size);
+
+    // Simple multiplexing: the switch signal selects which of the multiplexed
+    // signals this particular frame actually carries.
+    int64_t muxValue = 0;
+    const bool multiplexed = (binding.multiplexer != nullptr);
+    if(multiplexed)
+      muxValue = int64_t(rawSignalBits(*binding.multiplexer, msg.data, size));
+
+    for(const auto& sb : binding.signals)
+    {
+      if(multiplexed && sb.sig->isMultiplexed && sb.sig->multiplexValue != muxValue)
+        continue;
+
+      const double v = decodeSignal(*sb.sig, msg.data, size);
+
+      switch(sb.type)
+      {
+        case ossia::val_type::BOOL:
+          sb.param->push_value(v != 0.);
+          break;
+        case ossia::val_type::INT:
+          sb.param->push_value(int32_t(std::llround(v)));
+          break;
+        default:
+          sb.param->push_value(float(v));
+          break;
+      }
+    }
+  }
+
+  // Receive-only for now: see the note in CANProtocolFactory on transmit.
+  bool pull(parameter_base&) override { return false; }
+  bool push(const parameter_base&, const value&) override { return false; }
+  bool push_raw(const full_parameter_data&) override { return false; }
+  bool observe(parameter_base&, bool) override { return false; }
+  bool update(node_base&) override { return false; }
+
+  ossia::net::network_context_ptr m_context;
+  ossia::net::device_base* m_device{};
+
+  //! Owns the Message and Signal objects that the bindings point into. It is
+  //! not touched after the constructor, so those pointers stay valid.
+  Database m_db;
+
+  ossia::hash_map<uint64_t, message_binding> m_bindings;
+
+  //! Declared last on purpose. Members are destroyed in reverse declaration
+  //! order, so the socket -- and with it the liveness token that the receive
+  //! handler holds -- goes away before the database and the dispatch table
+  //! that handler reads from. It is also constructed last, which is required
+  //! anyway: its configuration is derived from m_db.
+  can_socket m_socket;
+};
+}
+}
+
+namespace Protocols
+{
+
+CANDevice::CANDevice(
+    const Device::DeviceSettings& settings, const ossia::net::network_context_ptr& ctx)
+    : OwningDeviceInterface{settings}
+    , m_ctx{ctx}
+{
+  m_capas.canRefreshTree = true;
+  m_capas.canAddNode = false;
+  m_capas.canRemoveNode = false;
+  m_capas.canRenameNode = false;
+  m_capas.canSetProperties = false;
+  m_capas.canSerialize = false;
+}
+
+CANDevice::~CANDevice() { }
+
+bool CANDevice::reconnect()
+{
+  disconnect();
+
+  try
+  {
+    const auto& set = m_settings.deviceSpecificSettings.value<CANSpecificSettings>();
+
+    auto proto = std::make_unique<ossia::net::can_protocol>(set, m_ctx);
+    auto dev = std::make_unique<ossia::net::generic_device>(
+        std::move(proto), settings().name.toStdString());
+    m_dev = std::move(dev);
+
+    deviceChanged(nullptr, m_dev.get());
+  }
+  catch(const std::exception& e)
+  {
+    qDebug() << "CAN error: " << e.what();
+  }
+  catch(...)
+  {
+    qDebug() << "CAN error";
+  }
+
+  return connected();
+}
+
+void CANDevice::disconnect()
+{
+  OwningDeviceInterface::disconnect();
+}
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
@@ -439,6 +439,13 @@ bool CANDevice::reconnect()
   {
     const auto& set = m_settings.deviceSpecificSettings.value<CANSpecificSettings>();
 
+    // Named explicitly rather than left to SocketCAN: an empty name reaches the
+    // kernel as "no such CAN interface: : No such device", which reads like a
+    // bug in score rather than like a field the user has to fill in.
+    if(set.interfaceName.isEmpty())
+      throw std::runtime_error(
+          "no CAN interface selected -- pick one in the device settings");
+
     auto proto = std::make_unique<ossia::net::can_protocol>(set, m_ctx);
     auto dev = std::make_unique<ossia::net::generic_device>(
         std::move(proto), settings().name.toStdString());
@@ -448,11 +455,15 @@ bool CANDevice::reconnect()
   }
   catch(const std::exception& e)
   {
-    qDebug() << "CAN error: " << e.what();
+    // qWarning, not qDebug: a device that failed to connect shows up in the
+    // explorer as an empty tree with no other explanation, and the reason must
+    // survive a build where debug output is filtered out.
+    qWarning() << "CAN device" << settings().name << "could not connect:" << e.what();
   }
   catch(...)
   {
-    qDebug() << "CAN error";
+    qWarning() << "CAN device" << settings().name
+               << "could not connect: unknown error";
   }
 
   return connected();

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
@@ -1,7 +1,6 @@
 #include <ossia/detail/config.hpp>
 #if defined(OSSIA_PROTOCOL_CAN)
 #include "CANDevice.hpp"
-
 #include "CANSpecificSettings.hpp"
 #include "DBCParser.hpp"
 
@@ -20,9 +19,8 @@
 
 #include <QDebug>
 
-#include <wobjectimpl.h>
-
 #include <cmath>
+#include <wobjectimpl.h>
 
 W_OBJECT_IMPL(Protocols::CANDevice)
 
@@ -457,8 +455,7 @@ bool CANDevice::reconnect()
   }
   catch(...)
   {
-    qWarning() << "CAN device" << settings().name
-               << "could not connect: unknown error";
+    qWarning() << "CAN device" << settings().name << "could not connect: unknown error";
   }
 
   return connected();

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.cpp
@@ -47,15 +47,11 @@ constexpr uint64_t frameKey(uint32_t id, bool extended) noexcept
 /**
  * Map a DBC unit string onto an ossia unit.
  *
- * Deliberately tiny. DBC unit strings are free text with no vocabulary, and
- * the vendor files in hand use "d" for degrees, plus "g", "d/s", "uT" and
- * "kPa" -- none of which exist as ossia dataspaces. Inventing a mapping for
- * those would attach a wrong unit (and therefore a wrong automatic conversion)
- * to the parameter, which is worse than having none: a parameter with no unit
- * is simply a number, which is exactly what those signals are.
- *
- * So: only units that are unambiguous *and* exist in ossia are mapped, and
- * everything else stays a plain float.
+ * Tiny on purpose: DBC units are free text with no vocabulary, and most of what
+ * vendor files use ("g", "d/s", "uT", "kPa") has no ossia dataspace. A wrong
+ * unit brings a wrong automatic conversion with it, which is worse than none -
+ * an unmapped signal is just a number, which is what it is. Only unambiguous
+ * units that exist in ossia are mapped.
  */
 ossia::unit_t unitFromDBC(std::string_view u)
 {
@@ -65,9 +61,8 @@ ossia::unit_t unitFromDBC(std::string_view u)
   if(u == "rad" || u == "radian" || u == "radians")
     return ossia::radian_u{};
 
-  // Distances: unambiguous symbols only. Note that "m" is left out on purpose
-  // in favour of nothing -- it is just as often "minutes" or a scale prefix in
-  // an automotive database.
+  // Unambiguous symbols only: "m" is left out, being as often "minutes" or a
+  // scale prefix in an automotive database.
   if(u == "km")
     return ossia::kilometer_u{};
   if(u == "cm")

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include <Device/Protocol/DeviceInterface.hpp>
+
+namespace Protocols
+{
+class CANDevice final : public Device::OwningDeviceInterface
+{
+  W_OBJECT(CANDevice)
+public:
+  CANDevice(
+      const Device::DeviceSettings& settings, const ossia::net::network_context_ptr& ctx);
+  ~CANDevice();
+
+  bool reconnect() override;
+  void disconnect() override;
+
+private:
+  const ossia::net::network_context_ptr& m_ctx;
+};
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANDevice.hpp
@@ -10,7 +10,8 @@ class CANDevice final : public Device::OwningDeviceInterface
   W_OBJECT(CANDevice)
 public:
   CANDevice(
-      const Device::DeviceSettings& settings, const ossia::net::network_context_ptr& ctx);
+      const Device::DeviceSettings& settings,
+      const ossia::net::network_context_ptr& ctx);
   ~CANDevice();
 
   bool reconnect() override;

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANInterfaces.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANInterfaces.cpp
@@ -1,0 +1,93 @@
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include "CANInterfaces.hpp"
+
+#include <QDir>
+#include <QFile>
+
+namespace Protocols::CAN
+{
+namespace
+{
+//! ARPHRD_CAN, from <linux/if_arp.h>. Read out of sysfs rather than included,
+//! so that this does not pull a kernel header in for one constant.
+constexpr int arphrdCan = 280;
+
+//! CANFD_MTU, from <linux/can.h>: 72 bytes (the 64-byte payload plus the
+//! canfd_frame header). A classic-only controller stays at CAN_MTU == 16.
+constexpr int canfdMtu = 72;
+
+int readIntFile(const QString& path)
+{
+  QFile f{path};
+  if(!f.open(QIODevice::ReadOnly | QIODevice::Text))
+    return -1;
+
+  bool ok = false;
+  const int v = f.readAll().trimmed().toInt(&ok);
+  return ok ? v : -1;
+}
+}
+
+std::vector<InterfaceInfo> availableInterfaces()
+{
+  std::vector<InterfaceInfo> out;
+
+  QDir sys{"/sys/class/net"};
+  auto entries = sys.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::System);
+  entries.sort();
+
+  for(const auto& name : entries)
+  {
+    const int type = readIntFile("/sys/class/net/" + name + "/type");
+
+    bool isCan{};
+    if(type >= 0)
+      isCan = (type == arphrdCan);
+    else
+      isCan = name.startsWith("can") || name.startsWith("vcan")
+              || name.startsWith("slcan");
+
+    if(!isCan)
+      continue;
+
+    out.push_back(
+        InterfaceInfo{
+            .name = name,
+            .fdCapable = readIntFile("/sys/class/net/" + name + "/mtu") >= canfdMtu});
+  }
+
+  return out;
+}
+
+QStringList availableInterfaceNames()
+{
+  QStringList out;
+  for(const auto& itf : availableInterfaces())
+    out.push_back(itf.name);
+  return out;
+}
+
+QString defaultInterface()
+{
+  // Real interfaces before virtual ones: on a machine that has both a physical
+  // adapter and a vcan left over from a test, the adapter is what the user
+  // means. Within each group the sysfs order (alphabetical) decides.
+  QString virtualCandidate;
+  for(const auto& itf : availableInterfaces())
+  {
+    if(itf.name.startsWith("vcan"))
+    {
+      if(virtualCandidate.isEmpty())
+        virtualCandidate = itf.name;
+    }
+    else
+    {
+      return itf.name;
+    }
+  }
+  return virtualCandidate;
+}
+
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANInterfaces.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANInterfaces.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include <QString>
+#include <QStringList>
+
+#include <vector>
+
+namespace Protocols::CAN
+{
+
+/**
+ * One SocketCAN network interface present on the machine.
+ */
+struct InterfaceInfo
+{
+  //! netdev name: "can0", "vcan0", "slcan0", or whatever a udev rule renamed it to.
+  QString name;
+
+  //! The interface accepts CAN FD frames (its MTU is at least CANFD_MTU).
+  bool fdCapable{false};
+};
+
+/**
+ * List the CAN interfaces of the machine, sorted by name.
+ *
+ * Matched on the link type (ARPHRD_CAN, as sysfs reports it in
+ * /sys/class/net/<if>/type) rather than on the name: an interface does not have
+ * to be called "canN" -- a USB adapter renamed by a udev rule is still a CAN
+ * interface -- and conversely a name is not proof of anything. The name
+ * prefixes are kept only as a fallback for the case where sysfs cannot be read.
+ *
+ * Returns an empty list on a machine with no CAN hardware and no vcan module,
+ * which is the common case: that is not an error and callers must handle it.
+ */
+std::vector<InterfaceInfo> availableInterfaces();
+
+//! Just the names, in the same order.
+QStringList availableInterfaceNames();
+
+/**
+ * The interface a new CAN device should default to, or an empty string.
+ *
+ * Empty is a deliberate outcome, not a failure: a default of "can0" on a
+ * machine that has no can0 is wrong on every machine without a physical CAN
+ * port, and produces "no such CAN interface: can0" at connection time for a
+ * setting the user never chose.
+ */
+QString defaultInterface();
+
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANInterfaces.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANInterfaces.hpp
@@ -24,14 +24,12 @@ struct InterfaceInfo
 /**
  * List the CAN interfaces of the machine, sorted by name.
  *
- * Matched on the link type (ARPHRD_CAN, as sysfs reports it in
- * /sys/class/net/<if>/type) rather than on the name: an interface does not have
- * to be called "canN" -- a USB adapter renamed by a udev rule is still a CAN
- * interface -- and conversely a name is not proof of anything. The name
- * prefixes are kept only as a fallback for the case where sysfs cannot be read.
+ * Matched on the link type (ARPHRD_CAN in /sys/class/net/<if>/type), not the
+ * name: a udev-renamed USB adapter is still a CAN interface. The name prefixes
+ * are only a fallback for when sysfs cannot be read.
  *
- * Returns an empty list on a machine with no CAN hardware and no vcan module,
- * which is the common case: that is not an error and callers must handle it.
+ * Empty on a machine with no CAN hardware and no vcan - the common case, and
+ * not an error.
  */
 std::vector<InterfaceInfo> availableInterfaces();
 

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
@@ -1,17 +1,98 @@
 #include <ossia/detail/config.hpp>
 #if defined(OSSIA_PROTOCOL_CAN)
 #include "CANDevice.hpp"
+#include "CANInterfaces.hpp"
 #include "CANProtocolFactory.hpp"
 #include "CANProtocolSettingsWidget.hpp"
 #include "CANSpecificSettings.hpp"
 
 #include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
 
+#include <ossia/detail/algorithms.hpp>
+
 #include <QObject>
+#include <QTimer>
 #include <QUrl>
 
 namespace Protocols
 {
+namespace
+{
+Device::DeviceSettings settingsForInterface(const CAN::InterfaceInfo& itf)
+{
+  Device::DeviceSettings set;
+  set.name = itf.name;
+  set.protocol = CANProtocolFactory::static_concreteKey();
+
+  CANSpecificSettings specif;
+  specif.interfaceName = itf.name;
+  // Not enabled from fdCapable: FD is not a mode switch, but asking for it on a
+  // socket whose driver does not really support it is a way to fail at open
+  // time for nothing. The database says whether payloads above 8 bytes are
+  // expected; the checkbox is one click away when they are.
+  specif.fd = false;
+
+  set.deviceSpecificSettings = QVariant::fromValue(specif);
+  return set;
+}
+
+/**
+ * Lists the SocketCAN interfaces of the machine in the device browser.
+ *
+ * Polled rather than event-driven: netlink would give exact notifications, but
+ * it means a socket, a subscription and a reader for a list that changes when
+ * somebody plugs a USB adapter in. One sysfs directory listing per second is
+ * cheaper than that in every sense.
+ */
+class CANInterfaceEnumerator final : public Device::DeviceEnumerator
+{
+public:
+  CANInterfaceEnumerator()
+  {
+    m_timer.setInterval(1000);
+    QObject::connect(&m_timer, &QTimer::timeout, this, [this] { rescan(); });
+    m_timer.start();
+  }
+
+  void enumerate(std::function<void(const QString&, const Device::DeviceSettings&)> f)
+      const override
+  {
+    m_current = CAN::availableInterfaces();
+    for(const auto& itf : m_current)
+      f(itf.name, settingsForInterface(itf));
+  }
+
+private:
+  void rescan()
+  {
+    auto next = CAN::availableInterfaces();
+    auto has = [](const std::vector<CAN::InterfaceInfo>& l, const QString& n) {
+      return ossia::any_of(l, [&n](const auto& i) { return i.name == n; });
+    };
+
+    for(const auto& itf : m_current)
+      if(!has(next, itf.name))
+        deviceRemoved(itf.name);
+
+    bool added = false;
+    for(const auto& itf : next)
+    {
+      if(!has(m_current, itf.name))
+      {
+        deviceAdded(itf.name, settingsForInterface(itf));
+        added = true;
+      }
+    }
+
+    m_current = std::move(next);
+    if(added)
+      sort();
+  }
+
+  QTimer m_timer;
+  mutable std::vector<CAN::InterfaceInfo> m_current;
+};
+}
 
 QString CANProtocolFactory::prettyName() const noexcept
 {
@@ -35,19 +116,28 @@ Device::DeviceInterface* CANProtocolFactory::makeDevice(
   return new CANDevice{settings, plugin.networkContext()};
 }
 
+Device::DeviceEnumerators
+CANProtocolFactory::getEnumerators(const score::DocumentContext& ctx) const
+{
+  return {{QObject::tr("Interfaces"), new CANInterfaceEnumerator}};
+}
+
 const Device::DeviceSettings& CANProtocolFactory::defaultSettings() const noexcept
 {
-  static const Device::DeviceSettings& settings = [&]() {
-    Device::DeviceSettings s;
-    s.protocol = concreteKey();
-    s.name = "CAN";
-    CANSpecificSettings settings;
-    settings.interfaceName = "can0";
-    s.deviceSpecificSettings = QVariant::fromValue(settings);
-    return s;
-  }();
+  Device::DeviceSettings s;
+  s.protocol = concreteKey();
+  s.name = "CAN";
 
-  return settings;
+  CANSpecificSettings specif;
+  // The first interface actually present, and nothing at all when there is
+  // none. Hardcoding "can0" made every fresh CAN device on a machine without a
+  // physical CAN port fail at connection time with "no such CAN interface:
+  // can0" -- a setting the user never chose and had no reason to suspect.
+  specif.interfaceName = CAN::defaultInterface();
+  s.deviceSpecificSettings = QVariant::fromValue(specif);
+
+  m_defaultSettings = std::move(s);
+  return m_defaultSettings;
 }
 
 Device::ProtocolSettingsWidget* CANProtocolFactory::makeSettingsWidget()

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
@@ -39,16 +39,10 @@ Device::DeviceInterface* CANProtocolFactory::makeDevice(
 Device::DeviceEnumerators
 CANProtocolFactory::getEnumerators(const score::DocumentContext& ctx) const
 {
-  // Not the interfaces: a machine has one or two of them, they are already in
-  // the settings widget's combo box, and an entry per interface tells the user
-  // nothing they did not know. What is worth browsing is the databases. A .dbc
-  // describes one device on the bus, a library holds many of them, and picking
-  // one is what actually gives a CAN device its node tree - so an entry per
-  // file lands in the dialog with the path filled in and the messages and
-  // signals it declares already listed underneath.
-  //
-  // "BO_" is the message keyword: it appears in every database that declares a
-  // frame, and a .dbc without one has nothing to offer a device.
+  // The databases, not the interfaces: the settings widget's combo already
+  // lists those, while a .dbc describes one device on the bus and is what gives
+  // the device its tree. "BO_" is the message keyword - a database without one
+  // has nothing to offer.
   auto library_enumerator = new LibraryDeviceEnumerator{
       "BO_",
       {"dbc"},
@@ -73,10 +67,8 @@ const Device::DeviceSettings& CANProtocolFactory::defaultSettings() const noexce
   s.name = "CAN";
 
   CANSpecificSettings specif;
-  // The first interface actually present, and nothing at all when there is
-  // none. Hardcoding "can0" made every fresh CAN device on a machine without a
-  // physical CAN port fail at connection time with "no such CAN interface:
-  // can0" -- a setting the user never chose and had no reason to suspect.
+  // The first interface present, or nothing: hardcoding "can0" made every
+  // fresh device fail with "no such CAN interface" on a machine without one.
   specif.interfaceName = CAN::defaultInterface();
   s.deviceSpecificSettings = QVariant::fromValue(specif);
 

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
@@ -7,6 +7,7 @@
 #include "CANSpecificSettings.hpp"
 
 #include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
+
 #include <Protocols/LibraryDeviceEnumerator.hpp>
 
 #include <QObject>
@@ -54,7 +55,7 @@ CANProtocolFactory::getEnumerators(const score::DocumentContext& ctx) const
     // rather than being a database with nowhere to read it from.
     specif.interfaceName = CAN::defaultInterface();
     return QVariant::fromValue(specif);
-      },
+  },
       ctx};
 
   return {{"Library", library_enumerator}};

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
@@ -7,93 +7,13 @@
 #include "CANSpecificSettings.hpp"
 
 #include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
-
-#include <ossia/detail/algorithms.hpp>
+#include <Protocols/LibraryDeviceEnumerator.hpp>
 
 #include <QObject>
-#include <QTimer>
 #include <QUrl>
 
 namespace Protocols
 {
-namespace
-{
-Device::DeviceSettings settingsForInterface(const CAN::InterfaceInfo& itf)
-{
-  Device::DeviceSettings set;
-  set.name = itf.name;
-  set.protocol = CANProtocolFactory::static_concreteKey();
-
-  CANSpecificSettings specif;
-  specif.interfaceName = itf.name;
-  // Not enabled from fdCapable: FD is not a mode switch, but asking for it on a
-  // socket whose driver does not really support it is a way to fail at open
-  // time for nothing. The database says whether payloads above 8 bytes are
-  // expected; the checkbox is one click away when they are.
-  specif.fd = false;
-
-  set.deviceSpecificSettings = QVariant::fromValue(specif);
-  return set;
-}
-
-/**
- * Lists the SocketCAN interfaces of the machine in the device browser.
- *
- * Polled rather than event-driven: netlink would give exact notifications, but
- * it means a socket, a subscription and a reader for a list that changes when
- * somebody plugs a USB adapter in. One sysfs directory listing per second is
- * cheaper than that in every sense.
- */
-class CANInterfaceEnumerator final : public Device::DeviceEnumerator
-{
-public:
-  CANInterfaceEnumerator()
-  {
-    m_timer.setInterval(1000);
-    QObject::connect(&m_timer, &QTimer::timeout, this, [this] { rescan(); });
-    m_timer.start();
-  }
-
-  void enumerate(std::function<void(const QString&, const Device::DeviceSettings&)> f)
-      const override
-  {
-    m_current = CAN::availableInterfaces();
-    for(const auto& itf : m_current)
-      f(itf.name, settingsForInterface(itf));
-  }
-
-private:
-  void rescan()
-  {
-    auto next = CAN::availableInterfaces();
-    auto has = [](const std::vector<CAN::InterfaceInfo>& l, const QString& n) {
-      return ossia::any_of(l, [&n](const auto& i) { return i.name == n; });
-    };
-
-    for(const auto& itf : m_current)
-      if(!has(next, itf.name))
-        deviceRemoved(itf.name);
-
-    bool added = false;
-    for(const auto& itf : next)
-    {
-      if(!has(m_current, itf.name))
-      {
-        deviceAdded(itf.name, settingsForInterface(itf));
-        added = true;
-      }
-    }
-
-    m_current = std::move(next);
-    if(added)
-      sort();
-  }
-
-  QTimer m_timer;
-  mutable std::vector<CAN::InterfaceInfo> m_current;
-};
-}
-
 QString CANProtocolFactory::prettyName() const noexcept
 {
   return QObject::tr("CAN");
@@ -119,7 +39,31 @@ Device::DeviceInterface* CANProtocolFactory::makeDevice(
 Device::DeviceEnumerators
 CANProtocolFactory::getEnumerators(const score::DocumentContext& ctx) const
 {
-  return {{QObject::tr("Interfaces"), new CANInterfaceEnumerator}};
+  // Not the interfaces: a machine has one or two of them, they are already in
+  // the settings widget's combo box, and an entry per interface tells the user
+  // nothing they did not know. What is worth browsing is the databases. A .dbc
+  // describes one device on the bus, a library holds many of them, and picking
+  // one is what actually gives a CAN device its node tree - so an entry per
+  // file lands in the dialog with the path filled in and the messages and
+  // signals it declares already listed underneath.
+  //
+  // "BO_" is the message keyword: it appears in every database that declares a
+  // frame, and a .dbc without one has nothing to offer a device.
+  auto library_enumerator = new LibraryDeviceEnumerator{
+      "BO_",
+      {"dbc"},
+      CANProtocolFactory::static_concreteKey(),
+      [](QByteArray, const QString& path) {
+    CANSpecificSettings specif;
+    specif.dbcPath = path;
+    // So that a device dropped in from the library is connectable as-is,
+    // rather than being a database with nowhere to read it from.
+    specif.interfaceName = CAN::defaultInterface();
+    return QVariant::fromValue(specif);
+      },
+      ctx};
+
+  return {{"Library", library_enumerator}};
 }
 
 const Device::DeviceSettings& CANProtocolFactory::defaultSettings() const noexcept

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.cpp
@@ -1,0 +1,86 @@
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include "CANDevice.hpp"
+#include "CANProtocolFactory.hpp"
+#include "CANProtocolSettingsWidget.hpp"
+#include "CANSpecificSettings.hpp"
+
+#include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
+
+#include <QObject>
+#include <QUrl>
+
+namespace Protocols
+{
+
+QString CANProtocolFactory::prettyName() const noexcept
+{
+  return QObject::tr("CAN");
+}
+
+QString CANProtocolFactory::category() const noexcept
+{
+  return StandardCategories::hardware;
+}
+
+QUrl CANProtocolFactory::manual() const noexcept
+{
+  return QUrl("https://ossia.io/score-docs/devices/can-device.html");
+}
+
+Device::DeviceInterface* CANProtocolFactory::makeDevice(
+    const Device::DeviceSettings& settings, const Explorer::DeviceDocumentPlugin& plugin,
+    const score::DocumentContext& ctx)
+{
+  return new CANDevice{settings, plugin.networkContext()};
+}
+
+const Device::DeviceSettings& CANProtocolFactory::defaultSettings() const noexcept
+{
+  static const Device::DeviceSettings& settings = [&]() {
+    Device::DeviceSettings s;
+    s.protocol = concreteKey();
+    s.name = "CAN";
+    CANSpecificSettings settings;
+    settings.interfaceName = "can0";
+    s.deviceSpecificSettings = QVariant::fromValue(settings);
+    return s;
+  }();
+
+  return settings;
+}
+
+Device::ProtocolSettingsWidget* CANProtocolFactory::makeSettingsWidget()
+{
+  return new CANProtocolSettingsWidget;
+}
+
+QVariant
+CANProtocolFactory::makeProtocolSpecificSettings(const VisitorVariant& visitor) const
+{
+  return makeProtocolSpecificSettings_T<CANSpecificSettings>(visitor);
+}
+
+void CANProtocolFactory::serializeProtocolSpecificSettings(
+    const QVariant& data, const VisitorVariant& visitor) const
+{
+  serializeProtocolSpecificSettings_T<CANSpecificSettings>(data, visitor);
+}
+
+bool CANProtocolFactory::checkCompatibility(
+    const Device::DeviceSettings& a, const Device::DeviceSettings& b) const noexcept
+{
+  auto lhs = a.deviceSpecificSettings.value<CANSpecificSettings>();
+  auto rhs = b.deviceSpecificSettings.value<CANSpecificSettings>();
+
+  // Several devices on one interface is the normal case, not a conflict: a
+  // chain of sensors is one DBC file opened N times with N node-id offsets,
+  // and SocketCAN gives each socket its own view of the bus. Only two devices
+  // that would decode the very same frames are actually redundant.
+  if(lhs.interfaceName != rhs.interfaceName)
+    return true;
+
+  return lhs.nodeIdOffset != rhs.nodeIdOffset || lhs.dbcPath != rhs.dbcPath;
+}
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include <Explorer/DefaultProtocolFactory.hpp>
+
+namespace Protocols
+{
+class CANProtocolFactory final : public DefaultProtocolFactory
+{
+  SCORE_CONCRETE("2492941c-18ee-4f96-ac3d-c3d42c0bb649")
+
+  QString prettyName() const noexcept override;
+  QString category() const noexcept override;
+  QUrl manual() const noexcept override;
+
+  Device::DeviceInterface* makeDevice(
+      const Device::DeviceSettings& settings, const Explorer::DeviceDocumentPlugin& plug,
+      const score::DocumentContext& ctx) override;
+
+  const Device::DeviceSettings& defaultSettings() const noexcept override;
+
+  Device::ProtocolSettingsWidget* makeSettingsWidget() override;
+
+  QVariant makeProtocolSpecificSettings(const VisitorVariant& visitor) const override;
+
+  void serializeProtocolSpecificSettings(
+      const QVariant& data, const VisitorVariant& visitor) const override;
+
+  bool checkCompatibility(
+      const Device::DeviceSettings& a,
+      const Device::DeviceSettings& b) const noexcept override;
+};
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolFactory.hpp
@@ -13,6 +13,9 @@ class CANProtocolFactory final : public DefaultProtocolFactory
   QString category() const noexcept override;
   QUrl manual() const noexcept override;
 
+  Device::DeviceEnumerators
+  getEnumerators(const score::DocumentContext& ctx) const override;
+
   Device::DeviceInterface* makeDevice(
       const Device::DeviceSettings& settings, const Explorer::DeviceDocumentPlugin& plug,
       const score::DocumentContext& ctx) override;
@@ -29,6 +32,12 @@ class CANProtocolFactory final : public DefaultProtocolFactory
   bool checkCompatibility(
       const Device::DeviceSettings& a,
       const Device::DeviceSettings& b) const noexcept override;
+
+  // defaultSettings() hands back a reference, but the interface it names is a
+  // property of the machine *now*: an adapter plugged in after score started
+  // must show up. Recomputed on each call into this, rather than cached in a
+  // function-local static like the other protocols do.
+  mutable Device::DeviceSettings m_defaultSettings;
 };
 }
 #endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
@@ -1,5 +1,6 @@
 #include <ossia/detail/config.hpp>
 #if defined(OSSIA_PROTOCOL_CAN)
+#include "CANInterfaces.hpp"
 #include "CANProtocolFactory.hpp"
 #include "CANProtocolSettingsWidget.hpp"
 #include "CANSpecificSettings.hpp"
@@ -28,52 +29,6 @@ W_OBJECT_IMPL(Protocols::CANProtocolSettingsWidget)
 
 namespace Protocols
 {
-namespace
-{
-//! ARPHRD_CAN, from <linux/if_arp.h>. Read out of sysfs rather than included,
-//! so that the widget does not pull a kernel header in for one constant.
-constexpr int arphrdCan = 280;
-
-/**
- * List the CAN interfaces of the machine.
- *
- * Matched on the link type rather than on the name: an interface does not have
- * to be called "canN" (a USB adapter renamed by a udev rule is still a CAN
- * interface), and conversely a name is not proof of anything. The name prefixes
- * are kept only as a fallback for the case where sysfs cannot be read.
- */
-QStringList canInterfaces()
-{
-  QStringList out;
-  QDir sys{"/sys/class/net"};
-  const auto entries = sys.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::System);
-
-  for(const auto& name : entries)
-  {
-    bool isCan = false;
-
-    QFile type{"/sys/class/net/" + name + "/type"};
-    if(type.open(QIODevice::ReadOnly | QIODevice::Text))
-    {
-      bool ok = false;
-      const int t = type.readAll().trimmed().toInt(&ok);
-      isCan = ok && (t == arphrdCan);
-    }
-    else
-    {
-      isCan = name.startsWith("can") || name.startsWith("vcan")
-              || name.startsWith("slcan");
-    }
-
-    if(isCan)
-      out.push_back(name);
-  }
-
-  out.sort();
-  return out;
-}
-}
-
 CANProtocolSettingsWidget::CANProtocolSettingsWidget(QWidget* parent)
     : Device::ProtocolSettingsWidget(parent)
 {
@@ -86,10 +41,23 @@ CANProtocolSettingsWidget::CANProtocolSettingsWidget(QWidget* parent)
   // machine), so the user must be able to type a name that is not in the list.
   m_interface = new QComboBox{this};
   m_interface->setEditable(true);
-  m_interface->addItems(canInterfaces());
-  if(m_interface->count() == 0)
-    m_interface->setCurrentText("can0");
+  m_interface->addItems(CAN::availableInterfaceNames());
   checkForChanges(m_interface);
+
+  // No fallback to "can0" here: a name that resolves to nothing looks like a
+  // valid setting and only fails at connection time. An empty field plus the
+  // warning below says what is actually going on.
+  m_noInterface = new QLabel{
+      tr("No CAN interface found on this machine.\n"
+         "Plug an adapter in and bring it up, e.g.:\n"
+         "  sudo ip link set can0 up type can bitrate 1000000\n"
+         "or create a virtual bus for testing:\n"
+         "  sudo modprobe vcan\n"
+         "  sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0"),
+      this};
+  m_noInterface->setWordWrap(true);
+  m_noInterface->setTextInteractionFlags(Qt::TextSelectableByMouse);
+  m_noInterface->setVisible(m_interface->count() == 0);
 
   m_dbcPath = new QLineEdit{this};
   m_dbcPath->setPlaceholderText(tr("Path to a .dbc database"));
@@ -134,6 +102,7 @@ CANProtocolSettingsWidget::CANProtocolSettingsWidget(QWidget* parent)
   auto layout = new QFormLayout;
   layout->addRow(tr("Name"), m_deviceNameEdit);
   layout->addRow(tr("Interface"), m_interface);
+  layout->addRow(QString{}, m_noInterface);
   score::setHelp(
       m_interface,
       tr("The SocketCAN network interface, e.g. can0 or vcan0.\n"
@@ -258,7 +227,13 @@ void CANProtocolSettingsWidget::setSettings(const Device::DeviceSettings& settin
   const auto& specif = settings.deviceSpecificSettings.value<CANSpecificSettings>();
 
   if(!specif.interfaceName.isEmpty())
+  {
+    // The combo is editable precisely so a score written elsewhere -- or before
+    // the adapter was plugged in -- keeps the name it was saved with instead of
+    // being silently rewritten to whatever this machine happens to have.
     m_interface->setCurrentText(specif.interfaceName);
+    m_noInterface->setVisible(false);
+  }
 
   m_dbcPath->setText(specif.dbcPath);
   m_nodeIdOffset->setValue(specif.nodeIdOffset);

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
@@ -104,10 +104,9 @@ CANProtocolSettingsWidget::CANProtocolSettingsWidget(QWidget* parent)
   layout->addRow(tr("Interface"), m_interface);
   layout->addRow(QString{}, m_noInterface);
   score::setHelp(
-      m_interface,
-      tr("The SocketCAN network interface, e.g. can0 or vcan0.\n"
-         "Bring it up first, e.g.:\n"
-         "  sudo ip link set can0 up type can bitrate 1000000"));
+      m_interface, tr("The SocketCAN network interface, e.g. can0 or vcan0.\n"
+                      "Bring it up first, e.g.:\n"
+                      "  sudo ip link set can0 up type can bitrate 1000000"));
 
   layout->addRow(tr("DBC file"), dbcLayout);
   layout->addRow(tr("Node id offset"), m_nodeIdOffset);

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
@@ -1,0 +1,272 @@
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include "CANProtocolFactory.hpp"
+#include "CANProtocolSettingsWidget.hpp"
+#include "CANSpecificSettings.hpp"
+#include "DBCParser.hpp"
+
+#include <State/Widgets/AddressFragmentLineEdit.hpp>
+
+#include <score/widgets/HelpInteraction.hpp>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDir>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QSpinBox>
+
+#include <wobjectimpl.h>
+
+W_OBJECT_IMPL(Protocols::CANProtocolSettingsWidget)
+
+namespace Protocols
+{
+namespace
+{
+//! ARPHRD_CAN, from <linux/if_arp.h>. Read out of sysfs rather than included,
+//! so that the widget does not pull a kernel header in for one constant.
+constexpr int arphrdCan = 280;
+
+/**
+ * List the CAN interfaces of the machine.
+ *
+ * Matched on the link type rather than on the name: an interface does not have
+ * to be called "canN" (a USB adapter renamed by a udev rule is still a CAN
+ * interface), and conversely a name is not proof of anything. The name prefixes
+ * are kept only as a fallback for the case where sysfs cannot be read.
+ */
+QStringList canInterfaces()
+{
+  QStringList out;
+  QDir sys{"/sys/class/net"};
+  const auto entries = sys.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::System);
+
+  for(const auto& name : entries)
+  {
+    bool isCan = false;
+
+    QFile type{"/sys/class/net/" + name + "/type"};
+    if(type.open(QIODevice::ReadOnly | QIODevice::Text))
+    {
+      bool ok = false;
+      const int t = type.readAll().trimmed().toInt(&ok);
+      isCan = ok && (t == arphrdCan);
+    }
+    else
+    {
+      isCan = name.startsWith("can") || name.startsWith("vcan")
+              || name.startsWith("slcan");
+    }
+
+    if(isCan)
+      out.push_back(name);
+  }
+
+  out.sort();
+  return out;
+}
+}
+
+CANProtocolSettingsWidget::CANProtocolSettingsWidget(QWidget* parent)
+    : Device::ProtocolSettingsWidget(parent)
+{
+  m_deviceNameEdit = new State::AddressFragmentLineEdit{this};
+  m_deviceNameEdit->setText("CAN");
+  checkForChanges(m_deviceNameEdit);
+
+  // Editable: the interface may legitimately not exist yet when the score is
+  // written (the adapter is plugged in later, or the file comes from another
+  // machine), so the user must be able to type a name that is not in the list.
+  m_interface = new QComboBox{this};
+  m_interface->setEditable(true);
+  m_interface->addItems(canInterfaces());
+  if(m_interface->count() == 0)
+    m_interface->setCurrentText("can0");
+  checkForChanges(m_interface);
+
+  m_dbcPath = new QLineEdit{this};
+  m_dbcPath->setPlaceholderText(tr("Path to a .dbc database"));
+  checkForChanges(m_dbcPath);
+
+  auto browse = new QPushButton{tr("Browse..."), this};
+  connect(browse, &QPushButton::clicked, this, &CANProtocolSettingsWidget::browseDBC);
+
+  auto dbcLayout = new QHBoxLayout{};
+  dbcLayout->addWidget(m_dbcPath);
+  dbcLayout->addWidget(browse);
+
+  m_nodeIdOffset = new QSpinBox{this};
+  // Wide enough to move a database anywhere inside the 29-bit space, in either
+  // direction; the parser refuses individual moves that would leave the range.
+  m_nodeIdOffset->setRange(-0x1FFFFFFF, 0x1FFFFFFF);
+  m_nodeIdOffset->setValue(0);
+  checkForChanges(m_nodeIdOffset);
+
+  m_float32Override = new QCheckBox{this};
+  m_float32Override->setChecked(false);
+  checkForChanges(m_float32Override);
+
+  m_fd = new QCheckBox{this};
+  checkForChanges(m_fd);
+
+  m_filterToDatabase = new QCheckBox{this};
+  m_filterToDatabase->setChecked(true);
+  checkForChanges(m_filterToDatabase);
+
+  m_summary = new QLabel{this};
+  m_summary->setWordWrap(true);
+  m_summary->setTextInteractionFlags(Qt::TextSelectableByMouse);
+
+  connect(
+      m_dbcPath, &QLineEdit::textChanged, this,
+      &CANProtocolSettingsWidget::updateDBCSummary);
+  connect(
+      m_nodeIdOffset, qOverload<int>(&QSpinBox::valueChanged), this,
+      &CANProtocolSettingsWidget::updateDBCSummary);
+
+  auto layout = new QFormLayout;
+  layout->addRow(tr("Name"), m_deviceNameEdit);
+  layout->addRow(tr("Interface"), m_interface);
+  score::setHelp(
+      m_interface,
+      tr("The SocketCAN network interface, e.g. can0 or vcan0.\n"
+         "Bring it up first, e.g.:\n"
+         "  sudo ip link set can0 up type can bitrate 1000000"));
+
+  layout->addRow(tr("DBC file"), dbcLayout);
+  layout->addRow(tr("Node id offset"), m_nodeIdOffset);
+  score::setHelp(
+      m_nodeIdOffset,
+      tr("Added to every message id of the database.\n"
+         "A DBC usually describes one device at one node id: a sensor whose file "
+         "is written for CANopen node 1 (0x181, 0x281...) is reached at node 2 "
+         "with an offset of 1.\n"
+         "This lets one file serve a whole chain of devices on one bus, one "
+         "score device per sensor."));
+
+  layout->addRow(tr("32-bit ints are floats"), m_float32Override);
+  score::setHelp(
+      m_float32Override,
+      tr("Decode every 32-bit integer signal as an IEEE 754 float instead.\n\n"
+         "Leave this off unless the database is known to be wrong. It exists "
+         "because some vendor files declare a float payload as a scaled integer "
+         "and omit the SIG_VALTYPE_ record that would say otherwise; decoding "
+         "such a file as written yields garbage.\n"
+         "Signals with an explicit float or double type are never affected."));
+
+  layout->addRow(tr("CAN FD"), m_fd);
+  score::setHelp(
+      m_fd, tr("Allow payloads larger than 8 bytes. Classic frames keep working."));
+
+  layout->addRow(tr("Filter to database"), m_filterToDatabase);
+  score::setHelp(
+      m_filterToDatabase,
+      tr("Ask the kernel to drop frames whose id is not in the database.\n"
+         "Filters are per socket, so several devices may share one bus without "
+         "paying for each other's traffic."));
+
+  layout->addRow(QString{}, m_summary);
+
+  setLayout(layout);
+
+  updateDBCSummary();
+}
+
+CANProtocolSettingsWidget::~CANProtocolSettingsWidget() { }
+
+void CANProtocolSettingsWidget::browseDBC()
+{
+  const auto path = QFileDialog::getOpenFileName(
+      this, tr("Open a CAN database"), QFileInfo{m_dbcPath->text()}.absolutePath(),
+      tr("CAN databases (*.dbc);;All files (*)"));
+
+  if(!path.isEmpty())
+    m_dbcPath->setText(path);
+}
+
+void CANProtocolSettingsWidget::updateDBCSummary()
+{
+  const auto path = m_dbcPath->text();
+  if(path.isEmpty())
+  {
+    m_summary->clear();
+    return;
+  }
+
+  auto db = CAN::parseDBCFile(path.toStdString());
+  CAN::applyNodeIdOffset(db, m_nodeIdOffset->value());
+
+  if(db.messages.empty())
+  {
+    m_summary->setText(tr("No message could be read from this file."));
+    return;
+  }
+
+  std::size_t signals_n = 0;
+  for(const auto& m : db.messages)
+    signals_n += m.signals.size();
+
+  // Show the identifiers with the offset already applied: the point of the
+  // offset is that the user can check it against the device in front of them.
+  QStringList ids;
+  for(const auto& m : db.messages)
+    ids.push_back(QString{"0x%1"}.arg(m.id, 0, 16));
+
+  QString text = tr("%1 messages, %2 signals: %3")
+                     .arg(db.messages.size())
+                     .arg(signals_n)
+                     .arg(ids.join(", "));
+
+  if(!db.warnings.empty())
+    text += "\n"
+            + tr("%1 warning(s), first: %2")
+                  .arg(db.warnings.size())
+                  .arg(QString::fromStdString(db.warnings.front()));
+
+  m_summary->setText(text);
+}
+
+Device::DeviceSettings CANProtocolSettingsWidget::getSettings() const
+{
+  Device::DeviceSettings s;
+  s.name = m_deviceNameEdit->text();
+  s.protocol = CANProtocolFactory::static_concreteKey();
+
+  CANSpecificSettings settings{};
+  settings.interfaceName = m_interface->currentText();
+  settings.dbcPath = m_dbcPath->text();
+  settings.nodeIdOffset = m_nodeIdOffset->value();
+  settings.float32Override = m_float32Override->isChecked();
+  settings.fd = m_fd->isChecked();
+  settings.filterToDatabase = m_filterToDatabase->isChecked();
+  s.deviceSpecificSettings = QVariant::fromValue(settings);
+
+  return s;
+}
+
+void CANProtocolSettingsWidget::setSettings(const Device::DeviceSettings& settings)
+{
+  m_deviceNameEdit->setText(settings.name);
+
+  const auto& specif = settings.deviceSpecificSettings.value<CANSpecificSettings>();
+
+  if(!specif.interfaceName.isEmpty())
+    m_interface->setCurrentText(specif.interfaceName);
+
+  m_dbcPath->setText(specif.dbcPath);
+  m_nodeIdOffset->setValue(specif.nodeIdOffset);
+  m_float32Override->setChecked(specif.float32Override);
+  m_fd->setChecked(specif.fd);
+  m_filterToDatabase->setChecked(specif.filterToDatabase);
+
+  updateDBCSummary();
+}
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.hpp
@@ -44,6 +44,10 @@ private:
   QCheckBox* m_fd{};
   QCheckBox* m_filterToDatabase{};
   QLabel* m_summary{};
+
+  //! Shown only when the machine has no CAN interface at all: the combo is then
+  //! empty and there is nothing else to tell the user why.
+  QLabel* m_noInterface{};
 };
 }
 #endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+
+#include <Device/Protocol/DeviceSettings.hpp>
+#include <Device/Protocol/ProtocolSettingsWidget.hpp>
+
+#include <Protocols/CAN/CANSpecificSettings.hpp>
+
+#include <verdigris>
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QLineEdit;
+class QSpinBox;
+
+namespace Protocols
+{
+
+class CANProtocolSettingsWidget final : public Device::ProtocolSettingsWidget
+{
+  W_OBJECT(CANProtocolSettingsWidget)
+
+public:
+  explicit CANProtocolSettingsWidget(QWidget* parent = nullptr);
+  virtual ~CANProtocolSettingsWidget();
+
+  Device::DeviceSettings getSettings() const override;
+  void setSettings(const Device::DeviceSettings& settings) override;
+
+private:
+  void browseDBC();
+
+  //! Parse the currently selected file and summarize it under the chooser, so
+  //! that a wrong file or a wrong offset is visible before connecting.
+  void updateDBCSummary();
+
+  QLineEdit* m_deviceNameEdit{};
+  QComboBox* m_interface{};
+  QLineEdit* m_dbcPath{};
+  QSpinBox* m_nodeIdOffset{};
+  QCheckBox* m_float32Override{};
+  QCheckBox* m_fd{};
+  QCheckBox* m_filterToDatabase{};
+  QLabel* m_summary{};
+};
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANSpecificSettings.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANSpecificSettings.hpp
@@ -1,0 +1,82 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include <score/tools/std/StringHash.hpp>
+
+#include <QString>
+
+#include <verdigris>
+
+namespace Protocols
+{
+
+struct CANSpecificSettings
+{
+  //! The netdev name of the CAN interface: "can0", "vcan0", "slcan0"...
+  //!
+  //! Deliberately not spelled `interface`: that is a macro on Windows, pulled
+  //! in by <objbase.h> through most of the Win32 headers. The field is
+  //! unreachable there anyway, but the name would still break the build of any
+  //! translation unit that happens to include both.
+  QString interfaceName;
+
+  //! Absolute path to the .dbc database describing the frames on the bus.
+  QString dbcPath;
+
+  /**
+   * Added to every message identifier read from the database.
+   *
+   * A DBC usually hardcodes the identifiers of one physical device. The LPMS
+   * files, for instance, are written for CANopen node 1: their frames are
+   * 0x181/0x281/0x381/0x481 (the CANopen "start id + node id" convention) plus
+   * the 0x701 heartbeat. The very same sensor configured as node 2 puts the
+   * same signals on 0x182/0x282/... -- the layout is identical, only the base
+   * changes.
+   *
+   * Rather than requiring one edited copy of the vendor file per sensor, the
+   * offset shifts the whole database at load time, so a chain of N devices on
+   * one bus is N score devices pointing at one file with offsets 0, 1, 2...
+   *
+   * Signed: a database written for node 3 can be pulled back to node 1 with -2.
+   */
+  int nodeIdOffset{0};
+
+  /**
+   * Decode every 32-bit integer signal as an IEEE 754 single instead.
+   *
+   * Off by default, and it must stay that way: it contradicts what the file
+   * says, and applying it to a database that means what it says turns good
+   * data into noise.
+   *
+   * It exists because some vendor files are simply wrong. LPMS3_32bit.dbc
+   * declares its signals `32@1-` with a `(1,0)` scaling and carries no
+   * SIG_VALTYPE_ record, yet the sensor's own command set
+   * (SET_CAN_DATA_PRECISION, 0x72) documents mode 1 as "32bit floating point".
+   * Decoded as written, a quaternion component of 1.0 reads as 1065353216.
+   *
+   * Signals that carry an explicit SIG_VALTYPE_ float or double type are never
+   * touched by this: an explicit statement in the file outranks the override.
+   */
+  bool float32Override{false};
+
+  /**
+   * Enable CAN FD (payloads above 8 bytes).
+   *
+   * Not a mode switch: classic frames keep arriving on the same socket.
+   */
+  bool fd{false};
+
+  /**
+   * Ask the kernel to drop every frame whose identifier is not in the database.
+   *
+   * SocketCAN applies filters per socket, so each device of a chain sees only
+   * its own node's frames and the others cost it nothing. Worth turning off
+   * only when debugging a bus whose traffic does not match the file.
+   */
+  bool filterToDatabase{true};
+};
+}
+
+Q_DECLARE_METATYPE(Protocols::CANSpecificSettings)
+W_REGISTER_ARGTYPE(Protocols::CANSpecificSettings)
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANSpecificSettings.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANSpecificSettings.hpp
@@ -12,12 +12,8 @@ namespace Protocols
 
 struct CANSpecificSettings
 {
-  //! The netdev name of the CAN interface: "can0", "vcan0", "slcan0"...
-  //!
-  //! Deliberately not spelled `interface`: that is a macro on Windows, pulled
-  //! in by <objbase.h> through most of the Win32 headers. The field is
-  //! unreachable there anyway, but the name would still break the build of any
-  //! translation unit that happens to include both.
+  //! The netdev name: "can0", "vcan0", "slcan0"...
+  //! Not spelled `interface`: that is a macro on Windows, via <objbase.h>.
   QString interfaceName;
 
   //! Absolute path to the .dbc database describing the frames on the bus.
@@ -26,18 +22,13 @@ struct CANSpecificSettings
   /**
    * Added to every message identifier read from the database.
    *
-   * A DBC usually hardcodes the identifiers of one physical device. The LPMS
-   * files, for instance, are written for CANopen node 1: their frames are
-   * 0x181/0x281/0x381/0x481 (the CANopen "start id + node id" convention) plus
-   * the 0x701 heartbeat. The very same sensor configured as node 2 puts the
-   * same signals on 0x182/0x282/... -- the layout is identical, only the base
-   * changes.
+   * A DBC hardcodes the identifiers of one device: the LPMS files are written
+   * for CANopen node 1 (0x181/0x281/0x381/0x481, plus the 0x701 heartbeat), and
+   * the same sensor as node 2 puts the same signals one higher. The offset
+   * shifts the whole database at load time, so a chain of N sensors is one file
+   * opened N times rather than N edited copies.
    *
-   * Rather than requiring one edited copy of the vendor file per sensor, the
-   * offset shifts the whole database at load time, so a chain of N devices on
-   * one bus is N score devices pointing at one file with offsets 0, 1, 2...
-   *
-   * Signed: a database written for node 3 can be pulled back to node 1 with -2.
+   * Signed, so a database written for node 3 can be pulled back with -2.
    */
   int nodeIdOffset{0};
 

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANSpecificSettingsSerialization.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANSpecificSettingsSerialization.cpp
@@ -1,0 +1,53 @@
+#include <ossia/detail/config.hpp>
+#if defined(OSSIA_PROTOCOL_CAN)
+#include "CANSpecificSettings.hpp"
+
+#include <score/serialization/DataStreamVisitor.hpp>
+#include <score/serialization/JSONVisitor.hpp>
+
+template <>
+void DataStreamReader::read(const Protocols::CANSpecificSettings& n)
+{
+  m_stream << n.interfaceName << n.dbcPath << n.nodeIdOffset << n.float32Override << n.fd
+           << n.filterToDatabase;
+  insertDelimiter();
+}
+
+template <>
+void DataStreamWriter::write(Protocols::CANSpecificSettings& n)
+{
+  m_stream >> n.interfaceName >> n.dbcPath >> n.nodeIdOffset >> n.float32Override >> n.fd
+      >> n.filterToDatabase;
+  checkDelimiter();
+}
+
+template <>
+void JSONReader::read(const Protocols::CANSpecificSettings& n)
+{
+  obj["Interface"] = n.interfaceName;
+  obj["DBC"] = n.dbcPath;
+  obj["NodeIdOffset"] = n.nodeIdOffset;
+  obj["Float32Override"] = n.float32Override;
+  obj["FD"] = n.fd;
+  obj["FilterToDatabase"] = n.filterToDatabase;
+}
+
+template <>
+void JSONWriter::write(Protocols::CANSpecificSettings& n)
+{
+  // tryGet throughout: a document saved before any one of these settings
+  // existed must still load, keeping the field's default.
+  if(auto v = obj.tryGet("Interface"))
+    n.interfaceName = QString::fromStdString(v->toStdString());
+  if(auto v = obj.tryGet("DBC"))
+    n.dbcPath = QString::fromStdString(v->toStdString());
+  if(auto v = obj.tryGet("NodeIdOffset"))
+    n.nodeIdOffset = v->toInt();
+  if(auto v = obj.tryGet("Float32Override"))
+    n.float32Override = v->toBool();
+  if(auto v = obj.tryGet("FD"))
+    n.fd = v->toBool();
+  if(auto v = obj.tryGet("FilterToDatabase"))
+    n.filterToDatabase = v->toBool();
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.cpp
@@ -147,13 +147,39 @@ std::string toUtf8(std::string s)
 const std::unordered_set<std::string_view>& topLevelKeywords()
 {
   static const std::unordered_set<std::string_view> k{
-      "VERSION",     "NS_",           "BS_",         "BU_",         "VAL_TABLE_",
-      "BO_",         "SG_",           "BO_TX_BU_",   "EV_",         "ENVVAR_DATA_",
-      "CM_",         "BA_DEF_",       "BA_DEF_DEF_", "BA_",         "VAL_",
-      "SIG_VALTYPE_", "SIG_GROUP_",   "SGTYPE_",     "SIG_TYPE_REF_", "SG_MUL_VAL_",
-      "CAT_DEF_",    "CAT_",          "FILTER",      "BA_DEF_REL_", "BA_REL_",
-      "BA_DEF_DEF_REL_", "BU_SG_REL_", "BU_EV_REL_", "BU_BO_REL_",  "NS_DESC_",
-      "BA_DEF_SGTYPE_", "BA_SGTYPE_", "SIGTYPE_VALTYPE_"};
+      "VERSION",
+      "NS_",
+      "BS_",
+      "BU_",
+      "VAL_TABLE_",
+      "BO_",
+      "SG_",
+      "BO_TX_BU_",
+      "EV_",
+      "ENVVAR_DATA_",
+      "CM_",
+      "BA_DEF_",
+      "BA_DEF_DEF_",
+      "BA_",
+      "VAL_",
+      "SIG_VALTYPE_",
+      "SIG_GROUP_",
+      "SGTYPE_",
+      "SIG_TYPE_REF_",
+      "SG_MUL_VAL_",
+      "CAT_DEF_",
+      "CAT_",
+      "FILTER",
+      "BA_DEF_REL_",
+      "BA_REL_",
+      "BA_DEF_DEF_REL_",
+      "BU_SG_REL_",
+      "BU_EV_REL_",
+      "BU_BO_REL_",
+      "NS_DESC_",
+      "BA_DEF_SGTYPE_",
+      "BA_SGTYPE_",
+      "SIGTYPE_VALTYPE_"};
   return k;
 }
 
@@ -614,10 +640,9 @@ struct Parser
       const char* worstName = nullptr;
       for(const auto& sg : msg.signals)
       {
-        const int lastBit
-            = (sg.byteOrder == ByteOrder::LittleEndian)
-                  ? sg.startBit + sg.length - 1
-                  : flipBitPos(flipBitPos(sg.startBit) + sg.length - 1);
+        const int lastBit = (sg.byteOrder == ByteOrder::LittleEndian)
+                                ? sg.startBit + sg.length - 1
+                                : flipBitPos(flipBitPos(sg.startBit) + sg.length - 1);
         const int neededBytes = lastBit / 8 + 1;
         if(neededBytes > msg.size && neededBytes > worst)
         {
@@ -642,8 +667,8 @@ struct Parser
     if(const auto* dup = db.findMessage(msg.id, msg.extended))
     {
       warnAt(
-          recordStart, "duplicate message id " + std::to_string(msg.id) + " ("
-                           + msg.name + " and " + dup->name + "); keeping the first");
+          recordStart, "duplicate message id " + std::to_string(msg.id) + " (" + msg.name
+                           + " and " + dup->name + "); keeping the first");
       return;
     }
 
@@ -693,12 +718,14 @@ struct Parser
             sig.isMultiplexer = true;
             t.remove_suffix(1);
           }
-          sig.multiplexValue = std::strtoll(std::string(t.substr(1)).c_str(), nullptr, 10);
+          sig.multiplexValue
+              = std::strtoll(std::string(t.substr(1)).c_str(), nullptr, 10);
         }
         else if(!t.empty())
         {
-          warnAt(recordStart, "unknown multiplexing indicator '" + std::string(t)
-                                  + "' on signal " + sig.name);
+          warnAt(
+              recordStart, "unknown multiplexing indicator '" + std::string(t)
+                               + "' on signal " + sig.name);
         }
       }
     }
@@ -803,7 +830,9 @@ struct Parser
     {
       // Legal, and occasionally deliberate, but it collapses every raw value
       // onto the offset -- worth saying out loud.
-      warnAt(recordStart, "SG_ " + sig.name + ": factor is 0, every value decodes to the offset");
+      warnAt(
+          recordStart,
+          "SG_ " + sig.name + ": factor is 0, every value decodes to the offset");
     }
 
     // `[0|0]` is how CANdb++ spells "no range given"; it is not a real domain
@@ -818,9 +847,8 @@ struct Parser
     if(msg.findSignal(sig.name))
     {
       warnAt(
-          recordStart,
-          "duplicate signal name " + sig.name + " in message " + msg.name
-              + "; keeping the first");
+          recordStart, "duplicate signal name " + sig.name + " in message " + msg.name
+                           + "; keeping the first");
       return;
     }
 
@@ -980,17 +1008,17 @@ struct Parser
       case 1:
         if(sg->length != 32)
           warnAt(
-              recordStart,
-              "SIG_VALTYPE_ declares " + name + " a float but its length is "
-                  + std::to_string(sg->length) + ", not 32");
+              recordStart, "SIG_VALTYPE_ declares " + name
+                               + " a float but its length is "
+                               + std::to_string(sg->length) + ", not 32");
         sg->valueType = ValueType::Float32;
         break;
       case 2:
         if(sg->length != 64)
           warnAt(
-              recordStart,
-              "SIG_VALTYPE_ declares " + name + " a double but its length is "
-                  + std::to_string(sg->length) + ", not 64");
+              recordStart, "SIG_VALTYPE_ declares " + name
+                               + " a double but its length is "
+                               + std::to_string(sg->length) + ", not 64");
         sg->valueType = ValueType::Double64;
         break;
       default:
@@ -1270,8 +1298,7 @@ static std::string preprocess(std::string_view content)
     Str,
     LineComment,
     BlockComment
-  } state
-      = Code;
+  } state = Code;
 
   for(std::size_t i = 0; i < content.size(); ++i)
   {

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.cpp
@@ -1,0 +1,1448 @@
+#include "DBCParser.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+/**
+ * Why this is a hand-written recursive-descent parser and not a Spirit X3
+ * grammar, given that X3 is available and used elsewhere in the tree
+ * (ossia/protocols/coap/link_format_parser.cpp, ValueParser.hpp...):
+ *
+ *  - The NS_ block makes the file non-dispatchable by leading keyword. It is a
+ *    bare list of the *same* tokens as the top-level constructs -- a real file
+ *    opens with `NS_ :` and then lines reading `CM_`, `BA_DEF_`, `VAL_`,
+ *    `SIG_VALTYPE_`, `SG_MUL_VAL_`... An alternation over the constructs would
+ *    start parsing the NS_ entries as records and fail. Handling it needs a
+ *    stateful "am I inside NS_" switch in the top-level loop, which is exactly
+ *    the thing a declarative grammar is supposed to remove.
+ *
+ *  - Per-record error recovery is a requirement here, not a nicety: vendor
+ *    files carry typos and dialect variants, and the contract for this parser
+ *    is to keep going and *name* what it could not read (Database::warnings).
+ *    X3 reports failure as one boolean plus an iterator; getting a diagnostic
+ *    per record means either an on_error handler on every rule or invoking the
+ *    parser once per record from a hand-written loop.
+ *
+ *  - DBC is line-sensitive in two places (the NS_ block ends at a blank line,
+ *    a BU_ node list and a SG_ receiver list end at the newline) and free-form
+ *    everywhere else, so no single X3 skipper fits.
+ *
+ *  - There is no recursion in the grammar. Message/signal nesting is one level
+ *    deep, everything else is flat, so a parser generator has no structure to
+ *    exploit -- and X3's compile-time cost is real.
+ *
+ * The lexical layer below is the only genuinely fiddly part, and it is ~120
+ * lines.
+ */
+
+namespace Protocols::CAN
+{
+
+const std::string* AttributeSet::find(std::string_view name) const noexcept
+{
+  for(auto& a : attributes)
+    if(a.name == name)
+      return &a.value;
+  return nullptr;
+}
+
+const Signal* Message::findSignal(std::string_view name) const noexcept
+{
+  for(auto& s : signals)
+    if(s.name == name)
+      return &s;
+  return nullptr;
+}
+
+const Message* Database::findMessage(uint32_t id, bool extended) const noexcept
+{
+  for(auto& m : messages)
+    if(m.id == id && m.extended == extended)
+      return &m;
+  return nullptr;
+}
+
+namespace
+{
+
+constexpr bool isIdentChar(char c) noexcept
+{
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+         || c == '_';
+}
+
+//! Note: a carriage return is deliberately *not* a blank. parseDBC() strips
+//! CRLF before parsing, so a '\r' reaching this point means the input was not
+//! normalized, and treating it as a blank would hide the end of a line.
+constexpr bool isBlank(char c) noexcept
+{
+  return c == ' ' || c == '\t';
+}
+
+constexpr bool isSpace(char c) noexcept
+{
+  return isBlank(c) || c == '\n';
+}
+
+/**
+ * Make a string from the file safe to hand to Qt and ossia as UTF-8.
+ *
+ * Real DBC files are not UTF-8. CANdb++ writes cp1252 and the reference
+ * readers default to cp1252 or ISO-8859-1; degree signs in units ("\xB0C") and
+ * umlauts in comments are everywhere. Passing those bytes on unchanged would
+ * produce invalid UTF-8 in a node description, which Qt renders as nothing.
+ *
+ * So: text that already is valid UTF-8 is left exactly as it is (a file that
+ * really is UTF-8 must not be mangled), and text that is not is transcoded
+ * from Latin-1, which is the best guess and never fails.
+ */
+std::string toUtf8(std::string s)
+{
+  const auto* p = reinterpret_cast<const unsigned char*>(s.data());
+  const std::size_t n = s.size();
+
+  bool valid = true;
+  for(std::size_t i = 0; i < n && valid;)
+  {
+    const unsigned char c = p[i];
+    int extra = 0;
+    if(c < 0x80)
+      extra = 0;
+    else if((c & 0xE0) == 0xC0)
+      extra = 1;
+    else if((c & 0xF0) == 0xE0)
+      extra = 2;
+    else if((c & 0xF8) == 0xF0)
+      extra = 3;
+    else
+      valid = false;
+
+    if(!valid)
+      break;
+
+    if(i + extra >= n)
+    {
+      valid = false;
+      break;
+    }
+    for(int k = 1; k <= extra; ++k)
+      if((p[i + k] & 0xC0) != 0x80)
+      {
+        valid = false;
+        break;
+      }
+    i += extra + 1;
+  }
+
+  if(valid)
+    return s;
+
+  std::string out;
+  out.reserve(s.size() + 8);
+  for(std::size_t i = 0; i < n; ++i)
+  {
+    const unsigned char c = p[i];
+    if(c < 0x80)
+    {
+      out.push_back(char(c));
+    }
+    else
+    {
+      out.push_back(char(0xC0 | (c >> 6)));
+      out.push_back(char(0x80 | (c & 0x3F)));
+    }
+  }
+  return out;
+}
+
+//! The top-level keywords, so that statement recovery can tell where the next
+//! record starts when the current one is missing its terminator.
+const std::unordered_set<std::string_view>& topLevelKeywords()
+{
+  static const std::unordered_set<std::string_view> k{
+      "VERSION",     "NS_",           "BS_",         "BU_",         "VAL_TABLE_",
+      "BO_",         "SG_",           "BO_TX_BU_",   "EV_",         "ENVVAR_DATA_",
+      "CM_",         "BA_DEF_",       "BA_DEF_DEF_", "BA_",         "VAL_",
+      "SIG_VALTYPE_", "SIG_GROUP_",   "SGTYPE_",     "SIG_TYPE_REF_", "SG_MUL_VAL_",
+      "CAT_DEF_",    "CAT_",          "FILTER",      "BA_DEF_REL_", "BA_REL_",
+      "BA_DEF_DEF_REL_", "BU_SG_REL_", "BU_EV_REL_", "BU_BO_REL_",  "NS_DESC_",
+      "BA_DEF_SGTYPE_", "BA_SGTYPE_", "SIGTYPE_VALTYPE_"};
+  return k;
+}
+
+//! A BA_DEF_ declaration, kept only so that BA_ enum assignments (which carry
+//! the *index* into the enum, not its text) can be resolved to their name.
+struct AttributeDefinition
+{
+  std::string name;
+  std::string objectKind; // "", "BU_", "BO_", "SG_", "EV_"
+  std::string type;       // INT, HEX, FLOAT, STRING, ENUM
+  std::vector<std::string> enumValues;
+};
+
+struct Parser
+{
+  std::string_view s;
+  std::size_t i = 0;
+  Database db;
+
+  std::unordered_map<std::string, std::vector<ValueDescription>> valueTables;
+  std::unordered_map<std::string, AttributeDefinition> attributeDefs;
+  std::unordered_set<std::string> warnedKinds;
+
+  static constexpr std::size_t maxWarnings = 200;
+
+  // ---------------------------------------------------------------- warnings
+
+  int lineAt(std::size_t pos) const noexcept
+  {
+    int line = 1;
+    for(std::size_t k = 0; k < pos && k < s.size(); ++k)
+      if(s[k] == '\n')
+        ++line;
+    return line;
+  }
+
+  void warn(std::string text) { warnAt(i, std::move(text)); }
+
+  void warnAt(std::size_t pos, std::string text)
+  {
+    if(db.warnings.size() >= maxWarnings)
+    {
+      if(db.warnings.size() == maxWarnings)
+        db.warnings.push_back("too many problems: further ones are not reported");
+      return;
+    }
+    db.warnings.push_back(
+        "line " + std::to_string(lineAt(pos)) + ": " + std::move(text));
+  }
+
+  //! One diagnostic per unsupported construct kind, not one per occurrence: a
+  //! large file may hold thousands of SIG_GROUP_ records and the user only
+  //! needs to be told once that they are being dropped.
+  void warnKindOnce(const std::string& kind, const std::string& text)
+  {
+    if(warnedKinds.insert(kind).second)
+      warn(text);
+  }
+
+  // ----------------------------------------------------------------- lexing
+
+  bool eof() const noexcept { return i >= s.size(); }
+  char cur() const noexcept { return i < s.size() ? s[i] : '\0'; }
+
+  void skipBlanks() noexcept
+  {
+    while(i < s.size() && isBlank(s[i]))
+      ++i;
+  }
+
+  void skipSpace() noexcept
+  {
+    while(i < s.size() && isSpace(s[i]))
+      ++i;
+  }
+
+  void skipLine() noexcept
+  {
+    while(i < s.size() && s[i] != '\n')
+      ++i;
+    if(i < s.size())
+      ++i;
+  }
+
+  //! True when the rest of the current line holds nothing but whitespace.
+  bool restOfLineBlank() const noexcept
+  {
+    for(std::size_t k = i; k < s.size() && s[k] != '\n'; ++k)
+      if(!isBlank(s[k]))
+        return false;
+    return true;
+  }
+
+  std::string_view readIdent() noexcept
+  {
+    const std::size_t start = i;
+    while(i < s.size() && isIdentChar(s[i]))
+      ++i;
+    return s.substr(start, i - start);
+  }
+
+  //! A run of non-whitespace, used for keyword dispatch and for the mixed
+  //! tokens (`m3M`, `1-`) that are not identifiers.
+  std::string_view readToken() noexcept
+  {
+    const std::size_t start = i;
+    while(i < s.size() && !isSpace(s[i]))
+      ++i;
+    return s.substr(start, i - start);
+  }
+
+  std::string_view peekToken() noexcept
+  {
+    const std::size_t save = i;
+    skipSpace();
+    const std::size_t start = i;
+    while(i < s.size() && !isSpace(s[i]))
+      ++i;
+    auto tok = s.substr(start, i - start);
+    i = save;
+    return tok;
+  }
+
+  bool consumeChar(char c) noexcept
+  {
+    skipBlanks();
+    if(cur() == c)
+    {
+      ++i;
+      return true;
+    }
+    return false;
+  }
+
+  bool expectChar(char c, std::string_view what)
+  {
+    if(consumeChar(c))
+      return true;
+    warn(std::string{"expected '"} + c + "' in " + std::string(what));
+    return false;
+  }
+
+  /**
+   * A quoted string. Newlines are allowed inside: CANdb++ writes multi-line
+   * CM_ comments verbatim. Both escaping dialects are accepted -- backslash
+   * escapes, and the doubled `""` that some tools emit.
+   */
+  std::string readQuoted(bool* ok = nullptr)
+  {
+    skipSpace();
+    if(ok)
+      *ok = false;
+    if(cur() != '"')
+      return {};
+    ++i;
+
+    std::string out;
+    while(i < s.size())
+    {
+      const char c = s[i];
+      if(c == '\\' && i + 1 < s.size())
+      {
+        const char n = s[i + 1];
+        // Only the escapes that actually occur; anything else keeps both
+        // characters, since a lone backslash in a comment is not an error.
+        switch(n)
+        {
+          case '"':
+            out.push_back('"');
+            i += 2;
+            continue;
+          case '\\':
+            out.push_back('\\');
+            i += 2;
+            continue;
+          case 'n':
+            out.push_back('\n');
+            i += 2;
+            continue;
+          case 't':
+            out.push_back('\t');
+            i += 2;
+            continue;
+          default:
+            out.push_back(c);
+            ++i;
+            continue;
+        }
+      }
+      if(c == '"')
+      {
+        // A doubled quote is a literal quote, not the end of the string.
+        if(i + 1 < s.size() && s[i + 1] == '"')
+        {
+          out.push_back('"');
+          i += 2;
+          continue;
+        }
+        ++i;
+        if(ok)
+          *ok = true;
+        return toUtf8(std::move(out));
+      }
+      out.push_back(c);
+      ++i;
+    }
+
+    warn("unterminated string");
+    return toUtf8(std::move(out));
+  }
+
+  //! The characters that can occur in a DBC number, including exponents.
+  static constexpr bool isNumberChar(char c) noexcept
+  {
+    return (c >= '0' && c <= '9') || c == '-' || c == '+' || c == '.' || c == 'e'
+           || c == 'E';
+  }
+
+  std::string_view readNumberToken() noexcept
+  {
+    skipBlanks();
+    const std::size_t start = i;
+    while(i < s.size() && isNumberChar(s[i]))
+      ++i;
+    return s.substr(start, i - start);
+  }
+
+  double readDouble(bool* ok = nullptr)
+  {
+    const auto tok = readNumberToken();
+    if(ok)
+      *ok = !tok.empty();
+    if(tok.empty())
+      return 0.;
+    // strtod needs a terminator; the tokens here are a handful of characters.
+    char buf[64];
+    const std::size_t n = std::min(tok.size(), sizeof(buf) - 1);
+    std::memcpy(buf, tok.data(), n);
+    buf[n] = '\0';
+    return std::strtod(buf, nullptr);
+  }
+
+  int64_t readInt(bool* ok = nullptr)
+  {
+    const auto tok = readNumberToken();
+    if(ok)
+      *ok = !tok.empty();
+    if(tok.empty())
+      return 0;
+    char buf[64];
+    const std::size_t n = std::min(tok.size(), sizeof(buf) - 1);
+    std::memcpy(buf, tok.data(), n);
+    buf[n] = '\0';
+    return std::strtoll(buf, nullptr, 10);
+  }
+
+  /**
+   * Skip the remainder of a statement, stopping at its `;`.
+   *
+   * Guarded against a missing terminator: if a newline is reached whose next
+   * token is a top-level keyword, the statement is assumed to have ended there
+   * rather than swallowing the rest of the file.
+   */
+  void skipStatement()
+  {
+    while(i < s.size())
+    {
+      const char c = s[i];
+      if(c == '"')
+      {
+        readQuoted();
+        continue;
+      }
+      if(c == ';')
+      {
+        ++i;
+        return;
+      }
+      if(c == '\n')
+      {
+        ++i;
+        const auto next = peekToken();
+        // A keyword at the start of a line means the previous record is over.
+        if(!next.empty() && topLevelKeywords().count(next) > 0)
+          return;
+        continue;
+      }
+      ++i;
+    }
+  }
+
+  // -------------------------------------------------------------- constructs
+
+  void parseVersion()
+  {
+    db.version = readQuoted();
+    skipBlanks();
+  }
+
+  /**
+   * The NS_ block: `NS_ :` followed by one bare keyword per line, terminated by
+   * a blank line. Those keywords are the same tokens as the real constructs,
+   * so this must consume them rather than let the dispatcher see them.
+   */
+  void parseNamespaceSection()
+  {
+    consumeChar(':');
+    skipLine();
+
+    while(i < s.size())
+    {
+      const std::size_t lineStart = i;
+      skipBlanks();
+      if(restOfLineBlank())
+      {
+        // Blank line: end of the block.
+        skipLine();
+        return;
+      }
+
+      const auto tok = peekToken();
+      // Defensive: some generators omit the blank line. A token that is not a
+      // bare NS_ entry (i.e. it is followed by something else on its line)
+      // means the block is over.
+      if(tok.empty())
+      {
+        skipLine();
+        continue;
+      }
+
+      skipSpace();
+      readToken();
+      if(!restOfLineBlank())
+      {
+        // `BS_:` / `BU_:` and friends carry content: rewind, the block ended.
+        i = lineStart;
+        return;
+      }
+      skipLine();
+    }
+  }
+
+  void parseNodes()
+  {
+    // `BU_: Node1 Node2 ...`, terminated by the end of the line. The node list
+    // itself is not needed for decoding, so it is consumed and dropped.
+    consumeChar(':');
+    skipLine();
+  }
+
+  std::vector<ValueDescription> parseValueDescriptionList()
+  {
+    std::vector<ValueDescription> out;
+    while(i < s.size())
+    {
+      skipSpace();
+      if(cur() == ';' || cur() == '\0')
+        break;
+      if(!isNumberChar(cur()))
+        break;
+
+      bool ok = false;
+      const int64_t v = readInt(&ok);
+      if(!ok)
+        break;
+
+      bool strOk = false;
+      auto name = readQuoted(&strOk);
+      if(!strOk)
+      {
+        warn("value description without a name");
+        break;
+      }
+      out.push_back(ValueDescription{v, std::move(name)});
+    }
+    return out;
+  }
+
+  void parseValueTable()
+  {
+    skipSpace();
+    const auto name = std::string(readIdent());
+    auto values = parseValueDescriptionList();
+    skipStatement();
+    if(name.empty())
+    {
+      warn("VAL_TABLE_ without a name");
+      return;
+    }
+    valueTables[name] = std::move(values);
+  }
+
+  void parseMessage()
+  {
+    const std::size_t recordStart = i;
+
+    skipSpace();
+    bool ok = false;
+    const int64_t rawId = readInt(&ok);
+    if(!ok || rawId < 0)
+    {
+      warnAt(recordStart, "BO_ without a valid identifier");
+      skipLine();
+      return;
+    }
+
+    skipSpace();
+    Message msg;
+    msg.name = std::string(readIdent());
+    // The extended flag lives in bit 31 of the identifier; the identifier
+    // itself is 29 bits. Masking is not optional: VECTOR__INDEPENDENT_SIG_MSG
+    // is 0xC0000000, i.e. flag set and a masked value of 0, which would
+    // otherwise collide with a legitimate id.
+    const auto raw = uint32_t(rawId);
+    msg.extended = (raw & dbcExtendedFlag) != 0;
+    msg.id = raw & dbcIdentifierMask;
+
+    if(!expectChar(':', "BO_ header"))
+    {
+      skipLine();
+      return;
+    }
+
+    msg.size = int(readInt());
+    skipBlanks();
+    msg.transmitter = std::string(readIdent());
+    skipLine();
+
+    if(msg.name.empty())
+    {
+      warnAt(recordStart, "BO_ without a name");
+      msg.name = "Message_" + std::to_string(msg.id);
+    }
+
+    // The signals belong to the message header that precedes them, so they are
+    // parsed here rather than as a top-level construct.
+    while(i < s.size())
+    {
+      const std::size_t save = i;
+      skipSpace();
+      if(peekToken() != "SG_")
+      {
+        i = save;
+        break;
+      }
+      skipSpace();
+      readToken();
+      parseSignal(msg);
+    }
+
+    // A signal that runs past the declared payload is a warning, never a
+    // rejection: it is common enough in real files (and universal in the
+    // VECTOR__INDEPENDENT_SIG_MSG body) that refusing it would lose whole
+    // databases. Bits past the end of a received frame simply read as zero.
+    // Reported once per message rather than once per signal.
+    {
+      int worst = 0;
+      const char* worstName = nullptr;
+      for(const auto& sg : msg.signals)
+      {
+        const int lastBit
+            = (sg.byteOrder == ByteOrder::LittleEndian)
+                  ? sg.startBit + sg.length - 1
+                  : flipBitPos(flipBitPos(sg.startBit) + sg.length - 1);
+        const int neededBytes = lastBit / 8 + 1;
+        if(neededBytes > msg.size && neededBytes > worst)
+        {
+          worst = neededBytes;
+          worstName = sg.name.c_str();
+        }
+      }
+      if(worstName && msg.name != independentSignalMessage)
+        warnAt(
+            recordStart, "message " + msg.name + " declares " + std::to_string(msg.size)
+                             + " bytes but signal " + worstName + " needs "
+                             + std::to_string(worst));
+    }
+
+    // Not a message: Vector's holding pen for the signals that are defined in
+    // the database but attached to no frame. Its identifier is meaningless and
+    // its signals all start at bit 0, so letting it through would create a
+    // bogus node full of overlapping parameters.
+    if(msg.name == independentSignalMessage)
+      return;
+
+    if(const auto* dup = db.findMessage(msg.id, msg.extended))
+    {
+      warnAt(
+          recordStart, "duplicate message id " + std::to_string(msg.id) + " ("
+                           + msg.name + " and " + dup->name + "); keeping the first");
+      return;
+    }
+
+    db.messages.push_back(std::move(msg));
+  }
+
+  void parseSignal(Message& msg)
+  {
+    const std::size_t recordStart = i;
+    Signal sig;
+
+    skipBlanks();
+    sig.name = std::string(readIdent());
+    if(sig.name.empty())
+    {
+      warnAt(recordStart, "SG_ without a name");
+      skipLine();
+      return;
+    }
+
+    skipBlanks();
+    // Optional multiplexing indicator between the name and the colon:
+    // `M` for the multiplexer switch, `m<n>` for a multiplexed signal, and
+    // `m<n>M` for a signal that is both (extended multiplexing).
+    if(cur() != ':')
+    {
+      const auto tok = readToken();
+      if(!tok.empty() && tok != ":")
+      {
+        std::string_view t = tok;
+        // Tolerate `m3:` written without a space before the colon.
+        if(!t.empty() && t.back() == ':')
+        {
+          t.remove_suffix(1);
+          --i; // give the colon back to expectChar below
+        }
+
+        if(t == "M")
+        {
+          sig.isMultiplexer = true;
+        }
+        else if(t.size() >= 2 && t.front() == 'm')
+        {
+          sig.isMultiplexed = true;
+          if(t.back() == 'M')
+          {
+            sig.isMultiplexer = true;
+            t.remove_suffix(1);
+          }
+          sig.multiplexValue = std::strtoll(std::string(t.substr(1)).c_str(), nullptr, 10);
+        }
+        else if(!t.empty())
+        {
+          warnAt(recordStart, "unknown multiplexing indicator '" + std::string(t)
+                                  + "' on signal " + sig.name);
+        }
+      }
+    }
+
+    if(!expectChar(':', "SG_ " + sig.name))
+    {
+      skipLine();
+      return;
+    }
+
+    bool ok = false;
+    sig.startBit = int(readInt(&ok));
+    if(!ok)
+    {
+      warnAt(recordStart, "SG_ " + sig.name + ": missing start bit");
+      skipLine();
+      return;
+    }
+    expectChar('|', "SG_ " + sig.name);
+    sig.length = int(readInt(&ok));
+    if(!ok)
+    {
+      warnAt(recordStart, "SG_ " + sig.name + ": missing length");
+      skipLine();
+      return;
+    }
+    expectChar('@', "SG_ " + sig.name);
+
+    skipBlanks();
+    const char order = cur();
+    if(order == '0' || order == '1')
+    {
+      sig.byteOrder = (order == '0') ? ByteOrder::BigEndian : ByteOrder::LittleEndian;
+      ++i;
+    }
+    else
+    {
+      warnAt(recordStart, "SG_ " + sig.name + ": unknown byte order, assuming Intel");
+    }
+
+    const char sign = cur();
+    if(sign == '+' || sign == '-')
+    {
+      sig.valueType = (sign == '-') ? ValueType::Signed : ValueType::Unsigned;
+      ++i;
+    }
+    else
+    {
+      warnAt(recordStart, "SG_ " + sig.name + ": missing sign, assuming unsigned");
+    }
+
+    expectChar('(', "SG_ " + sig.name);
+    sig.factor = readDouble();
+    expectChar(',', "SG_ " + sig.name);
+    sig.offset = readDouble();
+    expectChar(')', "SG_ " + sig.name);
+
+    expectChar('[', "SG_ " + sig.name);
+    sig.min = readDouble();
+    expectChar('|', "SG_ " + sig.name);
+    sig.max = readDouble();
+    expectChar(']', "SG_ " + sig.name);
+
+    sig.unit = readQuoted();
+
+    // Receivers run to the end of the line, comma-separated. `Vector__XXX` is
+    // the placeholder CANdb++ writes for "nobody in particular".
+    skipBlanks();
+    while(i < s.size() && s[i] != '\n' && s[i] != '\r')
+    {
+      auto r = readIdent();
+      if(r.empty())
+      {
+        // A comma or a stray character. Stepping over it must never step over
+        // the end of the line, or the receiver list would swallow the file.
+        ++i;
+      }
+      else if(r != "Vector__XXX")
+      {
+        sig.receivers.emplace_back(r);
+      }
+      // Only spaces and tabs: a CR is the end of the line here, not a blank.
+      while(i < s.size() && (s[i] == ' ' || s[i] == '\t'))
+        ++i;
+    }
+    skipLine();
+
+    // Validation. None of these are fatal for the file, only for the signal.
+    if(sig.length <= 0 || sig.length > 64)
+    {
+      warnAt(
+          recordStart, "SG_ " + sig.name + ": length " + std::to_string(sig.length)
+                           + " out of the 1..64 range; signal dropped");
+      return;
+    }
+    if(sig.startBit < 0)
+    {
+      warnAt(recordStart, "SG_ " + sig.name + ": negative start bit; signal dropped");
+      return;
+    }
+    if(sig.factor == 0.)
+    {
+      // Legal, and occasionally deliberate, but it collapses every raw value
+      // onto the offset -- worth saying out loud.
+      warnAt(recordStart, "SG_ " + sig.name + ": factor is 0, every value decodes to the offset");
+    }
+
+    // `[0|0]` is how CANdb++ spells "no range given"; it is not a real domain
+    // and must not be pushed onto a parameter as one.
+    sig.hasRange = !(sig.min == 0. && sig.max == 0.);
+    if(sig.hasRange && sig.min > sig.max)
+    {
+      warnAt(recordStart, "SG_ " + sig.name + ": min > max; range ignored");
+      sig.hasRange = false;
+    }
+
+    if(msg.findSignal(sig.name))
+    {
+      warnAt(
+          recordStart,
+          "duplicate signal name " + sig.name + " in message " + msg.name
+              + "; keeping the first");
+      return;
+    }
+
+    msg.signals.push_back(std::move(sig));
+  }
+
+  //! Look up a message by its raw (unmasked) DBC identifier, as written in the
+  //! CM_/VAL_/BA_/SIG_VALTYPE_ back-references.
+  Message* messageByRawId(int64_t rawId)
+  {
+    const auto raw = uint32_t(rawId);
+    const bool ext = (raw & dbcExtendedFlag) != 0;
+    const uint32_t id = raw & dbcIdentifierMask;
+    for(auto& m : db.messages)
+      if(m.id == id && m.extended == ext)
+        return &m;
+    return nullptr;
+  }
+
+  Signal* signalByRawId(int64_t rawId, std::string_view name)
+  {
+    if(auto* m = messageByRawId(rawId))
+      for(auto& sg : m->signals)
+        if(sg.name == name)
+          return &sg;
+    return nullptr;
+  }
+
+  //! True when the reference points at the independent-signal pseudo-message,
+  //! which was deliberately dropped -- so a failed lookup is expected and must
+  //! not produce a warning.
+  bool isIndependentSignalRef(int64_t rawId) const noexcept
+  {
+    return uint32_t(rawId) == (dbcExtendedFlag | 0x40000000u);
+  }
+
+  void parseComment()
+  {
+    const std::size_t recordStart = i;
+    skipSpace();
+    const auto kind = peekToken();
+
+    if(kind == "BO_")
+    {
+      skipSpace();
+      readToken();
+      skipSpace();
+      const int64_t id = readInt();
+      auto text = readQuoted();
+      skipStatement();
+      if(auto* m = messageByRawId(id))
+        m->comment = std::move(text);
+      else if(!isIndependentSignalRef(id))
+        warnAt(recordStart, "CM_ BO_ for unknown message " + std::to_string(id));
+    }
+    else if(kind == "SG_")
+    {
+      skipSpace();
+      readToken();
+      skipSpace();
+      const int64_t id = readInt();
+      skipSpace();
+      const auto name = std::string(readIdent());
+      auto text = readQuoted();
+      skipStatement();
+      if(auto* sg = signalByRawId(id, name))
+        sg->comment = std::move(text);
+      else if(!isIndependentSignalRef(id))
+        warnAt(
+            recordStart,
+            "CM_ SG_ for unknown signal " + name + " in message " + std::to_string(id));
+    }
+    else if(kind == "BU_" || kind == "EV_")
+    {
+      // Node and environment-variable comments: consumed, nothing in the node
+      // tree corresponds to them.
+      skipStatement();
+    }
+    else
+    {
+      // `CM_ "text";` -- a comment on the database itself.
+      db.comment = readQuoted();
+      skipStatement();
+    }
+  }
+
+  void parseValues()
+  {
+    const std::size_t recordStart = i;
+    skipSpace();
+
+    // `VAL_ <msgid> <signal> ...` for a signal, `VAL_ <envvar> ...` for an
+    // environment variable. Only the former starts with a number.
+    if(!isNumberChar(cur()))
+    {
+      skipStatement(); // environment variable: no node tree counterpart
+      return;
+    }
+
+    const int64_t id = readInt();
+    skipSpace();
+    const auto name = std::string(readIdent());
+
+    skipSpace();
+    std::vector<ValueDescription> values;
+    if(isNumberChar(cur()))
+    {
+      values = parseValueDescriptionList();
+    }
+    else
+    {
+      // Dialect: the enumeration can be given by VAL_TABLE_ name instead of
+      // being spelled out.
+      const auto table = std::string(readIdent());
+      if(auto it = valueTables.find(table); it != valueTables.end())
+        values = it->second;
+      else if(!table.empty())
+        warnAt(recordStart, "VAL_ refers to unknown value table " + table);
+    }
+    skipStatement();
+
+    if(auto* sg = signalByRawId(id, name))
+      sg->valueTable = std::move(values);
+    else if(!isIndependentSignalRef(id))
+      warnAt(
+          recordStart,
+          "VAL_ for unknown signal " + name + " in message " + std::to_string(id));
+  }
+
+  void parseSignalValueType()
+  {
+    const std::size_t recordStart = i;
+    skipSpace();
+    const int64_t id = readInt();
+    skipSpace();
+    const auto name = std::string(readIdent());
+    // The colon is written by most tools but is absent in some dialects.
+    consumeChar(':');
+    skipSpace();
+    const int64_t type = readInt();
+    skipStatement();
+
+    auto* sg = signalByRawId(id, name);
+    if(!sg)
+    {
+      if(!isIndependentSignalRef(id))
+        warnAt(
+            recordStart, "SIG_VALTYPE_ for unknown signal " + name + " in message "
+                             + std::to_string(id));
+      return;
+    }
+
+    switch(type)
+    {
+      case 0:
+        break; // integer: keep the sign from the SG_ line
+      case 1:
+        if(sg->length != 32)
+          warnAt(
+              recordStart,
+              "SIG_VALTYPE_ declares " + name + " a float but its length is "
+                  + std::to_string(sg->length) + ", not 32");
+        sg->valueType = ValueType::Float32;
+        break;
+      case 2:
+        if(sg->length != 64)
+          warnAt(
+              recordStart,
+              "SIG_VALTYPE_ declares " + name + " a double but its length is "
+                  + std::to_string(sg->length) + ", not 64");
+        sg->valueType = ValueType::Double64;
+        break;
+      default:
+        warnAt(recordStart, "SIG_VALTYPE_ with unknown type " + std::to_string(type));
+        break;
+    }
+  }
+
+  void parseAttributeDefinition(bool relation)
+  {
+    const std::size_t recordStart = i;
+    AttributeDefinition def;
+
+    skipSpace();
+    if(cur() != '"')
+      def.objectKind = std::string(readIdent());
+
+    def.name = readQuoted();
+    skipSpace();
+    def.type = std::string(readIdent());
+
+    if(def.type == "ENUM")
+    {
+      while(i < s.size())
+      {
+        skipSpace();
+        if(cur() != '"')
+          break;
+        def.enumValues.push_back(readQuoted());
+        skipSpace();
+        if(cur() == ',')
+          ++i;
+        else
+          break;
+      }
+    }
+    skipStatement();
+
+    if(def.name.empty())
+    {
+      warnAt(recordStart, "BA_DEF_ without a name");
+      return;
+    }
+    // Relation attributes (BA_DEF_REL_) describe node-to-message relations,
+    // which have no counterpart here; their definitions are kept out of the
+    // table so that a BA_REL_ cannot be mistaken for an object attribute.
+    if(!relation)
+      attributeDefs[def.name] = std::move(def);
+  }
+
+  //! Read an attribute value, which is either a quoted string or a number.
+  std::string readAttributeValue()
+  {
+    skipSpace();
+    if(cur() == '"')
+      return readQuoted();
+
+    const auto tok = readNumberToken();
+    if(!tok.empty())
+      return std::string(tok);
+
+    return std::string(readIdent());
+  }
+
+  void parseAttributeDefault()
+  {
+    skipSpace();
+    const auto name = readQuoted();
+    auto value = readAttributeValue();
+    skipStatement();
+    if(name.empty())
+      return;
+
+    if(auto it = attributeDefs.find(name); it != attributeDefs.end())
+      defaults[name] = std::move(value);
+  }
+
+  std::unordered_map<std::string, std::string> defaults;
+
+  //! Resolve a BA_ value: for an ENUM attribute the file carries the *index*
+  //! into the enumeration, not the text, so it is mapped back here.
+  std::string resolveAttributeValue(const std::string& name, std::string value)
+  {
+    auto it = attributeDefs.find(name);
+    if(it == attributeDefs.end() || it->second.type != "ENUM")
+      return value;
+    if(value.empty() || !isNumberChar(value.front()))
+      return value; // already textual
+
+    const long idx = std::strtol(value.c_str(), nullptr, 10);
+    if(idx >= 0 && std::size_t(idx) < it->second.enumValues.size())
+      return it->second.enumValues[std::size_t(idx)];
+    return value;
+  }
+
+  void parseAttribute()
+  {
+    const std::size_t recordStart = i;
+    skipSpace();
+    const auto name = readQuoted();
+
+    skipSpace();
+    const auto kind = peekToken();
+
+    if(kind == "BO_")
+    {
+      skipSpace();
+      readToken();
+      skipSpace();
+      const int64_t id = readInt();
+      auto value = resolveAttributeValue(name, readAttributeValue());
+      skipStatement();
+      if(auto* m = messageByRawId(id))
+        m->attributes.attributes.push_back({name, std::move(value)});
+      else if(!isIndependentSignalRef(id))
+        warnAt(recordStart, "BA_ for unknown message " + std::to_string(id));
+    }
+    else if(kind == "SG_")
+    {
+      skipSpace();
+      readToken();
+      skipSpace();
+      const int64_t id = readInt();
+      skipSpace();
+      const auto sigName = std::string(readIdent());
+      auto value = resolveAttributeValue(name, readAttributeValue());
+      skipStatement();
+      if(auto* sg = signalByRawId(id, sigName))
+        sg->attributes.attributes.push_back({name, std::move(value)});
+      else if(!isIndependentSignalRef(id))
+        warnAt(recordStart, "BA_ for unknown signal " + sigName);
+    }
+    else if(kind == "BU_" || kind == "EV_")
+    {
+      skipStatement();
+    }
+    else
+    {
+      auto value = resolveAttributeValue(name, readAttributeValue());
+      skipStatement();
+      db.attributes.attributes.push_back({name, std::move(value)});
+    }
+  }
+
+  void parseExtendedMultiplexing()
+  {
+    // `SG_MUL_VAL_ <msgid> <multiplexed> <multiplexor> <a>-<b>, <c>-<d>;`
+    //
+    // Extended multiplexing allows several multiplexor signals per message and
+    // value *ranges* per multiplexed signal. Decoding it is not implemented, so
+    // the record is reported rather than dropped in silence: a message that
+    // uses it would otherwise decode its multiplexed signals unconditionally
+    // and produce plausible-looking rubbish.
+    const std::size_t recordStart = i;
+    skipSpace();
+    const int64_t id = readInt();
+    skipSpace();
+    const auto sigName = std::string(readIdent());
+    skipStatement();
+
+    warnAt(
+        recordStart,
+        "SG_MUL_VAL_ (extended multiplexing) on signal " + sigName + " of message "
+            + std::to_string(id)
+            + " is not supported; that signal will be decoded unconditionally");
+  }
+
+  // ------------------------------------------------------------------- drive
+
+  void run()
+  {
+    while(i < s.size())
+    {
+      skipSpace();
+      if(i >= s.size())
+        break;
+
+      const std::size_t recordStart = i;
+      const auto kw = readIdent();
+
+      if(kw.empty())
+      {
+        // Not an identifier at all: a stray character. Skip the line rather
+        // than spin.
+        skipLine();
+        continue;
+      }
+
+      if(kw == "VERSION")
+        parseVersion();
+      else if(kw == "NS_")
+        parseNamespaceSection();
+      else if(kw == "BS_")
+        skipLine(); // bit timing, obsolete and always empty in practice
+      else if(kw == "BU_")
+        parseNodes();
+      else if(kw == "VAL_TABLE_")
+        parseValueTable();
+      else if(kw == "BO_")
+        parseMessage();
+      else if(kw == "CM_")
+        parseComment();
+      else if(kw == "VAL_")
+        parseValues();
+      else if(kw == "SIG_VALTYPE_")
+        parseSignalValueType();
+      else if(kw == "BA_DEF_")
+        parseAttributeDefinition(false);
+      else if(kw == "BA_DEF_REL_")
+        parseAttributeDefinition(true);
+      else if(kw == "BA_DEF_DEF_" || kw == "BA_DEF_DEF_REL_")
+        parseAttributeDefault();
+      else if(kw == "BA_")
+        parseAttribute();
+      else if(kw == "SG_MUL_VAL_")
+        parseExtendedMultiplexing();
+      else if(kw == "SG_")
+      {
+        warnAt(recordStart, "SG_ outside of a message");
+        skipLine();
+      }
+      else if(
+          kw == "BO_TX_BU_" || kw == "EV_" || kw == "ENVVAR_DATA_" || kw == "SIG_GROUP_"
+          || kw == "SGTYPE_" || kw == "SIG_TYPE_REF_" || kw == "BA_REL_"
+          || kw == "BA_DEF_SGTYPE_" || kw == "BA_SGTYPE_" || kw == "SIGTYPE_VALTYPE_"
+          || kw == "CAT_DEF_" || kw == "CAT_" || kw == "FILTER" || kw == "BU_SG_REL_"
+          || kw == "BU_EV_REL_" || kw == "BU_BO_REL_")
+      {
+        // Known, understood, and irrelevant to decoding a frame into a node
+        // tree. Reported once per kind so that the user is never left guessing
+        // why part of their file had no effect.
+        warnKindOnce(
+            std::string(kw),
+            std::string(kw) + " records are parsed but not used for decoding");
+        skipStatement();
+      }
+      else
+      {
+        warnKindOnce(
+            std::string(kw), "unknown DBC construct '" + std::string(kw) + "', skipped");
+        skipStatement();
+      }
+    }
+  }
+};
+
+}
+
+/**
+ * Preprocess the file: drop carriage returns and source comments.
+ *
+ * Both are done here, once, rather than taught to every loop in the parser.
+ *
+ * CRLF: vendor files really are CRLF -- both LPMS files are -- and a '\r'
+ * treated as a blank rather than as end-of-line turns a line-terminated
+ * construct (a BU_ node list, a SG_ receiver list) into one that runs to the
+ * end of the file.
+ *
+ * Comments: line comments and block comments are not in the Vector
+ * format, but they occur in real files and two of the major readers accept
+ * them. They cannot be stripped with a plain scan, because a unit or a comment
+ * string may legitimately contain "//" -- so this walks strings and comments
+ * with the same state machine.
+ *
+ * Every removed byte is either dropped or replaced by nothing *except*
+ * newlines, which are always kept: the line numbers in the diagnostics must
+ * stay those of the file the user is looking at.
+ */
+static std::string preprocess(std::string_view content)
+{
+  std::string out;
+  out.reserve(content.size());
+
+  enum
+  {
+    Code,
+    Str,
+    LineComment,
+    BlockComment
+  } state
+      = Code;
+
+  for(std::size_t i = 0; i < content.size(); ++i)
+  {
+    const char c = content[i];
+    const char n = (i + 1 < content.size()) ? content[i + 1] : '\0';
+
+    switch(state)
+    {
+      case Code:
+        if(c == '"')
+        {
+          state = Str;
+          out.push_back(c);
+        }
+        else if(c == '/' && n == '/')
+        {
+          state = LineComment;
+          ++i;
+        }
+        else if(c == '/' && n == '*')
+        {
+          state = BlockComment;
+          ++i;
+        }
+        else if(c != '\r')
+        {
+          out.push_back(c);
+        }
+        break;
+
+      case Str:
+        // Inside a string nothing is a comment and nothing is an escape except
+        // a backslash, which is copied together with whatever follows it so
+        // that \" does not end the string here.
+        if(c == '\\' && n != '\0')
+        {
+          out.push_back(c);
+          out.push_back(n);
+          ++i;
+        }
+        else if(c == '"')
+        {
+          state = Code;
+          out.push_back(c);
+        }
+        else if(c != '\r')
+        {
+          out.push_back(c);
+        }
+        break;
+
+      case LineComment:
+        if(c == '\n')
+        {
+          state = Code;
+          out.push_back(c);
+        }
+        break;
+
+      case BlockComment:
+        if(c == '*' && n == '/')
+        {
+          state = Code;
+          ++i;
+        }
+        else if(c == '\n')
+        {
+          // Keep the newline so the line numbering survives.
+          out.push_back(c);
+        }
+        break;
+    }
+  }
+
+  return out;
+}
+
+Database parseDBC(std::string_view content)
+{
+  const std::string normalized = preprocess(content);
+  content = normalized;
+
+  Parser p{.s = content};
+  p.run();
+
+  // Fold in the BA_DEF_DEF_ defaults for the attributes that no BA_ set. Done
+  // once at the end rather than per record so that a default cannot overwrite
+  // an explicit value regardless of the order they appear in the file.
+  auto applyDefaults = [&](AttributeSet& set) {
+    for(auto& [name, value] : p.defaults)
+      if(!set.find(name))
+        set.attributes.push_back({name, value});
+  };
+  applyDefaults(p.db.attributes);
+
+  return std::move(p.db);
+}
+
+Database parseDBCFile(const std::string& path)
+{
+  std::ifstream f{path, std::ios::binary};
+  if(!f)
+  {
+    Database db;
+    db.warnings.push_back("could not open " + path);
+    return db;
+  }
+
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  const auto content = ss.str();
+
+  auto db = parseDBC(content);
+  if(db.messages.empty() && db.warnings.empty())
+    db.warnings.push_back(path + " defines no message");
+  return db;
+}
+
+void applyNodeIdOffset(Database& db, int32_t offset)
+{
+  if(offset == 0)
+    return;
+
+  for(auto& m : db.messages)
+  {
+    const int64_t shifted = int64_t(m.id) + offset;
+    // A standard identifier is 11 bits, an extended one 29. Wrapping or
+    // truncating would silently point the message at a different device, which
+    // is worse than leaving it where the file put it.
+    const int64_t limit = m.extended ? int64_t(dbcIdentifierMask) : 0x7FF;
+    if(shifted < 0 || shifted > limit)
+    {
+      db.warnings.push_back(
+          "node id offset " + std::to_string(offset) + " puts message " + m.name
+          + " outside the identifier range; left at " + std::to_string(m.id));
+      continue;
+    }
+    m.id = uint32_t(shifted);
+  }
+}
+
+void applyFloat32Override(Database& db)
+{
+  for(auto& m : db.messages)
+    for(auto& sg : m.signals)
+    {
+      // Only integer signals: a SIG_VALTYPE_ record is an explicit statement by
+      // the file's author and outranks this heuristic.
+      const bool isInteger
+          = sg.valueType == ValueType::Signed || sg.valueType == ValueType::Unsigned;
+      if(isInteger && sg.length == 32)
+        sg.valueType = ValueType::Float32;
+    }
+}
+
+}

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.cpp
@@ -9,35 +9,17 @@
 #include <unordered_set>
 
 /**
- * Why this is a hand-written recursive-descent parser and not a Spirit X3
- * grammar, given that X3 is available and used elsewhere in the tree
- * (ossia/protocols/coap/link_format_parser.cpp, ValueParser.hpp...):
+ * Hand-written rather than a Spirit X3 grammar, though X3 is used elsewhere in
+ * the tree:
  *
- *  - The NS_ block makes the file non-dispatchable by leading keyword. It is a
- *    bare list of the *same* tokens as the top-level constructs -- a real file
- *    opens with `NS_ :` and then lines reading `CM_`, `BA_DEF_`, `VAL_`,
- *    `SIG_VALTYPE_`, `SG_MUL_VAL_`... An alternation over the constructs would
- *    start parsing the NS_ entries as records and fail. Handling it needs a
- *    stateful "am I inside NS_" switch in the top-level loop, which is exactly
- *    the thing a declarative grammar is supposed to remove.
- *
- *  - Per-record error recovery is a requirement here, not a nicety: vendor
- *    files carry typos and dialect variants, and the contract for this parser
- *    is to keep going and *name* what it could not read (Database::warnings).
- *    X3 reports failure as one boolean plus an iterator; getting a diagnostic
- *    per record means either an on_error handler on every rule or invoking the
- *    parser once per record from a hand-written loop.
- *
- *  - DBC is line-sensitive in two places (the NS_ block ends at a blank line,
- *    a BU_ node list and a SG_ receiver list end at the newline) and free-form
- *    everywhere else, so no single X3 skipper fits.
- *
- *  - There is no recursion in the grammar. Message/signal nesting is one level
- *    deep, everything else is flat, so a parser generator has no structure to
- *    exploit -- and X3's compile-time cost is real.
- *
- * The lexical layer below is the only genuinely fiddly part, and it is ~120
- * lines.
+ *  - The NS_ block is a bare list of the same tokens as the top-level
+ *    constructs, so the file is not dispatchable by leading keyword without a
+ *    stateful "inside NS_" switch.
+ *  - Vendor files carry typos, and the contract is to keep going and name what
+ *    could not be read (Database::warnings). X3 reports failure as a bool.
+ *  - DBC is line-sensitive in two places and free-form elsewhere, so no single
+ *    skipper fits.
+ *  - The grammar has no recursion to exploit.
  */
 
 namespace Protocols::CAN

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.hpp
@@ -1,0 +1,305 @@
+#pragma once
+
+/**
+ * @file A small, dependency-free reader for Vector DBC (CAN database) files.
+ *
+ * Scope: what a DBC needs to *decode* a bus. See DBCParser.cpp for the list of
+ * constructs that are parsed, tolerated-and-skipped, or unsupported.
+ *
+ * This header is deliberately free of Qt, of ossia and of anything Linux, so
+ * that the parser and the bit extraction can be unit-tested on their own -- the
+ * protocol side of the CAN device is Linux-only, the file format is not.
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Protocols::CAN
+{
+
+//! Bit numbering of a signal inside a frame.
+enum class ByteOrder
+{
+  //! `@0` in the file. The start bit is the position of the signal's *most*
+  //! significant bit, and the following bits run towards the end of the frame.
+  BigEndian,
+
+  //! `@1` in the file. The start bit is the position of the signal's *least*
+  //! significant bit, and the following bits run towards the end of the frame.
+  LittleEndian
+};
+
+//! How the extracted bits are to be read as a number.
+enum class ValueType
+{
+  Unsigned,  //!< `+` in the file
+  Signed,    //!< `-` in the file, two's complement
+  Float32,   //!< SIG_VALTYPE_ ... 1
+  Double64   //!< SIG_VALTYPE_ ... 2
+};
+
+//! One entry of a VAL_ / VAL_TABLE_ enumeration.
+struct ValueDescription
+{
+  int64_t value{};
+  std::string name;
+};
+
+/**
+ * A BA_ attribute, resolved to text.
+ *
+ * Attributes are a free-form extension mechanism: the type of each one is
+ * declared by a BA_DEF_ elsewhere in the file and there is no fixed vocabulary,
+ * so they are kept verbatim and left for the caller to interpret. The common
+ * ones are "GenMsgCycleTime" on a message and "BusType" on the database.
+ */
+struct Attribute
+{
+  std::string name;
+  std::string value;
+};
+
+//! Attributes attached to one object, with the BA_DEF_DEF_ defaults folded in.
+struct AttributeSet
+{
+  std::vector<Attribute> attributes;
+
+  //! nullptr when the attribute is neither set nor defaulted.
+  const std::string* find(std::string_view name) const noexcept;
+};
+
+struct Signal
+{
+  std::string name;
+  std::string unit;
+  std::string comment;
+  std::vector<std::string> receivers;
+
+  //! Position of the signal's LSB (little-endian) or MSB (big-endian) in the
+  //! DBC bit numbering: bit `p` is bit `p % 8` (LSB = 0) of byte `p / 8`.
+  int startBit{};
+
+  //! 1 to 64.
+  int length{1};
+
+  ByteOrder byteOrder{ByteOrder::LittleEndian};
+  ValueType valueType{ValueType::Unsigned};
+
+  double factor{1.};
+  double offset{0.};
+  double min{};
+  double max{};
+
+  //! `[min|max]` was `[0|0]`, i.e. the file states no range. Very common: a
+  //! degenerate domain must not be pushed onto the parameter.
+  bool hasRange{};
+
+  //! `M` in the file: this signal selects which multiplexed signals of the
+  //! message are present in a given frame.
+  bool isMultiplexer{};
+
+  //! `m<N>` in the file: this signal is only present in frames whose
+  //! multiplexer signal carries the value `multiplexValue`.
+  bool isMultiplexed{};
+  int64_t multiplexValue{};
+
+  std::vector<ValueDescription> valueTable;
+
+  AttributeSet attributes;
+};
+
+struct Message
+{
+  //! Identifier with the DBC extended-id flag (bit 31) removed and masked to
+  //! 29 bits. Never compare this alone: `{id, extended}` is the key, as a
+  //! standard and an extended frame may carry the same numeric identifier.
+  uint32_t id{};
+
+  //! Bit 31 of the raw DBC identifier.
+  bool extended{};
+
+  std::string name;
+  std::string comment;
+  std::string transmitter;
+
+  //! Declared payload length in bytes (the DBC "DLC").
+  int size{};
+
+  std::vector<Signal> signals;
+
+  AttributeSet attributes;
+
+  const Signal* findSignal(std::string_view name) const noexcept;
+};
+
+struct Database
+{
+  std::vector<Message> messages;
+
+  //! `CM_ "..."` at file scope.
+  std::string comment;
+
+  //! DBC "VERSION" record.
+  std::string version;
+
+  AttributeSet attributes;
+
+  //! Non-fatal problems: unknown constructs, references to unknown messages or
+  //! signals, out-of-range values. Parsing never fails on these -- real vendor
+  //! files contain typos and dialect quirks, and refusing the file over one
+  //! bad line would be worse than decoding the other 99% of it.
+  std::vector<std::string> warnings;
+
+  const Message* findMessage(uint32_t id, bool extended) const noexcept;
+};
+
+//! The magic message name under which Vector CANdb++ parks the signals that are
+//! defined in the database but not assigned to any frame. It is not a message
+//! and must never become part of the node tree.
+inline constexpr const char* independentSignalMessage = "VECTOR__INDEPENDENT_SIG_MSG";
+
+//! Bit 31 of a raw DBC identifier marks a 29-bit (extended) identifier.
+inline constexpr uint32_t dbcExtendedFlag = 0x80000000u;
+inline constexpr uint32_t dbcIdentifierMask = 0x1FFFFFFFu;
+
+//! Parse a DBC held in memory. Never throws; see Database::warnings.
+Database parseDBC(std::string_view content);
+
+//! Parse a DBC from disk. On failure the database is empty and a warning
+//! explains why.
+Database parseDBCFile(const std::string& path);
+
+/**
+ * Convert a DBC bit position to its "MSB-first sequential" index and back.
+ *
+ * DBC numbers bits inside a byte from the LSB (0) to the MSB (7), but a
+ * big-endian signal runs from its MSB *downwards* inside a byte and then
+ * continues in the next byte. Flipping the low three bits of the position maps
+ * that discontinuous walk onto plain increments: in flipped space, index 0 is
+ * the MSB of byte 0, index 7 its LSB, index 8 the MSB of byte 1, and so on.
+ *
+ * The mapping is an involution: flipBitPos(flipBitPos(p)) == p.
+ */
+constexpr int flipBitPos(int p) noexcept
+{
+  return (p & ~7) | (7 - (p & 7));
+}
+
+/**
+ * Extract `length` raw bits of a signal, right-aligned and zero-extended.
+ *
+ * Bits that fall outside the frame read as zero rather than out of bounds: a
+ * device may legitimately send a frame shorter than the DLC the database
+ * declares, and dropping the whole frame over it would lose the signals that
+ * *are* present.
+ */
+inline uint64_t
+extractRawBits(const uint8_t* data, int dataSize, int startBit, int length, ByteOrder order) noexcept
+{
+  if(length <= 0 || length > 64)
+    return 0;
+
+  const int frameBits = dataSize * 8;
+  uint64_t out = 0;
+
+  // Walk the value from its MSB down to its LSB, so that each step is a plain
+  // shift-in. `k` is the significance of the bit being read.
+  for(int k = length - 1; k >= 0; --k)
+  {
+    int pos;
+    if(order == ByteOrder::LittleEndian)
+    {
+      // The start bit is the LSB and significance grows with the position.
+      pos = startBit + k;
+    }
+    else
+    {
+      // The start bit is the MSB; significance grows *backwards* along the
+      // flipped axis, on which the signal's bits are contiguous.
+      pos = flipBitPos(flipBitPos(startBit) + (length - 1 - k));
+    }
+
+    out <<= 1;
+    if(pos >= 0 && pos < frameBits)
+      out |= uint64_t((data[pos >> 3] >> (pos & 7)) & 1u);
+  }
+
+  return out;
+}
+
+//! Interpret `length` right-aligned bits as a two's-complement number.
+constexpr int64_t signExtend(uint64_t raw, int length) noexcept
+{
+  if(length <= 0 || length >= 64)
+    return int64_t(raw);
+
+  const uint64_t signBit = uint64_t(1) << (length - 1);
+  if(raw & signBit)
+    return int64_t(raw | ~((uint64_t(1) << length) - 1));
+  return int64_t(raw);
+}
+
+//! Extract one signal from a frame and apply its value type, factor and offset.
+inline double decodeSignal(const Signal& sig, const uint8_t* data, int dataSize) noexcept
+{
+  const uint64_t raw = extractRawBits(data, dataSize, sig.startBit, sig.length, sig.byteOrder);
+
+  double physical{};
+  switch(sig.valueType)
+  {
+    case ValueType::Float32: {
+      const auto bits = uint32_t(raw);
+      float f{};
+      std::memcpy(&f, &bits, sizeof(f));
+      physical = double(f);
+      break;
+    }
+    case ValueType::Double64: {
+      double d{};
+      std::memcpy(&d, &raw, sizeof(d));
+      physical = d;
+      break;
+    }
+    case ValueType::Signed:
+      physical = double(signExtend(raw, sig.length));
+      break;
+    case ValueType::Unsigned:
+      physical = double(raw);
+      break;
+  }
+
+  return physical * sig.factor + sig.offset;
+}
+
+//! The raw, unscaled bits of a signal -- what a multiplexer switch is compared
+//! against, and what the tests use as an oracle.
+inline uint64_t rawSignalBits(const Signal& sig, const uint8_t* data, int dataSize) noexcept
+{
+  return extractRawBits(data, dataSize, sig.startBit, sig.length, sig.byteOrder);
+}
+
+/**
+ * Shift every message identifier of the database by `offset`.
+ *
+ * See CANSpecificSettings::nodeIdOffset: one vendor DBC hardcodes one node id,
+ * and the same file has to serve every device of a chain.
+ *
+ * Messages that would leave the identifier space are left untouched and a
+ * warning is recorded, rather than silently wrapping onto another device.
+ */
+void applyNodeIdOffset(Database& db, int32_t offset);
+
+/**
+ * Reinterpret every 32-bit integer signal as an IEEE 754 single.
+ *
+ * Opt-in and off by default: it exists for databases that declare a float
+ * payload as `32@1-` with a `(1,0)` scaling and no SIG_VALTYPE_ record, which
+ * decodes to garbage as written. Signals that already carry an explicit
+ * SIG_VALTYPE_ float type are untouched.
+ */
+void applyFloat32Override(Database& db);
+
+}

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.hpp
@@ -6,9 +6,9 @@
  * Scope: what a DBC needs to *decode* a bus. See DBCParser.cpp for the list of
  * constructs that are parsed, tolerated-and-skipped, or unsupported.
  *
- * This header is deliberately free of Qt, of ossia and of anything Linux, so
- * that the parser and the bit extraction can be unit-tested on their own -- the
- * protocol side of the CAN device is Linux-only, the file format is not.
+ * Free of Qt, ossia and anything Linux, so the parser and the bit extraction
+ * can be tested on their own: the protocol side is Linux-only, the format is
+ * not.
  */
 
 #include <cstdint>

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/DBCParser.hpp
@@ -35,10 +35,10 @@ enum class ByteOrder
 //! How the extracted bits are to be read as a number.
 enum class ValueType
 {
-  Unsigned,  //!< `+` in the file
-  Signed,    //!< `-` in the file, two's complement
-  Float32,   //!< SIG_VALTYPE_ ... 1
-  Double64   //!< SIG_VALTYPE_ ... 2
+  Unsigned, //!< `+` in the file
+  Signed,   //!< `-` in the file, two's complement
+  Float32,  //!< SIG_VALTYPE_ ... 1
+  Double64  //!< SIG_VALTYPE_ ... 2
 };
 
 //! One entry of a VAL_ / VAL_TABLE_ enumeration.
@@ -196,8 +196,9 @@ constexpr int flipBitPos(int p) noexcept
  * declares, and dropping the whole frame over it would lose the signals that
  * *are* present.
  */
-inline uint64_t
-extractRawBits(const uint8_t* data, int dataSize, int startBit, int length, ByteOrder order) noexcept
+inline uint64_t extractRawBits(
+    const uint8_t* data, int dataSize, int startBit, int length,
+    ByteOrder order) noexcept
 {
   if(length <= 0 || length > 64)
     return 0;
@@ -245,7 +246,8 @@ constexpr int64_t signExtend(uint64_t raw, int length) noexcept
 //! Extract one signal from a frame and apply its value type, factor and offset.
 inline double decodeSignal(const Signal& sig, const uint8_t* data, int dataSize) noexcept
 {
-  const uint64_t raw = extractRawBits(data, dataSize, sig.startBit, sig.length, sig.byteOrder);
+  const uint64_t raw
+      = extractRawBits(data, dataSize, sig.startBit, sig.length, sig.byteOrder);
 
   double physical{};
   switch(sig.valueType)
@@ -276,7 +278,8 @@ inline double decodeSignal(const Signal& sig, const uint8_t* data, int dataSize)
 
 //! The raw, unscaled bits of a signal -- what a multiplexer switch is compared
 //! against, and what the tests use as an oracle.
-inline uint64_t rawSignalBits(const Signal& sig, const uint8_t* data, int dataSize) noexcept
+inline uint64_t
+rawSignalBits(const Signal& sig, const uint8_t* data, int dataSize) noexcept
 {
   return extractRawBits(data, dataSize, sig.startBit, sig.length, sig.byteOrder);
 }

--- a/src/plugins/score-plugin-protocols/Protocols/LibraryDeviceEnumerator.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/LibraryDeviceEnumerator.cpp
@@ -16,9 +16,22 @@ namespace Protocols
 LibraryDeviceEnumerator::LibraryDeviceEnumerator(
     std::string pattern, QStringList ext, Device::ProtocolFactory::ConcreteKey k,
     std::function<QVariant(QByteArray)> createDev, const score::DocumentContext& ctx)
+    : LibraryDeviceEnumerator{
+          std::move(pattern), std::move(ext), k,
+          [createDev = std::move(createDev)](QByteArray arr, const QString&) {
+  return createDev(std::move(arr));
+          },
+          ctx}
+{
+}
+
+LibraryDeviceEnumerator::LibraryDeviceEnumerator(
+    std::string pattern, QStringList ext, Device::ProtocolFactory::ConcreteKey k,
+    std::function<QVariant(QByteArray, const QString&)> createDev,
+    const score::DocumentContext& ctx)
     : m_pattern{std::move(pattern)}
     , m_key{k}
-    , m_createDeviceSettings{createDev}
+    , m_createDeviceSettings{std::move(createDev)}
 {
   m_watch.setWatchedFolder(
       ctx.app.settings<Library::Settings::Model>().getPackagesPath().toStdString());
@@ -44,7 +57,7 @@ void LibraryDeviceEnumerator::next(std::string_view path)
     Device::DeviceSettings s;
     s.name = QFileInfo{filepath}.baseName();
     s.protocol = m_key;
-    s.deviceSpecificSettings = m_createDeviceSettings(score::mapAsByteArray(f));
+    s.deviceSpecificSettings = m_createDeviceSettings(score::mapAsByteArray(f), filepath);
     deviceAdded(s.name, s);
   });
 }
@@ -58,7 +71,7 @@ std::function<void()> LibraryDeviceEnumerator::asyncNext(std::string_view path)
     Device::DeviceSettings s;
     s.name = QFileInfo{filepath}.baseName();
     s.protocol = m_key;
-    s.deviceSpecificSettings = m_createDeviceSettings(score::mapAsByteArray(f));
+    s.deviceSpecificSettings = m_createDeviceSettings(score::mapAsByteArray(f), filepath);
     result = [this, s = std::move(s)]() mutable {
       deviceAdded(s.name, s);
     };

--- a/src/plugins/score-plugin-protocols/Protocols/LibraryDeviceEnumerator.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/LibraryDeviceEnumerator.cpp
@@ -19,9 +19,8 @@ LibraryDeviceEnumerator::LibraryDeviceEnumerator(
     : LibraryDeviceEnumerator{
           std::move(pattern), std::move(ext), k,
           [createDev = std::move(createDev)](QByteArray arr, const QString&) {
-  return createDev(std::move(arr));
-          },
-          ctx}
+            return createDev(std::move(arr));
+          }, ctx}
 {
 }
 
@@ -57,7 +56,8 @@ void LibraryDeviceEnumerator::next(std::string_view path)
     Device::DeviceSettings s;
     s.name = QFileInfo{filepath}.baseName();
     s.protocol = m_key;
-    s.deviceSpecificSettings = m_createDeviceSettings(score::mapAsByteArray(f), filepath);
+    s.deviceSpecificSettings
+        = m_createDeviceSettings(score::mapAsByteArray(f), filepath);
     deviceAdded(s.name, s);
   });
 }
@@ -71,7 +71,8 @@ std::function<void()> LibraryDeviceEnumerator::asyncNext(std::string_view path)
     Device::DeviceSettings s;
     s.name = QFileInfo{filepath}.baseName();
     s.protocol = m_key;
-    s.deviceSpecificSettings = m_createDeviceSettings(score::mapAsByteArray(f), filepath);
+    s.deviceSpecificSettings
+        = m_createDeviceSettings(score::mapAsByteArray(f), filepath);
     result = [this, s = std::move(s)]() mutable {
       deviceAdded(s.name, s);
     };

--- a/src/plugins/score-plugin-protocols/Protocols/LibraryDeviceEnumerator.hpp
+++ b/src/plugins/score-plugin-protocols/Protocols/LibraryDeviceEnumerator.hpp
@@ -16,12 +16,23 @@ class SCORE_PLUGIN_PROTOCOLS_EXPORT LibraryDeviceEnumerator
 public:
   std::string m_pattern;
   Device::ProtocolFactory::ConcreteKey m_key;
-  std::function<QVariant(QByteArray)> m_createDeviceSettings;
+  //! Called with the contents of a matching file and with its path.
+  //!
+  //! Both are needed: most protocols embed the file in their settings, but some
+  //! - CAN, whose settings name a .dbc - only want to remember where it is.
+  std::function<QVariant(QByteArray, const QString&)> m_createDeviceSettings;
   score::RecursiveWatch m_watch;
 
+  //! For settings that embed the file's contents.
   LibraryDeviceEnumerator(
       std::string pattern, QStringList extension, Device::ProtocolFactory::ConcreteKey k,
       std::function<QVariant(QByteArray)> createDev, const score::DocumentContext& ctx);
+
+  //! For settings that reference the file by path.
+  LibraryDeviceEnumerator(
+      std::string pattern, QStringList extension, Device::ProtocolFactory::ConcreteKey k,
+      std::function<QVariant(QByteArray, const QString&)> createDev,
+      const score::DocumentContext& ctx);
 
   void next(std::string_view path);
   std::function<void()> asyncNext(std::string_view path);

--- a/src/plugins/score-plugin-protocols/Tests/CANvcanTest.cpp
+++ b/src/plugins/score-plugin-protocols/Tests/CANvcanTest.cpp
@@ -1,0 +1,230 @@
+/**
+ * End-to-end test of the CAN device's decoding path over a real SocketCAN
+ * interface: a frame is written on `vcan0`, received by a second socket bound
+ * to the same interface, dispatched by (id, extended) through the same kind of
+ * table the protocol builds, and decoded through the DBC.
+ *
+ * This is deliberately *not* the score protocol object: instantiating that
+ * needs a document and a network context, which would turn a decoding test into
+ * an application test. What is exercised here is everything between the wire
+ * and the value -- which is where a byte-order or an identifier-masking mistake
+ * would actually show up.
+ *
+ * Skipped, not failed, when vcan0 is absent: CI machines generally do not have
+ * the vcan module loaded.
+ */
+
+#include <Protocols/CAN/DBCParser.hpp>
+
+#include <ossia/network/sockets/can_socket.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#if defined(__linux__)
+#include <boost/asio/io_context.hpp>
+
+#include <net/if.h>
+#include <sys/ioctl.h>
+
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+using namespace Protocols::CAN;
+
+namespace
+{
+constexpr const char* can_iface = "vcan0";
+
+bool ifacePresent()
+{
+  int fd = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+  if(fd < 0)
+    return false;
+
+  ifreq ifr{};
+  std::strncpy(ifr.ifr_name, can_iface, sizeof(ifr.ifr_name) - 1);
+  const bool ok = ::ioctl(fd, SIOCGIFINDEX, &ifr) == 0;
+  ::close(fd);
+  return ok;
+}
+
+//! Run the io_context until `pred` holds or we give up.
+template <typename F>
+bool spin(boost::asio::io_context& ctx, F pred, int ms = 1000)
+{
+  for(int i = 0; i < ms; i++)
+  {
+    ctx.poll();
+    ctx.restart();
+    if(pred())
+      return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return pred();
+}
+
+std::string dataPath(const char* name)
+{
+  return std::string{SCORE_CAN_TEST_DATA} + "/" + name;
+}
+
+constexpr uint64_t frameKey(uint32_t id, bool extended) noexcept
+{
+  return (uint64_t(extended) << 32) | uint64_t(id);
+}
+}
+
+TEST_CASE("A DBC-described frame decodes off a real CAN bus", "[can][vcan]")
+{
+  if(!ifacePresent())
+  {
+    SUCCEED("skipped: no vcan0 interface (modprobe vcan; ip link add dev vcan0 "
+            "type vcan; ip link set up vcan0)");
+    return;
+  }
+
+  auto db = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  REQUIRE(db.messages.size() == 5);
+
+  // The same dispatch table the protocol builds: keyed on the (id, extended)
+  // pair, built once.
+  std::unordered_map<uint64_t, const Message*> byId;
+  for(const auto& m : db.messages)
+    byId.emplace(frameKey(m.id, m.extended), &m);
+
+  boost::asio::io_context ctx;
+
+  ossia::net::can_configuration conf;
+  conf.interface_name = can_iface;
+
+  ossia::net::can_socket rx{conf, ctx};
+  ossia::net::can_socket tx{conf, ctx};
+  rx.open();
+  tx.open();
+
+  std::vector<ossia::net::can_message> received;
+  rx.receive([&](const ossia::net::can_message& m) { received.push_back(m); });
+
+  // PDO4 at node 1, carrying the documented worked example in W.
+  //   W =  9878 = 0x2696 -> 96 26      X = -1234 = 0xFB2E -> 2E FB
+  //   Y =     0          -> 00 00      Z = 32767 = 0x7FFF -> FF 7F
+  ossia::net::can_message out;
+  out.id = 0x481;
+  out.extended = false;
+  out.size = 8;
+  const uint8_t payload[8] = {0x96, 0x26, 0x2E, 0xFB, 0x00, 0x00, 0xFF, 0x7F};
+  std::memcpy(out.data, payload, 8);
+
+  // A frame that is not in the database, to check it is ignored rather than
+  // decoded as something else.
+  ossia::net::can_message noise;
+  noise.id = 0x123;
+  noise.extended = false;
+  noise.size = 8;
+
+  REQUIRE(!tx.write(out));
+  REQUIRE(!tx.write(noise));
+
+  REQUIRE(spin(ctx, [&] { return received.size() >= 2; }));
+
+  int decoded = 0;
+  int ignored = 0;
+  for(const auto& msg : received)
+  {
+    const auto it = byId.find(frameKey(msg.id, msg.extended));
+    if(it == byId.end())
+    {
+      ++ignored;
+      continue;
+    }
+
+    const Message& m = *it->second;
+    REQUIRE(m.name == "PDO4_Transmit");
+
+    REQUIRE(decodeSignal(*m.findSignal("QuaternionW"), msg.data, msg.size)
+            == Catch::Approx(0.9878));
+    REQUIRE(decodeSignal(*m.findSignal("QuaternionX"), msg.data, msg.size)
+            == Catch::Approx(-0.1234));
+    REQUIRE(decodeSignal(*m.findSignal("QuaternionY"), msg.data, msg.size)
+            == Catch::Approx(0.0));
+    // The vendor's typo, preserved.
+    REQUIRE(decodeSignal(*m.findSignal("QuatetnionZ"), msg.data, msg.size)
+            == Catch::Approx(3.2767));
+    ++decoded;
+  }
+
+  REQUIRE(decoded == 1);
+  REQUIRE(ignored == 1);
+
+  rx.close();
+  tx.close();
+  ctx.poll();
+}
+
+TEST_CASE("The node id offset picks a different device off the same bus", "[can][vcan]")
+{
+  if(!ifacePresent())
+  {
+    SUCCEED("skipped: no vcan0 interface");
+    return;
+  }
+
+  // Two databases from one file: node 1 and node 2. This is the chain-of-
+  // sensors case -- one vendor DBC, N score devices, N offsets.
+  auto node1 = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  auto node2 = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  applyNodeIdOffset(node2, 1);
+
+  REQUIRE(node1.findMessage(0x481, false) != nullptr);
+  REQUIRE(node2.findMessage(0x482, false) != nullptr);
+  REQUIRE(node2.findMessage(0x481, false) == nullptr);
+
+  boost::asio::io_context ctx;
+  ossia::net::can_configuration conf;
+  conf.interface_name = can_iface;
+
+  ossia::net::can_socket rx{conf, ctx};
+  ossia::net::can_socket tx{conf, ctx};
+  rx.open();
+  tx.open();
+
+  std::vector<ossia::net::can_message> received;
+  rx.receive([&](const ossia::net::can_message& m) { received.push_back(m); });
+
+  // The second sensor's PDO4.
+  ossia::net::can_message out;
+  out.id = 0x482;
+  out.size = 8;
+  const uint8_t payload[8] = {0x96, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  std::memcpy(out.data, payload, 8);
+  REQUIRE(!tx.write(out));
+
+  REQUIRE(spin(ctx, [&] { return !received.empty(); }));
+
+  const auto& msg = received.front();
+  REQUIRE(msg.id == 0x482);
+
+  // The node-1 database does not know this frame; the node-2 one does.
+  REQUIRE(node1.findMessage(msg.id, msg.extended) == nullptr);
+
+  const auto* m = node2.findMessage(msg.id, msg.extended);
+  REQUIRE(m != nullptr);
+  REQUIRE(m->name == "PDO4_Transmit");
+  REQUIRE(decodeSignal(*m->findSignal("QuaternionW"), msg.data, msg.size)
+          == Catch::Approx(0.9878));
+
+  rx.close();
+  tx.close();
+  ctx.poll();
+}
+
+#else
+TEST_CASE("CAN over vcan is Linux-only", "[can][vcan]")
+{
+  SUCCEED("skipped: SocketCAN is only available on Linux");
+}
+#endif

--- a/src/plugins/score-plugin-protocols/Tests/CANvcanTest.cpp
+++ b/src/plugins/score-plugin-protocols/Tests/CANvcanTest.cpp
@@ -82,8 +82,9 @@ TEST_CASE("A DBC-described frame decodes off a real CAN bus", "[can][vcan]")
 {
   if(!ifacePresent())
   {
-    SUCCEED("skipped: no vcan0 interface (modprobe vcan; ip link add dev vcan0 "
-            "type vcan; ip link set up vcan0)");
+    SUCCEED(
+        "skipped: no vcan0 interface (modprobe vcan; ip link add dev vcan0 "
+        "type vcan; ip link set up vcan0)");
     return;
   }
 
@@ -145,15 +146,19 @@ TEST_CASE("A DBC-described frame decodes off a real CAN bus", "[can][vcan]")
     const Message& m = *it->second;
     REQUIRE(m.name == "PDO4_Transmit");
 
-    REQUIRE(decodeSignal(*m.findSignal("QuaternionW"), msg.data, msg.size)
-            == Catch::Approx(0.9878));
-    REQUIRE(decodeSignal(*m.findSignal("QuaternionX"), msg.data, msg.size)
-            == Catch::Approx(-0.1234));
-    REQUIRE(decodeSignal(*m.findSignal("QuaternionY"), msg.data, msg.size)
-            == Catch::Approx(0.0));
+    REQUIRE(
+        decodeSignal(*m.findSignal("QuaternionW"), msg.data, msg.size)
+        == Catch::Approx(0.9878));
+    REQUIRE(
+        decodeSignal(*m.findSignal("QuaternionX"), msg.data, msg.size)
+        == Catch::Approx(-0.1234));
+    REQUIRE(
+        decodeSignal(*m.findSignal("QuaternionY"), msg.data, msg.size)
+        == Catch::Approx(0.0));
     // The vendor's typo, preserved.
-    REQUIRE(decodeSignal(*m.findSignal("QuatetnionZ"), msg.data, msg.size)
-            == Catch::Approx(3.2767));
+    REQUIRE(
+        decodeSignal(*m.findSignal("QuatetnionZ"), msg.data, msg.size)
+        == Catch::Approx(3.2767));
     ++decoded;
   }
 
@@ -214,8 +219,9 @@ TEST_CASE("The node id offset picks a different device off the same bus", "[can]
   const auto* m = node2.findMessage(msg.id, msg.extended);
   REQUIRE(m != nullptr);
   REQUIRE(m->name == "PDO4_Transmit");
-  REQUIRE(decodeSignal(*m->findSignal("QuaternionW"), msg.data, msg.size)
-          == Catch::Approx(0.9878));
+  REQUIRE(
+      decodeSignal(*m->findSignal("QuaternionW"), msg.data, msg.size)
+      == Catch::Approx(0.9878));
 
   rx.close();
   tx.close();

--- a/src/plugins/score-plugin-protocols/Tests/CMakeLists.txt
+++ b/src/plugins/score-plugin-protocols/Tests/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Tests for the CAN protocol.
+#
+# Split in two on purpose:
+#  - the DBC parser and the bit extraction are pure, portable logic and are
+#    tested without a bus, a socket or an application;
+#  - the round-trip test needs a real SocketCAN interface and skips itself when
+#    there is none, as CI machines generally have no vcan module.
+#
+# Both compile DBCParser.cpp straight into the test rather than linking the
+# plugin: the parser has no guard of its own precisely so that it stays
+# testable, and linking score_plugin_protocols would drag the whole protocol
+# stack (and a Qt/ossia runtime) into a test of arithmetic.
+
+set(CAN_TEST_DATA "${CMAKE_CURRENT_SOURCE_DIR}/data")
+set(CAN_PARSER_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../Protocols/CAN/DBCParser.cpp")
+
+score_add_test(test_protocol_can_dbc
+  SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/DBCParserTest.cpp"
+    "${CAN_PARSER_SRC}")
+
+target_include_directories(test_protocol_can_dbc
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
+target_compile_definitions(test_protocol_can_dbc
+  PRIVATE SCORE_CAN_TEST_DATA="${CAN_TEST_DATA}")
+
+if(LINUX)
+  score_add_test(test_protocol_can_vcan
+    SOURCES
+      "${CMAKE_CURRENT_SOURCE_DIR}/CANvcanTest.cpp"
+      "${CAN_PARSER_SRC}"
+    LIBS ossia)
+
+  target_include_directories(test_protocol_can_vcan
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
+  target_compile_definitions(test_protocol_can_vcan
+    PRIVATE SCORE_CAN_TEST_DATA="${CAN_TEST_DATA}")
+endif()

--- a/src/plugins/score-plugin-protocols/Tests/DBCParserTest.cpp
+++ b/src/plugins/score-plugin-protocols/Tests/DBCParserTest.cpp
@@ -1,0 +1,1209 @@
+/**
+ * Tests for the DBC parser and for the signal bit extraction.
+ *
+ * The expected values below are hand-computed from the DBC bit-numbering rules
+ * and written out in the comments, never taken from a run of the code under
+ * test: this is the one place in the CAN device where a wrong answer looks
+ * exactly like a right one, so an oracle derived from the implementation would
+ * be worthless.
+ *
+ * The numbering, restated once so the derivations below can be checked:
+ *  - Bit position `p` is bit `p % 8` of byte `p / 8`, counting bit 0 as the
+ *    least significant bit of the byte.
+ *  - An Intel (`@1`, little-endian) signal's start bit is its LSB, and the
+ *    value's bit `k` sits at position `start + k`.
+ *  - A Motorola (`@0`, big-endian) signal's start bit is its MSB. Its bits are
+ *    contiguous on the "flipped" axis `flip(p) = (p & ~7) | (7 - (p & 7))`, on
+ *    which index 0 is the MSB of byte 0, index 7 its LSB, index 8 the MSB of
+ *    byte 1, and so on -- so flipped index `f` is bit `7 - (f % 8)` of byte
+ *    `f / 8`.
+ */
+
+#include <Protocols/CAN/DBCParser.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <cstring>
+#include <fstream>
+#include <string>
+
+using namespace Protocols::CAN;
+
+namespace
+{
+//! A payload with every nibble distinct, so that a misplaced shift shows up as
+//! a wrong digit rather than as a plausible number.
+constexpr uint8_t payload[8] = {0x21, 0x43, 0x65, 0x87, 0xA9, 0xCB, 0xED, 0x0F};
+
+uint64_t le(int start, int len)
+{
+  return extractRawBits(payload, 8, start, len, ByteOrder::LittleEndian);
+}
+uint64_t be(int start, int len)
+{
+  return extractRawBits(payload, 8, start, len, ByteOrder::BigEndian);
+}
+
+std::string dataPath(const char* name)
+{
+  return std::string{SCORE_CAN_TEST_DATA} + "/" + name;
+}
+
+Database parseString(std::string_view s)
+{
+  return parseDBC(s);
+}
+}
+
+TEST_CASE("flipBitPos is an involution and maps bytes MSB-first", "[can][dbc]")
+{
+  // Within byte 0: position 7 (the MSB) is flipped index 0, position 0 (the
+  // LSB) is flipped index 7.
+  REQUIRE(flipBitPos(0) == 7);
+  REQUIRE(flipBitPos(7) == 0);
+  REQUIRE(flipBitPos(1) == 6);
+  REQUIRE(flipBitPos(6) == 1);
+
+  // Byte 1 follows byte 0 on the flipped axis.
+  REQUIRE(flipBitPos(15) == 8);
+  REQUIRE(flipBitPos(8) == 15);
+  REQUIRE(flipBitPos(12) == 11);
+
+  // Byte 4.
+  REQUIRE(flipBitPos(39) == 32);
+  REQUIRE(flipBitPos(32) == 39);
+
+  for(int p = 0; p < 512; ++p)
+    REQUIRE(flipBitPos(flipBitPos(p)) == p);
+}
+
+TEST_CASE("Little-endian bit extraction", "[can][dbc]")
+{
+  // Byte-aligned, one byte: bits 0..7 are byte 0 verbatim.
+  REQUIRE(le(0, 8) == 0x21);
+  REQUIRE(le(8, 8) == 0x43);
+  REQUIRE(le(16, 8) == 0x65);
+  REQUIRE(le(56, 8) == 0x0F);
+
+  // Byte-aligned, two bytes: little-endian, so byte 1 is the high half.
+  //   value = byte0 | (byte1 << 8) = 0x21 | 0x4300
+  REQUIRE(le(0, 16) == 0x4321);
+  //   value = byte2 | (byte3 << 8) = 0x65 | 0x8700
+  REQUIRE(le(16, 16) == 0x8765);
+
+  // The whole frame, little-endian.
+  REQUIRE(le(0, 64) == 0x0FEDCBA987654321ull);
+
+  // Single bits. 0x21 == 0b0010'0001, so only bits 0 and 5 are set.
+  REQUIRE(le(0, 1) == 1);
+  REQUIRE(le(1, 1) == 0);
+  REQUIRE(le(5, 1) == 1);
+  REQUIRE(le(6, 1) == 0);
+
+  // Straddling one byte boundary, nibble-aligned:
+  //   bits 4..11 = high nibble of byte0 (0x2) as the low 4 bits,
+  //                low nibble of byte1 (0x3) as the high 4 bits
+  //   value = 0x2 | (0x3 << 4) = 0x32
+  REQUIRE(le(4, 8) == 0x32);
+
+  // Straddling three bytes, not nibble-aligned in length:
+  //   bits 12..31 = high nibble of byte1 (0x4)  -> value bits 0..3
+  //                 byte2 (0x65)                -> value bits 4..11
+  //                 byte3 (0x87)                -> value bits 12..19
+  //   value = 0x4 | (0x65 << 4) | (0x87 << 12) = 0x87654
+  REQUIRE(le(12, 20) == 0x87654);
+
+  // A 3-bit field inside one byte: bits 1..3 of 0b0010'0001 are 0,0,0.
+  REQUIRE(le(1, 3) == 0);
+  // Bits 4..6 of 0b0010'0001 are b4=0, b5=1, b6=0 -> value 0b010 = 2.
+  REQUIRE(le(4, 3) == 2);
+}
+
+TEST_CASE("Big-endian bit extraction", "[can][dbc]")
+{
+  // The canonical byte-aligned Motorola signal: start bit 7 is the MSB of
+  // byte 0, so flip(7) == 0 and the signal is flipped indices 0..7 == byte 0.
+  REQUIRE(be(7, 8) == 0x21);
+  REQUIRE(be(15, 8) == 0x43);
+  REQUIRE(be(63, 8) == 0x0F);
+
+  // Two bytes, big-endian: flip(7) == 0, flipped 0..15 == byte0 then byte1.
+  REQUIRE(be(7, 16) == 0x2143);
+  // flip(15) == 8, flipped 8..23 == byte1 then byte2.
+  REQUIRE(be(15, 16) == 0x4365);
+  // flip(39) == 32, flipped 32..47 == byte4 then byte5.
+  REQUIRE(be(39, 16) == 0xA9CB);
+
+  // The whole frame, big-endian.
+  REQUIRE(be(7, 64) == 0x21436587A9CBED0Full);
+
+  // Sub-byte, MSB-first: flip(7) == 0, flipped 0..3 are byte0 bits 7,6,5,4,
+  // i.e. the high nibble of 0x21 == 0x2.
+  REQUIRE(be(7, 4) == 0x2);
+
+  // Straddling a byte boundary. start 3 -> flip(3) == 4, so the signal is
+  // flipped indices 4..11:
+  //   flipped  4,5,6,7   = byte0 bits 3,2,1,0 = low nibble of 0x21 = 0b0001
+  //   flipped  8,9,10,11 = byte1 bits 7,6,5,4 = high nibble of 0x43 = 0b0100
+  //   value (MSB first)  = 0b0001'0100 = 0x14
+  REQUIRE(be(3, 8) == 0x14);
+
+  // A 4-bit field straddling the boundary. start 1 -> flip(1) == 6,
+  // flipped 6..9:
+  //   flipped 6 = byte0 bit 1 -> 0x21 == 0b0010'0001, b1 = 0
+  //   flipped 7 = byte0 bit 0 ->                      b0 = 1
+  //   flipped 8 = byte1 bit 7 -> 0x43 == 0b0100'0011, b7 = 0
+  //   flipped 9 = byte1 bit 6 ->                      b6 = 1
+  //   value (MSB first) = 0b0101 = 5
+  REQUIRE(be(1, 4) == 5);
+
+  // A 12-bit field, straddling and aligned to neither nibble nor byte.
+  // start 4 -> flip(4) == 3, so flipped 3..14:
+  //   flipped 3..7   = byte0 bits 4,3,2,1,0 -> 0x21 = 0b0010'0001 -> 0,0,0,0,1
+  //   flipped 8..14  = byte1 bits 7,6,5,4,3,2,1 -> 0x43 = 0b0100'0011
+  //                    -> 0,1,0,0,0,0,1
+  //   value = 0b00001'0100001 = (1 << 7) | 0b0100001 = 128 + 33 = 161 = 0x0A1
+  REQUIRE(be(4, 12) == 0x0A1);
+
+  // Single bits: flipped index 0 is byte0's MSB, which is 0 for 0x21.
+  REQUIRE(be(7, 1) == 0);
+  // start 5 is byte0 bit 5, which is set in 0x21.
+  REQUIRE(be(5, 1) == 1);
+  // start 0 is byte0 bit 0, also set.
+  REQUIRE(be(0, 1) == 1);
+}
+
+TEST_CASE("Extraction past the end of the frame reads as zero", "[can][dbc]")
+{
+  // A device may send fewer bytes than the database declares; the signals that
+  // *are* present must still decode.
+  const uint8_t two[2] = {0xFF, 0xFF};
+  REQUIRE(extractRawBits(two, 2, 0, 16, ByteOrder::LittleEndian) == 0xFFFF);
+  // Bits 16..31 do not exist -> zero, and the low half still reads.
+  REQUIRE(extractRawBits(two, 2, 0, 32, ByteOrder::LittleEndian) == 0x0000FFFF);
+  REQUIRE(extractRawBits(two, 2, 16, 8, ByteOrder::LittleEndian) == 0);
+
+  // Degenerate lengths are refused rather than read.
+  REQUIRE(extractRawBits(payload, 8, 0, 0, ByteOrder::LittleEndian) == 0);
+  REQUIRE(extractRawBits(payload, 8, 0, 65, ByteOrder::LittleEndian) == 0);
+}
+
+TEST_CASE("Sign extension", "[can][dbc]")
+{
+  // 16-bit edges.
+  REQUIRE(signExtend(0x0000, 16) == 0);
+  REQUIRE(signExtend(0x7FFF, 16) == 32767);
+  REQUIRE(signExtend(0x8000, 16) == -32768);
+  REQUIRE(signExtend(0xFFFF, 16) == -1);
+
+  // 8-bit edges.
+  REQUIRE(signExtend(0x7F, 8) == 127);
+  REQUIRE(signExtend(0x80, 8) == -128);
+  REQUIRE(signExtend(0xFF, 8) == -1);
+
+  // A 1-bit signed signal: the only bit is the sign bit, so it is 0 or -1.
+  REQUIRE(signExtend(0, 1) == 0);
+  REQUIRE(signExtend(1, 1) == -1);
+
+  // 2-bit: 0, 1, -2, -1.
+  REQUIRE(signExtend(0b00, 2) == 0);
+  REQUIRE(signExtend(0b01, 2) == 1);
+  REQUIRE(signExtend(0b10, 2) == -2);
+  REQUIRE(signExtend(0b11, 2) == -1);
+
+  // 32-bit edges.
+  REQUIRE(signExtend(0x7FFFFFFFull, 32) == 2147483647ll);
+  REQUIRE(signExtend(0x80000000ull, 32) == -2147483648ll);
+  REQUIRE(signExtend(0xFFFFFFFFull, 32) == -1);
+
+  // 64 bits is already the full width: the pattern is reinterpreted, not
+  // extended.
+  REQUIRE(signExtend(0xFFFFFFFFFFFFFFFFull, 64) == -1);
+  REQUIRE(signExtend(0x8000000000000000ull, 64) == INT64_MIN);
+}
+
+TEST_CASE("Factor and offset scaling", "[can][dbc]")
+{
+  Signal sig;
+  sig.startBit = 0;
+  sig.length = 16;
+  sig.byteOrder = ByteOrder::LittleEndian;
+  sig.valueType = ValueType::Unsigned;
+
+  // 0x2696 == 9878, the worked example from the LPMS documentation.
+  const uint8_t data[2] = {0x96, 0x26};
+
+  sig.factor = 1.;
+  sig.offset = 0.;
+  REQUIRE(decodeSignal(sig, data, 2) == Catch::Approx(9878.));
+
+  sig.factor = 0.0001;
+  sig.offset = 0.;
+  REQUIRE(decodeSignal(sig, data, 2) == Catch::Approx(0.9878));
+
+  // Offset is applied after the factor: raw * factor + offset.
+  sig.factor = 0.5;
+  sig.offset = 100.;
+  REQUIRE(decodeSignal(sig, data, 2) == Catch::Approx(9878. * 0.5 + 100.));
+
+  // A negative factor is legal and inverts the scale.
+  sig.factor = -1.;
+  sig.offset = 0.;
+  REQUIRE(decodeSignal(sig, data, 2) == Catch::Approx(-9878.));
+
+  // Signed reading of the same bits: 0x2696 is positive, but 0x9626 is not.
+  const uint8_t negative[2] = {0x26, 0x96}; // little-endian -> 0x9626
+  sig.valueType = ValueType::Signed;
+  sig.factor = 1.;
+  REQUIRE(decodeSignal(sig, negative, 2) == Catch::Approx(double(int16_t(0x9626))));
+  REQUIRE(int16_t(0x9626) == -27098); // 0x9626 == 38438; 38438 - 65536 == -27098
+}
+
+TEST_CASE("IEEE 754 signals", "[can][dbc]")
+{
+  Signal sig;
+  sig.startBit = 0;
+  sig.length = 32;
+  sig.byteOrder = ByteOrder::LittleEndian;
+  sig.valueType = ValueType::Float32;
+  sig.factor = 1.;
+  sig.offset = 0.;
+
+  // 1.0f == 0x3F800000, little-endian on the wire.
+  const uint8_t one[4] = {0x00, 0x00, 0x80, 0x3F};
+  REQUIRE(decodeSignal(sig, one, 4) == Catch::Approx(1.0));
+
+  // -2.5f == 0xC0200000.
+  const uint8_t negTwoFive[4] = {0x00, 0x00, 0x20, 0xC0};
+  REQUIRE(decodeSignal(sig, negTwoFive, 4) == Catch::Approx(-2.5));
+
+  // Big-endian float: same bits, reversed byte order on the wire, start bit at
+  // the MSB of byte 0.
+  sig.byteOrder = ByteOrder::BigEndian;
+  sig.startBit = 7;
+  const uint8_t oneBE[4] = {0x3F, 0x80, 0x00, 0x00};
+  REQUIRE(decodeSignal(sig, oneBE, 4) == Catch::Approx(1.0));
+
+  // double: 1.0 == 0x3FF0000000000000.
+  Signal dbl;
+  dbl.startBit = 0;
+  dbl.length = 64;
+  dbl.byteOrder = ByteOrder::LittleEndian;
+  dbl.valueType = ValueType::Double64;
+  dbl.factor = 1.;
+  dbl.offset = 0.;
+  const uint8_t oneD[8] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F};
+  REQUIRE(decodeSignal(dbl, oneD, 8) == Catch::Approx(1.0));
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+TEST_CASE("The real LPMS3 16-bit database", "[can][dbc]")
+{
+  auto db = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+
+  INFO([&] {
+    std::string s;
+    for(auto& w : db.warnings)
+      s += w + "\n";
+    return s;
+  }());
+  REQUIRE(db.warnings.empty());
+
+  // Exactly the five real frames. The vendor file also holds a sixth BO_ --
+  // VECTOR__INDEPENDENT_SIG_MSG, id 3221225472 -- which is not a message but
+  // Vector's pool of unattached signals, and must not be in the tree.
+  REQUIRE(db.messages.size() == 5);
+
+  for(const auto& m : db.messages)
+    REQUIRE(m.name != std::string{independentSignalMessage});
+
+  // CANopen: start id + node id, with the file written for node 1.
+  //   PDO1 0x180+1 = 0x181 = 385     PDO3 0x380+1 = 0x381 = 897
+  //   PDO2 0x280+1 = 0x281 = 641     PDO4 0x480+1 = 0x481 = 1153
+  //   heartbeat 0x700+1 = 0x701 = 1793
+  REQUIRE(db.findMessage(0x181, false) != nullptr);
+  REQUIRE(db.findMessage(0x281, false) != nullptr);
+  REQUIRE(db.findMessage(0x381, false) != nullptr);
+  REQUIRE(db.findMessage(0x481, false) != nullptr);
+  REQUIRE(db.findMessage(0x701, false) != nullptr);
+
+  REQUIRE(db.findMessage(0x181, false)->name == "PDO1_Transmit");
+  REQUIRE(db.findMessage(0x481, false)->name == "PDO4_Transmit");
+
+  // All of them are standard (11-bit) identifiers.
+  for(const auto& m : db.messages)
+    REQUIRE(m.extended == false);
+
+  // The vendor file misspells the heartbeat message; the parser must not
+  // "correct" or reject it.
+  REQUIRE(db.findMessage(0x701, false)->name == "Heatbeat");
+  // ...and it declares no signal at all.
+  REQUIRE(db.findMessage(0x701, false)->signals.empty());
+  REQUIRE(db.findMessage(0x701, false)->size == 8);
+
+  // The attribute at the end of the file.
+  const auto* bus = db.attributes.find("BusType");
+  REQUIRE(bus != nullptr);
+  REQUIRE(*bus == "CAN");
+}
+
+TEST_CASE("Decoding a synthetic LPMS PDO4 quaternion frame", "[can][dbc]")
+{
+  auto db = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  const auto* pdo4 = db.findMessage(0x481, false);
+  REQUIRE(pdo4 != nullptr);
+  REQUIRE(pdo4->signals.size() == 4);
+
+  // The four components are 16-bit signed Intel values with a 0.0001 factor,
+  // at start bits 0, 16, 32 and 48. Note the vendor's typo on the Z component.
+  const auto* w = pdo4->findSignal("QuaternionW");
+  const auto* x = pdo4->findSignal("QuaternionX");
+  const auto* y = pdo4->findSignal("QuaternionY");
+  const auto* z = pdo4->findSignal("QuatetnionZ");
+  REQUIRE(w != nullptr);
+  REQUIRE(x != nullptr);
+  REQUIRE(y != nullptr);
+  REQUIRE(z != nullptr);
+
+  REQUIRE(w->startBit == 0);
+  REQUIRE(x->startBit == 16);
+  REQUIRE(y->startBit == 32);
+  REQUIRE(z->startBit == 48);
+  REQUIRE(w->length == 16);
+  REQUIRE(w->byteOrder == ByteOrder::LittleEndian);
+  REQUIRE(w->valueType == ValueType::Signed);
+  REQUIRE(w->factor == Catch::Approx(0.0001));
+  REQUIRE(w->unit.empty());
+  REQUIRE(w->hasRange);
+  REQUIRE(w->min == Catch::Approx(-3.2768));
+  REQUIRE(w->max == Catch::Approx(3.2767));
+
+  // W =  9878 = 0x2696 -> bytes 96 26   (the documented worked example)
+  // X = -1234        -> 0x10000 - 1234 = 64302 = 0xFB2E -> bytes 2E FB
+  // Y =     0        -> 0x0000            -> bytes 00 00
+  // Z = 32767 = 0x7FFF -> bytes FF 7F
+  const uint8_t frame[8] = {0x96, 0x26, 0x2E, 0xFB, 0x00, 0x00, 0xFF, 0x7F};
+
+  REQUIRE(decodeSignal(*w, frame, 8) == Catch::Approx(0.9878));
+  REQUIRE(decodeSignal(*x, frame, 8) == Catch::Approx(-0.1234));
+  REQUIRE(decodeSignal(*y, frame, 8) == Catch::Approx(0.0));
+  REQUIRE(decodeSignal(*z, frame, 8) == Catch::Approx(3.2767));
+
+  // And the raw bits, independently of the scaling.
+  REQUIRE(rawSignalBits(*w, frame, 8) == 9878);
+  REQUIRE(rawSignalBits(*z, frame, 8) == 32767);
+}
+
+TEST_CASE("The node id offset shifts message ids", "[can][dbc]")
+{
+  auto db = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  REQUIRE(db.findMessage(0x181, false) != nullptr);
+
+  // The same sensor configured as CANopen node 2 puts the identical signal
+  // layout one identifier higher.
+  applyNodeIdOffset(db, 1);
+
+  REQUIRE(db.findMessage(0x181, false) == nullptr);
+  REQUIRE(db.findMessage(0x182, false) != nullptr);
+  REQUIRE(db.findMessage(0x182, false)->name == "PDO1_Transmit");
+  REQUIRE(db.findMessage(0x282, false) != nullptr);
+  REQUIRE(db.findMessage(0x382, false) != nullptr);
+  REQUIRE(db.findMessage(0x482, false) != nullptr);
+  REQUIRE(db.findMessage(0x702, false) != nullptr);
+
+  // The signals are untouched: only the frame they arrive in moves.
+  REQUIRE(db.findMessage(0x482, false)->findSignal("QuaternionW") != nullptr);
+
+  // A negative offset pulls the database back down.
+  applyNodeIdOffset(db, -1);
+  REQUIRE(db.findMessage(0x181, false) != nullptr);
+  REQUIRE(db.findMessage(0x182, false) == nullptr);
+
+  // Zero is a no-op.
+  const auto before = db.messages.front().id;
+  applyNodeIdOffset(db, 0);
+  REQUIRE(db.messages.front().id == before);
+}
+
+TEST_CASE("The node id offset refuses to leave the identifier range", "[can][dbc]")
+{
+  // A standard identifier is 11 bits: shifting 0x181 up by 0x700 would leave
+  // it. Rather than wrap onto some other device's frame, the message stays put
+  // and a warning is recorded.
+  auto db = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  applyNodeIdOffset(db, 0x700);
+
+  REQUIRE(!db.warnings.empty());
+  // 0x181 + 0x700 = 0x881 > 0x7FF, so PDO1 is left where it was.
+  REQUIRE(db.findMessage(0x181, false) != nullptr);
+
+  auto db2 = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  applyNodeIdOffset(db2, -0x2000);
+  REQUIRE(!db2.warnings.empty());
+  REQUIRE(db2.findMessage(0x181, false) != nullptr);
+}
+
+TEST_CASE("The 32-bit float override", "[can][dbc]")
+{
+  auto db = parseDBCFile(dataPath("LPMS3_32bit.dbc"));
+  REQUIRE(db.messages.size() == 5);
+
+  const auto* pdo1 = db.findMessage(0x181, false);
+  REQUIRE(pdo1 != nullptr);
+  const auto* accX = pdo1->findSignal("Acc_CalibratedX");
+  REQUIRE(accX != nullptr);
+
+  // As written the file declares a signed 32-bit integer with an identity
+  // scaling, and states no range.
+  REQUIRE(accX->length == 32);
+  REQUIRE(accX->valueType == ValueType::Signed);
+  REQUIRE(accX->factor == Catch::Approx(1.0));
+  REQUIRE(accX->hasRange == false);
+
+  // 1.0f == 0x3F800000, little-endian on the wire.
+  const uint8_t frame[8] = {0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x80, 0x3F};
+
+  // Decoded as the file says: the bit pattern read as an integer.
+  REQUIRE(decodeSignal(*accX, frame, 8) == Catch::Approx(1065353216.0));
+
+  // Decoded with the override: what the sensor actually sends.
+  applyFloat32Override(db);
+  const auto* accX2 = db.findMessage(0x181, false)->findSignal("Acc_CalibratedX");
+  REQUIRE(accX2->valueType == ValueType::Float32);
+  REQUIRE(decodeSignal(*accX2, frame, 8) == Catch::Approx(1.0));
+}
+
+TEST_CASE("The float override leaves non-32-bit and explicit signals alone", "[can][dbc]")
+{
+  // 16-bit signals must not be touched.
+  auto db16 = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
+  applyFloat32Override(db16);
+  const auto* w = db16.findMessage(0x481, false)->findSignal("QuaternionW");
+  REQUIRE(w->valueType == ValueType::Signed);
+
+  // A signal with an explicit SIG_VALTYPE_ double is not downgraded to a float.
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ Wide : 0|64@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Narrow : 0|32@1+ (1,0) [0|0] "" Vector__XXX
+
+SIG_VALTYPE_ 100 Wide : 2;
+)");
+  REQUIRE(db.messages.size() == 1);
+  applyFloat32Override(db);
+  REQUIRE(db.messages[0].findSignal("Wide")->valueType == ValueType::Double64);
+  REQUIRE(db.messages[0].findSignal("Narrow")->valueType == ValueType::Float32);
+}
+
+TEST_CASE("The extended identifier flag", "[can][dbc]")
+{
+  // Bit 31 of the BO_ id marks a 29-bit identifier; the identifier itself is
+  // the low 29 bits. 0x98765432 -> extended, id 0x18765432.
+  auto db = parseString(R"(VERSION ""
+
+BO_ 2557891634 Extended: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 291 Standard: 8 Vector__XXX
+ SG_ B : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+
+  REQUIRE(db.messages.size() == 2);
+
+  const auto* ext = db.findMessage(0x18765432, true);
+  REQUIRE(ext != nullptr);
+  REQUIRE(ext->name == "Extended");
+  REQUIRE(ext->extended == true);
+
+  const auto* std_ = db.findMessage(0x123, false);
+  REQUIRE(std_ != nullptr);
+  REQUIRE(std_->name == "Standard");
+  REQUIRE(std_->extended == false);
+
+  // The pair is the key: the same number as a standard frame is a different
+  // message, and must not be found.
+  REQUIRE(db.findMessage(0x18765432, false) == nullptr);
+  REQUIRE(db.findMessage(0x123, true) == nullptr);
+}
+
+TEST_CASE("A standard and an extended message may share a number", "[can][dbc]")
+{
+  // 0x80000064 is extended id 100; 100 is standard id 100. Keying on the raw
+  // value alone would make one of them shadow the other.
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 AsStandard: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 2147483748 AsExtended: 8 Vector__XXX
+ SG_ B : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+
+  REQUIRE(db.messages.size() == 2);
+  REQUIRE(db.findMessage(100, false) != nullptr);
+  REQUIRE(db.findMessage(100, true) != nullptr);
+  REQUIRE(db.findMessage(100, false)->name == "AsStandard");
+  REQUIRE(db.findMessage(100, true)->name == "AsExtended");
+}
+
+TEST_CASE("VECTOR__INDEPENDENT_SIG_MSG is skipped", "[can][dbc]")
+{
+  // 3221225472 == 0xC0000000: the extended flag is set and the masked id is 0,
+  // which is exactly why it must be matched by name and dropped -- keyed on the
+  // raw number it would look like a legitimate extended message.
+  auto db = parseString(R"(VERSION ""
+
+BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
+ SG_ Unused1 : 0|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ Unused2 : 0|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+
+BO_ 100 Real: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
+CM_ BO_ 3221225472 "This is a message for not used signals.";
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].name == "Real");
+  REQUIRE(db.findMessage(0, true) == nullptr);
+
+  // The CM_ that refers to it must not produce a warning: the reference is
+  // expected to dangle.
+  REQUIRE(db.warnings.empty());
+}
+
+TEST_CASE("Value tables become enumerations", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ Gear : 0|4@1+ (1,0) [0|15] "" Vector__XXX
+ SG_ Mode : 8|4@1+ (1,0) [0|15] "" Vector__XXX
+
+VAL_TABLE_ ModeTable 0 "Idle" 1 "Run" 2 "Fault" ;
+VAL_ 100 Gear 0 "Neutral" 1 "First" 2 "Second" -1 "Reverse" ;
+VAL_ 100 Mode ModeTable ;
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  const auto* gear = db.messages[0].findSignal("Gear");
+  REQUIRE(gear != nullptr);
+  REQUIRE(gear->valueTable.size() == 4);
+  REQUIRE(gear->valueTable[0].value == 0);
+  REQUIRE(gear->valueTable[0].name == "Neutral");
+  REQUIRE(gear->valueTable[2].name == "Second");
+  // Negative enumerators are legal.
+  REQUIRE(gear->valueTable[3].value == -1);
+  REQUIRE(gear->valueTable[3].name == "Reverse");
+
+  // A VAL_ may name a VAL_TABLE_ instead of spelling the pairs out.
+  const auto* mode = db.messages[0].findSignal("Mode");
+  REQUIRE(mode != nullptr);
+  REQUIRE(mode->valueTable.size() == 3);
+  REQUIRE(mode->valueTable[1].name == "Run");
+}
+
+TEST_CASE("Comments", "[can][dbc]")
+{
+  auto db = parseString("VERSION \"\"\r\n"
+                        "\r\n"
+                        "BO_ 100 Msg: 8 Vector__XXX\r\n"
+                        " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
+                        "\r\n"
+                        "CM_ \"A database comment\";\r\n"
+                        "CM_ BO_ 100 \"A message comment\";\r\n"
+                        "CM_ SG_ 100 A \"A signal comment\nspanning two lines\";\r\n");
+
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.comment == "A database comment");
+  REQUIRE(db.messages[0].comment == "A message comment");
+  // Comments may contain newlines: CANdb++ writes them verbatim.
+  REQUIRE(db.messages[0].findSignal("A")->comment == "A signal comment\nspanning two lines");
+}
+
+TEST_CASE("CRLF line endings", "[can][dbc]")
+{
+  // The vendor files really are CRLF. A '\r' treated as a blank rather than as
+  // end-of-line turns the receiver list of the first signal into a construct
+  // that runs to the end of the file, and the database silently comes back
+  // empty -- which is exactly what happened before this was handled.
+  const std::string crlf = "VERSION \"\"\r\n"
+                           "\r\n"
+                           "BO_ 100 Msg: 8 Vector__XXX\r\n"
+                           " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
+                           " SG_ B : 8|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
+                           "\r\n"
+                           "BO_ 200 Msg2: 8 Vector__XXX\r\n"
+                           " SG_ C : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n";
+
+  auto db = parseString(crlf);
+  REQUIRE(db.messages.size() == 2);
+  REQUIRE(db.messages[0].signals.size() == 2);
+  REQUIRE(db.messages[1].signals.size() == 1);
+  REQUIRE(db.warnings.empty());
+
+  // The same content with LF endings must parse identically.
+  std::string lf;
+  for(char c : crlf)
+    if(c != '\r')
+      lf.push_back(c);
+
+  auto db2 = parseString(lf);
+  REQUIRE(db2.messages.size() == db.messages.size());
+  REQUIRE(db2.messages[0].signals.size() == db.messages[0].signals.size());
+  REQUIRE(db2.messages[0].signals[0].name == db.messages[0].signals[0].name);
+}
+
+TEST_CASE("Multiplexing indicators", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Muxed: 8 Vector__XXX
+ SG_ Selector M : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ WhenZero m0 : 8|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ WhenOne m1 : 8|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Always : 24|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  const auto& m = db.messages[0];
+  REQUIRE(m.signals.size() == 4);
+
+  const auto* sel = m.findSignal("Selector");
+  REQUIRE(sel->isMultiplexer);
+  REQUIRE(!sel->isMultiplexed);
+
+  const auto* zero = m.findSignal("WhenZero");
+  REQUIRE(zero->isMultiplexed);
+  REQUIRE(!zero->isMultiplexer);
+  REQUIRE(zero->multiplexValue == 0);
+
+  const auto* one = m.findSignal("WhenOne");
+  REQUIRE(one->isMultiplexed);
+  REQUIRE(one->multiplexValue == 1);
+
+  const auto* always = m.findSignal("Always");
+  REQUIRE(!always->isMultiplexed);
+  REQUIRE(!always->isMultiplexer);
+}
+
+TEST_CASE("Extended multiplexing is reported, not silently dropped", "[can][dbc]")
+{
+  // SG_MUL_VAL_ is not implemented. A database that uses it would decode its
+  // multiplexed signals unconditionally, so the user has to be told.
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Muxed: 8 Vector__XXX
+ SG_ Selector M : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Sub m0 : 8|16@1+ (1,0) [0|0] "" Vector__XXX
+
+SG_MUL_VAL_ 100 Sub Selector 1-3, 5-7;
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(!db.warnings.empty());
+
+  bool mentioned = false;
+  for(const auto& w : db.warnings)
+    if(w.find("SG_MUL_VAL_") != std::string::npos)
+      mentioned = true;
+  REQUIRE(mentioned);
+}
+
+TEST_CASE("A degenerate [0|0] range is not a domain", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ NoRange : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Ranged : 8|8@1+ (1,0) [0|255] "" Vector__XXX
+ SG_ NegRange : 16|8@1- (1,0) [-128|127] "" Vector__XXX
+)");
+
+  const auto& m = db.messages[0];
+  REQUIRE(m.findSignal("NoRange")->hasRange == false);
+  REQUIRE(m.findSignal("Ranged")->hasRange == true);
+  REQUIRE(m.findSignal("Ranged")->max == Catch::Approx(255.));
+  REQUIRE(m.findSignal("NegRange")->hasRange == true);
+  REQUIRE(m.findSignal("NegRange")->min == Catch::Approx(-128.));
+}
+
+TEST_CASE("Malformed input is survivable", "[can][dbc]")
+{
+  // Empty input.
+  REQUIRE(parseString("").messages.empty());
+  REQUIRE(parseString("   \n\n  \n").messages.empty());
+
+  // Only a header.
+  REQUIRE(parseString("VERSION \"1.0\"\n").messages.empty());
+  REQUIRE(parseString("VERSION \"1.0\"\n").version == "1.0");
+
+  // A signal with an impossible length is dropped, the message survives.
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ TooWide : 0|65@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Zero : 0|0@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Fine : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].signals.size() == 1);
+  REQUIRE(db.messages[0].signals[0].name == "Fine");
+  REQUIRE(db.warnings.size() >= 2);
+
+  // An unterminated string does not hang or read out of bounds.
+  auto db2 = parseString("VERSION \"unterminated\n");
+  REQUIRE(!db2.warnings.empty());
+
+  // A truncated SG_ line.
+  auto db3 = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ Broken :
+ SG_ Fine : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+  REQUIRE(db3.messages.size() == 1);
+  REQUIRE(!db3.warnings.empty());
+}
+
+TEST_CASE("Duplicates are rejected with a diagnostic", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 First: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 100 Second: 8 Vector__XXX
+ SG_ B : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+  // Two messages with the same (id, extended): the first wins, and the clash is
+  // reported rather than resolved by chance.
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].name == "First");
+  REQUIRE(!db.warnings.empty());
+
+  auto db2 = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ A : 8|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+  REQUIRE(db2.messages[0].signals.size() == 1);
+  REQUIRE(db2.messages[0].signals[0].startBit == 0);
+  REQUIRE(!db2.warnings.empty());
+}
+
+TEST_CASE("Attributes", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
+BA_DEF_ BO_ "GenMsgCycleTime" INT 0 65535;
+BA_DEF_ SG_ "GenSigStartValue" FLOAT 0 100;
+BA_DEF_ "BusType" STRING ;
+BA_DEF_ BO_ "MsgKind" ENUM "Cyclic","Event","Mixed";
+BA_DEF_DEF_ "GenMsgCycleTime" 100;
+BA_DEF_DEF_ "BusType" "CAN";
+BA_ "GenMsgCycleTime" BO_ 100 20;
+BA_ "GenSigStartValue" SG_ 100 A 3.5;
+BA_ "MsgKind" BO_ 100 1;
+BA_ "BusType" "CAN FD";
+)");
+
+  REQUIRE(db.messages.size() == 1);
+
+  const auto* cycle = db.messages[0].attributes.find("GenMsgCycleTime");
+  REQUIRE(cycle != nullptr);
+  REQUIRE(*cycle == "20");
+
+  const auto* start = db.messages[0].signals[0].attributes.find("GenSigStartValue");
+  REQUIRE(start != nullptr);
+  REQUIRE(*start == "3.5");
+
+  // An ENUM attribute is written as an index into the BA_DEF_ list; it is
+  // resolved back to the name it stands for.
+  const auto* kind = db.messages[0].attributes.find("MsgKind");
+  REQUIRE(kind != nullptr);
+  REQUIRE(*kind == "Event");
+
+  // A database-level attribute.
+  const auto* bus = db.attributes.find("BusType");
+  REQUIRE(bus != nullptr);
+  REQUIRE(*bus == "CAN FD");
+}
+
+TEST_CASE("Known but unused constructs are reported once each", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BU_: Alpha Beta Gamma
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_TX_BU_ 100 : Alpha,Beta;
+SIG_GROUP_ 100 GroupA 1 : A;
+SIG_GROUP_ 100 GroupB 1 : A;
+EV_ SomeVar: 0 [0|100] "" 0 1 DUMMY_NODE_VECTOR0 Vector__XXX;
+)");
+
+  // The message still parses despite the constructs around it.
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].signals.size() == 1);
+
+  // Two SIG_GROUP_ records, but only one diagnostic about them: a large file
+  // must not drown the user in identical warnings.
+  int sigGroupWarnings = 0;
+  for(const auto& w : db.warnings)
+    if(w.find("SIG_GROUP_") != std::string::npos)
+      ++sigGroupWarnings;
+  REQUIRE(sigGroupWarnings == 1);
+}
+
+TEST_CASE("The NS_ block is not mistaken for content", "[can][dbc]")
+{
+  // The NS_ section lists the very same tokens as the real constructs. A parser
+  // that dispatches on the leading keyword without knowing about NS_ would try
+  // to read `CM_`, `VAL_` and `SIG_VALTYPE_` as records.
+  auto db = parseString(R"(VERSION ""
+
+
+NS_ :
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_:
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].name == "Msg");
+  REQUIRE(db.warnings.empty());
+}
+
+TEST_CASE("Signal syntax variants", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ NoSpaceColon: 0|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BigEndian : 15|16@0- (0.5,-40) [-40|100] "degC" Vector__XXX
+ SG_ MultiRx : 32|8@1+ (1,0) [0|0] "" Alpha,Beta
+ SG_ Exponent : 40|8@1+ (1e-3,0) [0|0] "" Vector__XXX
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  const auto& m = db.messages[0];
+  REQUIRE(m.signals.size() == 4);
+
+  // A missing space before the colon is accepted.
+  REQUIRE(m.findSignal("NoSpaceColon") != nullptr);
+  REQUIRE(m.findSignal("NoSpaceColon")->startBit == 0);
+
+  const auto* bigE = m.findSignal("BigEndian");
+  REQUIRE(bigE != nullptr);
+  REQUIRE(bigE->byteOrder == ByteOrder::BigEndian);
+  REQUIRE(bigE->valueType == ValueType::Signed);
+  REQUIRE(bigE->startBit == 15);
+  REQUIRE(bigE->factor == Catch::Approx(0.5));
+  REQUIRE(bigE->offset == Catch::Approx(-40.));
+  REQUIRE(bigE->unit == "degC");
+
+  // Several receivers, comma-separated; the Vector__XXX placeholder is dropped
+  // but real node names are kept.
+  const auto* rx = m.findSignal("MultiRx");
+  REQUIRE(rx->receivers.size() == 2);
+  REQUIRE(rx->receivers[0] == "Alpha");
+  REQUIRE(rx->receivers[1] == "Beta");
+  REQUIRE(m.findSignal("NoSpaceColon")->receivers.empty());
+
+  // Exponent notation in the factor.
+  REQUIRE(m.findSignal("Exponent")->factor == Catch::Approx(0.001));
+}
+
+TEST_CASE("SIG_VALTYPE_ with and without the colon", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ F : 0|32@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ G : 32|32@1+ (1,0) [0|0] "" Vector__XXX
+
+SIG_VALTYPE_ 100 F : 1;
+SIG_VALTYPE_ 100 G 1;
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].findSignal("F")->valueType == ValueType::Float32);
+  // The colon is optional in some dialects.
+  REQUIRE(db.messages[0].findSignal("G")->valueType == ValueType::Float32);
+}
+
+TEST_CASE("Escaped and doubled quotes in strings", "[can][dbc]")
+{
+  auto db = parseString("VERSION \"\"\n"
+                        "\n"
+                        "BO_ 100 Msg: 8 Vector__XXX\n"
+                        " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\n"
+                        "\n"
+                        "CM_ BO_ 100 \"a \\\"quoted\\\" word\";\n");
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].comment == "a \"quoted\" word");
+
+  auto db2 = parseString("VERSION \"\"\n"
+                         "\n"
+                         "BO_ 100 Msg: 8 Vector__XXX\n"
+                         " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\n"
+                         "\n"
+                         "CM_ BO_ 100 \"a \"\"doubled\"\" word\";\n");
+  REQUIRE(db2.messages.size() == 1);
+  REQUIRE(db2.messages[0].comment == "a \"doubled\" word");
+}
+
+TEST_CASE("A one-bit and a 64-bit signal round-trip through the parser", "[can][dbc]")
+{
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ Flag : 7|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ Whole : 0|64@1+ (1,0) [0|0] "" Vector__XXX
+)");
+
+  const auto& m = db.messages[0];
+  const auto* flag = m.findSignal("Flag");
+  const auto* whole = m.findSignal("Whole");
+  REQUIRE(flag->length == 1);
+  REQUIRE(whole->length == 64);
+
+  const uint8_t frame[8] = {0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+
+  // Bit 7 of byte 0 is set in 0x80.
+  REQUIRE(rawSignalBits(*flag, frame, 8) == 1);
+  // The whole frame, little-endian: byte 7 is the most significant.
+  REQUIRE(rawSignalBits(*whole, frame, 8) == 0x0100000000000080ull);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-checks against independent implementations
+//
+// The two blocks below are the strongest oracles available for the big-endian
+// case, because neither expectation was produced by this code: the first comes
+// from Vector CANdb++ itself and the second from decoding the same payloads
+// through cantools and canmatrix, which agreed bit for bit.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Big-endian start bits agree with Vector CANdb++", "[can][dbc][oracle]")
+{
+  // Expected LSB/MSB positions as reported by Vector CANdb++ for a set of
+  // Motorola signals (the table canmatrix pins in test_candbpp_startbit).
+  // "MSB" is the DBC start bit itself; "LSB" is the position of the signal's
+  // least significant bit, which is what the flipped-axis walk has to land on.
+  struct Case
+  {
+    int start;
+    int length;
+    int expectedLsb;
+  };
+
+  static constexpr Case cases[] = {
+      {39, 4, 36},  {52, 1, 52},  {51, 12, 56}, {6, 1, 6},   {5, 1, 5},
+      {23, 3, 21},  {7, 1, 7},    {34, 11, 40}, {18, 11, 24}, {4, 13, 8},
+  };
+
+  for(const auto& c : cases)
+  {
+    INFO("start " << c.start << " length " << c.length);
+    // The signal runs from flip(start) for `length` bits along the flipped
+    // axis; its LSB is the last of those, mapped back.
+    const int lsb = flipBitPos(flipBitPos(c.start) + c.length - 1);
+    REQUIRE(lsb == c.expectedLsb);
+  }
+}
+
+TEST_CASE("Big-endian extraction agrees with cantools and canmatrix", "[can][dbc][oracle]")
+{
+  // Signals and expected raw values obtained by decoding the payloads below
+  // through cantools and through canmatrix; the two agreed on every cell.
+  //
+  //  BE_7_16  :  7|16@0+     BE_39_1  : 39|1@0+
+  //  BE_23_4  : 23|4@0+      BE_38_11 : 38|11@0+
+  //  BE_19_4  : 19|4@0+      BE_43_12 : 43|12@0+
+  //  BE_31_8  : 31|8@0+      LE_56_8  : 56|8@1+
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 M: 8 ECU1
+ SG_ BE_7_16 : 7|16@0+ (1,0) [0|0] "" ECU2
+ SG_ BE_23_4 : 23|4@0+ (1,0) [0|0] "" ECU2
+ SG_ BE_19_4 : 19|4@0+ (1,0) [0|0] "" ECU2
+ SG_ BE_31_8 : 31|8@0+ (1,0) [0|0] "" ECU2
+ SG_ BE_39_1 : 39|1@0+ (1,0) [0|0] "" ECU2
+ SG_ BE_38_11 : 38|11@0+ (1,0) [0|0] "" ECU2
+ SG_ BE_43_12 : 43|12@0+ (1,0) [0|0] "" ECU2
+ SG_ LE_56_8 : 56|8@1+ (1,0) [0|0] "" ECU2
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  const auto& m = db.messages[0];
+  REQUIRE(m.signals.size() == 8);
+
+  struct Expected
+  {
+    const char* name;
+    uint64_t values[3];
+  };
+
+  // payload 0: 01 02 03 04 05 06 07 08
+  // payload 1: ff 00 ff 00 ff 00 ff 00
+  // payload 2: 12 34 56 78 9a bc de f0
+  static constexpr uint8_t payloads[3][8]
+      = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+         {0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00},
+         {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0}};
+
+  static const Expected expected[] = {
+      {"BE_7_16", {258, 65280, 4660}}, {"BE_23_4", {0, 15, 5}},
+      {"BE_19_4", {3, 15, 6}},         {"BE_31_8", {4, 0, 120}},
+      {"BE_39_1", {0, 1, 1}},          {"BE_38_11", {80, 2032, 427}},
+      {"BE_43_12", {1543, 255, 3294}}, {"LE_56_8", {8, 0, 240}},
+  };
+
+  for(const auto& e : expected)
+  {
+    const auto* sig = m.findSignal(e.name);
+    REQUIRE(sig != nullptr);
+    for(int p = 0; p < 3; ++p)
+    {
+      INFO(e.name << " on payload " << p);
+      REQUIRE(rawSignalBits(*sig, payloads[p], 8) == e.values[p]);
+    }
+  }
+}
+
+TEST_CASE("Line and block comments are stripped outside strings", "[can][dbc]")
+{
+  // Not in the Vector format, but they occur in the wild and two of the major
+  // readers accept them. Crucially, "//" inside a quoted string is data.
+  auto db = parseString(R"(VERSION "" // trailing comment
+
+/* a block comment
+   spanning lines */
+BO_ 100 Msg: 8 Vector__XXX
+ SG_ A : 0|8@1+ (1,0) [0|0] "u//nit" Vector__XXX
+
+// a whole-line comment
+CM_ BO_ 100 "text // not a comment";
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].name == "Msg");
+  // The unit really does contain a double slash.
+  REQUIRE(db.messages[0].findSignal("A")->unit == "u//nit");
+  REQUIRE(db.messages[0].comment == "text // not a comment");
+  REQUIRE(db.warnings.empty());
+}
+
+TEST_CASE("Latin-1 text is transcoded to UTF-8", "[can][dbc]")
+{
+  // CANdb++ writes cp1252/ISO-8859-1: a degree sign is the byte 0xB0, which is
+  // not valid UTF-8 on its own and would render as nothing downstream.
+  std::string src = "VERSION \"\"\n\nBO_ 100 Msg: 8 Vector__XXX\n SG_ A : 0|8@1+ (1,0) [0|0] \"";
+  src += char(0xB0);
+  src += "C\" Vector__XXX\n";
+
+  auto db = parseString(src);
+  REQUIRE(db.messages.size() == 1);
+
+  // U+00B0 as UTF-8 is C2 B0.
+  const auto& unit = db.messages[0].findSignal("A")->unit;
+  REQUIRE(unit.size() == 3);
+  REQUIRE(uint8_t(unit[0]) == 0xC2);
+  REQUIRE(uint8_t(unit[1]) == 0xB0);
+  REQUIRE(unit[2] == 'C');
+
+  // Text that already is valid UTF-8 must survive untouched.
+  std::string utf8 = "VERSION \"\"\n\nBO_ 100 Msg: 8 Vector__XXX\n SG_ A : 0|8@1+ (1,0) [0|0] \"\xC2\xB0" "C\" Vector__XXX\n";
+  auto db2 = parseString(utf8);
+  REQUIRE(db2.messages[0].findSignal("A")->unit == "\xC2\xB0" "C");
+}
+
+TEST_CASE("A signal running past the DLC is a warning, not a rejection", "[can][dbc]")
+{
+  // Real files do this; refusing them would lose whole databases. The bits
+  // past the end of a received frame read as zero.
+  auto db = parseString(R"(VERSION ""
+
+BO_ 100 Msg: 2 Vector__XXX
+ SG_ Fits : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Overruns : 8|32@1+ (1,0) [0|0] "" Vector__XXX
+)");
+
+  REQUIRE(db.messages.size() == 1);
+  REQUIRE(db.messages[0].signals.size() == 2);
+
+  bool mentioned = false;
+  for(const auto& w : db.warnings)
+    if(w.find("Overruns") != std::string::npos)
+      mentioned = true;
+  REQUIRE(mentioned);
+
+  // And it still decodes what is there.
+  const uint8_t frame[2] = {0xAA, 0xBB};
+  REQUIRE(rawSignalBits(*db.messages[0].findSignal("Fits"), frame, 2) == 0xAA);
+  REQUIRE(rawSignalBits(*db.messages[0].findSignal("Overruns"), frame, 2) == 0xBB);
+}
+
+TEST_CASE("Both VECTOR__INDEPENDENT_SIG_MSG identifiers are skipped", "[can][dbc]")
+{
+  // The pseudo-message appears with 0xC0000000 and with 0x40000000 in real
+  // corpora, which is why it is matched by name rather than by id.
+  for(const char* id : {"3221225472", "1073741824"})
+  {
+    std::string src = "VERSION \"\"\n\nBO_ ";
+    src += id;
+    src += " VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX\n"
+           " SG_ Orphan : 0|16@1- (0.01,0) [0|0] \"\" Vector__XXX\n"
+           "\nBO_ 100 Real: 8 Vector__XXX\n"
+           " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\n";
+
+    INFO("id " << id);
+    auto db = parseString(src);
+    REQUIRE(db.messages.size() == 1);
+    REQUIRE(db.messages[0].name == "Real");
+  }
+}

--- a/src/plugins/score-plugin-protocols/Tests/DBCParserTest.cpp
+++ b/src/plugins/score-plugin-protocols/Tests/DBCParserTest.cpp
@@ -474,7 +474,8 @@ TEST_CASE("The 32-bit float override", "[can][dbc]")
   REQUIRE(decodeSignal(*accX2, frame, 8) == Catch::Approx(1.0));
 }
 
-TEST_CASE("The float override leaves non-32-bit and explicit signals alone", "[can][dbc]")
+TEST_CASE(
+    "The float override leaves non-32-bit and explicit signals alone", "[can][dbc]")
 {
   // 16-bit signals must not be touched.
   auto db16 = parseDBCFile(dataPath("LPMS3_16bit.dbc"));
@@ -607,20 +608,22 @@ VAL_ 100 Mode ModeTable ;
 
 TEST_CASE("Comments", "[can][dbc]")
 {
-  auto db = parseString("VERSION \"\"\r\n"
-                        "\r\n"
-                        "BO_ 100 Msg: 8 Vector__XXX\r\n"
-                        " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
-                        "\r\n"
-                        "CM_ \"A database comment\";\r\n"
-                        "CM_ BO_ 100 \"A message comment\";\r\n"
-                        "CM_ SG_ 100 A \"A signal comment\nspanning two lines\";\r\n");
+  auto db = parseString(
+      "VERSION \"\"\r\n"
+      "\r\n"
+      "BO_ 100 Msg: 8 Vector__XXX\r\n"
+      " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
+      "\r\n"
+      "CM_ \"A database comment\";\r\n"
+      "CM_ BO_ 100 \"A message comment\";\r\n"
+      "CM_ SG_ 100 A \"A signal comment\nspanning two lines\";\r\n");
 
   REQUIRE(db.messages.size() == 1);
   REQUIRE(db.comment == "A database comment");
   REQUIRE(db.messages[0].comment == "A message comment");
   // Comments may contain newlines: CANdb++ writes them verbatim.
-  REQUIRE(db.messages[0].findSignal("A")->comment == "A signal comment\nspanning two lines");
+  REQUIRE(
+      db.messages[0].findSignal("A")->comment == "A signal comment\nspanning two lines");
 }
 
 TEST_CASE("CRLF line endings", "[can][dbc]")
@@ -629,14 +632,15 @@ TEST_CASE("CRLF line endings", "[can][dbc]")
   // end-of-line turns the receiver list of the first signal into a construct
   // that runs to the end of the file, and the database silently comes back
   // empty -- which is exactly what happened before this was handled.
-  const std::string crlf = "VERSION \"\"\r\n"
-                           "\r\n"
-                           "BO_ 100 Msg: 8 Vector__XXX\r\n"
-                           " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
-                           " SG_ B : 8|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
-                           "\r\n"
-                           "BO_ 200 Msg2: 8 Vector__XXX\r\n"
-                           " SG_ C : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n";
+  const std::string crlf
+      = "VERSION \"\"\r\n"
+        "\r\n"
+        "BO_ 100 Msg: 8 Vector__XXX\r\n"
+        " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
+        " SG_ B : 8|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n"
+        "\r\n"
+        "BO_ 200 Msg2: 8 Vector__XXX\r\n"
+        " SG_ C : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\r\n";
 
   auto db = parseString(crlf);
   REQUIRE(db.messages.size() == 2);
@@ -975,21 +979,23 @@ SIG_VALTYPE_ 100 G 1;
 
 TEST_CASE("Escaped and doubled quotes in strings", "[can][dbc]")
 {
-  auto db = parseString("VERSION \"\"\n"
-                        "\n"
-                        "BO_ 100 Msg: 8 Vector__XXX\n"
-                        " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\n"
-                        "\n"
-                        "CM_ BO_ 100 \"a \\\"quoted\\\" word\";\n");
+  auto db = parseString(
+      "VERSION \"\"\n"
+      "\n"
+      "BO_ 100 Msg: 8 Vector__XXX\n"
+      " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\n"
+      "\n"
+      "CM_ BO_ 100 \"a \\\"quoted\\\" word\";\n");
   REQUIRE(db.messages.size() == 1);
   REQUIRE(db.messages[0].comment == "a \"quoted\" word");
 
-  auto db2 = parseString("VERSION \"\"\n"
-                         "\n"
-                         "BO_ 100 Msg: 8 Vector__XXX\n"
-                         " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\n"
-                         "\n"
-                         "CM_ BO_ 100 \"a \"\"doubled\"\" word\";\n");
+  auto db2 = parseString(
+      "VERSION \"\"\n"
+      "\n"
+      "BO_ 100 Msg: 8 Vector__XXX\n"
+      " SG_ A : 0|8@1+ (1,0) [0|0] \"\" Vector__XXX\n"
+      "\n"
+      "CM_ BO_ 100 \"a \"\"doubled\"\" word\";\n");
   REQUIRE(db2.messages.size() == 1);
   REQUIRE(db2.messages[0].comment == "a \"doubled\" word");
 }
@@ -1040,8 +1046,8 @@ TEST_CASE("Big-endian start bits agree with Vector CANdb++", "[can][dbc][oracle]
   };
 
   static constexpr Case cases[] = {
-      {39, 4, 36},  {52, 1, 52},  {51, 12, 56}, {6, 1, 6},   {5, 1, 5},
-      {23, 3, 21},  {7, 1, 7},    {34, 11, 40}, {18, 11, 24}, {4, 13, 8},
+      {39, 4, 36}, {52, 1, 52}, {51, 12, 56}, {6, 1, 6},    {5, 1, 5},
+      {23, 3, 21}, {7, 1, 7},   {34, 11, 40}, {18, 11, 24}, {4, 13, 8},
   };
 
   for(const auto& c : cases)
@@ -1054,7 +1060,8 @@ TEST_CASE("Big-endian start bits agree with Vector CANdb++", "[can][dbc][oracle]
   }
 }
 
-TEST_CASE("Big-endian extraction agrees with cantools and canmatrix", "[can][dbc][oracle]")
+TEST_CASE(
+    "Big-endian extraction agrees with cantools and canmatrix", "[can][dbc][oracle]")
 {
   // Signals and expected raw values obtained by decoding the payloads below
   // through cantools and through canmatrix; the two agreed on every cell.
@@ -1140,7 +1147,8 @@ TEST_CASE("Latin-1 text is transcoded to UTF-8", "[can][dbc]")
 {
   // CANdb++ writes cp1252/ISO-8859-1: a degree sign is the byte 0xB0, which is
   // not valid UTF-8 on its own and would render as nothing downstream.
-  std::string src = "VERSION \"\"\n\nBO_ 100 Msg: 8 Vector__XXX\n SG_ A : 0|8@1+ (1,0) [0|0] \"";
+  std::string src
+      = "VERSION \"\"\n\nBO_ 100 Msg: 8 Vector__XXX\n SG_ A : 0|8@1+ (1,0) [0|0] \"";
   src += char(0xB0);
   src += "C\" Vector__XXX\n";
 
@@ -1155,7 +1163,10 @@ TEST_CASE("Latin-1 text is transcoded to UTF-8", "[can][dbc]")
   REQUIRE(unit[2] == 'C');
 
   // Text that already is valid UTF-8 must survive untouched.
-  std::string utf8 = "VERSION \"\"\n\nBO_ 100 Msg: 8 Vector__XXX\n SG_ A : 0|8@1+ (1,0) [0|0] \"\xC2\xB0" "C\" Vector__XXX\n";
+  std::string utf8
+      = "VERSION \"\"\n\nBO_ 100 Msg: 8 Vector__XXX\n SG_ A : 0|8@1+ (1,0) [0|0] "
+        "\"\xC2\xB0"
+        "C\" Vector__XXX\n";
   auto db2 = parseString(utf8);
   REQUIRE(db2.messages[0].findSignal("A")->unit == "\xC2\xB0" "C");
 }

--- a/src/plugins/score-plugin-protocols/Tests/DBCParserTest.cpp
+++ b/src/plugins/score-plugin-protocols/Tests/DBCParserTest.cpp
@@ -1,13 +1,11 @@
 /**
- * Tests for the DBC parser and for the signal bit extraction.
+ * Tests for the DBC parser and the signal bit extraction.
  *
- * The expected values below are hand-computed from the DBC bit-numbering rules
- * and written out in the comments, never taken from a run of the code under
- * test: this is the one place in the CAN device where a wrong answer looks
- * exactly like a right one, so an oracle derived from the implementation would
- * be worthless.
+ * Expected values are hand-computed from the bit-numbering rules and shown in
+ * the comments, never taken from a run of the code under test - a wrong answer
+ * here looks exactly like a right one.
  *
- * The numbering, restated once so the derivations below can be checked:
+ * The numbering, restated so the derivations can be checked:
  *  - Bit position `p` is bit `p % 8` of byte `p / 8`, counting bit 0 as the
  *    least significant bit of the byte.
  *  - An Intel (`@1`, little-endian) signal's start bit is its LSB, and the

--- a/src/plugins/score-plugin-protocols/Tests/data/LPMS3_16bit.dbc
+++ b/src/plugins/score-plugin-protocols/Tests/data/LPMS3_16bit.dbc
@@ -1,0 +1,108 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_:
+
+
+BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
+ SG_ Temperature : 0|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ Pressure : 0|16@1- (0.01,0) [-327.68|327.67] "kPa" Vector__XXX
+ SG_ Lin_AccZ : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Lin_AccY : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Lin_AccX : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ EulerZ : 0|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ EulerY : 0|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ EulerX : 0|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ QuaternionZ : 0|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+ SG_ QuaternionY : 0|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+ SG_ QuaternionX : 0|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+ SG_ QuaternionW : 0|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+ SG_ Angular_RateZ : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ Angular_RateY : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ Angular_RateX : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ Mag_CalibratedZ : 0|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ Mag_CalibratedY : 0|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ Mag_CalibratedX : 0|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ Mag_RawZ : 0|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ Mag_RawY : 0|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ Mag_RawX : 0|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ GyroII_Align_CalibratedZ : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_Align_CalibratedY : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_Align_CalibratedX : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_Bias_CalibratedZ : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_Bias_CalibratedY : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_Bias_CalibratedX : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_RawZ : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_RawY : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_RawX : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ Acc_CalibratedZ : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Acc_CalibratedY : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Acc_CalibratedX : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Acc_RawZ : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Acc_RawY : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Acc_RawX : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+
+BO_ 1793 Heatbeat: 8 Vector__XXX
+
+BO_ 1153 PDO4_Transmit: 8 Vector__XXX
+ SG_ QuatetnionZ : 48|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+ SG_ QuaternionY : 32|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+ SG_ QuaternionX : 16|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+ SG_ QuaternionW : 0|16@1- (0.0001,0) [-3.2768|3.2767] "" Vector__XXX
+
+BO_ 897 PDO3_Transmit: 8 Vector__XXX
+ SG_ EulerZ : 48|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ EulerY : 32|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ EulerX : 16|16@1- (0.01,0) [-327.68|327.67] "d" Vector__XXX
+ SG_ Mag_CalibratedZ : 0|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+
+BO_ 641 PDO2_Transmit: 8 Vector__XXX
+ SG_ Mag_CalibratedY : 48|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ Mag_CalibratedX : 32|16@1- (0.01,0) [-327.68|327.67] "uT" Vector__XXX
+ SG_ GyroII_Align_CalibratedZ : 16|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ GyroII_Align_CalibratedY : 0|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+
+BO_ 385 PDO1_Transmit: 8 Vector__XXX
+ SG_ GyroII_Align_CalibratedX : 48|16@1- (0.1,0) [-3276.8|3276.7] "d/s" Vector__XXX
+ SG_ Acc_CalibratedZ : 32|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Acc_CalibratedY : 16|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+ SG_ Acc_CalibratedX : 0|16@1- (0.001,0) [-32.768|32.767] "g" Vector__XXX
+
+
+
+CM_ BO_ 3221225472 "This is a message for not used signals, created by Vector CANdb++ DBC OLE DB Provider.";
+BA_DEF_  "BusType" STRING ;
+BA_DEF_DEF_  "BusType" "CAN";
+

--- a/src/plugins/score-plugin-protocols/Tests/data/LPMS3_32bit.dbc
+++ b/src/plugins/score-plugin-protocols/Tests/data/LPMS3_32bit.dbc
@@ -1,0 +1,100 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_:
+
+
+BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
+ SG_ Temperature : 0|32@1- (1,0) [0|0] "d" Vector__XXX
+ SG_ Pressure : 0|32@1- (1,0) [0|0] "kPa" Vector__XXX
+ SG_ Lin_AccZ : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Lin_AccY : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Lin_AccX : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ EulerZ : 0|32@1- (1,0) [0|0] "d" Vector__XXX
+ SG_ EulerY : 0|32@1- (1,0) [0|0] "d" Vector__XXX
+ SG_ EulerX : 0|32@1- (1,0) [0|0] "d" Vector__XXX
+ SG_ QuaternionZ : 0|32@1- (1,0) [0|0] "" Vector__XXX
+ SG_ QuaternionY : 0|32@1- (1,0) [0|0] "" Vector__XXX
+ SG_ QuaternionX : 0|32@1- (1,0) [0|0] "" Vector__XXX
+ SG_ QuaternionW : 0|32@1- (1,0) [0|0] "" Vector__XXX
+ SG_ Angular_RateZ : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ Angular_RateY : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ Angular_RateX : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ Mag_CalibratedZ : 0|32@1- (1,0) [0|0] "uT" Vector__XXX
+ SG_ Mag_CalibratedY : 0|32@1- (1,0) [0|0] "uT" Vector__XXX
+ SG_ Mag_CalibratedX : 0|32@1- (1,0) [0|0] "uT" Vector__XXX
+ SG_ Mag_RawZ : 0|32@1- (1,0) [0|0] "uT" Vector__XXX
+ SG_ Mag_RawY : 0|32@1- (1,0) [0|0] "uT" Vector__XXX
+ SG_ Mag_RawX : 0|32@1- (1,0) [0|0] "uT" Vector__XXX
+ SG_ GyroII_Align_CalibratedZ : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_Align_CalibratedY : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_Align_CalibratedX : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_Bias_CalibratedZ : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_Bias_CalibratedY : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_Bias_CalibratedX : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_RawZ : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_RawY : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_RawX : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ Acc_CalibratedZ : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Acc_CalibratedY : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Acc_CalibratedX : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Acc_RawZ : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Acc_RawY : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Acc_RawX : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+
+BO_ 1793 Heatbeat: 8 Vector__XXX
+
+BO_ 1153 PDO4_Transmit: 8 Vector__XXX
+ SG_ Mag_CalibratedX : 32|32@1- (1,0) [0|0] "uT" Vector__XXX
+ SG_ Mag_CalibratedZ : 0|32@1- (1,0) [0|0] "uT" Vector__XXX
+
+BO_ 897 PDO3_Transmit: 8 Vector__XXX
+ SG_ GyroII_Align_CalibratedZ : 32|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ GyroII_Align_CalibratedY : 0|32@1- (1,0) [0|0] "d/s" Vector__XXX
+
+BO_ 641 PDO2_Transmit: 8 Vector__XXX
+ SG_ GyroII_Align_CalibratedX : 32|32@1- (1,0) [0|0] "d/s" Vector__XXX
+ SG_ Acc_CalibratedZ : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+
+BO_ 385 PDO1_Transmit: 8 Vector__XXX
+ SG_ Acc_CalibratedY : 32|32@1- (1,0) [0|0] "g" Vector__XXX
+ SG_ Acc_CalibratedX : 0|32@1- (1,0) [0|0] "g" Vector__XXX
+
+
+
+CM_ BO_ 3221225472 "This is a message for not used signals, created by Vector CANdb++ DBC OLE DB Provider.";
+BA_DEF_  "BusType" STRING ;
+BA_DEF_DEF_  "BusType" "CAN";
+

--- a/src/plugins/score-plugin-protocols/score_plugin_protocols.cpp
+++ b/src/plugins/score-plugin-protocols/score_plugin_protocols.cpp
@@ -66,6 +66,9 @@
 #if defined(OSSIA_PROTOCOL_GPS)
 #include <Protocols/GPS/GPSProtocolFactory.hpp>
 #endif
+#if defined(OSSIA_PROTOCOL_CAN)
+#include <Protocols/CAN/CANProtocolFactory.hpp>
+#endif
 #if defined(OSSIA_PROTOCOL_EVDEV)
 #include <Protocols/Evdev/EvdevProtocolFactory.hpp>
 #include <Protocols/Evdev/EvdevSpecificSettings.hpp>
@@ -165,6 +168,10 @@ std::vector<score::InterfaceBase*> score_plugin_protocols::factories(
 #if defined(OSSIA_PROTOCOL_GPS)
          ,
          Protocols::GPSProtocolFactory
+#endif
+#if defined(OSSIA_PROTOCOL_CAN)
+         ,
+         Protocols::CANProtocolFactory
 #endif
 #if defined(OSSIA_PROTOCOL_EVDEV)
          ,

--- a/tests/fixtures/score_test/App.hpp
+++ b/tests/fixtures/score_test/App.hpp
@@ -18,6 +18,8 @@
 // and both close any documents fn left open before tearing the app down (the
 // GUI presenter teardown must happen while the factory families are alive).
 
+#include <ossia/context.hpp>
+
 #include <core/application/MinimalApplication.hpp>
 #include <core/document/Document.hpp>
 #include <core/presenter/DocumentManager.hpp>
@@ -46,6 +48,14 @@ inline void prepare_test_environment(bool headless)
   if(headless && !qEnvironmentVariableIsSet("QT_QPA_PLATFORM"))
     qputenv("QT_QPA_PLATFORM", "offscreen");
 #endif
+
+  // Nothing interactive: the package manager asks "Download the user library?"
+  // one second after its first refresh, and score::question() is a modal
+  // QDialog::exec(). A test that runs the event loop for any length of time
+  // otherwise wedges in that nested loop with nobody to answer it -- which is
+  // the same escape hatch the model itself documents for tests and CI.
+  if(!qEnvironmentVariableIsSet("SCORE_SANITIZE_SKIP_CHECKS"))
+    qputenv("SCORE_SANITIZE_SKIP_CHECKS", "1");
 
   // No real audio device: force the dummy backend (honored at startup by
   // Audio::Settings::Model). Avoids connecting to a live PipeWire/JACK server.
@@ -97,9 +107,12 @@ void run_in_app(F&& fn)
   QLocale::setDefault(QLocale::C);
   std::setlocale(LC_ALL, "C");
 
-  // Register this (main) thread as the UI thread, exactly as ossia::context
-  // does during a normal score::Application bootstrap.
-  ossia::set_thread_pinned(ossia::thread_type::Ui, 0);
+  // The same bootstrap score::Application does (Application.cpp): this pins
+  // the current thread as the UI one *and* registers the Ossia QML types.
+  // Pinning by hand instead, as this used to, left `Ossia.Type` &co undefined,
+  // so any QML a test loads would throw the moment it referenced one - which a
+  // Mapper device's createTree() does on its first line.
+  ossia::context ossia_ctx;
 
   score::MinimalApplication app;
 
@@ -119,7 +132,8 @@ void run_in_gui_app(F&& fn)
   QLocale::setDefault(QLocale::C);
   std::setlocale(LC_ALL, "C");
 
-  ossia::set_thread_pinned(ossia::thread_type::Ui, 0);
+  // Same bootstrap as run_in_app(); see the comment there.
+  ossia::context ossia_ctx;
 
   static int argc = 1;
   static char arg0[] = "score-test";

--- a/tests/fixtures/score_test/App.hpp
+++ b/tests/fixtures/score_test/App.hpp
@@ -18,14 +18,13 @@
 // and both close any documents fn left open before tearing the app down (the
 // GUI presenter teardown must happen while the factory families are alive).
 
-#include <ossia/context.hpp>
+#include <score/application/GUIApplicationContext.hpp>
 
 #include <core/application/MinimalApplication.hpp>
 #include <core/document/Document.hpp>
 #include <core/presenter/DocumentManager.hpp>
 
-#include <score/application/GUIApplicationContext.hpp>
-
+#include <ossia/context.hpp>
 #include <ossia/detail/thread.hpp>
 
 #include <QApplication>

--- a/tests/unit/CANEnumeratorTest.cpp
+++ b/tests/unit/CANEnumeratorTest.cpp
@@ -1,17 +1,13 @@
 // The CAN protocol's device browser entry and its default interface.
 //
-// The browser lists the .dbc databases found in the user library, the way the
-// OSC / Serial / WS protocols list their own file types. It used to list the
-// machine's CAN interfaces instead, which told the user nothing the settings
-// widget's combo box did not already show; a database, on the other hand,
-// arrives with a whole node tree attached and there can be any number of them.
+// The browser lists the .dbc databases of the user library, as the OSC / Serial
+// / WS protocols list their own file types. It used to list the machine's CAN
+// interfaces, which the settings widget's combo already shows.
 //
-// defaultSettings() also used to hardcode "can0" -- an interface that does not
-// exist on any machine without a physical CAN port, which turned every fresh
-// CAN device into "no such CAN interface: can0: No such device" at connection
-// time. That is asserted here against an independent walk of /sys/class/net
-// done in the test itself, so a bug in the implementation's own helper cannot
-// make the test agree with it.
+// defaultSettings() used to hardcode "can0", so a fresh device on a machine
+// without a physical CAN port failed with "no such CAN interface". Both are
+// checked against an independent walk of /sys/class/net done here, so a bug in
+// the implementation's own helper cannot make the test agree with it.
 
 #include <Device/Protocol/DeviceInterface.hpp>
 #include <Device/Protocol/ProtocolFactoryInterface.hpp>

--- a/tests/unit/CANEnumeratorTest.cpp
+++ b/tests/unit/CANEnumeratorTest.cpp
@@ -100,6 +100,10 @@ struct library_files
     QDir{}.mkpath(dir);
   }
 
+  //! The library lives under the documents directory, which a CI container may
+  //! not have: nothing to test there rather than a failure.
+  bool usable() const { return QFileInfo{dir}.isWritable(); }
+
   ~library_files() { QDir{dir}.removeRecursively(); }
 
   //! Returns the absolute path of the file it wrote.
@@ -107,7 +111,8 @@ struct library_files
   {
     const QString path = dir + '/' + name;
     QFile f{path};
-    REQUIRE(f.open(QIODevice::WriteOnly));
+    if(!f.open(QIODevice::WriteOnly))
+      FAIL("could not write " << path.toStdString());
     REQUIRE(f.write(content) == content.size());
     f.close();
     written.push_back(path);
@@ -191,6 +196,8 @@ TEST_CASE("the CAN protocol offers the databases in the library", "[can]")
     }
 
     library_files lib{ctx};
+    if(!lib.usable())
+      SKIP("no writable user library at " << lib.dir.toStdString());
     const auto dbc = lib.write("LPMS3_sample.dbc", sample_dbc);
 
     auto doc = score::test::new_document(ctx);
@@ -250,6 +257,8 @@ TEST_CASE("the CAN protocol offers only actual databases", "[can]")
     }
 
     library_files lib{ctx};
+    if(!lib.usable())
+      SKIP("no writable user library at " << lib.dir.toStdString());
     lib.write("real.dbc", sample_dbc);
 
     // Right extension, but no message in it: nothing for a device to read.

--- a/tests/unit/CANEnumeratorTest.cpp
+++ b/tests/unit/CANEnumeratorTest.cpp
@@ -1,0 +1,217 @@
+// The CAN protocol's device browser entry and its default interface.
+//
+// Both used to be missing or wrong: CANProtocolFactory had no getEnumerators()
+// override, so selecting "CAN" in the add-device dialog showed an empty list,
+// and defaultSettings() hardcoded "can0" -- an interface that does not exist on
+// any machine without a physical CAN port, which turned every fresh CAN device
+// into "no such CAN interface: can0: No such device" at connection time.
+//
+// Everything here is asserted against an independent walk of /sys/class/net
+// done in the test itself, not against the implementation's own helper, so a
+// bug in the helper cannot make the test agree with it.
+
+#include <Device/Protocol/ProtocolFactoryInterface.hpp>
+#include <Device/Protocol/ProtocolList.hpp>
+
+#include <Protocols/CAN/CANSpecificSettings.hpp>
+
+#include <core/document/Document.hpp>
+
+#include <QDir>
+#include <QFile>
+
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <algorithm>
+
+namespace
+{
+//! The uuid of Protocols::CANProtocolFactory. Spelled out rather than taken
+//! from the class so that a renamed or moved factory still has to keep the key
+//! its saved scores refer to.
+constexpr UuidKey<Device::ProtocolFactory> can_protocol_key()
+{
+  return UuidKey<Device::ProtocolFactory>{"2492941c-18ee-4f96-ac3d-c3d42c0bb649"};
+}
+
+//! ARPHRD_CAN.
+constexpr int arphrd_can = 280;
+
+//! What the machine actually has, read straight out of sysfs.
+QStringList sysfsCanInterfaces()
+{
+  QStringList out;
+  QDir sys{"/sys/class/net"};
+  for(const auto& name :
+      sys.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::System))
+  {
+    QFile type{"/sys/class/net/" + name + "/type"};
+    if(!type.open(QIODevice::ReadOnly | QIODevice::Text))
+      continue;
+
+    bool ok = false;
+    if(type.readAll().trimmed().toInt(&ok) == arphrd_can && ok)
+      out.push_back(name);
+  }
+  out.sort();
+  return out;
+}
+
+Device::ProtocolFactory* canFactory(const score::GUIApplicationContext& ctx)
+{
+  auto& list = ctx.interfaces<Device::ProtocolFactoryList>();
+  return list.get(can_protocol_key());
+}
+}
+
+#if defined(__linux__)
+
+TEST_CASE("the CAN protocol enumerates the interfaces sysfs reports", "[can]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* factory = canFactory(ctx);
+    if(!factory)
+    {
+      SUCCEED("this build has no CAN protocol");
+      return;
+    }
+
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    auto enumerators = factory->getEnumerators(doc->context());
+    REQUIRE(enumerators.size() == 1);
+    REQUIRE(enumerators[0].second != nullptr);
+
+    std::vector<std::pair<QString, Device::DeviceSettings>> found;
+    enumerators[0].second->enumerate(
+        [&](const QString& name, const Device::DeviceSettings& s) {
+      found.emplace_back(name, s);
+    });
+
+    const auto expected = sysfsCanInterfaces();
+
+    QStringList names;
+    for(auto& [n, s] : found)
+      names.push_back(n);
+    names.sort();
+    REQUIRE(names == expected);
+
+    // Each entry must be usable as-is: right protocol key, and an interface
+    // name the kernel will accept. An entry whose settings still had to be
+    // filled in by hand would defeat the point of the browser.
+    for(auto& [n, s] : found)
+    {
+      REQUIRE(s.protocol == can_protocol_key());
+      REQUIRE(!s.name.isEmpty());
+
+      const auto specif = s.deviceSpecificSettings.value<Protocols::CANSpecificSettings>();
+      REQUIRE(specif.interfaceName == n);
+      REQUIRE(expected.contains(specif.interfaceName));
+    }
+
+    delete enumerators[0].second;
+  });
+}
+
+TEST_CASE("the CAN protocol never enumerates a non-CAN netdev", "[can]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* factory = canFactory(ctx);
+    if(!factory)
+    {
+      SUCCEED("this build has no CAN protocol");
+      return;
+    }
+
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    auto enumerators = factory->getEnumerators(doc->context());
+    REQUIRE(enumerators.size() == 1);
+
+    QStringList names;
+    enumerators[0].second->enumerate(
+        [&](const QString& name, const Device::DeviceSettings&) {
+      names.push_back(name);
+    });
+
+    // "lo" is on every machine and is ARPHRD_LOOPBACK (772), so it is the one
+    // netdev we can always assert is filtered out. Matching on the name prefix
+    // instead of the link type would also have let it through only by accident.
+    REQUIRE(!names.contains("lo"));
+
+    for(const auto& n : names)
+    {
+      QFile type{"/sys/class/net/" + n + "/type"};
+      REQUIRE(type.open(QIODevice::ReadOnly | QIODevice::Text));
+      REQUIRE(type.readAll().trimmed().toInt() == arphrd_can);
+    }
+
+    delete enumerators[0].second;
+  });
+}
+
+TEST_CASE("the CAN default settings name an interface that exists", "[can]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* factory = canFactory(ctx);
+    if(!factory)
+    {
+      SUCCEED("this build has no CAN protocol");
+      return;
+    }
+
+    const auto settings = factory->defaultSettings();
+    const auto specif
+        = settings.deviceSpecificSettings.value<Protocols::CANSpecificSettings>();
+
+    const auto present = sysfsCanInterfaces();
+
+    if(present.isEmpty())
+    {
+      // Empty, not "can0": naming an interface that is not there produces a
+      // failure at connect time for a value the user never chose.
+      REQUIRE(specif.interfaceName.isEmpty());
+    }
+    else
+    {
+      REQUIRE(present.contains(specif.interfaceName));
+
+      // A physical adapter wins over a vcan left over from a test.
+      const bool anyPhysical = std::any_of(
+          present.begin(), present.end(),
+          [](const QString& n) { return !n.startsWith("vcan"); });
+      if(anyPhysical)
+        REQUIRE(!specif.interfaceName.startsWith("vcan"));
+    }
+  });
+}
+
+TEST_CASE("the CAN default settings follow the machine, not a cached value", "[can]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* factory = canFactory(ctx);
+    if(!factory)
+    {
+      SUCCEED("this build has no CAN protocol");
+      return;
+    }
+
+    // defaultSettings() returns a reference; two calls must still both describe
+    // the machine as it is now (an adapter plugged in after startup has to show
+    // up), and the second must not invalidate what the first said.
+    const auto a = factory->defaultSettings();
+    const auto b = factory->defaultSettings();
+
+    REQUIRE(
+        a.deviceSpecificSettings.value<Protocols::CANSpecificSettings>().interfaceName
+        == b.deviceSpecificSettings.value<Protocols::CANSpecificSettings>()
+               .interfaceName);
+  });
+}
+
+#endif

--- a/tests/unit/CANEnumeratorTest.cpp
+++ b/tests/unit/CANEnumeratorTest.cpp
@@ -14,7 +14,6 @@
 #include <Device/Protocol/ProtocolList.hpp>
 
 #include <Library/LibrarySettings.hpp>
-
 #include <Protocols/CAN/CANSpecificSettings.hpp>
 
 #include <core/document/Document.hpp>
@@ -25,10 +24,9 @@
 #include <QFile>
 #include <QFileInfo>
 
+#include <catch2/catch_all.hpp>
 #include <score_test/App.hpp>
 #include <score_test/Document.hpp>
-
-#include <catch2/catch_all.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -51,8 +49,7 @@ QStringList sysfsCanInterfaces()
 {
   QStringList out;
   QDir sys{"/sys/class/net"};
-  for(const auto& name :
-      sys.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::System))
+  for(const auto& name : sys.entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::System))
   {
     QFile type{"/sys/class/net/" + name + "/type"};
     if(!type.open(QIODevice::ReadOnly | QIODevice::Text))
@@ -103,10 +100,7 @@ struct library_files
     QDir{}.mkpath(dir);
   }
 
-  ~library_files()
-  {
-    QDir{dir}.removeRecursively();
-  }
+  ~library_files() { QDir{dir}.removeRecursively(); }
 
   //! Returns the absolute path of the file it wrote.
   QString write(const QString& name, const QByteArray& content)
@@ -307,9 +301,10 @@ TEST_CASE("the CAN default settings name an interface that exists", "[can]")
       REQUIRE(present.contains(specif.interfaceName));
 
       // A physical adapter wins over a vcan left over from a test.
-      const bool anyPhysical = std::any_of(
-          present.begin(), present.end(),
-          [](const QString& n) { return !n.startsWith("vcan"); });
+      const bool anyPhysical
+          = std::any_of(present.begin(), present.end(), [](const QString& n) {
+        return !n.startsWith("vcan");
+      });
       if(anyPhysical)
         REQUIRE(!specif.interfaceName.startsWith("vcan"));
     }

--- a/tests/unit/CANEnumeratorTest.cpp
+++ b/tests/unit/CANEnumeratorTest.cpp
@@ -1,24 +1,33 @@
 // The CAN protocol's device browser entry and its default interface.
 //
-// Both used to be missing or wrong: CANProtocolFactory had no getEnumerators()
-// override, so selecting "CAN" in the add-device dialog showed an empty list,
-// and defaultSettings() hardcoded "can0" -- an interface that does not exist on
-// any machine without a physical CAN port, which turned every fresh CAN device
-// into "no such CAN interface: can0: No such device" at connection time.
+// The browser lists the .dbc databases found in the user library, the way the
+// OSC / Serial / WS protocols list their own file types. It used to list the
+// machine's CAN interfaces instead, which told the user nothing the settings
+// widget's combo box did not already show; a database, on the other hand,
+// arrives with a whole node tree attached and there can be any number of them.
 //
-// Everything here is asserted against an independent walk of /sys/class/net
-// done in the test itself, not against the implementation's own helper, so a
-// bug in the helper cannot make the test agree with it.
+// defaultSettings() also used to hardcode "can0" -- an interface that does not
+// exist on any machine without a physical CAN port, which turned every fresh
+// CAN device into "no such CAN interface: can0: No such device" at connection
+// time. That is asserted here against an independent walk of /sys/class/net
+// done in the test itself, so a bug in the implementation's own helper cannot
+// make the test agree with it.
 
+#include <Device/Protocol/DeviceInterface.hpp>
 #include <Device/Protocol/ProtocolFactoryInterface.hpp>
 #include <Device/Protocol/ProtocolList.hpp>
+
+#include <Library/LibrarySettings.hpp>
 
 #include <Protocols/CAN/CANSpecificSettings.hpp>
 
 #include <core/document/Document.hpp>
 
+#include <QApplication>
 #include <QDir>
+#include <QElapsedTimer>
 #include <QFile>
+#include <QFileInfo>
 
 #include <score_test/App.hpp>
 #include <score_test/Document.hpp>
@@ -26,6 +35,7 @@
 #include <catch2/catch_all.hpp>
 
 #include <algorithm>
+#include <memory>
 
 namespace
 {
@@ -65,11 +75,122 @@ Device::ProtocolFactory* canFactory(const score::GUIApplicationContext& ctx)
   auto& list = ctx.interfaces<Device::ProtocolFactoryList>();
   return list.get(can_protocol_key());
 }
+
+//! A minimal but real database: one message, two signals.
+constexpr auto sample_dbc = R"_(VERSION ""
+
+BS_:
+
+BU_: Sensor
+
+BO_ 385 PDO1_Transmit: 4 Sensor
+ SG_ AccelerationX : 0|16@1- (0.001,0) [-32|32] "g" Vector__XXX
+ SG_ AccelerationY : 16|16@1- (0.001,0) [-32|32] "g" Vector__XXX
+)_";
+
+/**
+ * Files dropped in the library for the duration of one test case.
+ *
+ * The test application's library root is
+ * ~/Documents/ossia/score-test (applicationName is "score-test", not "score"),
+ * so this never touches the real one.
+ */
+struct library_files
+{
+  QString dir;
+  QStringList written;
+
+  explicit library_files(const score::GUIApplicationContext& ctx)
+  {
+    dir = ctx.settings<Library::Settings::Model>().getPackagesPath()
+          + "/can-enumerator-test";
+    QDir{}.mkpath(dir);
+  }
+
+  ~library_files()
+  {
+    QDir{dir}.removeRecursively();
+  }
+
+  //! Returns the absolute path of the file it wrote.
+  QString write(const QString& name, const QByteArray& content)
+  {
+    const QString path = dir + '/' + name;
+    QFile f{path};
+    REQUIRE(f.open(QIODevice::WriteOnly));
+    REQUIRE(f.write(content) == content.size());
+    f.close();
+    written.push_back(path);
+    return QFileInfo{path}.absoluteFilePath();
+  }
+};
+
+struct enumerated
+{
+  QString name;
+  Device::DeviceSettings settings;
+};
+
+/**
+ * Collects what an enumerator reports, until \a until shows up or the deadline
+ * passes.
+ *
+ * LibraryDeviceEnumerator scans on a worker thread and reports through queued
+ * signals, so there is nothing to read synchronously: enumerate() on it is a
+ * no-op by design, and the only way to observe it is to run the event loop.
+ *
+ * Waiting for a named entry rather than for a fixed duration is what keeps this
+ * honest in both directions: a test that asserts a file is *absent* has to know
+ * the scan actually ran, and the file that must be there is the proof of it.
+ */
+std::vector<enumerated> collect(
+    Device::DeviceEnumerator& e, const QString& until,
+    std::chrono::seconds deadline = std::chrono::seconds(20))
+{
+  std::vector<enumerated> out;
+  QObject::connect(
+      &e, &Device::DeviceEnumerator::deviceAdded, qApp,
+      [&out](const QString& n, const Device::DeviceSettings& s) {
+    out.push_back({n, s});
+  });
+
+  const auto seen = [&out, &until] {
+    return std::any_of(out.begin(), out.end(), [&until](const enumerated& e) {
+      return e.name == until;
+    });
+  };
+
+  QElapsedTimer t;
+  t.start();
+  while(!seen() && t.elapsed() < deadline.count() * 1000)
+    QApplication::processEvents(QEventLoop::AllEvents, 20);
+
+  // The commit actions are delivered in batches of up to 255; drain whatever
+  // else is on its way, so that "this file was not offered" means it, rather
+  // than meaning "it was in the next batch".
+  const auto drain = t.elapsed() + 250;
+  while(t.elapsed() < drain)
+    QApplication::processEvents(QEventLoop::AllEvents, 20);
+
+  return out;
+}
+
+const enumerated* find(const std::vector<enumerated>& v, const QString& name)
+{
+  auto it = std::find_if(
+      v.begin(), v.end(), [&name](const enumerated& e) { return e.name == name; });
+  return it == v.end() ? nullptr : &*it;
+}
+
+Protocols::CANSpecificSettings specific(const Device::DeviceSettings& s)
+{
+  return s.deviceSpecificSettings.value<Protocols::CANSpecificSettings>();
+}
 }
 
 #if defined(__linux__)
 
-TEST_CASE("the CAN protocol enumerates the interfaces sysfs reports", "[can]")
+TEST_CASE("the CAN protocol offers the databases in the library", "[can]")
 {
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
     auto* factory = canFactory(ctx);
@@ -78,6 +199,9 @@ TEST_CASE("the CAN protocol enumerates the interfaces sysfs reports", "[can]")
       SUCCEED("this build has no CAN protocol");
       return;
     }
+
+    library_files lib{ctx};
+    const auto dbc = lib.write("LPMS3_sample.dbc", sample_dbc);
 
     auto doc = score::test::new_document(ctx);
     REQUIRE(doc);
@@ -85,39 +209,47 @@ TEST_CASE("the CAN protocol enumerates the interfaces sysfs reports", "[can]")
     auto enumerators = factory->getEnumerators(doc->context());
     REQUIRE(enumerators.size() == 1);
     REQUIRE(enumerators[0].second != nullptr);
+    std::unique_ptr<Device::DeviceEnumerator> owned{enumerators[0].second};
 
-    std::vector<std::pair<QString, Device::DeviceSettings>> found;
-    enumerators[0].second->enumerate(
-        [&](const QString& name, const Device::DeviceSettings& s) {
-      found.emplace_back(name, s);
-    });
+    const auto found = collect(*owned, "LPMS3_sample");
 
-    const auto expected = sysfsCanInterfaces();
+    // Named after the file, so that a library of a dozen vendor databases is
+    // navigable.
+    const auto* e = find(found, "LPMS3_sample");
+    REQUIRE(e != nullptr);
+    REQUIRE(e->settings.protocol == can_protocol_key());
 
-    QStringList names;
-    for(auto& [n, s] : found)
-      names.push_back(n);
-    names.sort();
-    REQUIRE(names == expected);
-
-    // Each entry must be usable as-is: right protocol key, and an interface
-    // name the kernel will accept. An entry whose settings still had to be
-    // filled in by hand would defeat the point of the browser.
-    for(auto& [n, s] : found)
+    SECTION("the database is filled in, so the device arrives with its tree")
     {
-      REQUIRE(s.protocol == can_protocol_key());
-      REQUIRE(!s.name.isEmpty());
-
-      const auto specif = s.deviceSpecificSettings.value<Protocols::CANSpecificSettings>();
-      REQUIRE(specif.interfaceName == n);
-      REQUIRE(expected.contains(specif.interfaceName));
+      const auto specif = specific(e->settings);
+      REQUIRE(specif.dbcPath == dbc);
+      REQUIRE(QFile::exists(specif.dbcPath));
     }
 
-    delete enumerators[0].second;
+    SECTION("and so is the interface, so it is connectable as-is")
+    {
+      // Only assertable when the machine has one at all; on a machine with no
+      // CAN interface the field is legitimately empty and the user must pick.
+      const auto present = sysfsCanInterfaces();
+      const auto specif = specific(e->settings);
+      if(present.empty())
+        REQUIRE(specif.interfaceName.isEmpty());
+      else
+        REQUIRE(present.contains(specif.interfaceName));
+    }
+
+    SECTION("the defaults of the settings are left alone")
+    {
+      const auto specif = specific(e->settings);
+      // float32Override contradicts what a database says and must stay opt-in
+      // even for a file the browser offered.
+      REQUIRE(!specif.float32Override);
+      REQUIRE(specif.nodeIdOffset == 0);
+    }
   });
 }
 
-TEST_CASE("the CAN protocol never enumerates a non-CAN netdev", "[can]")
+TEST_CASE("the CAN protocol offers only actual databases", "[can]")
 {
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
     auto* factory = canFactory(ctx);
@@ -127,31 +259,32 @@ TEST_CASE("the CAN protocol never enumerates a non-CAN netdev", "[can]")
       return;
     }
 
+    library_files lib{ctx};
+    lib.write("real.dbc", sample_dbc);
+
+    // Right extension, but no message in it: nothing for a device to read.
+    lib.write("empty.dbc", "VERSION \"\"\n\nBS_:\n\nBU_: Sensor\n");
+
+    // The message keyword, but not a database: the extension is what says
+    // "this is a CAN file", and matching content alone would drag in every
+    // stray text file that happens to contain "BO_".
+    lib.write("notes.txt", sample_dbc);
+
     auto doc = score::test::new_document(ctx);
     REQUIRE(doc);
 
     auto enumerators = factory->getEnumerators(doc->context());
     REQUIRE(enumerators.size() == 1);
+    std::unique_ptr<Device::DeviceEnumerator> owned{enumerators[0].second};
 
-    QStringList names;
-    enumerators[0].second->enumerate(
-        [&](const QString& name, const Device::DeviceSettings&) {
-      names.push_back(name);
-    });
+    // "real" is the control: once it has arrived the scan has run, so the
+    // absence of the other two is a statement about the filter, not about
+    // timing.
+    const auto found = collect(*owned, "real");
 
-    // "lo" is on every machine and is ARPHRD_LOOPBACK (772), so it is the one
-    // netdev we can always assert is filtered out. Matching on the name prefix
-    // instead of the link type would also have let it through only by accident.
-    REQUIRE(!names.contains("lo"));
-
-    for(const auto& n : names)
-    {
-      QFile type{"/sys/class/net/" + n + "/type"};
-      REQUIRE(type.open(QIODevice::ReadOnly | QIODevice::Text));
-      REQUIRE(type.readAll().trimmed().toInt() == arphrd_can);
-    }
-
-    delete enumerators[0].second;
+    REQUIRE(find(found, "real") != nullptr);
+    REQUIRE(find(found, "empty") == nullptr);
+    REQUIRE(find(found, "notes") == nullptr);
   });
 }
 
@@ -165,16 +298,12 @@ TEST_CASE("the CAN default settings name an interface that exists", "[can]")
       return;
     }
 
-    const auto settings = factory->defaultSettings();
-    const auto specif
-        = settings.deviceSpecificSettings.value<Protocols::CANSpecificSettings>();
-
     const auto present = sysfsCanInterfaces();
+    const auto specif = specific(factory->defaultSettings());
 
-    if(present.isEmpty())
+    if(present.empty())
     {
-      // Empty, not "can0": naming an interface that is not there produces a
-      // failure at connect time for a value the user never chose.
+      // Nothing rather than a name the kernel will reject.
       REQUIRE(specif.interfaceName.isEmpty());
     }
     else
@@ -201,16 +330,12 @@ TEST_CASE("the CAN default settings follow the machine, not a cached value", "[c
       return;
     }
 
-    // defaultSettings() returns a reference; two calls must still both describe
-    // the machine as it is now (an adapter plugged in after startup has to show
-    // up), and the second must not invalidate what the first said.
+    // Recomputed on every call, so an adapter plugged in after score started
+    // shows up; two consecutive calls must still agree.
     const auto a = factory->defaultSettings();
     const auto b = factory->defaultSettings();
 
-    REQUIRE(
-        a.deviceSpecificSettings.value<Protocols::CANSpecificSettings>().interfaceName
-        == b.deviceSpecificSettings.value<Protocols::CANSpecificSettings>()
-               .interfaceName);
+    REQUIRE(specific(a).interfaceName == specific(b).interfaceName);
   });
 }
 

--- a/tests/unit/CANScriptingTest.cpp
+++ b/tests/unit/CANScriptingTest.cpp
@@ -1,42 +1,15 @@
-/**
- * End-to-end test of the CAN device, driven entirely through score's JavaScript
- * scripting API.
- *
- * The existing CAN tests are unit-level: the DBC parser on one side, raw
- * SocketCAN frames through ossia::net::can_socket on the other. Neither ever
- * instantiates the score device, so nothing covered the part the user actually
- * gets: a device created from settings, a DBC turned into an ossia node tree, a
- * frame on the wire turned into a value at an address.
- *
- * Everything here goes through the object score's console panel binds to the
- * global name `Score` -- JS::EditJsContext -- exactly as it is installed in
- * JS::ApplicationPlugin:
- *
- *   Score.createDevice(name, uuid, settings)   creates and connects the device
- *   Score.deviceToOSCQuery(name)               the namespace it produced
- *   Score.iterateDevice(name, fn)              every (address, value) pair
- *   Score.removeDevice(name)
- *
- * The test only ever writes frames on the bus and reads the tree back through
- * those calls: no protocol internals, no direct parameter access. That is the
- * point -- the layer under test is everything between a CAN frame and what a
- * script sees, which is where the device's own bugs would live.
- *
- * The libossia QML layer was the other candidate, and is the wrong one here:
- * Protocols.can() hands a script a raw socket and builds no tree at all
- * (libossia's own tests/Qt/QmlCanTest.cpp already covers it), while
- * ossia::qt::qml_device owns the generic_device it creates and has no way to
- * adopt an existing one -- neither goes anywhere near CANDevice or the DBC, so
- * a test written against them would exercise ossia, not this protocol.
- *
- * The `Device` global of the console (ossia's qml_engine_functions, i.e.
- * Device.read/Device.write) would have given plain numbers instead of the typed
- * objects iterateDevice returns, but JS::DeviceContext carries no export macro
- * and is not linkable from here. Not worth changing the plugin's ABI for a
- * nicer-looking test.
- *
- * Skipped, not failed, when vcan0 is absent.
- */
+// End-to-end test of the CAN device, through score's `Score` scripting object
+// (JS::EditJsContext, what the console panel binds).
+//
+// The other CAN tests are unit-level - the DBC parser on one side, raw frames
+// through ossia::net::can_socket on the other - and never instantiate the score
+// device. Here everything goes through createDevice / iterateDevice /
+// deviceToOSCQuery: a frame on the wire becomes a value at an address.
+//
+// libossia's QML layer was the other candidate and is the wrong one:
+// Protocols.can() builds no tree, and qml_device cannot adopt an existing one.
+//
+// Skipped, not failed, when vcan0 is absent.
 
 #include <Device/Protocol/ProtocolFactoryInterface.hpp>
 

--- a/tests/unit/CANScriptingTest.cpp
+++ b/tests/unit/CANScriptingTest.cpp
@@ -20,10 +20,9 @@
 #include <QJSEngine>
 #include <QQmlEngine>
 
+#include <catch2/catch_all.hpp>
 #include <score_test/App.hpp>
 #include <score_test/Document.hpp>
-
-#include <catch2/catch_all.hpp>
 
 #if defined(__linux__)
 
@@ -34,10 +33,10 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 
-#include <chrono>
 #include <array>
-#include <string>
+#include <chrono>
 #include <cstring>
+#include <string>
 #include <thread>
 
 namespace
@@ -76,8 +75,7 @@ struct Console
 
   Console()
   {
-    engine.globalObject().setProperty(
-        "Score", engine.newQObject(new JS::EditJsContext));
+    engine.globalObject().setProperty("Score", engine.newQObject(new JS::EditJsContext));
   }
 
   /**
@@ -102,7 +100,8 @@ struct Console
   //! JSON serialization uses, which is what createDevice() feeds them to.
   void createCanDevice(const QString& name, int nodeIdOffset = 0)
   {
-    eval(QString{R"js(
+    eval(
+        QString{R"js(
       Score.createDevice("%1", "%2", {
         "Interface": "%3",
         "DBC": "%4",
@@ -112,8 +111,8 @@ struct Console
         "FilterToDatabase": false
       })
     )js"}
-             .arg(name, can_uuid, can_iface, dbcPath())
-             .arg(nodeIdOffset));
+            .arg(name, can_uuid, can_iface, dbcPath())
+            .arg(nodeIdOffset));
   }
 
   //! Every address the device exposes, sorted, one per line. Returned as one
@@ -121,7 +120,8 @@ struct Console
   //! mismatch is then readable instead of forty {?}.
   std::string addresses(const QString& device)
   {
-    return eval(QString{R"js(
+    return eval(
+               QString{R"js(
       (function() {
         var out = [];
         Score.iterateDevice("%1", function(addr, value) { out.push(addr); });
@@ -129,7 +129,7 @@ struct Console
         return out.join("\n");
       })()
     )js"}
-                    .arg(device))
+                   .arg(device))
         .toString()
         .toStdString();
   }
@@ -144,7 +144,8 @@ struct Console
    */
   QJSValue valueAt(const QString& device, const QString& address)
   {
-    return eval(QString{R"js(
+    return eval(
+        QString{R"js(
       (function() {
         var found;
         Score.iterateDevice("%1", function(addr, value) {
@@ -154,7 +155,7 @@ struct Console
         return found;
       })()
     )js"}
-                    .arg(device, address));
+            .arg(device, address));
   }
 };
 
@@ -166,10 +167,10 @@ struct Bus
 
   Bus()
       : tx{[] {
-          ossia::net::can_configuration conf;
-          conf.interface_name = can_iface;
-          return conf;
-        }(), ctx}
+             ossia::net::can_configuration conf;
+             conf.interface_name = can_iface;
+             return conf;
+           }(), ctx}
   {
     tx.open();
   }
@@ -199,8 +200,8 @@ struct Bus
 //!   W =  9878 = 0x2696   X = -1234 = 0xFB2E   Y = 0   Z = 32767 = 0x7FFF
 //! little-endian on the wire, so low byte first.
 constexpr uint32_t pdo4_node1 = 0x481;
-constexpr std::array<uint8_t, 8> pdo4_payload{
-    0x96, 0x26, 0x2E, 0xFB, 0x00, 0x00, 0xFF, 0x7F};
+constexpr std::array<uint8_t, 8> pdo4_payload{0x96, 0x26, 0x2E, 0xFB,
+                                              0x00, 0x00, 0xFF, 0x7F};
 
 /**
  * Pump both the Qt event loop and the clock until `pred` holds.
@@ -247,26 +248,26 @@ TEST_CASE("a CAN device created from a script exposes the DBC tree", "[can][js]"
     // whole point of the database is that the script sees names.
     const auto addrs = js.addresses("imu");
 
-    const std::string expected =
-        "imu:/PDO1_Transmit/Acc_CalibratedX\n"
-        "imu:/PDO1_Transmit/Acc_CalibratedY\n"
-        "imu:/PDO1_Transmit/Acc_CalibratedZ\n"
-        "imu:/PDO1_Transmit/GyroII_Align_CalibratedX\n"
-        "imu:/PDO2_Transmit/GyroII_Align_CalibratedY\n"
-        "imu:/PDO2_Transmit/GyroII_Align_CalibratedZ\n"
-        "imu:/PDO2_Transmit/Mag_CalibratedX\n"
-        "imu:/PDO2_Transmit/Mag_CalibratedY\n"
-        "imu:/PDO3_Transmit/EulerX\n"
-        "imu:/PDO3_Transmit/EulerY\n"
-        "imu:/PDO3_Transmit/EulerZ\n"
-        "imu:/PDO3_Transmit/Mag_CalibratedZ\n"
-        "imu:/PDO4_Transmit/QuaternionW\n"
-        "imu:/PDO4_Transmit/QuaternionX\n"
-        "imu:/PDO4_Transmit/QuaternionY\n"
-        // The vendor's typo in QuatetnionZ, kept: renaming a signal would break
-        // every score written against the file. It sorts last because JS orders
-        // by UTF-16 code unit and 'r' < 't'.
-        "imu:/PDO4_Transmit/QuatetnionZ";
+    const std::string expected
+        = "imu:/PDO1_Transmit/Acc_CalibratedX\n"
+          "imu:/PDO1_Transmit/Acc_CalibratedY\n"
+          "imu:/PDO1_Transmit/Acc_CalibratedZ\n"
+          "imu:/PDO1_Transmit/GyroII_Align_CalibratedX\n"
+          "imu:/PDO2_Transmit/GyroII_Align_CalibratedY\n"
+          "imu:/PDO2_Transmit/GyroII_Align_CalibratedZ\n"
+          "imu:/PDO2_Transmit/Mag_CalibratedX\n"
+          "imu:/PDO2_Transmit/Mag_CalibratedY\n"
+          "imu:/PDO3_Transmit/EulerX\n"
+          "imu:/PDO3_Transmit/EulerY\n"
+          "imu:/PDO3_Transmit/EulerZ\n"
+          "imu:/PDO3_Transmit/Mag_CalibratedZ\n"
+          "imu:/PDO4_Transmit/QuaternionW\n"
+          "imu:/PDO4_Transmit/QuaternionX\n"
+          "imu:/PDO4_Transmit/QuaternionY\n"
+          // The vendor's typo in QuatetnionZ, kept: renaming a signal would break
+          // every score written against the file. It sorts last because JS orders
+          // by UTF-16 code unit and 'r' < 't'.
+          "imu:/PDO4_Transmit/QuatetnionZ";
     REQUIRE(addrs == expected);
 
     // Heatbeat (0x701) has no SG_ record at all, so it is a node with no

--- a/tests/unit/CANScriptingTest.cpp
+++ b/tests/unit/CANScriptingTest.cpp
@@ -1,0 +1,474 @@
+/**
+ * End-to-end test of the CAN device, driven entirely through score's JavaScript
+ * scripting API.
+ *
+ * The existing CAN tests are unit-level: the DBC parser on one side, raw
+ * SocketCAN frames through ossia::net::can_socket on the other. Neither ever
+ * instantiates the score device, so nothing covered the part the user actually
+ * gets: a device created from settings, a DBC turned into an ossia node tree, a
+ * frame on the wire turned into a value at an address.
+ *
+ * Everything here goes through the object score's console panel binds to the
+ * global name `Score` -- JS::EditJsContext -- exactly as it is installed in
+ * JS::ApplicationPlugin:
+ *
+ *   Score.createDevice(name, uuid, settings)   creates and connects the device
+ *   Score.deviceToOSCQuery(name)               the namespace it produced
+ *   Score.iterateDevice(name, fn)              every (address, value) pair
+ *   Score.removeDevice(name)
+ *
+ * The test only ever writes frames on the bus and reads the tree back through
+ * those calls: no protocol internals, no direct parameter access. That is the
+ * point -- the layer under test is everything between a CAN frame and what a
+ * script sees, which is where the device's own bugs would live.
+ *
+ * The libossia QML layer was the other candidate, and is the wrong one here:
+ * Protocols.can() hands a script a raw socket and builds no tree at all
+ * (libossia's own tests/Qt/QmlCanTest.cpp already covers it), while
+ * ossia::qt::qml_device owns the generic_device it creates and has no way to
+ * adopt an existing one -- neither goes anywhere near CANDevice or the DBC, so
+ * a test written against them would exercise ossia, not this protocol.
+ *
+ * The `Device` global of the console (ossia's qml_engine_functions, i.e.
+ * Device.read/Device.write) would have given plain numbers instead of the typed
+ * objects iterateDevice returns, but JS::DeviceContext carries no export macro
+ * and is not linkable from here. Not worth changing the plugin's ABI for a
+ * nicer-looking test.
+ *
+ * Skipped, not failed, when vcan0 is absent.
+ */
+
+#include <Device/Protocol/ProtocolFactoryInterface.hpp>
+
+#include <JS/Qml/EditContext.hpp>
+
+#include <core/document/Document.hpp>
+
+#include <QJSEngine>
+#include <QQmlEngine>
+
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#if defined(__linux__)
+
+#include <ossia/network/sockets/can_socket.hpp>
+
+#include <boost/asio/io_context.hpp>
+
+#include <net/if.h>
+#include <sys/ioctl.h>
+
+#include <chrono>
+#include <array>
+#include <string>
+#include <cstring>
+#include <thread>
+
+namespace
+{
+constexpr const char* can_iface = "vcan0";
+constexpr const char* can_uuid = "2492941c-18ee-4f96-ac3d-c3d42c0bb649";
+
+bool ifacePresent()
+{
+  int fd = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+  if(fd < 0)
+    return false;
+
+  ifreq ifr{};
+  std::strncpy(ifr.ifr_name, can_iface, sizeof(ifr.ifr_name) - 1);
+  const bool ok = ::ioctl(fd, SIOCGIFINDEX, &ifr) == 0;
+  ::close(fd);
+  return ok;
+}
+
+QString dbcPath()
+{
+  return QString{SCORE_CAN_TEST_DATA} + "/LPMS3_16bit.dbc";
+}
+
+/**
+ * The scripting environment of the console panel, rebuilt here.
+ *
+ * JS::ApplicationPlugin binds the very same JS::EditJsContext to `Score` on its
+ * QQmlEngine; going through the plugin instance instead would mean reaching for
+ * a class that carries no export macro. The object under test is the same one.
+ */
+struct Console
+{
+  QQmlEngine engine;
+
+  Console()
+  {
+    engine.globalObject().setProperty(
+        "Score", engine.newQObject(new JS::EditJsContext));
+  }
+
+  QJSValue eval(const QString& js)
+  {
+    auto res = engine.evaluate(js);
+    INFO("script: " << js.toStdString());
+    INFO("result: " << res.toString().toStdString());
+    REQUIRE(!res.isError());
+    return res;
+  }
+
+  //! Create a CAN device. The settings keys are the ones the protocol's own
+  //! JSON serialization uses, which is what createDevice() feeds them to.
+  void createCanDevice(const QString& name, int nodeIdOffset = 0)
+  {
+    eval(QString{R"js(
+      Score.createDevice("%1", "%2", {
+        "Interface": "%3",
+        "DBC": "%4",
+        "NodeIdOffset": %5,
+        "Float32Override": false,
+        "FD": false,
+        "FilterToDatabase": false
+      })
+    )js"}
+             .arg(name, can_uuid, can_iface, dbcPath())
+             .arg(nodeIdOffset));
+  }
+
+  //! Every address the device exposes, sorted, one per line. Returned as one
+  //! std::string rather than a list: Catch2 knows how to print it, and a
+  //! mismatch is then readable instead of forty {?}.
+  std::string addresses(const QString& device)
+  {
+    return eval(QString{R"js(
+      (function() {
+        var out = [];
+        Score.iterateDevice("%1", function(addr, value) { out.push(addr); });
+        out.sort();
+        return out.join("\n");
+      })()
+    )js"}
+                    .arg(device))
+        .toString()
+        .toStdString();
+  }
+
+  /**
+   * The value at one address, or undefined when the address is not there.
+   *
+   * iterateDevice hands the callback the typed form ossia's
+   * js_value_outbound_visitor produces -- `{ type: Ossia.Type.Float, value: x }`
+   * -- not a bare number. That is the shape a real script sees, so the test
+   * unwraps it the same way one would have to.
+   */
+  QJSValue valueAt(const QString& device, const QString& address)
+  {
+    return eval(QString{R"js(
+      (function() {
+        var found;
+        Score.iterateDevice("%1", function(addr, value) {
+          if(addr === "%2")
+            found = value.value;
+        });
+        return found;
+      })()
+    )js"}
+                    .arg(device, address));
+  }
+};
+
+//! A transmitter on the bus, independent of anything score does.
+struct Bus
+{
+  boost::asio::io_context ctx;
+  ossia::net::can_socket tx;
+
+  Bus()
+      : tx{[] {
+          ossia::net::can_configuration conf;
+          conf.interface_name = can_iface;
+          return conf;
+        }(), ctx}
+  {
+    tx.open();
+  }
+
+  ~Bus()
+  {
+    tx.close();
+    ctx.poll();
+  }
+
+  // std::array, not std::initializer_list: an initializer_list returned from a
+  // function dangles, and the frame then carries whatever is on the stack.
+  void write(uint32_t id, const std::array<uint8_t, 8>& payload)
+  {
+    ossia::net::can_message m;
+    m.id = id;
+    m.extended = false;
+    m.size = uint8_t(payload.size());
+    std::memcpy(m.data, payload.data(), payload.size());
+    REQUIRE(!tx.write(m));
+    ctx.poll();
+    ctx.restart();
+  }
+};
+
+//! PDO4 at node 1 with the documented worked example:
+//!   W =  9878 = 0x2696   X = -1234 = 0xFB2E   Y = 0   Z = 32767 = 0x7FFF
+//! little-endian on the wire, so low byte first.
+constexpr uint32_t pdo4_node1 = 0x481;
+constexpr std::array<uint8_t, 8> pdo4_payload{
+    0x96, 0x26, 0x2E, 0xFB, 0x00, 0x00, 0xFF, 0x7F};
+
+/**
+ * Pump both the Qt event loop and the clock until `pred` holds.
+ *
+ * The frame is received on the document plug-in's own asio thread, so there is
+ * nothing for the test to poll -- only to wait for, while keeping Qt alive so
+ * that the device's queued signals get through.
+ */
+template <typename F>
+bool waitFor(F pred, int ms = 2000)
+{
+  // Polled every 10ms rather than every 1ms: `pred` here evaluates a script
+  // that walks the whole device, and a 1ms period turns a two-second timeout
+  // into a couple of thousand redundant Catch2 assertions.
+  for(int i = 0; i < ms / 10; i++)
+  {
+    QApplication::processEvents();
+    if(pred())
+      return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  QApplication::processEvents();
+  return pred();
+}
+}
+
+TEST_CASE("a CAN device created from a script exposes the DBC tree", "[can][js]")
+{
+  if(!ifacePresent())
+  {
+    SUCCEED("skipped: no vcan0 interface");
+    return;
+  }
+
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    Console js;
+    js.createCanDevice("imu");
+    QApplication::processEvents();
+
+    // One address per DBC signal, named <Message>/<Signal>, under the device
+    // name the script chose. The identifiers are not in the tree at all: the
+    // whole point of the database is that the script sees names.
+    const auto addrs = js.addresses("imu");
+
+    const std::string expected =
+        "imu:/PDO1_Transmit/Acc_CalibratedX\n"
+        "imu:/PDO1_Transmit/Acc_CalibratedY\n"
+        "imu:/PDO1_Transmit/Acc_CalibratedZ\n"
+        "imu:/PDO1_Transmit/GyroII_Align_CalibratedX\n"
+        "imu:/PDO2_Transmit/GyroII_Align_CalibratedY\n"
+        "imu:/PDO2_Transmit/GyroII_Align_CalibratedZ\n"
+        "imu:/PDO2_Transmit/Mag_CalibratedX\n"
+        "imu:/PDO2_Transmit/Mag_CalibratedY\n"
+        "imu:/PDO3_Transmit/EulerX\n"
+        "imu:/PDO3_Transmit/EulerY\n"
+        "imu:/PDO3_Transmit/EulerZ\n"
+        "imu:/PDO3_Transmit/Mag_CalibratedZ\n"
+        "imu:/PDO4_Transmit/QuaternionW\n"
+        "imu:/PDO4_Transmit/QuaternionX\n"
+        "imu:/PDO4_Transmit/QuaternionY\n"
+        // The vendor's typo in QuatetnionZ, kept: renaming a signal would break
+        // every score written against the file. It sorts last because JS orders
+        // by UTF-16 code unit and 'r' < 't'.
+        "imu:/PDO4_Transmit/QuatetnionZ";
+    REQUIRE(addrs == expected);
+
+    // Heatbeat (0x701) has no SG_ record at all, so it is a node with no
+    // parameter: absent from iterateDevice, present in the namespace.
+    const auto ns = js.eval(R"js( Score.deviceToOSCQuery("imu") )js").toString();
+    REQUIRE(ns.contains("/Heatbeat"));
+
+    // VECTOR__INDEPENDENT_SIG_MSG is Vector's holder for unused signals, not a
+    // frame anything transmits; it must not become a node.
+    REQUIRE(!ns.contains("VECTOR__INDEPENDENT_SIG_MSG"));
+
+    js.eval(R"js( Score.removeDevice("imu") )js");
+  });
+}
+
+TEST_CASE("a frame on the bus becomes a decoded value in the script", "[can][js]")
+{
+  if(!ifacePresent())
+  {
+    SUCCEED("skipped: no vcan0 interface");
+    return;
+  }
+
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    Console js;
+    js.createCanDevice("imu");
+    QApplication::processEvents();
+
+    Bus bus;
+    bus.write(pdo4_node1, pdo4_payload);
+
+    // 9878 raw, scaled by the 0.0001 the DBC states.
+    REQUIRE(waitFor([&] {
+      auto v = js.valueAt("imu", "imu:/PDO4_Transmit/QuaternionW");
+      return v.isNumber() && std::abs(v.toNumber() - 0.9878) < 1e-4;
+    }));
+
+    REQUIRE(
+        js.valueAt("imu", "imu:/PDO4_Transmit/QuaternionX").toNumber()
+        == Catch::Approx(-0.1234).margin(1e-4));
+    REQUIRE(
+        js.valueAt("imu", "imu:/PDO4_Transmit/QuaternionY").toNumber()
+        == Catch::Approx(0.0).margin(1e-4));
+    REQUIRE(
+        js.valueAt("imu", "imu:/PDO4_Transmit/QuatetnionZ").toNumber()
+        == Catch::Approx(3.2767).margin(1e-4));
+
+    // Nothing else moved: a PDO4 frame carries no accelerometer.
+    REQUIRE(
+        js.valueAt("imu", "imu:/PDO1_Transmit/Acc_CalibratedX").toNumber()
+        == Catch::Approx(0.0).margin(1e-6));
+
+    js.eval(R"js( Score.removeDevice("imu") )js");
+  });
+}
+
+TEST_CASE("a frame whose id is not in the database changes nothing", "[can][js]")
+{
+  if(!ifacePresent())
+  {
+    SUCCEED("skipped: no vcan0 interface");
+    return;
+  }
+
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    Console js;
+    js.createCanDevice("imu");
+    QApplication::processEvents();
+
+    Bus bus;
+
+    // A known frame first, so that "nothing changed" is not just "nothing ever
+    // arrives": the device is demonstrably listening.
+    bus.write(pdo4_node1, pdo4_payload);
+    REQUIRE(waitFor([&] {
+      auto v = js.valueAt("imu", "imu:/PDO4_Transmit/QuaternionW");
+      return v.isNumber() && std::abs(v.toNumber() - 0.9878) < 1e-4;
+    }));
+
+    // 0x123 is in no message of this database. Its payload would decode to
+    // something quite different if it were mistakenly matched.
+    bus.write(0x123, {{0xFF, 0x7F, 0xFF, 0x7F, 0xFF, 0x7F, 0xFF, 0x7F}});
+    waitFor([] { return false; }, 200);
+
+    const std::string after = js.eval(R"js(
+      (function() {
+        var out = [];
+        Score.iterateDevice("imu", function(addr, value) { out.push(addr + "=" + value.value); });
+        out.sort();
+        return out.join("\n");
+      })()
+    )js")
+                                  .toString()
+                                  .toStdString();
+
+    bus.write(0x123, {{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}});
+    waitFor([] { return false; }, 200);
+
+    const std::string after2 = js.eval(R"js(
+      (function() {
+        var out = [];
+        Score.iterateDevice("imu", function(addr, value) { out.push(addr + "=" + value.value); });
+        out.sort();
+        return out.join("\n");
+      })()
+    )js")
+                                   .toString()
+                                   .toStdString();
+
+    REQUIRE(after == after2);
+    REQUIRE(after.find("imu:/PDO4_Transmit/QuaternionW=0.9878") != std::string::npos);
+
+    js.eval(R"js( Score.removeDevice("imu") )js");
+  });
+}
+
+TEST_CASE("the node id offset moves the whole database to another node", "[can][js]")
+{
+  if(!ifacePresent())
+  {
+    SUCCEED("skipped: no vcan0 interface");
+    return;
+  }
+
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    Console js;
+
+    // The chain-of-sensors case: one vendor file, two score devices, two
+    // offsets. The addresses are identical -- only the identifiers they listen
+    // to differ, which is exactly what makes one file serve a whole bus.
+    js.createCanDevice("node1", 0);
+    js.createCanDevice("node2", 1);
+    QApplication::processEvents();
+
+    auto strip = [](std::string s, const std::string& prefix) {
+      for(auto p = s.find(prefix); p != std::string::npos; p = s.find(prefix))
+        s.erase(p, prefix.size());
+      return s;
+    };
+    REQUIRE(
+        strip(js.addresses("node1"), "node1") == strip(js.addresses("node2"), "node2"));
+    REQUIRE(!js.addresses("node1").empty());
+
+    Bus bus;
+
+    // 0x482 is PDO4 of the sensor at node 2: node2's shifted database knows it,
+    // node1's does not.
+    bus.write(0x482, pdo4_payload);
+    REQUIRE(waitFor([&] {
+      auto v = js.valueAt("node2", "node2:/PDO4_Transmit/QuaternionW");
+      return v.isNumber() && std::abs(v.toNumber() - 0.9878) < 1e-4;
+    }));
+    REQUIRE(
+        js.valueAt("node1", "node1:/PDO4_Transmit/QuaternionW").toNumber()
+        == Catch::Approx(0.0).margin(1e-6));
+
+    // And the other way around.
+    bus.write(pdo4_node1, {{0x2E, 0xFB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}});
+    REQUIRE(waitFor([&] {
+      auto v = js.valueAt("node1", "node1:/PDO4_Transmit/QuaternionW");
+      return v.isNumber() && std::abs(v.toNumber() + 0.1234) < 1e-4;
+    }));
+    REQUIRE(
+        js.valueAt("node2", "node2:/PDO4_Transmit/QuaternionW").toNumber()
+        == Catch::Approx(0.9878).margin(1e-4));
+
+    js.eval(R"js( Score.removeDevice("node1") )js");
+    js.eval(R"js( Score.removeDevice("node2") )js");
+  });
+}
+
+#else
+TEST_CASE("CAN scripting is Linux-only", "[can][js]")
+{
+  SUCCEED("skipped: SocketCAN is only available on Linux");
+}
+#endif

--- a/tests/unit/CANScriptingTest.cpp
+++ b/tests/unit/CANScriptingTest.cpp
@@ -107,12 +107,21 @@ struct Console
         "Score", engine.newQObject(new JS::EditJsContext));
   }
 
+  /**
+   * Evaluate `js`, failing the test if it throws.
+   *
+   * FAIL rather than REQUIRE because this is reached from inside the polling
+   * predicates: an assertion there counts once per poll, which would make the
+   * test's assertion count depend on how fast the machine is. FAIL only counts
+   * when it fires.
+   */
   QJSValue eval(const QString& js)
   {
     auto res = engine.evaluate(js);
-    INFO("script: " << js.toStdString());
-    INFO("result: " << res.toString().toStdString());
-    REQUIRE(!res.isError());
+    if(res.isError())
+      FAIL(
+          "script failed: " << res.toString().toStdString()
+                            << "\nscript was: " << js.toStdString());
     return res;
   }
 
@@ -230,9 +239,8 @@ constexpr std::array<uint8_t, 8> pdo4_payload{
 template <typename F>
 bool waitFor(F pred, int ms = 2000)
 {
-  // Polled every 10ms rather than every 1ms: `pred` here evaluates a script
-  // that walks the whole device, and a 1ms period turns a two-second timeout
-  // into a couple of thousand redundant Catch2 assertions.
+  // Polled every 10ms rather than every 1ms: `pred` evaluates a script that
+  // walks the whole device.
   for(int i = 0; i < ms / 10; i++)
   {
     QApplication::processEvents();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -73,6 +73,20 @@ score_add_test(test_unit_device_edit_dialog
   APP
   PLUGINS score_plugin_deviceexplorer score_lib_device score_lib_state)
 
+# The CAN protocol's device browser entry and its default interface, against an
+# independent walk of /sys/class/net.
+if(TARGET score_plugin_protocols)
+  score_add_test(test_unit_can_enumerator
+    SOURCES CANEnumeratorTest.cpp
+    APP
+    PLUGINS score_plugin_protocols score_lib_device)
+  target_include_directories(test_unit_can_enumerator PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-protocols")
+  if(LINUX)
+    target_compile_definitions(test_unit_can_enumerator PRIVATE OSSIA_PROTOCOL_CAN)
+  endif()
+endif()
+
 # --- core data model (score-lib-state / score-lib-process, P3R2) -----------
 score_add_test(test_unit_state_serialization
   SOURCES StateSerializationTest.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -106,6 +106,20 @@ if(LINUX AND TARGET score_plugin_protocols AND TARGET score_plugin_js)
     SCORE_CAN_TEST_DATA="${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-protocols/Tests/data")
 endif()
 
+# The Mapper device driving libossia's QML protocol bindings: `Protocols` is a
+# context property of the mapper's engine, and that engine runs on its own
+# thread -- neither of which libossia's own QJSEngine-level tests can cover.
+if(LINUX AND TARGET score_plugin_protocols AND TARGET score_plugin_js)
+  score_add_test(test_unit_mapper_protocols
+    SOURCES MapperProtocolsTest.cpp
+    APP
+    PLUGINS score_plugin_js score_plugin_protocols score_lib_device
+    LIBS ossia ${QT_PREFIX}::Qml)
+  target_include_directories(test_unit_mapper_protocols PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-js"
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-protocols")
+endif()
+
 # --- core data model (score-lib-state / score-lib-process, P3R2) -----------
 score_add_test(test_unit_state_serialization
   SOURCES StateSerializationTest.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -73,13 +73,14 @@ score_add_test(test_unit_device_edit_dialog
   APP
   PLUGINS score_plugin_deviceexplorer score_lib_device score_lib_state)
 
-# The CAN protocol's device browser entry and its default interface, against an
-# independent walk of /sys/class/net.
-if(TARGET score_plugin_protocols)
+# The CAN protocol's device browser entry: the .dbc databases of the user
+# library, plus the default interface against an independent walk of
+# /sys/class/net.
+if(TARGET score_plugin_protocols AND TARGET score_plugin_library)
   score_add_test(test_unit_can_enumerator
     SOURCES CANEnumeratorTest.cpp
     APP
-    PLUGINS score_plugin_protocols score_lib_device)
+    PLUGINS score_plugin_protocols score_plugin_library score_lib_device)
   target_include_directories(test_unit_can_enumerator PRIVATE
     "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-protocols")
   if(LINUX)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -87,6 +87,24 @@ if(TARGET score_plugin_protocols)
   endif()
 endif()
 
+# End-to-end CAN, driven through score's JavaScript scripting API (the `Score`
+# object of the console panel): a device created from a script, real frames on
+# vcan0, and the resulting node tree read back through iterateDevice.
+# Skips itself when vcan0 is absent.
+if(LINUX AND TARGET score_plugin_protocols AND TARGET score_plugin_js)
+  score_add_test(test_unit_can_scripting
+    SOURCES CANScriptingTest.cpp
+    APP
+    PLUGINS score_plugin_js score_plugin_protocols score_lib_device
+    LIBS ossia ${QT_PREFIX}::Qml)
+  target_include_directories(test_unit_can_scripting PRIVATE
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-js"
+    "${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-protocols")
+  target_compile_definitions(test_unit_can_scripting PRIVATE
+    OSSIA_PROTOCOL_CAN
+    SCORE_CAN_TEST_DATA="${SCORE_ROOT_SOURCE_DIR}/src/plugins/score-plugin-protocols/Tests/data")
+endif()
+
 # --- core data model (score-lib-state / score-lib-process, P3R2) -----------
 score_add_test(test_unit_state_serialization
   SOURCES StateSerializationTest.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -65,6 +65,14 @@ score_add_test(test_unit_device_explorer_node
   SOURCES DeviceExplorerNodeTest.cpp
   PLUGINS score_lib_device)
 
+# Add-device dialog: switching protocol must not leave an enumerator signal in
+# flight pointing at a QTreeWidgetItem the switch deleted (use-after-free in
+# QTreeWidgetItem::setExpanded reported from a release build).
+score_add_test(test_unit_device_edit_dialog
+  SOURCES DeviceEditDialogTest.cpp
+  APP
+  PLUGINS score_plugin_deviceexplorer score_lib_device score_lib_state)
+
 # --- core data model (score-lib-state / score-lib-process, P3R2) -----------
 score_add_test(test_unit_state_serialization
   SOURCES StateSerializationTest.cpp

--- a/tests/unit/DeviceEditDialogTest.cpp
+++ b/tests/unit/DeviceEditDialogTest.cpp
@@ -1,0 +1,296 @@
+// Regression test for the use-after-free that crashed the "Add device" dialog
+// when the selected protocol changed while an enumerator still had a
+// deviceAdded()/deviceRemoved()/sort() in flight.
+//
+// The dialog's addItem/rmItem/sort lambdas capture `cat`, a raw
+// QTreeWidgetItem* owned by the devices tree. Switching protocol calls
+// m_devices->clear(), which deletes every one of those items. An enumerator
+// that emits from a worker thread turns the connection into a queued one, and
+// Qt only drops posted metacalls when their *receiver* dies -- not when the
+// sender does. With `this` (the dialog) as the receiver the call was still
+// delivered after the switch and dereferenced a freed item, which is the
+// SIGSEGV inside QTreeWidgetItem::setExpanded seen in the field.
+//
+// The three tests below post a deviceAdded / deviceRemoved / sort from a
+// non-GUI thread, switch protocol without pumping the event loop in between,
+// and then pump it. Before the fix each of them is a heap-use-after-free under
+// ASan (and a plain crash in a release build); after it, nothing is delivered.
+
+#include <Device/Protocol/ProtocolFactoryInterface.hpp>
+#include <Device/Protocol/ProtocolList.hpp>
+#include <Device/Protocol/ProtocolSettingsWidget.hpp>
+
+#include <Explorer/Explorer/DeviceExplorerModel.hpp>
+#include <Explorer/Explorer/Widgets/DeviceEditDialog.hpp>
+
+#include <score/plugins/Interface.hpp>
+
+#include <QApplication>
+#include <QTreeWidget>
+
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <thread>
+
+namespace
+{
+// An enumerator whose signals are emitted from a plain std::thread, exactly
+// like SimpleBLE's scan callback does in BLEEnumerator: Qt::AutoConnection then
+// resolves to a queued connection and posts a metacall to the connection's
+// context object.
+class ThreadedEnumerator final : public Device::DeviceEnumerator
+{
+public:
+  void enumerate(std::function<void(const QString&, const Device::DeviceSettings&)>)
+      const override
+  {
+  }
+
+  // Returns once the metacall is queued: emit() posts the event synchronously.
+  void postAddFromWorkerThread(Device::DeviceSettings s)
+  {
+    std::thread t{[this, s = std::move(s)] { deviceAdded(s.name, s); }};
+    t.join();
+  }
+
+  void postRemoveFromWorkerThread(QString name)
+  {
+    std::thread t{[this, name = std::move(name)] { deviceRemoved(name); }};
+    t.join();
+  }
+
+  void postSortFromWorkerThread()
+  {
+    std::thread t{[this] { sort(); }};
+    t.join();
+  }
+};
+
+class DummySettingsWidget final : public Device::ProtocolSettingsWidget
+{
+public:
+  Device::DeviceSettings m_settings;
+  Device::DeviceSettings getSettings() const override { return m_settings; }
+  void setSettings(const Device::DeviceSettings& s) override { m_settings = s; }
+};
+
+template <typename Self>
+class DummyFactory : public Device::ProtocolFactory
+{
+public:
+  QString category() const noexcept override { return QStringLiteral("Test"); }
+
+  Device::DeviceInterface* makeDevice(
+      const Device::DeviceSettings&, const Explorer::DeviceDocumentPlugin&,
+      const score::DocumentContext&) override
+  {
+    return nullptr;
+  }
+  Device::ProtocolSettingsWidget* makeSettingsWidget() override
+  {
+    return new DummySettingsWidget;
+  }
+  Device::AddressDialog* makeAddAddressDialog(
+      const Device::DeviceInterface&, const score::DocumentContext&, QWidget*) override
+  {
+    return nullptr;
+  }
+  Device::AddressDialog* makeEditAddressDialog(
+      const Device::AddressSettings&, const Device::DeviceInterface&,
+      const score::DocumentContext&, QWidget*) override
+  {
+    return nullptr;
+  }
+  const Device::DeviceSettings& defaultSettings() const noexcept override
+  {
+    static const Device::DeviceSettings s = [] {
+      Device::DeviceSettings set;
+      set.name = QStringLiteral("dummy");
+      set.protocol = Self::static_concreteKey();
+      return set;
+    }();
+    return s;
+  }
+  void serializeProtocolSpecificSettings(const QVariant&, const VisitorVariant&)
+      const override
+  {
+  }
+  QVariant makeProtocolSpecificSettings(const VisitorVariant&) const override
+  {
+    return {};
+  }
+  bool checkCompatibility(
+      const Device::DeviceSettings&, const Device::DeviceSettings&) const noexcept override
+  {
+    return true;
+  }
+};
+
+// Protocol whose enumerator emits off-thread.
+class AsyncFactory final : public DummyFactory<AsyncFactory>
+{
+  SCORE_CONCRETE("15cbe4b4-6c9c-4a70-9e2c-3a2c85dd53b0")
+public:
+  mutable ThreadedEnumerator* last{};
+
+  QString prettyName() const noexcept override { return QStringLiteral("AAsync"); }
+  Device::DeviceEnumerators
+  getEnumerators(const score::DocumentContext&) const override
+  {
+    auto e = new ThreadedEnumerator;
+    last = e;
+    return {{QStringLiteral("Devices"), e}};
+  }
+};
+
+// Protocol with no enumerator at all: selecting it is what clears the tree,
+// which is precisely the case of the CAN protocol in the original report.
+class PlainFactory final : public DummyFactory<PlainFactory>
+{
+  SCORE_CONCRETE("2f5df6f0-6e26-4a06-9f19-96b6d2b1f9f3")
+public:
+  QString prettyName() const noexcept override { return QStringLiteral("BPlain"); }
+};
+
+struct Harness
+{
+  Device::ProtocolFactoryList protocols;
+  AsyncFactory* async{};
+  PlainFactory* plain{};
+
+  Harness()
+  {
+    auto a = std::make_unique<AsyncFactory>();
+    async = a.get();
+    protocols.insert(std::move(a));
+
+    auto p = std::make_unique<PlainFactory>();
+    plain = p.get();
+    protocols.insert(std::move(p));
+  }
+};
+
+// Build the dialog, select the async protocol, and hand back the enumerator it
+// created. `settings` selection goes through the public setSettings(), which is
+// the same code path a click on the protocol list takes.
+struct Fixture
+{
+  Harness h;
+  Explorer::DeviceEditDialog* dialog{};
+  ThreadedEnumerator* enumerator{};
+
+  Fixture(const score::GUIApplicationContext& ctx, score::Document& doc)
+  {
+    auto& model = Explorer::deviceExplorerFromContext(doc.context());
+    dialog = new Explorer::DeviceEditDialog{
+        model, h.protocols, Explorer::DeviceEditDialog::Creating, nullptr};
+
+    dialog->setSettings(h.async->defaultSettings());
+    QApplication::processEvents();
+
+    enumerator = h.async->last;
+    REQUIRE(enumerator != nullptr);
+  }
+
+  ~Fixture() { delete dialog; }
+
+  Device::DeviceSettings someDevice(QString name) const
+  {
+    Device::DeviceSettings s;
+    s.name = std::move(name);
+    s.protocol = AsyncFactory::static_concreteKey();
+    return s;
+  }
+
+  // Switch to the enumerator-less protocol. This is the m_devices->clear() that
+  // frees the QTreeWidgetItem the pending metacall captured.
+  void switchToPlain() { dialog->setSettings(h.plain->defaultSettings()); }
+};
+}
+
+TEST_CASE("deviceAdded queued across a protocol switch is dropped", "[deviceexplorer]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    Fixture f{ctx, *doc};
+
+    // Sanity: a synchronous add lands in the tree, so the test is exercising a
+    // wiring that actually works.
+    f.enumerator->deviceAdded(QStringLiteral("sync"), f.someDevice("sync"));
+
+    // Now queue one from a worker thread and switch protocol before the event
+    // loop ever runs.
+    f.enumerator->postAddFromWorkerThread(f.someDevice("async"));
+    f.switchToPlain();
+
+    // Before the fix: heap-use-after-free in addItem -> QTreeWidgetItem::setExpanded.
+    QApplication::processEvents();
+    QApplication::processEvents();
+
+    SUCCEED("no use-after-free while delivering the queued deviceAdded");
+  });
+}
+
+TEST_CASE("deviceRemoved queued across a protocol switch is dropped", "[deviceexplorer]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    Fixture f{ctx, *doc};
+    f.enumerator->deviceAdded(QStringLiteral("sync"), f.someDevice("sync"));
+
+    f.enumerator->postRemoveFromWorkerThread(QStringLiteral("sync"));
+    f.switchToPlain();
+
+    QApplication::processEvents();
+    QApplication::processEvents();
+
+    SUCCEED("no use-after-free while delivering the queued deviceRemoved");
+  });
+}
+
+TEST_CASE("sort queued across a protocol switch is dropped", "[deviceexplorer]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    Fixture f{ctx, *doc};
+    f.enumerator->deviceAdded(QStringLiteral("sync"), f.someDevice("sync"));
+
+    f.enumerator->postSortFromWorkerThread();
+    f.switchToPlain();
+
+    QApplication::processEvents();
+    QApplication::processEvents();
+
+    SUCCEED("no use-after-free while delivering the queued sort");
+  });
+}
+
+// The dialog itself dying with events in flight must be safe too: here the
+// receiver is destroyed, which Qt already handles, but the test pins the
+// behaviour so a future refactor cannot regress it.
+TEST_CASE("queued enumerator signals survive dialog destruction", "[deviceexplorer]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    {
+      Fixture f{ctx, *doc};
+      f.enumerator->postAddFromWorkerThread(f.someDevice("async"));
+    }
+
+    QApplication::processEvents();
+    QApplication::processEvents();
+
+    SUCCEED("no use-after-free after the dialog is gone");
+  });
+}

--- a/tests/unit/DeviceEditDialogTest.cpp
+++ b/tests/unit/DeviceEditDialogTest.cpp
@@ -22,10 +22,9 @@
 #include <QApplication>
 #include <QTreeWidget>
 
+#include <catch2/catch_all.hpp>
 #include <score_test/App.hpp>
 #include <score_test/Document.hpp>
-
-#include <catch2/catch_all.hpp>
 
 #include <thread>
 
@@ -38,8 +37,8 @@ namespace
 class ThreadedEnumerator final : public Device::DeviceEnumerator
 {
 public:
-  void enumerate(std::function<void(const QString&, const Device::DeviceSettings&)>)
-      const override
+  void enumerate(
+      std::function<void(const QString&, const Device::DeviceSettings&)>) const override
   {
   }
 
@@ -108,16 +107,16 @@ public:
     }();
     return s;
   }
-  void serializeProtocolSpecificSettings(const QVariant&, const VisitorVariant&)
-      const override
+  void serializeProtocolSpecificSettings(
+      const QVariant&, const VisitorVariant&) const override
   {
   }
   QVariant makeProtocolSpecificSettings(const VisitorVariant&) const override
   {
     return {};
   }
-  bool checkCompatibility(
-      const Device::DeviceSettings&, const Device::DeviceSettings&) const noexcept override
+  bool checkCompatibility(const Device::DeviceSettings&, const Device::DeviceSettings&)
+      const noexcept override
   {
     return true;
   }
@@ -131,8 +130,7 @@ public:
   mutable ThreadedEnumerator* last{};
 
   QString prettyName() const noexcept override { return QStringLiteral("AAsync"); }
-  Device::DeviceEnumerators
-  getEnumerators(const score::DocumentContext&) const override
+  Device::DeviceEnumerators getEnumerators(const score::DocumentContext&) const override
   {
     auto e = new ThreadedEnumerator;
     last = e;

--- a/tests/unit/DeviceEditDialogTest.cpp
+++ b/tests/unit/DeviceEditDialogTest.cpp
@@ -1,20 +1,14 @@
 // Regression test for the use-after-free that crashed the "Add device" dialog
-// when the selected protocol changed while an enumerator still had a
-// deviceAdded()/deviceRemoved()/sort() in flight.
+// when the protocol changed with an enumerator signal still in flight.
 //
-// The dialog's addItem/rmItem/sort lambdas capture `cat`, a raw
-// QTreeWidgetItem* owned by the devices tree. Switching protocol calls
-// m_devices->clear(), which deletes every one of those items. An enumerator
-// that emits from a worker thread turns the connection into a queued one, and
-// Qt only drops posted metacalls when their *receiver* dies -- not when the
-// sender does. With `this` (the dialog) as the receiver the call was still
-// delivered after the switch and dereferenced a freed item, which is the
-// SIGSEGV inside QTreeWidgetItem::setExpanded seen in the field.
+// The dialog's addItem/rmItem/sort lambdas capture a QTreeWidgetItem* owned by
+// the tree, and switching protocol deletes it. An enumerator emitting from a
+// worker thread makes the connection queued, and Qt drops posted metacalls only
+// when their *receiver* dies - not when the sender does - so with the dialog as
+// receiver the call still arrived, on a freed item.
 //
-// The three tests below post a deviceAdded / deviceRemoved / sort from a
-// non-GUI thread, switch protocol without pumping the event loop in between,
-// and then pump it. Before the fix each of them is a heap-use-after-free under
-// ASan (and a plain crash in a release build); after it, nothing is delivered.
+// Only the deviceRemoved case reports cleanly under ASan: the other two
+// dereference the item inside uninstrumented Qt.
 
 #include <Device/Protocol/ProtocolFactoryInterface.hpp>
 #include <Device/Protocol/ProtocolList.hpp>

--- a/tests/unit/MapperProtocolsTest.cpp
+++ b/tests/unit/MapperProtocolsTest.cpp
@@ -1,0 +1,369 @@
+/**
+ * The Mapper device driving Protocols.can() and Protocols.serial().
+ *
+ * libossia's own QML tests install `Protocols` on a bare QJSEngine. That covers
+ * the bindings but not the way they are actually reached: in score, `Protocols`
+ * is a context property of the Mapper device's engine, which runs on a thread of
+ * its own, and the values a script produces have to come back out through the
+ * mapper's node tree.
+ *
+ * Each test here creates a real Mapper device from a script, moves bytes on a
+ * real transport, and reads the result back through Score.iterateDevice().
+ */
+
+#include <JS/Qml/EditContext.hpp>
+
+#include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
+#include <Device/Protocol/DeviceInterface.hpp>
+
+#include <core/document/Document.hpp>
+
+#include <QJSEngine>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QQmlEngine>
+
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#if defined(__linux__)
+
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string>
+#include <unistd.h>
+
+namespace
+{
+constexpr const char* can_iface = "vcan0";
+constexpr const char* mapper_uuid = "910e2d87-a087-430d-b725-c988fe2bea01";
+
+//! A raw SocketCAN peer, to put frames on the bus from the test side.
+struct raw_can
+{
+  int fd{-1};
+
+  raw_can()
+  {
+    fd = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if(fd < 0)
+      return;
+
+    ifreq ifr{};
+    std::strncpy(ifr.ifr_name, can_iface, sizeof(ifr.ifr_name) - 1);
+    if(::ioctl(fd, SIOCGIFINDEX, &ifr) != 0)
+    {
+      ::close(fd);
+      fd = -1;
+      return;
+    }
+
+    sockaddr_can addr{};
+    addr.can_family = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+    if(::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0)
+    {
+      ::close(fd);
+      fd = -1;
+    }
+  }
+  ~raw_can()
+  {
+    if(fd >= 0)
+      ::close(fd);
+  }
+
+  bool valid() const { return fd >= 0; }
+
+  void send(uint32_t id, std::initializer_list<uint8_t> bytes) const
+  {
+    can_frame f{};
+    f.can_id = id;
+    f.can_dlc = uint8_t(bytes.size());
+    int i = 0;
+    for(auto b : bytes)
+      f.data[i++] = b;
+    (void)::write(fd, &f, sizeof(f));
+  }
+};
+
+//! A pty pair: the script opens the slave, the test writes on the master.
+struct pty_pair
+{
+  int master{-1};
+  std::string slave;
+
+  pty_pair()
+  {
+    master = ::posix_openpt(O_RDWR | O_NOCTTY);
+    if(master < 0)
+      return;
+    if(::grantpt(master) != 0 || ::unlockpt(master) != 0)
+      return;
+    if(const char* name = ::ptsname(master))
+      slave = name;
+  }
+  ~pty_pair()
+  {
+    if(master >= 0)
+      ::close(master);
+  }
+
+  bool valid() const { return master >= 0 && !slave.empty(); }
+};
+
+struct fixture
+{
+  const score::GUIApplicationContext& ctx;
+  score::Document& doc;
+  QQmlEngine engine;
+
+  fixture(const score::GUIApplicationContext& c, score::Document& d)
+      : ctx{c}
+      , doc{d}
+  {
+    engine.globalObject().setProperty(
+        "Score", engine.newQObject(new JS::EditJsContext));
+  }
+
+  /**
+   * Evaluate `js`, failing the test if it throws.
+   *
+   * FAIL rather than REQUIRE because this is reached from inside the polling
+   * predicates: an assertion there counts once per poll, which would make the
+   * test's assertion count depend on how fast the machine is. FAIL only counts
+   * when it fires.
+   */
+  QJSValue eval(const QString& js)
+  {
+    auto res = engine.evaluate(js);
+    if(res.isError())
+      FAIL(
+          "script failed: " << res.toString().toStdString()
+                            << "\nscript was: " << js.toStdString());
+    return res;
+  }
+
+  //! Create a Mapper device running `qml`.
+  void createMapper(const QString& name, const QString& qml)
+  {
+    const auto settings
+        = QJsonDocument{QJsonObject{{"Text", qml}}}.toJson(QJsonDocument::Compact);
+    eval(QStringLiteral("Score.createDevice(\"%1\", \"%2\", %3)")
+             .arg(name, mapper_uuid, QString::fromUtf8(settings)));
+  }
+
+  /**
+   * Every (address, value) pair of a device, as iterateDevice yields them.
+   *
+   * Compiled once and reported with FAIL rather than REQUIRE: this is called
+   * from inside spin()'s predicate, and an assertion there would count once per
+   * poll - which makes the test's assertion count depend on how fast the
+   * machine is. FAIL only counts when it fires.
+   */
+  QVariantMap contents(const QString& name)
+  {
+    if(!m_iterate.isCallable())
+    {
+      m_iterate = engine.evaluate(QStringLiteral(R"js(
+        (function(name) {
+          var res = {};
+          Score.iterateDevice(name, function(addr, v) { res[addr] = v.value; });
+          return res;
+        })
+      )js"));
+      if(!m_iterate.isCallable())
+        FAIL("could not compile the iterateDevice wrapper: "
+             << m_iterate.toString().toStdString());
+    }
+
+    auto res = m_iterate.call({name});
+    if(res.isError())
+      FAIL("iterateDevice failed: " << res.toString().toStdString());
+    return res.toVariant().toMap();
+  }
+
+  QJSValue m_iterate;
+
+  //! Run both loops until `pred` holds, or give up.
+  template <typename F>
+  bool spin(F pred, int ms = 5000)
+  {
+    for(int i = 0; i < ms / 5; i++)
+    {
+      QCoreApplication::processEvents();
+      if(pred())
+        return true;
+      ::usleep(5000);
+    }
+    return pred();
+  }
+};
+}
+
+TEST_CASE("control: a plain mapper builds its tree", "[mapper]")
+{
+  score::test::run_in_app([&](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+    fixture f{ctx, *doc};
+    f.createMapper("plain", QStringLiteral(R"qml(
+import Ossia 1.0 as Ossia
+Ossia.Mapper {
+  property int v: 7
+  function createTree() {
+    return [ { name: "v", type: Ossia.Type.Int, interval: 20,
+               read: function() { return v; } } ];
+  }
+}
+)qml"));
+    REQUIRE(f.spin([&] { return f.contents("plain").contains("plain:/v"); }));
+  });
+}
+
+TEST_CASE("a mapper script reads a CAN bus through Protocols.can", "[mapper]")
+{
+  raw_can peer;
+  if(!peer.valid())
+    SKIP("no " << can_iface << " interface available");
+
+  score::test::run_in_app([&](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+    fixture f{ctx, *doc};
+
+    // The script keeps the last frame it saw and exposes it as two nodes; the
+    // interval is what turns them into something iterateDevice can observe.
+    f.createMapper("can_mapper", QStringLiteral(R"qml(
+import Ossia 1.0 as Ossia
+
+Ossia.Mapper
+{
+  property var sock: null
+  property int rpm: 0
+  property int frames: 0
+
+  // The socket is opened from createTree(), the mapper's own entry point: a
+  // script that only imports Ossia has no Component attached property.
+  function createTree() {
+    sock = Protocols.can({
+      Transport: { Interface: "%1" },
+      onMessage: function(frame) {
+        if(frame.id !== 0x123)
+          return;
+        // The payload is an ArrayBuffer, as the serial protocol's are. Checked
+        // explicitly: new Uint8Array() also accepts a plain array, so reading
+        // the bytes alone would not tell the two apart.
+        if(!(frame.bytes instanceof ArrayBuffer))
+          return;
+        var b = new Uint8Array(frame.bytes);
+        rpm = b[0] | (b[1] << 8);
+        frames = frames + 1;
+      }
+    });
+
+    return [
+      { name: "rpm",    type: Ossia.Type.Int, interval: 20,
+        read: function() { return rpm; } },
+      { name: "frames", type: Ossia.Type.Int, interval: 20,
+        read: function() { return frames; } }
+    ];
+  }
+}
+)qml")
+                                   .arg(QString::fromUtf8(can_iface)));
+
+    // The tree exists before any frame has arrived.
+    REQUIRE(f.spin([&] { return f.contents("can_mapper").contains("can_mapper:/rpm"); }));
+
+    // 0x0BB8 == 3000, little-endian across the first two bytes.
+    peer.send(0x123, {0xB8, 0x0B, 0, 0});
+
+    const bool got = f.spin([&] {
+      return f.contents("can_mapper").value("can_mapper:/rpm").toInt() == 3000;
+    });
+    INFO("tree: " << QJsonDocument::fromVariant(f.contents("can_mapper"))
+                         .toJson()
+                         .toStdString());
+    REQUIRE(got);
+    REQUIRE(f.contents("can_mapper").value("can_mapper:/frames").toInt() >= 1);
+
+    SECTION("a frame for another identifier is ignored")
+    {
+      const int before = f.contents("can_mapper").value("can_mapper:/frames").toInt();
+      peer.send(0x456, {0xFF, 0xFF, 0, 0});
+      f.spin([] { return false; }, 300);
+
+      const auto after = f.contents("can_mapper");
+      REQUIRE(after.value("can_mapper:/frames").toInt() == before);
+      REQUIRE(after.value("can_mapper:/rpm").toInt() == 3000);
+    }
+
+    f.eval(QStringLiteral("Score.removeDevice(\"can_mapper\")"));
+  });
+}
+
+TEST_CASE("a mapper script reads a serial port through Protocols.serial", "[mapper]")
+{
+  pty_pair pty;
+  if(!pty.valid())
+    SKIP("could not open a pty pair");
+
+  score::test::run_in_app([&](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+    fixture f{ctx, *doc};
+
+    f.createMapper("serial_mapper", QStringLiteral(R"qml(
+import Ossia 1.0 as Ossia
+
+Ossia.Mapper
+{
+  property var sock: null
+  property int last: 0
+
+  function createTree() {
+    sock = Protocols.serial({
+      Transport: { Port: "%1", Baud: 115200 },
+      Framing: { Mode: "Line" },
+      onMessage: function(txt) { last = parseInt(txt, 10); }
+    });
+
+    return [
+      { name: "value", type: Ossia.Type.Int, interval: 20,
+        read: function() { return last; } }
+    ];
+  }
+}
+)qml")
+                                      .arg(QString::fromStdString(pty.slave)));
+
+    REQUIRE(f.spin(
+        [&] { return f.contents("serial_mapper").contains("serial_mapper:/value"); }));
+
+    const char* line = "4242\n";
+    REQUIRE(::write(pty.master, line, std::strlen(line)) > 0);
+
+    const bool got = f.spin([&] {
+      return f.contents("serial_mapper").value("serial_mapper:/value").toInt() == 4242;
+    });
+    INFO("tree: " << QJsonDocument::fromVariant(f.contents("serial_mapper"))
+                         .toJson()
+                         .toStdString());
+    REQUIRE(got);
+
+    f.eval(QStringLiteral("Score.removeDevice(\"serial_mapper\")"));
+  });
+}
+
+#endif

--- a/tests/unit/MapperProtocolsTest.cpp
+++ b/tests/unit/MapperProtocolsTest.cpp
@@ -1,15 +1,11 @@
-/**
- * The Mapper device driving Protocols.can() and Protocols.serial().
- *
- * libossia's own QML tests install `Protocols` on a bare QJSEngine. That covers
- * the bindings but not the way they are actually reached: in score, `Protocols`
- * is a context property of the Mapper device's engine, which runs on a thread of
- * its own, and the values a script produces have to come back out through the
- * mapper's node tree.
- *
- * Each test here creates a real Mapper device from a script, moves bytes on a
- * real transport, and reads the result back through Score.iterateDevice().
- */
+// The Mapper device driving Protocols.can() and Protocols.serial().
+//
+// libossia's QML tests install `Protocols` on a bare QJSEngine. In score it is a
+// context property of the Mapper's engine, that engine runs on its own thread,
+// and what a script produces has to come back out through the mapper's tree.
+//
+// Each test creates a real Mapper from a script, moves bytes on a real
+// transport, and reads the result back through Score.iterateDevice().
 
 #include <JS/Qml/EditContext.hpp>
 

--- a/tests/unit/MapperProtocolsTest.cpp
+++ b/tests/unit/MapperProtocolsTest.cpp
@@ -7,10 +7,11 @@
 // Each test creates a real Mapper from a script, moves bytes on a real
 // transport, and reads the result back through Score.iterateDevice().
 
-#include <JS/Qml/EditContext.hpp>
+#include <Device/Protocol/DeviceInterface.hpp>
 
 #include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
-#include <Device/Protocol/DeviceInterface.hpp>
+
+#include <JS/Qml/EditContext.hpp>
 
 #include <core/document/Document.hpp>
 
@@ -19,13 +20,11 @@
 #include <QJsonObject>
 #include <QQmlEngine>
 
+#include <catch2/catch_all.hpp>
 #include <score_test/App.hpp>
 #include <score_test/Document.hpp>
 
-#include <catch2/catch_all.hpp>
-
 #if defined(__linux__)
-
 
 #include <linux/can.h>
 #include <linux/can/raw.h>
@@ -33,11 +32,12 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
-#include <cstring>
 #include <fcntl.h>
 #include <stdlib.h>
-#include <string>
 #include <unistd.h>
+
+#include <cstring>
+#include <string>
 
 namespace
 {
@@ -128,8 +128,7 @@ struct fixture
       : ctx{c}
       , doc{d}
   {
-    engine.globalObject().setProperty(
-        "Score", engine.newQObject(new JS::EditJsContext));
+    engine.globalObject().setProperty("Score", engine.newQObject(new JS::EditJsContext));
   }
 
   /**
@@ -179,8 +178,9 @@ struct fixture
         })
       )js"));
       if(!m_iterate.isCallable())
-        FAIL("could not compile the iterateDevice wrapper: "
-             << m_iterate.toString().toStdString());
+        FAIL(
+            "could not compile the iterateDevice wrapper: "
+            << m_iterate.toString().toStdString());
     }
 
     auto res = m_iterate.call({name});
@@ -240,7 +240,8 @@ TEST_CASE("a mapper script reads a CAN bus through Protocols.can", "[mapper]")
 
     // The script keeps the last frame it saw and exposes it as two nodes; the
     // interval is what turns them into something iterateDevice can observe.
-    f.createMapper("can_mapper", QStringLiteral(R"qml(
+    f.createMapper(
+        "can_mapper", QStringLiteral(R"qml(
 import Ossia 1.0 as Ossia
 
 Ossia.Mapper
@@ -277,10 +278,11 @@ Ossia.Mapper
   }
 }
 )qml")
-                                   .arg(QString::fromUtf8(can_iface)));
+                          .arg(QString::fromUtf8(can_iface)));
 
     // The tree exists before any frame has arrived.
-    REQUIRE(f.spin([&] { return f.contents("can_mapper").contains("can_mapper:/rpm"); }));
+    REQUIRE(
+        f.spin([&] { return f.contents("can_mapper").contains("can_mapper:/rpm"); }));
 
     // 0x0BB8 == 3000, little-endian across the first two bytes.
     peer.send(0x123, {0xB8, 0x0B, 0, 0});
@@ -288,9 +290,9 @@ Ossia.Mapper
     const bool got = f.spin([&] {
       return f.contents("can_mapper").value("can_mapper:/rpm").toInt() == 3000;
     });
-    INFO("tree: " << QJsonDocument::fromVariant(f.contents("can_mapper"))
-                         .toJson()
-                         .toStdString());
+    INFO(
+        "tree: "
+        << QJsonDocument::fromVariant(f.contents("can_mapper")).toJson().toStdString());
     REQUIRE(got);
     REQUIRE(f.contents("can_mapper").value("can_mapper:/frames").toInt() >= 1);
 
@@ -320,7 +322,8 @@ TEST_CASE("a mapper script reads a serial port through Protocols.serial", "[mapp
     REQUIRE(doc);
     fixture f{ctx, *doc};
 
-    f.createMapper("serial_mapper", QStringLiteral(R"qml(
+    f.createMapper(
+        "serial_mapper", QStringLiteral(R"qml(
 import Ossia 1.0 as Ossia
 
 Ossia.Mapper
@@ -342,7 +345,7 @@ Ossia.Mapper
   }
 }
 )qml")
-                                      .arg(QString::fromStdString(pty.slave)));
+                             .arg(QString::fromStdString(pty.slave)));
 
     REQUIRE(f.spin(
         [&] { return f.contents("serial_mapper").contains("serial_mapper:/value"); }));
@@ -353,9 +356,10 @@ Ossia.Mapper
     const bool got = f.spin([&] {
       return f.contents("serial_mapper").value("serial_mapper:/value").toInt() == 4242;
     });
-    INFO("tree: " << QJsonDocument::fromVariant(f.contents("serial_mapper"))
-                         .toJson()
-                         .toStdString());
+    INFO(
+        "tree: " << QJsonDocument::fromVariant(f.contents("serial_mapper"))
+                        .toJson()
+                        .toStdString());
     REQUIRE(got);
 
     f.eval(QStringLiteral("Score.removeDevice(\"serial_mapper\")"));


### PR DESCRIPTION
Adds a CAN device to score, driven by a DBC database. Depends on
ossia/libossia#929 and bumps the submodule to it — **this cannot land first**.

## What it does

A CAN device is an interface plus a `.dbc` file. The database is parsed into an
ossia node tree — one node per message, one child per signal — and each frame on
the bus becomes a value at an address. The device browser lists the `.dbc` files
of the user library, so picking one in the "add device" dialog fills the path in
and shows the messages and signals it declares before you connect.

Several sensors on one bus is the normal case rather than a conflict: a chain is
one vendor file opened N times with N different node-id offsets, since a DBC
hardcodes the identifiers of a single device (the LPMS files are written for
CANopen node 1). SocketCAN delivers every frame to every socket, each with its
own filters, so nothing is shared between them.

Linux only, since SocketCAN is.

## Pieces

- **`DBCParser`** — a hand-written reader for the Vector DBC format, free of Qt,
  ossia and Linux so it can be tested on its own. Handles `BO_`/`SG_`/`VAL_`/
  `CM_`/`BA_DEF_`/`SIG_VALTYPE_`/`SG_MUL_VAL_`, both bit orders, multiplexing,
  and keeps going on records it cannot read rather than failing the file —
  vendor files carry typos, and the contract is to name what was skipped.
- **`CANDevice`** — the protocol: DBC to tree, frame to value, per-socket
  filters, node-id offset.
- **`CANInterfaces`** — the interfaces the machine has, matched on link type
  (`ARPHRD_CAN`) rather than on the name, so a udev-renamed USB adapter counts.
- The settings widget, with the interface combo and a live summary of the
  selected database.

## Two fixes that came out of this

**A use-after-free in the "Add device" dialog** (`7b0af1dd31`), which is not
CAN-specific — it crashed on selecting *any* protocol while an enumerator still
had a signal in flight. The dialog's `addItem`/`rmItem`/`sort` lambdas capture a
`QTreeWidgetItem*` that the following `m_devices->clear()` deletes; an enumerator
emitting from a worker thread makes the connection queued, and Qt retracts posted
metacalls only when their *receiver* dies, never when the sender does. Each
selection now gets its own context object, destroyed before those items.

Reproduced by `test_unit_device_edit_dialog`, which posts the signals from a
`std::thread` and switches protocol before the loop runs. With
`DeviceEditDialog.cpp` compiled `-fsanitize=address`, the `deviceRemoved` case
reports `heap-use-after-free` in `QTreeWidgetItem::childCount` — the same shape
as the field trace — and is clean after.

**`defaultSettings()` hardcoded `"can0"`**, so a fresh device on a machine
without a physical CAN port failed at connect time with `no such CAN interface:
can0` — a setting the user never chose. It now names the first interface present,
or nothing at all, and an empty name says so instead of letting the kernel report
a blank one.

## Test harness

Two fixes there, both of which affect every test, not just these:

- `run_in_app()` pinned the UI thread by hand, with a comment claiming that was
  what `ossia::context` does at startup. It is half of it: `ossia::context` also
  calls `qml_plugin::reg("Ossia")`, which registers `Ossia.Type` and friends.
  Without it any QML a test loads throws the moment it names one — a Mapper
  device does that on the first line of `createTree()`, and the call still
  returns `true` with an empty `QVariant`, so the device came up connected with
  an empty tree and nothing logged.
- `SCORE_SANITIZE_SKIP_CHECKS` is now set. The package manager asks "Download the
  user library?" a second after its first refresh, and `score::question` is a
  modal `QDialog::exec()`: headless, nobody answers, and any test that runs the
  event loop wedges in that nested loop. The model already documents that
  variable as the escape hatch for tests and CI.

Also worth knowing: **`qWarning` is swallowed in the test harness**, which is why
the mapper failure above was completely silent.

## Tests

| | |
|---|---|
| `test_protocol_can_dbc` | 843 assertions / 37 cases |
| `test_protocol_can_vcan` | 21 / 2 |
| `test_unit_can_enumerator` | 39 / 4 |
| `test_unit_can_scripting` | 27 / 4 |
| `test_unit_mapper_protocols` | 12 / 3 |
| `test_unit_device_edit_dialog` | 12 / 4 |

The DBC expectations are hand-computed from the bit-numbering rules and written
out in the comments, never taken from a run of the code under test — a wrong
answer there looks exactly like a right one.

`test_unit_can_scripting` drives the device end to end through the `Score`
scripting object, and `test_unit_mapper_protocols` drives `Protocols.can()` and
`Protocols.serial()` from a real Mapper device — libossia's own QML tests install
`Protocols` on a bare `QJSEngine`, which does not exercise the mapper's context
property or its engine thread.

Everything but the DBC parser needs `vcan0` and skips itself without it:

```
sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0
```

## Not covered

Everything was exercised against `vcan0` only — no physical CAN hardware here.
The FD-capability probe, the physical-before-virtual preference in
`defaultSettings()`, and a udev-renamed adapter have no coverage. FD is
deliberately *not* auto-enabled from the interface's MTU.

`float32Override` stays opt-in: it contradicts what a database says, and applying
it to a file that means what it says turns good data into noise. It exists
because `LPMS3_32bit.dbc` declares `32@1-` with `(1,0)` scaling and no
`SIG_VALTYPE_`, while the sensor's own command set documents that mode as 32-bit
float. Unverified against real CAN traffic.

## Pre-existing, unrelated

Every `APP` test in a developer build aborts *after* printing "All tests passed",
which makes ctest mark them failed. Under ASan it is a double-free in
`libobsensor::Logger::~Logger` from the vendored OrbbecSDK clearing a map twice at
static destruction. The untouched `test_unit_graphics_combo` dies the same way.
