### PR TITLE
ci: build the depth-camera addon, without its camera SDKs

### DIFF
--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -16,7 +16,13 @@ clone_addon() {
 
   (
   if [[ ! -d "$folder" ]]; then
-    if [[ -n "${SKIP_SUBMODULE:-}" ]]; then
+    if [[ -n "${NO_SUBMODULES:-}" ]]; then
+      # An addon that vendors whole SDKs it only needs for its own standalone
+      # build: score compiles the half that links into it, which is written not
+      # to need them. Clone the top level and leave the submodules alone.
+      local ndepth=(); [[ ${#shallow[@]} -gt 0 ]] && ndepth=(--depth 1)
+      git clone ${ndepth[@]+"${ndepth[@]}"} "$url" "$folder"
+    elif [[ -n "${SKIP_SUBMODULE:-}" ]]; then
       # Skip a heavy nested submodule score never compiles (SKIP_SUBMODULE is
       # "<super-path> <submodule-name>"): clone, init that super, mark it none, recurse.
       # ${arr[@]+...} guard: macOS bash 3.2 errors on empty arrays under set -u
@@ -92,6 +98,13 @@ then
   clone_addon    https://github.com/ossia/score-addon-spatgris
   clone_addon   https://github.com/ossia/score-addon-ultraleap
   clone_addon     https://github.com/ossia/score-addon-sysinfo
+
+  # Depth cameras (Orbbec, Kinect, Azure Kinect, RealSense). Without submodules
+  # on purpose: the repository vendors four camera SDKs that together take
+  # longer to build than the rest of score, and none of them belong in this
+  # build. The plug-in reaches cameras through a pure-C ABI and the SDKs ship as
+  # a separate downloadable package, built from the addon's own repository.
+  NO_SUBMODULES=1 clone_addon https://github.com/ossia/score-addon-orbbec
 fi
 
 if [[ "$CI_PLATFORM" == "LINUX" || "$CI_PLATFORM" == "WIN32" ]]; then


### PR DESCRIPTION
Adds [`score-addon-orbbec`](https://github.com/ossia/score-addon-orbbec) (Orbbec, Kinect v1/v2, Azure Kinect, Intel RealSense) to `ci/common.deps.sh` — **without its camera SDKs**.

## Why not just `clone_addon`

That addon is two halves:

- the **plug-in**, which links no camera SDK at all. It reaches cameras only through `DepthCamera/Backend/depthcam_abi.h`, a pure-C ABI, and is a few hundred kilobytes. This is the half that belongs in score.
- the **backends**, one self-contained shared object per SDK, built from the addon's own repository and shipped as a downloadable package (`packages/depth-camera`, ~8 MB for all five camera families).

Cloning the repository recursively pulls the OrbbecSDK, libfreenect, libfreenect2 and librealsense. Building them takes longer than the rest of score put together, and nothing in this build would link against any of them.

## What this does

`clone_addon` gains a `NO_SUBMODULES` mode alongside the existing `SKIP_SUBMODULE` one, and the addon is cloned with it.

No flag has to be passed on the CMake side either: the addon's `SCORE_DEPTHCAM_BUILD_BACKENDS` defaults to whether the submodules are actually checked out. A recursive clone builds everything; this one builds the plug-in. (Companion commit: ossia/score-addon-orbbec@cb4b59f.)

The resulting plug-in is a complete, working device — it just reports "no camera backend is installed" until a package is. Before that companion commit, a checkout without submodules made the addon `return()` early, so score would have had no depth-camera device at all rather than one waiting for a package.

## Checked

- The `NO_SUBMODULES` clone run for real against the addon: **1 MB** checked out, all four submodule directories empty.
- `SCORE_DEPTHCAM_BUILD_BACKENDS` resolves `OFF` on that checkout and `ON` on a recursive one.
- `score_addon_orbbec` configures and links with the backends off — no `score_depthcam_*` targets in the build graph at all.
- `bash -n ci/common.deps.sh`.

Not checked: the addon has never been through score's CI, so this is the first time these three platforms will try to compile it. The plug-in itself is Linux/Windows/macOS only and returns early elsewhere; it is placed in the non-WASM block for that reason.

Naming note: the repository is likely to be renamed `score-addon-depthcamera`, at which point the URL here needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uvR7UomMUJRaHbfEG1gk5
