### PR TITLE
ci: build score-addon-openzen

### DIFF
--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -89,6 +89,7 @@ then
   clone_addon         https://github.com/ossia/score-addon-led
   clone_addon         https://github.com/ossia/score-addon-lsl
   clone_addon         https://github.com/ossia/score-addon-ndi
+  clone_addon      https://github.com/ossia/score-addon-openzen
   clone_addon    https://github.com/ossia/score-addon-spatgris
   clone_addon   https://github.com/ossia/score-addon-ultraleap
   clone_addon     https://github.com/ossia/score-addon-sysinfo


### PR DESCRIPTION
Builds [score-addon-openzen](https://github.com/ossia/score-addon-openzen) in CI.
One line; the add-on itself lives in its own repo.

It gives score LP-Research LPMS inertial measurement units over serial, USB and
Bluetooth, through [OpenZen](https://bitbucket.org/lpresearch/openzen). Sensors
are matched by serial number so a unit is found again after being replugged, and
a link that drops is reconnected without disturbing the device tree. The
measurement set — accelerometer, gyroscope, magnetometer, quaternion, Euler,
pressure, altitude, temperature, heave, GNSS — is read from the sensor rather
than picked by hand, and the node tree only ever grows, so a reconnection never
deletes a node a score has cables to.

Placed in the non-WASM group with the other hardware add-ons: it needs a serial
port, so there is nothing for it to do in a browser.

## What I have and have not verified

Developed and hardware-tested on **Linux** against an LPMS-CURS3 over USB:
streaming at ~100 Hz with auto-detected measurements, surviving unplug/replug.
The add-on carries its own Catch2 suite — pure mapping tests that run anywhere,
plus `[hardware]`-tagged ones that skip without a sensor.

**This PR is the first time it is compiled on macOS and Windows.** OpenZen has
platform backends for both and `openzen.cmake` selects between them, but I have
only ever built the Linux one. If either fails here, the fallback is to narrow
the guard to Linux in this same file — one line — rather than to hold the
add-on back.

## Two things worth knowing

The add-on's `3rdparty/openzen` submodule points at
[jcelerier/openzen](https://github.com/jcelerier/openzen), branch
`score-integration`, which carries six patches over upstream — upstream is
effectively unmaintained on Bitbucket. Three of them are what make an LPMS-CURS3
work at all (termios ordering before the read thread starts, the connection
negotiator trusting the V1 handshake for models absent from its table, and
taking the gyro slot from the output bitset); the rest are build fixes and a
couple of thread-safety corrections. That is a dependency of an org add-on on a
personal fork, so it is probably worth forking into `ossia/` — say the word and
I will.

A recursive shallow clone the way `clone_addon` does it was verified end to end:
it resolves the fork at the right commit and pulls 58 MB.
