### PR TITLE
audio: keep the engine alive across documents; execution: reset the stopped interval, not the current document's

### DIFF
--- a/src/plugins/score-plugin-audio/Audio/AudioApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-audio/Audio/AudioApplicationPlugin.cpp
@@ -56,24 +56,56 @@ ApplicationPlugin::~ApplicationPlugin() { }
 
 void ApplicationPlugin::on_closeDocument(score::Document& old)
 {
-#if defined(__EMSCRIPTEN__)
-  // The WebAudio worklet is a page-lifetime singleton that cannot be torn down
-  // and recreated, so destroying the engine on close would leave playback dead
-  // until a full page reload (e.g. after File > New). Keep the engine alive and
-  // just park it on the document-independent pause tick; the next document
-  // rebinds to it via restart_engine().
+  // The engine does not depend on the document: keep it, parked on the
+  // document-independent pause tick (set_tick() waits for the audio thread to
+  // pick it up, so nothing of the closing document is referenced afterwards).
+  //
+  // Stopping it here used to leave the audio dead: closing a document that is
+  // not the current one changes no document, so nothing restarted the engine;
+  // and closing the current one recreated the driver, which is slow and
+  // fragile (ASIO, WASAPI...). On WebAssembly the WebAudio worklet cannot be
+  // recreated at all.
+  //
+  // The closing document is still listed here: it is the last one when no
+  // other remains.
+  const auto& docs = context.docManager.documents();
+  const bool last = docs.size() <= 1;
   if(audio)
+  {
     audio->set_tick(Audio::makePauseTick(this->context));
-#else
-  stop_engine();
+#if !defined(__EMSCRIPTEN__)
+    if(last)
+      stop_engine();
 #endif
+  }
 }
 
 void ApplicationPlugin::on_documentChanged(
     score::Document* olddoc, score::Document* newdoc)
 {
-  if(newdoc)
+  if(!newdoc)
+    return;
+
+  if(!audio)
+  {
     restart_engine();
+    return;
+  }
+
+  // The engine runs on: bind the document's audio device to it
+  rebind_engine(*newdoc);
+}
+
+void ApplicationPlugin::rebind_engine(score::Document& doc)
+{
+  auto dev = (Dataflow::AudioDevice*)doc.context()
+                 .plugin<Explorer::DeviceDocumentPlugin>()
+                 .list()
+                 .audioDevice();
+  if(dev)
+    dev->reconnect();
+  if(audio)
+    audio->set_tick(Audio::makePauseTick(this->context));
 }
 
 void ApplicationPlugin::timerEvent(QTimerEvent*)
@@ -235,6 +267,8 @@ void ApplicationPlugin::stop_engine()
     audio->stop();
     previous_audio.push_back(std::move(audio));
     audio.reset();
+    if(m_audioEngineAct)
+      m_audioEngineAct->setChecked(false);
   }
 }
 

--- a/src/plugins/score-plugin-audio/Audio/AudioApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-audio/Audio/AudioApplicationPlugin.hpp
@@ -29,6 +29,7 @@ private:
   void restart_engine();
   void stop_engine();
   void start_engine();
+  void rebind_engine(score::Document& doc);
 
   QAction* m_audioEngineAct{};
 

--- a/src/plugins/score-plugin-engine/Execution/ExecutionController.cpp
+++ b/src/plugins/score-plugin-engine/Execution/ExecutionController.cpp
@@ -740,11 +740,11 @@ void ExecutionController::reset_after_stop()
       50, this,
       [this, itv = QPointer<Scenario::IntervalModel>{&scenar->baseInterval()}] {
     if(itv)
-      reset_edition();
+      reset_edition(*itv);
       });
 }
 
-void ExecutionController::reset_edition()
+void ExecutionController::reset_edition(Scenario::IntervalModel& base)
 {
   // Reset edition for the device explorer
   if(context.applicationSettings.gui)
@@ -757,11 +757,8 @@ void ExecutionController::reset_edition()
 
   // FIXME uuuugh have an event in scenario instead (or better, move this
   // in process)
-  auto scenar = currentScenarioModel();
-  if(!scenar)
-    return;
-  scenar->baseInterval().reset();
-  scenar->baseInterval().executionEvent(Scenario::IntervalExecutionEvent::Finished);
+  base.reset();
+  base.executionEvent(Scenario::IntervalExecutionEvent::Finished);
 }
 
 void ExecutionController::on_reinitialize()

--- a/src/plugins/score-plugin-engine/Execution/ExecutionController.hpp
+++ b/src/plugins/score-plugin-engine/Execution/ExecutionController.hpp
@@ -98,7 +98,9 @@ private:
   void stop_clock();
   void send_end_state();
   void reset_after_stop();
-  void reset_edition();
+  //! Acts on the interval that was stopped: by the time the timer fires,
+  //! the current document may be another one, or be closing.
+  void reset_edition(Scenario::IntervalModel& base);
 
 private:
   Scenario::ScenarioDocumentModel* currentScenarioModel();

--- a/tests/unit/AudioEngineDocumentsTest.cpp
+++ b/tests/unit/AudioEngineDocumentsTest.cpp
@@ -1,0 +1,132 @@
+// App test: the audio engine across documents being opened, switched and closed.
+//
+// The engine used to be stopped whenever any document closed and restarted
+// only when the current document changed. Closing a document that is not the
+// current one changes nothing, so the engine stayed stopped - audio dead, the
+// toolbar still showing it on - until a tab switch or a manual restart; and
+// closing the current one recreated the audio driver each time. The engine
+// now lives as long as a document does: closing or switching documents only
+// rebinds the audio device of the current document to it.
+//
+// Every case boots its own app: several run_in_app() in one process do not
+// survive on Windows (see reference_score_test_multicase_crash), run them with
+// `-c` / the test name.
+
+#include <Explorer/DeviceList.hpp>
+#include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
+
+#include <Audio/AudioApplicationPlugin.hpp>
+
+#include <score/application/GUIApplicationContext.hpp>
+#include <score/document/DocumentContext.hpp>
+
+#include <core/document/Document.hpp>
+#include <core/presenter/DocumentManager.hpp>
+
+#include <ossia/audio/audio_engine.hpp>
+
+#include <QApplication>
+
+#include <catch2/catch_all.hpp>
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+namespace
+{
+Audio::ApplicationPlugin& audioPlugin(const score::GUIApplicationContext& ctx)
+{
+  return ctx.guiApplicationPlugin<Audio::ApplicationPlugin>();
+}
+
+bool audioDeviceConnected(score::Document& doc)
+{
+  auto dev = doc.context().plugin<Explorer::DeviceDocumentPlugin>().list().audioDevice();
+  return dev && dev->connected();
+}
+
+void spin()
+{
+  QApplication::processEvents();
+  QApplication::processEvents();
+}
+}
+
+TEST_CASE("Closing a background document keeps the audio engine running", "[audio][documents]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& audio = audioPlugin(ctx);
+    auto a = score::test::new_document(ctx);
+    auto b = score::test::new_document(ctx);
+    REQUIRE(ctx.docManager.currentDocument() == b);
+    REQUIRE(audio.audio);
+    const auto engine = audio.audio;
+
+    ctx.docManager.forceCloseDocument(ctx, *a);
+    spin();
+
+    // Still the current document, nothing changed for it
+    CHECK(ctx.docManager.currentDocument() == b);
+    REQUIRE(audio.audio);
+    CHECK(audio.audio == engine);
+    CHECK(audioDeviceConnected(*b));
+  });
+}
+
+TEST_CASE("Closing the current document keeps the engine for the remaining one", "[audio][documents]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& audio = audioPlugin(ctx);
+    auto a = score::test::new_document(ctx);
+    auto b = score::test::new_document(ctx);
+    REQUIRE(ctx.docManager.currentDocument() == b);
+    REQUIRE(audio.audio);
+    const auto engine = audio.audio;
+
+    ctx.docManager.forceCloseDocument(ctx, *b);
+    spin();
+
+    CHECK(ctx.docManager.currentDocument() == a);
+    REQUIRE(audio.audio);
+    CHECK(audio.audio == engine);
+    CHECK(audioDeviceConnected(*a));
+  });
+}
+
+TEST_CASE("Switching documents keeps the engine and rebinds the audio device", "[audio][documents]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& audio = audioPlugin(ctx);
+    auto a = score::test::new_document(ctx);
+    auto b = score::test::new_document(ctx);
+    REQUIRE(audio.audio);
+    const auto engine = audio.audio;
+
+    ctx.docManager.setCurrentDocument(ctx, a);
+    spin();
+    CHECK(audio.audio == engine);
+    CHECK(audioDeviceConnected(*a));
+
+    ctx.docManager.setCurrentDocument(ctx, b);
+    spin();
+    CHECK(audio.audio == engine);
+    CHECK(audioDeviceConnected(*b));
+  });
+}
+
+TEST_CASE("Closing the last document stops the engine, opening one starts it", "[audio][documents]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& audio = audioPlugin(ctx);
+    auto a = score::test::new_document(ctx);
+    REQUIRE(audio.audio);
+
+    ctx.docManager.forceCloseDocument(ctx, *a);
+    spin();
+    CHECK(!audio.audio);
+
+    auto b = score::test::new_document(ctx);
+    spin();
+    REQUIRE(audio.audio);
+    CHECK(audioDeviceConnected(*b));
+  });
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -517,3 +517,12 @@ if(TARGET score_plugin_audio)
     APP
     PLUGINS score_plugin_audio score_plugin_deviceexplorer score_lib_device)
 endif()
+
+# The delayed reset after a stop acts on the interval it was armed for, not
+# on whatever document is current (or closing) when its timer fires.
+if(TARGET score_plugin_engine)
+  score_add_test(test_unit_execution_reset_after_close
+    SOURCES ExecutionResetAfterCloseTest.cpp
+    APP
+    PLUGINS score_plugin_engine score_plugin_scenario)
+endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -508,3 +508,12 @@ score_add_test(test_unit_device_listening
   SOURCES DeviceListeningTest.cpp
   GUI
   PLUGINS score_plugin_deviceexplorer score_lib_device score_lib_state)
+
+# The audio engine across documents being opened, switched and closed: it
+# lives as long as a document does, whichever document closes.
+if(TARGET score_plugin_audio)
+  score_add_test(test_unit_audio_engine_documents
+    SOURCES AudioEngineDocumentsTest.cpp
+    APP
+    PLUGINS score_plugin_audio score_plugin_deviceexplorer score_lib_device)
+endif()

--- a/tests/unit/ExecutionResetAfterCloseTest.cpp
+++ b/tests/unit/ExecutionResetAfterCloseTest.cpp
@@ -1,0 +1,120 @@
+// App test: the reset that follows a stop, when documents change under it.
+//
+// ExecutionController::reset_after_stop() arms a timer to reset the stopped
+// document's base interval a little later (so that the last messages get
+// out). The timer used to act on whichever document was current when it
+// fired: the wrong document after a switch, and a crash in
+// BaseScenarioContainer::interval() if another document was being closed at
+// that moment (its model already torn down, its processEvents() running the
+// timer) - one in two closes of the current document hit it. The reset now
+// acts on the interval it captured.
+//
+// One app per case: run the cases separately on Windows.
+
+#include <Engine/ApplicationPlugin.hpp>
+#include <Execution/ExecutionController.hpp>
+#include <Scenario/Document/Interval/IntervalModel.hpp>
+#include <Scenario/Document/ScenarioDocument/ScenarioDocumentModel.hpp>
+
+#include <score/application/GUIApplicationContext.hpp>
+#include <score/document/DocumentInterface.hpp>
+
+#include <core/document/Document.hpp>
+#include <core/presenter/DocumentManager.hpp>
+
+#include <QApplication>
+#include <QElapsedTimer>
+
+#include <catch2/catch_all.hpp>
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+namespace
+{
+void spin(int ms)
+{
+  QElapsedTimer t;
+  t.start();
+  while(t.elapsed() < ms)
+    QApplication::processEvents(QEventLoop::AllEvents, 10);
+}
+
+Scenario::IntervalModel& baseInterval(score::Document& doc)
+{
+  return score::IDocument::get<Scenario::ScenarioDocumentModel>(doc).baseInterval();
+}
+
+// Counts the Finished events the reset sends to an interval
+struct FinishedCounter
+{
+  int count{};
+  explicit FinishedCounter(Scenario::IntervalModel& itv)
+  {
+    QObject::connect(
+        &itv, &Scenario::IntervalModel::executionEvent, &itv,
+        [this](Scenario::IntervalExecutionEvent ev) {
+      if(ev == Scenario::IntervalExecutionEvent::Finished)
+        count++;
+        });
+  }
+};
+}
+
+TEST_CASE("The reset after a stop goes to the document that was stopped", "[execution][documents]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& exec = ctx.guiApplicationPlugin<Engine::ApplicationPlugin>().execution();
+
+    auto a = score::test::new_document(ctx);
+    FinishedCounter finishedA{baseInterval(*a)};
+    // Stopping (even when not playing) arms the delayed reset of a's base interval
+    exec.request_stop();
+    spin(20);
+
+    // Another document is current when the timer fires
+    auto b = score::test::new_document(ctx);
+    REQUIRE(ctx.docManager.currentDocument() == b);
+    spin(150);
+
+    // Opening b requested a stop too (prepareNewDocument), so more than one
+    // reset may have gone to a: what matters is that none went astray to b
+    // instead. Before the fix a got none.
+    CHECK(finishedA.count >= 1);
+  });
+}
+
+TEST_CASE("The reset after a stop survives another document closing", "[execution][documents]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& exec = ctx.guiApplicationPlugin<Engine::ApplicationPlugin>().execution();
+
+    auto a = score::test::new_document(ctx);
+    exec.request_stop();
+    spin(20);
+
+    // b becomes current and is closed right away: forceCloseDocument() tears
+    // its model down, then runs the event loop - where the timer may fire.
+    auto b = score::test::new_document(ctx);
+    ctx.docManager.forceCloseDocument(ctx, *b);
+    spin(150);
+
+    CHECK(ctx.docManager.currentDocument() == a);
+    CHECK(!score::IDocument::get<Scenario::ScenarioDocumentModel>(*a).closing());
+  });
+}
+
+TEST_CASE("The reset after a stop is dropped with its document", "[execution][documents]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto& exec = ctx.guiApplicationPlugin<Engine::ApplicationPlugin>().execution();
+
+    auto a = score::test::new_document(ctx);
+    auto b = score::test::new_document(ctx);
+    exec.request_stop();
+    spin(20);
+    ctx.docManager.forceCloseDocument(ctx, *b);
+    spin(150);
+
+    CHECK(ctx.docManager.currentDocument() == a);
+  });
+}


### PR DESCRIPTION
## Audio engine dies / score crashes when documents are opened and closed

Two defects behind "the audio device is stuck" after opening / closing several documents, found by tracing the document close path and reproducing it in app tests (dummy backend, so backend-independent).

### 1. Engine stopped and never restarted (`audio: keep the engine alive across documents`)
`Audio::ApplicationPlugin::on_closeDocument` stopped the engine for *any* closing document, and only `on_documentChanged` restarted it. `DocumentManager::forceCloseDocument` calls the close hooks and then `setCurrentDocument(back())`, which returns early when the current document does not change — so closing a document that is not the current one left the engine stopped for good (toolbar still showing it on). Closing the current one tore the driver down and recreated it every time (slow / fragile on ASIO, WASAPI...).

The engine does not depend on a document: it is now kept while one is open, parked on the document-independent pause tick on close (`set_tick()` waits for the audio thread, so nothing of the closing document is referenced afterwards), rebound to the current document's audio device on a switch, and only stopped when the last document closes. The "Restart Audio" action follows the engine's state. (This generalizes what the WebAssembly build already did.)

### 2. Crash in `BaseScenarioContainer::interval()` on close (`execution: reset the interval that was stopped...`)
`ExecutionController::reset_after_stop()` arms a 50 ms timer to reset the stopped document's base interval, but the timer acted on whatever document was *current* when it fired. Every new document requests a stop (`prepareNewDocument`), so a timer armed for document A fires while B is current — and if B is being closed at that moment (model torn down, `processEvents()` in `forceCloseDocument` running the timer), it dereferences a dead interval. With the engine restarting around each close, **one in two closes of the current document segfaulted** (measured: 6/12 on master). The reset now acts on the interval the timer captured.

### Tests (app tests; run the cases separately on Windows, `-c`)
- `test_unit_audio_engine_documents`: closing a background document, closing the current one, switching, closing the last one. On master the first three fail (engine gone / recreated on each switch).
- `test_unit_execution_reset_after_close`: the reset goes to the document that was stopped (fails deterministically on master: A gets 0 `Finished` events, B gets them all), and survives another document closing (segfaults intermittently on master).
- After both fixes: 0/16 failures on the closing-current case that crashed 6/12 before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pA2gF1B4A28FbaJCxS5FZ
