### PR TITLE
files: open the pickers next to the current file, else in the project

### DIFF
--- a/src/lib/core/presenter/DocumentManager.cpp
+++ b/src/lib/core/presenter/DocumentManager.cpp
@@ -528,7 +528,8 @@ Document* DocumentManager::loadStack(const score::GUIApplicationContext& ctx)
     return nullptr;
 
   QString loadname
-      = QFileDialog::getOpenFileName(m_view, tr("Open Stack"), QString(), "*.stack");
+      = QFileDialog::getOpenFileName(
+          m_view, tr("Open Stack"), getDialogDirectory(nullptr).absolutePath(), "*.stack");
   if(!loadname.isEmpty() && (loadname.indexOf(".stack") != -1))
   {
     return loadStack(ctx, loadname);

--- a/src/lib/score/tools/File.cpp
+++ b/src/lib/score/tools/File.cpp
@@ -6,6 +6,7 @@
 #include <QDir>
 #include <QRegularExpression>
 #include <QSettings>
+#include <QStandardPaths>
 
 #include <cstring>
 #include <string_view>
@@ -243,4 +244,28 @@ QString stageImportedFileFromPath(const QString& sourcePath) noexcept
   return {};
 }
 #endif
+}
+
+namespace score
+{
+static QString userDocumentsFolder() noexcept
+{
+  return QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+}
+
+QString
+pickerStartFolder(const QString& current, const score::DocumentContext& ctx) noexcept
+{
+  return pickerStartFolder(
+      current, pathRoots(ctx), userDocumentsFolder(), QDir::currentPath());
+}
+
+QString pickerStartFolder(const QString& current) noexcept
+{
+  PathRoots roots;
+  QSettings set;
+  if(auto lib = set.value("Library/RootPath").toString(); QDir{lib}.exists())
+    roots.library = QFileInfo{lib}.canonicalFilePath();
+  return pickerStartFolder(current, roots, userDocumentsFolder(), QDir::currentPath());
+}
 }

--- a/src/lib/score/tools/FilePath.hpp
+++ b/src/lib/score/tools/FilePath.hpp
@@ -21,6 +21,17 @@ relativizeFilePath(const QString& filename, const score::DocumentContext& ctx) n
 SCORE_LIB_BASE_EXPORT
 QString addUniqueSuffix(const QString& fileName);
 
+//! Where a file / folder picker should open for a control of this document
+//! whose current value is @p current: see the PathRoots overload.
+SCORE_LIB_BASE_EXPORT
+QString
+pickerStartFolder(const QString& current, const score::DocumentContext& ctx) noexcept;
+
+//! Same, outside of any document (application settings): the library, the
+//! user's documents folder, or the working directory.
+SCORE_LIB_BASE_EXPORT
+QString pickerStartFolder(const QString& current) noexcept;
+
 struct FilePath
 {
   QString absolute;

--- a/src/lib/score/tools/ProjectFiles.cpp
+++ b/src/lib/score/tools/ProjectFiles.cpp
@@ -466,3 +466,31 @@ bool materializeFile(
   return true;
 }
 }
+
+namespace score
+{
+QString pickerStartFolder(
+    const QString& current, const PathRoots& roots, const QString& userDocuments,
+    const QString& workingDir) noexcept
+{
+  const auto existingDir = [](const QString& p) { return !p.isEmpty() && QDir{p}.exists(); };
+
+  // Where the current file is, if it still is there
+  if(!current.isEmpty())
+  {
+    const QFileInfo fi{locateFilePath(current, roots)};
+    if(fi.isDir())
+      return fi.absoluteFilePath();
+    if(fi.exists())
+      return fi.absolutePath();
+  }
+
+  if(const auto p = roots.documentFolder(); existingDir(p))
+    return p;
+  if(existingDir(roots.library))
+    return roots.library;
+  if(existingDir(userDocuments))
+    return userDocuments;
+  return workingDir;
+}
+}

--- a/src/lib/score/tools/ProjectFiles.hpp
+++ b/src/lib/score/tools/ProjectFiles.hpp
@@ -51,6 +51,17 @@ struct SCORE_LIB_BASE_EXPORT PathRoots
   QString documentFolder() const noexcept;
 };
 
+//! Where a file / folder picker should open for a control whose current
+//! value is @p current (absolute, document-relative, <PROJECT>: or
+//! <LIBRARY>:-prefixed, or empty). In order: the folder of the current file
+//! (or the current folder itself) if it exists, the document's folder, the
+//! library, the user's documents folder, the working directory - the first
+//! one that exists. Never empty.
+SCORE_LIB_BASE_EXPORT
+QString pickerStartFolder(
+    const QString& current, const PathRoots& roots, const QString& userDocuments,
+    const QString& workingDir) noexcept;
+
 //! Roots of a live document.
 SCORE_LIB_BASE_EXPORT
 PathRoots pathRoots(const score::DocumentContext& ctx) noexcept;

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -1040,9 +1040,10 @@ struct ProgramEdit
 // Open a file for import. On wasm this uses the async getOpenFileContent API and
 // stages the picked bytes into MEMFS (there is no local filesystem / synchronous
 // dialog); `onPicked` then receives a real, readable path. On desktop it is the
-// usual synchronous getOpenFileName. `onPicked(const QString& path)`.
+// usual synchronous getOpenFileName, opened in `startDir` (see
+// score::pickerStartFolder). `onPicked(const QString& path)`.
 template <typename F>
-inline void openFileToImport(const QString& filters, F onPicked)
+inline void openFileToImport(const QString& filters, const QString& startDir, F onPicked)
 {
 #if defined(__EMSCRIPTEN__)
   QFileDialog::getOpenFileContent(
@@ -1056,7 +1057,7 @@ inline void openFileToImport(const QString& filters, F onPicked)
   });
 #else
   const QString fn
-      = QFileDialog::getOpenFileName(nullptr, QObject::tr("Open File"), {}, filters);
+      = QFileDialog::getOpenFileName(nullptr, QObject::tr("Open File"), startDir, filters);
   if(!fn.isEmpty())
     onPicked(fn);
 #endif
@@ -1079,7 +1080,10 @@ struct FileChooser
     act->setIcon(QIcon(":/icons/search.png"));
     sl->setPlaceholderText(QObject::tr("Open File"));
     auto on_open = [=, &ctx, &inlet] {
-      openFileToImport(inlet.filters(), [=, &ctx](const QString& filename) {
+      const auto current = QString::fromStdString(ossia::convert<std::string>(inlet.value()));
+      openFileToImport(
+          inlet.filters(), score::pickerStartFolder(current, ctx),
+          [=, &ctx](const QString& filename) {
         auto path = score::relativizeFilePath(filename, ctx);
         sl->setText(path);
       });
@@ -1112,7 +1116,10 @@ struct FileChooser
     auto bt = new score::QGraphicsTextButton{"Choose a file...", parent};
     initWidgetProperties(inlet, *bt);
     auto on_open = [&inlet, &ctx] {
-      openFileToImport(inlet.filters(), [&inlet, &ctx](const QString& filename) {
+      const auto current = QString::fromStdString(ossia::convert<std::string>(inlet.value()));
+      openFileToImport(
+          inlet.filters(), score::pickerStartFolder(current, ctx),
+          [&inlet, &ctx](const QString& filename) {
         auto path = score::relativizeFilePath(filename, ctx);
         CommandDispatcher<>{ctx.commandStack}.submit<SetControlValue<Control_T>>(
             inlet, path.toStdString());
@@ -1184,7 +1191,10 @@ struct FolderChooser
     sl->setPlaceholderText(QObject::tr("Open Folder"));
     auto on_open = [=, &ctx, &inlet] {
       auto filename
-          = QFileDialog::getExistingDirectory(nullptr, "Open Folder", {});
+          = QFileDialog::getExistingDirectory(
+              nullptr, "Open Folder",
+              score::pickerStartFolder(
+                  QString::fromStdString(ossia::convert<std::string>(inlet.value())), ctx));
       if(filename.isEmpty())
         return;
       auto path = score::relativizeFilePath(filename, ctx);
@@ -1219,7 +1229,10 @@ struct FolderChooser
     initWidgetProperties(inlet, *bt);
     auto on_open = [&inlet, &ctx] {
       auto filename
-          = QFileDialog::getExistingDirectory(nullptr, "Open Folder", {});
+          = QFileDialog::getExistingDirectory(
+              nullptr, "Open Folder",
+              score::pickerStartFolder(
+                  QString::fromStdString(ossia::convert<std::string>(inlet.value())), ctx));
       if(filename.isEmpty())
         return;
 

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/DeviceExplorerWidget.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/DeviceExplorerWidget.cpp
@@ -57,6 +57,8 @@
 
 #include <ossia-qt/js_utilities.hpp>
 
+#include <score/tools/FilePath.hpp>
+
 #include <QAbstractProxyModel>
 #include <QAction>
 #include <QClipboard>
@@ -1145,7 +1147,8 @@ void DeviceExplorerWidget::importDevice()
     return;
 
   auto fileName = QFileDialog::getOpenFileName(
-      this, tr("Device file"), QString{}, tr("Device file (*.device)"));
+      this, tr("Device file"), score::pickerStartFolder({}, m->deviceModel().context()),
+      tr("Device file (*.device)"));
   if(fileName.isEmpty())
     return;
 
@@ -1185,7 +1188,8 @@ void DeviceExplorerWidget::exportDevice()
     return;
 
   auto fileName = QFileDialog::getSaveFileName(
-      this, tr("Device file"), QString{}, tr("Device file (*.device)"));
+      this, tr("Device file"), score::pickerStartFolder({}, model()->deviceModel().context()),
+      tr("Device file (*.device)"));
   if(!fileName.endsWith(".device"))
     fileName.append(".device");
 

--- a/src/plugins/score-plugin-gfx/Gfx/Images/ImageListChooser.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Images/ImageListChooser.cpp
@@ -143,7 +143,7 @@ private:
   void on_addItems()
   {
     auto files = QFileDialog::getOpenFileNames(
-        this, tr("Choose images..."), QString{},
+        this, tr("Choose images..."), score::pickerStartFolder({}, ctx),
         QString{"Images (*.png *.jpg *.jpeg *.gif *.bmp *.tiff *.heic *.jp2 *.svg *.tga "
                 "*.wbmp)"});
     for(auto f : files)

--- a/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
+++ b/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <score/tools/FilePath.hpp>
 #include <Process/Dataflow/ControlWidgets.hpp>
 
 #include <Media/MediaFileHandle.hpp>
@@ -67,7 +68,10 @@ struct AudioFileChooser : WidgetFactory::FileChooser
   {
     auto bt = new score::QGraphicsWaveformButton{parent};
     auto on_open = [&inlet, &ctx] {
-      WidgetFactory::openFileToImport(inlet.filters(), [&inlet, &ctx](const QString& filename) {
+      const auto current = QString::fromStdString(ossia::convert<std::string>(inlet.value()));
+      WidgetFactory::openFileToImport(
+          inlet.filters(), score::pickerStartFolder(current, ctx),
+          [&inlet, &ctx](const QString& filename) {
         // On wasm `filename` is the staged MEMFS path; relativize so it is
         // stored consistently with drops.
         auto path = score::relativizeFilePath(filename, ctx);

--- a/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.cpp
+++ b/src/plugins/score-plugin-media/Media/Effect/Settings/PluginTab.cpp
@@ -1,5 +1,7 @@
 #include "PluginTab.hpp"
 
+#include <score/tools/FilePath.hpp>
+
 #include <QFileDialog>
 #include <QFormLayout>
 #include <QGridLayout>
@@ -95,7 +97,8 @@ QWidget* makePluginSettingsWidget(PluginTabSpec spec)
       addPath, &QPushButton::clicked, pathList,
       [pathList, items, commit = spec.commitPaths, splitter] {
     auto path
-        = QFileDialog::getExistingDirectory(splitter, QObject::tr("Plug-in path"));
+        = QFileDialog::getExistingDirectory(
+            splitter, QObject::tr("Plug-in path"), score::pickerStartFolder({}));
     if(!path.isEmpty())
     {
       pathList->addItem(path);

--- a/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
+++ b/src/plugins/score-plugin-protocols/Protocols/CAN/CANProtocolSettingsWidget.cpp
@@ -10,6 +10,8 @@
 
 #include <score/widgets/HelpInteraction.hpp>
 
+#include <score/tools/FilePath.hpp>
+
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDir>
@@ -152,7 +154,7 @@ CANProtocolSettingsWidget::~CANProtocolSettingsWidget() { }
 void CANProtocolSettingsWidget::browseDBC()
 {
   const auto path = QFileDialog::getOpenFileName(
-      this, tr("Open a CAN database"), QFileInfo{m_dbcPath->text()}.absolutePath(),
+      this, tr("Open a CAN database"), score::pickerStartFolder(m_dbcPath->text()),
       tr("CAN databases (*.dbc);;All files (*)"));
 
   if(!path.isEmpty())

--- a/src/plugins/score-plugin-remotecontrol/RemoteControl/Settings/View.cpp
+++ b/src/plugins/score-plugin-remotecontrol/RemoteControl/Settings/View.cpp
@@ -4,6 +4,8 @@
 #include <score/widgets/FormWidget.hpp>
 #include <score/widgets/SignalUtils.hpp>
 
+#include <score/tools/FilePath.hpp>
+
 #include <QCheckBox>
 #include <QFormLayout>
 #include <QPushButton>
@@ -61,7 +63,8 @@ View::View()
     connect(browse, &QPushButton::clicked, this, [this]
     {
       auto f{QFileDialog::getExistingDirectory(
-          nullptr, tr("Web UI folder"), m_web_ui_path->displayText())};
+          nullptr, tr("Web UI folder"),
+          score::pickerStartFolder(m_web_ui_path->displayText()))};
       if (!f.isEmpty()) webUiPathChanged(f);
     });
 

--- a/src/plugins/score-plugin-scenario/Scenario/Settings/ScenarioSettingsView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Settings/ScenarioSettingsView.cpp
@@ -15,6 +15,8 @@
 #include <score/widgets/SignalUtils.hpp>
 #include <score/widgets/TimeSpinBox.hpp>
 
+#include <score/tools/FilePath.hpp>
+
 #include <QApplication>
 #include <QCheckBox>
 #include <QComboBox>
@@ -128,7 +130,8 @@ public:
 
     connect(&save, &QPushButton::clicked, this, [&] {
       auto f = QFileDialog::getSaveFileName(
-          nullptr, tr("Save edited skin file"), skinFile, tr("*.json"));
+          nullptr, tr("Save edited skin file"), score::pickerStartFolder(skinFile),
+          tr("*.json"));
       if(f.isEmpty())
         return;
       QFile fl{f};
@@ -184,7 +187,7 @@ View::View()
     ls->setMaximumWidth(100);
     connect(ls, &QPushButton::clicked, this, [this, skinPath] {
       auto f = QFileDialog::getOpenFileName(
-          nullptr, tr("Load skin"), skinPath, tr("*.json"));
+          nullptr, tr("Load skin"), score::pickerStartFolder(skinPath), tr("*.json"));
       if(!f.isEmpty())
       {
         SkinChanged(f);
@@ -228,7 +231,8 @@ View::View()
     m_editor = new QLineEdit{};
     auto btn = new QPushButton{tr("Browse..."), m_widg};
     connect(btn, &QPushButton::pressed, this, [this, subw] {
-      auto file = QFileDialog::getOpenFileName(subw, tr("Default editor"));
+      auto file = QFileDialog::getOpenFileName(
+          subw, tr("Default editor"), score::pickerStartFolder(m_editor->text()));
       if(!file.isEmpty())
       {
         m_editor->setText(file);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -553,3 +553,8 @@ if(TARGET score_plugin_audio)
     APP
     PLUGINS score_plugin_audio score_plugin_deviceexplorer score_lib_device)
 endif()
+
+# Where the file / folder pickers open: next to the current file, else the
+# project, the library, the user's documents, the working directory.
+score_add_test(test_unit_picker_start_folder
+  SOURCES PickerStartFolderTest.cpp)

--- a/tests/unit/PickerStartFolderTest.cpp
+++ b/tests/unit/PickerStartFolderTest.cpp
@@ -1,0 +1,90 @@
+// Unit test: where a file / folder picker opens (score::pickerStartFolder).
+//
+// The pickers of the file and folder controls (and the other document-aware
+// ones) used to open wherever the last Qt dialog had been, which looked
+// random. The rule: the folder of the control's current file if it exists,
+// else the document's folder, else the library, else the user's documents
+// folder, else the working directory.
+
+#include <score/tools/ProjectFiles.hpp>
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+struct Sandbox
+{
+  QTemporaryDir tmp;
+  QString root{QDir{tmp.path()}.canonicalPath()};
+  QString project{root + "/project"};
+  QString library{root + "/library"};
+  QString documents{root + "/documents"};
+  QString work{root + "/work"};
+
+  Sandbox()
+  {
+    for(const QString& d :
+        {project, library, documents, work, QString{project + "/media"}})
+      QDir{}.mkpath(d);
+    touch(project + "/doc.score");
+    touch(project + "/media/kick.wav");
+    touch(library + "/lib.wav");
+  }
+
+  static void touch(const QString& p)
+  {
+    QFile f{p};
+    if(f.open(QIODevice::WriteOnly))
+      f.write("x");
+  }
+
+  score::PathRoots roots() const { return {project + "/doc.score", library}; }
+  QString pick(const QString& current, const score::PathRoots& r) const
+  {
+    return score::pickerStartFolder(current, r, documents, work);
+  }
+};
+}
+
+TEST_CASE("A picker opens next to the control's current file", "[files][picker]")
+{
+  Sandbox s;
+  const auto r = s.roots();
+
+  CHECK(s.pick(s.project + "/media/kick.wav", r) == s.project + "/media");
+  // Stored relative to the project, or to the library
+  CHECK(s.pick("<PROJECT>:/media/kick.wav", r) == s.project + "/media");
+  CHECK(s.pick("media/kick.wav", r) == s.project + "/media");
+  CHECK(s.pick("<LIBRARY>:/lib.wav", r) == s.library);
+  // A folder control: the folder itself
+  CHECK(s.pick(s.project + "/media", r) == s.project + "/media");
+  CHECK(s.pick("<PROJECT>:/media", r) == s.project + "/media");
+}
+
+TEST_CASE("A picker falls back from the project to the library, the documents, the working directory", "[files][picker]")
+{
+  Sandbox s;
+
+  // The current file is gone: the project
+  CHECK(s.pick(s.project + "/media/gone.wav", s.roots()) == s.project);
+  CHECK(s.pick("<PROJECT>:/gone.wav", s.roots()) == s.project);
+  CHECK(s.pick({}, s.roots()) == s.project);
+
+  // No document (never saved): the library
+  score::PathRoots unsaved{{}, s.library};
+  CHECK(s.pick({}, unsaved) == s.library);
+  CHECK(s.pick("<PROJECT>:/gone.wav", unsaved) == s.library);
+
+  // A document whose folder no longer exists, no library: the documents
+  score::PathRoots noLibrary{s.root + "/removed/doc.score", {}};
+  CHECK(s.pick({}, noLibrary) == s.documents);
+  score::PathRoots deadLibrary{{}, s.root + "/nowhere"};
+  CHECK(s.pick({}, deadLibrary) == s.documents);
+
+  // Nothing at all: the working directory, whatever it is
+  CHECK(score::pickerStartFolder({}, score::PathRoots{}, s.root + "/nodocs", s.work) == s.work);
+}


### PR DESCRIPTION
## File / folder pickers open in a sensible place

The pickers (`Process::FileChooser` / `FolderChooser`, the image list chooser, device file import/export, the audio file chooser, and the settings' path fields) passed an empty start directory to Qt, so each one opened wherever the previous dialog had been — which looks random.

`score::pickerStartFolder()` (in `score/tools/ProjectFiles.hpp`, next to the `PathRoots` path math) gives every picker its start folder, the first of these that exists:
1. the folder of the control's current file — resolving `<PROJECT>:`, `<LIBRARY>:` and document-relative values — or the current folder itself for a folder control;
2. the document's folder;
3. the user library;
4. the user's documents folder;
5. the application's working directory.

`openFileToImport()` takes the start directory (desktop; the wasm path is unchanged). Pickers without a document (settings) use the overload that goes library → documents → working directory.

Tests: `test_unit_picker_start_folder` (pure, on a temporary tree): current-file folder for absolute / `<PROJECT>:` / relative / `<LIBRARY>:` values and folder controls, then each fallback step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pA2gF1B4A28FbaJCxS5FZ
