### PR TITLE
ci: move to ossia SDK 39

### DIFF
--- a/ci/appimage.deps.sh
+++ b/ci/appimage.deps.sh
@@ -19,7 +19,7 @@ else
   export CPU_ARCH_SUFFIX="-x86_64"
 fi
 
-wget -nv "https://github.com/ossia/sdk/releases/download/sdk38/sdk-linux${CPU_ARCH_SUFFIX}.tar.xz"
+wget -nv "https://github.com/ossia/sdk/releases/download/sdk39/sdk-linux${CPU_ARCH_SUFFIX}.tar.xz"
 tar xaf sdk-linux${CPU_ARCH_SUFFIX}.tar.xz
 rm -rf  sdk-linux${CPU_ARCH_SUFFIX}.tar.xz
 

--- a/ci/osx.package.deps.sh
+++ b/ci/osx.package.deps.sh
@@ -33,7 +33,7 @@ brew install gnu-tar ninja xz
 wget -nv "https://github.com/jcelerier/cninja/releases/download/v3.7.9/cninja-v3.7.9-macOS-$MACOS_ARCH.tar.gz" -O cninja.tgz &
 
 SDK_ARCHIVE=sdk-macOS-$MACOS_ARCH.tar.xz
-wget -nv https://github.com/ossia/sdk/releases/download/sdk38/$SDK_ARCHIVE -O "$SDK_ARCHIVE"
+wget -nv https://github.com/ossia/sdk/releases/download/sdk39/$SDK_ARCHIVE -O "$SDK_ARCHIVE"
 
 sudo mkdir -p "/opt/ossia-sdk-$MACOS_ARCH/"
 sudo chown -R "$(whoami)" /opt

--- a/ci/wasm.deps.sh
+++ b/ci/wasm.deps.sh
@@ -14,7 +14,7 @@ $SUDO apt-get install -y --no-install-recommends \
 
 # The wasm SDK built by ossia/sdk CI (Qt 6.12, emsdk 5.0.5, ffmpeg 8.1).
 export SDK_ARCHIVE=sdk-wasm.tar.xz
-wget -nv https://github.com/ossia/sdk/releases/download/sdk38/$SDK_ARCHIVE -O $SDK_ARCHIVE
+wget -nv https://github.com/ossia/sdk/releases/download/sdk39/$SDK_ARCHIVE -O $SDK_ARCHIVE
 
 $SUDO mkdir -p /opt/ossia-sdk-wasm
 $SUDO chown -R "$(whoami)" /opt/ossia-sdk-wasm

--- a/ci/win32.deps.sh
+++ b/ci/win32.deps.sh
@@ -15,7 +15,7 @@ fi
 set -x
 mkdir -p /c/ossia-sdk-$SDK_ARCH
 cd /c/ossia-sdk-$SDK_ARCH
-curl -L https://github.com/ossia/sdk/releases/download/sdk38/sdk-mingw-$SDK_ARCH.7z --output sdk-mingw-$SDK_ARCH.7z
+curl -L https://github.com/ossia/sdk/releases/download/sdk39/sdk-mingw-$SDK_ARCH.7z --output sdk-mingw-$SDK_ARCH.7z
 7z x sdk-mingw-$SDK_ARCH.7z
 rm sdk-mingw-$SDK_ARCH.7z
 ls

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -268,7 +268,7 @@ elseif(TARGET avcodec)
       endif()
     endif()
 
-    # ossia SDK 38 (ffmpeg 9) builds libavcodec / libavformat against a set of
+    # ossia SDK 39 (ffmpeg 9) builds libavcodec / libavformat against a set of
     # codec and protocol libraries that earlier SDKs did not have: dav1d, x264,
     # x265, opus, vpx, webp, SVT-JPEG-XS, mp3lame, libxml2, SRT (which itself
     # links the SDK's openssl) and freetype+harfbuzz for the drawtext filter.

--- a/tools/fetch-sdk.sh
+++ b/tools/fetch-sdk.sh
@@ -3,7 +3,7 @@
 if [[ $# > 0 ]]; then
   export SDK_VERSION=$1
 else
-  export SDK_VERSION=sdk38
+  export SDK_VERSION=sdk39
 fi
 
 echo "Running on OSTYPE: '$OSTYPE'"


### PR DESCRIPTION
Bumps the four platform SDK download URLs (appimage, macOS, wasm, mingw) from sdk38 to sdk39, and takes `tools/fetch-sdk.sh` along in the same commit — the 38 bump needed a follow-up for that file, this one does not. The `score-plugin-media` hunk is a comment only (the line naming the SDK version behind the ffmpeg codec libraries); no build logic changes. `ci/win32.msvc.deps.sh` (sdk35) and `BOOST_SDK` (sdk31, a different repository and version scheme) are deliberately left alone, as in the 38 bump.

**Do not merge until the SDK 39 release build completes:** https://github.com/ossia/sdk/actions/runs/32802394285 — until that run finishes successfully the sdk39 release assets do not exist and every CI job here will 404 on download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZgzE8JjWvHDtaVUhxpLE