### PR TITLE
ffmpeg: order the SDK's private archives after the libav* that need them

### DIFF
--- a/cmake/ScoreExternalAddon.developer.cmake
+++ b/cmake/ScoreExternalAddon.developer.cmake
@@ -94,7 +94,9 @@ find_package(Qt6 6.2 REQUIRED
     ShaderToolsPrivate
 )
 
-find_package(FFmpeg COMPONENTS AVCODEC AVFORMAT AVDEVICE AVUTIL SWRESAMPLE SWSCALE POSTPROC)
+# No POSTPROC: libpostproc was removed in ffmpeg 8, and requesting it as a
+# component only makes find_package report FFmpeg missing.
+find_package(FFmpeg COMPONENTS AVCODEC AVFORMAT AVDEVICE AVUTIL SWRESAMPLE SWSCALE)
 
 # ossia-config.hpp
 file(CONFIGURE

--- a/cmake/modules/FindFFmpeg.cmake
+++ b/cmake/modules/FindFFmpeg.cmake
@@ -88,16 +88,10 @@ macro(find_component _component _pkgconfig _library _header)
   endif()
 
   if(OSSIA_SDK)
-    # The SDK is the only acceptable provider, so neither pkg-config's answer
-    # nor the platform paths get a say. ffmpeg 9 (SDK 39) dropped libpostproc:
-    # left to fall through, POSTPROC resolves to the distro's shared
-    # libpostproc.so -- which carries a DT_NEEDED on libavutil.so.59 -- and
-    # drags /usr/include/x86_64-linux-gnu (ffmpeg 7 headers) into
-    # FFMPEG_INCLUDE_DIRS and into the imported target's interface. Two libav*
-    # ABIs, one binary, and the failure only shows up at runtime.
-    #
-    # Purge a hit cached by an earlier configure that pointed outside the SDK,
-    # otherwise an existing build directory keeps the system library forever.
+    # The SDK is the only acceptable provider: otherwise a component the SDK's
+    # ffmpeg no longer ships (libpostproc, gone in ffmpeg 8) falls through to
+    # the distro's, dragging a second libavutil ABI and its headers in.
+    # Purge a hit cached by an earlier configure that pointed outside the SDK.
     foreach(_var ${_component}_INCLUDE_DIRS ${_component}_LIBRARIES)
       if(${_var})
         string(FIND "${${_var}}" "${OSSIA_SDK}" _ffmpeg_in_sdk)
@@ -221,28 +215,9 @@ if(TARGET postproc)
   endif()
 endif()
 
-# The SDK's libav* are static archives built against a pile of codec and
-# protocol libraries that live elsewhere in the SDK: dav1d, x264, x265, opus,
-# vpx, webp, SVT-JPEG-XS, mp3lame, libxml2, SRT (itself linking the SDK's
-# openssl), freetype+harfbuzz for the drawtext filter, and the compression
-# libraries libavformat demuxes with. pkg-config lists them all -- libavcodec.pc
-# ends in "-ldav1d ... -lsrt" -- but this module imports only the av* archives,
-# so nothing puts them on the link line.
-#
-# They belong on an imported ffmpeg target, NOT on a consumer such as
-# score_plugin_media. A static link resolves left to right and CMake orders a
-# target's dependencies *after* it, so with score_plugin_gfx naming
-# "avcodec avformat ... score_plugin_media", the av* archives are pushed past
-# score_plugin_media's entire interface: anything added over there lands
-# *before* libavcodec.a and every symbol it carries stays undefined. avutil is
-# the sink of the ffmpeg graph -- every other libav* links it -- so its
-# interface is the one position guaranteed to come after all of them.
-#
-# Each entry is looked up, never required: SDK 36 has none of these, and some
-# are target-dependent (Windows-on-ARM has no OpenSSL mingw target, so libsrt is
-# built there without encryption). Found => linked, missing => nothing changes,
-# which is what keeps a single tree building against several SDKs. The whole
-# block is inert for a distro or homebrew ffmpeg, which resolves its own deps.
+# The SDK's static libav* need private codec/protocol archives that nothing else
+# puts on the link line. avutil is the sink of the ffmpeg graph, so its
+# interface is the only position that lands after every libav*.
 if(OSSIA_SDK AND TARGET avutil)
   set(_ffmpeg_sdk_libdirs
     "${OSSIA_SDK}/sysroot/lib"     # Linux + Windows: shared dep prefix
@@ -254,48 +229,42 @@ if(OSSIA_SDK AND TARGET avutil)
     "${OSSIA_SDK}/harfbuzz/lib"
   )
 
-  # Ordered for a single left-to-right pass: dependants before dependencies.
-  # webpmux -> webp -> sharpyuv, srt -> ssl -> crypto, xml2 -> lzma, and bz2 /
-  # lzma are libavformat's, not libavcodec's, so they trail the codecs.
+  # Ordered for a single left-to-right pass: dependants before dependencies
+  # (webpmux -> webp -> sharpyuv, srt -> ssl -> crypto, xml2 -> lzma).
   #
-  # jpeg: the SDK builds libjpeg-turbo (Qt is configured -system-libjpeg), and
-  # on aarch64 Linux libavdevice reaches it too -- ffmpeg's --enable-libv4l2
-  # resolves libv4l2.pc statically, whose Libs.private ends in "-ljpeg".
+  # placebo: the SDK's ffmpeg is built --enable-libplacebo, so libavfilter has
+  # 80 undefined pl_* symbols and nothing was linking the archive. libplacebo
+  # needs glslang; its Vulkan backend is dispatched at runtime, so there is no
+  # loader to link. Only libglslang.a has content -- the SDK installs the other
+  # glslang component names as stub archives.
   foreach(_sdk_lib
       dav1d x264 x265 opus vpx webpmux webp sharpyuv SvtJpegxs mp3lame
+      placebo glslang glslang-default-resource-limits
       srt xml2 freetype harfbuzz jpeg bz2 lzma ssl crypto)
-    # NO_DEFAULT_PATH is deliberate: these have to be the SDK's own copies.
-    # Silently linking a system libssl or libfreetype here is exactly the kind
-    # of leak the SDK exists to prevent, and it would only show up as a crash
-    # on someone else's machine.
-    find_library(FFMPEG_SDK_LIB_${_sdk_lib}
+    # NO_DEFAULT_PATH: these have to be the SDK's own copies, not the system's.
+    string(MAKE_C_IDENTIFIER "${_sdk_lib}" _sdk_var)
+    find_library(FFMPEG_SDK_LIB_${_sdk_var}
       NAMES ${_sdk_lib}
       PATHS ${_ffmpeg_sdk_libdirs}
       NO_DEFAULT_PATH
     )
-    mark_as_advanced(FFMPEG_SDK_LIB_${_sdk_lib})
-    if(FFMPEG_SDK_LIB_${_sdk_lib})
-      imported_link_libraries(avutil "${FFMPEG_SDK_LIB_${_sdk_lib}}")
+    mark_as_advanced(FFMPEG_SDK_LIB_${_sdk_var})
+    if(FFMPEG_SDK_LIB_${_sdk_var})
+      imported_link_libraries(avutil "${FFMPEG_SDK_LIB_${_sdk_var}}")
     endif()
   endforeach()
 
-  # libvpx, libwebp, libsrt and x265 all use pthreads. Being raw archive paths
-  # they carry no dependency information for CMake to order around, so name this
-  # after them. No-op where the compiler driver already implies it.
+  # libvpx, libwebp, libsrt and x265 use pthreads; raw archive paths carry no
+  # dependency information, so name this after them.
   find_package(Threads)
   if(TARGET Threads::Threads)
     imported_link_libraries(avutil Threads::Threads)
   endif()
 
   if(WIN32)
-    # System import libraries the SDK's ffmpeg pulls in, taken from the Libs:
-    # lines of the .pc files it installs:
-    #   libavcodec   mediafoundation -> mfuuid, ole32, strmiids
-    #   libavformat  schannel        -> secur32, ncrypt, crypt32
-    #                srt             -> ws2_32, wsock32, advapi32, shell32
-    #   libavdevice                  -> psapi, uuid, oleaut32, shlwapi, gdi32
-    # All are OS import libraries present in both mingw and MSVC, so listing
-    # them costs nothing where they were already coming in via Qt.
+    # System import libraries named by the Libs: lines of the SDK's ffmpeg .pc
+    # files (mediafoundation, schannel, srt, avdevice), plus shlwapi for
+    # libplacebo.
     imported_link_libraries(avutil
       mfuuid ole32 oleaut32 uuid shlwapi psapi gdi32 advapi32 shell32
       secur32 ncrypt crypt32 ws2_32 wsock32

--- a/cmake/modules/FindFFmpeg.cmake
+++ b/cmake/modules/FindFFmpeg.cmake
@@ -10,10 +10,12 @@
 # For each of the components it will additionally set.
 #   - AVCODEC
 #   - AVDEVICE
+#   - AVFILTER
 #   - AVFORMAT
 #   - AVUTIL
-#   - POSTPROCESS
+#   - POSTPROC
 #   - SWSCALE
+#   - SWRESAMPLE
 # the following variables will be defined
 #  <component>_FOUND        - System has <component>
 #  <component>_INCLUDE_DIRS - Include directory necessary for using the <component> headers
@@ -85,21 +87,51 @@ macro(find_component _component _pkgconfig _library _header)
      endif ()
   endif()
 
-  find_path(${_component}_INCLUDE_DIRS ${_header}
-    HINTS
-      ${PC_${_component}_INCLUDEDIR}
-      ${PC_${_component}_INCLUDE_DIRS}
-      "${OSSIA_SDK}/ffmpeg/include"
-    PATH_SUFFIXES
-      ffmpeg
-  )
+  if(OSSIA_SDK)
+    # The SDK is the only acceptable provider, so neither pkg-config's answer
+    # nor the platform paths get a say. ffmpeg 9 (SDK 39) dropped libpostproc:
+    # left to fall through, POSTPROC resolves to the distro's shared
+    # libpostproc.so -- which carries a DT_NEEDED on libavutil.so.59 -- and
+    # drags /usr/include/x86_64-linux-gnu (ffmpeg 7 headers) into
+    # FFMPEG_INCLUDE_DIRS and into the imported target's interface. Two libav*
+    # ABIs, one binary, and the failure only shows up at runtime.
+    #
+    # Purge a hit cached by an earlier configure that pointed outside the SDK,
+    # otherwise an existing build directory keeps the system library forever.
+    foreach(_var ${_component}_INCLUDE_DIRS ${_component}_LIBRARIES)
+      if(${_var})
+        string(FIND "${${_var}}" "${OSSIA_SDK}" _ffmpeg_in_sdk)
+        if(NOT _ffmpeg_in_sdk EQUAL 0)
+          unset(${_var} CACHE)
+        endif()
+      endif()
+    endforeach()
 
-  find_library(${_component}_LIBRARIES NAMES ${_library}
+    find_path(${_component}_INCLUDE_DIRS ${_header}
+      HINTS "${OSSIA_SDK}/ffmpeg/include"
+      PATH_SUFFIXES ffmpeg
+      NO_DEFAULT_PATH
+    )
+
+    find_library(${_component}_LIBRARIES NAMES ${_library}
+      HINTS "${OSSIA_SDK}/ffmpeg/lib"
+      NO_DEFAULT_PATH
+    )
+  else()
+    find_path(${_component}_INCLUDE_DIRS ${_header}
       HINTS
-      ${PC_${_component}_LIBDIR}
-      ${PC_${_component}_LIBRARY_DIRS}
-      "${OSSIA_SDK}/ffmpeg/lib"
-  )
+        ${PC_${_component}_INCLUDEDIR}
+        ${PC_${_component}_INCLUDE_DIRS}
+      PATH_SUFFIXES
+        ffmpeg
+    )
+
+    find_library(${_component}_LIBRARIES NAMES ${_library}
+        HINTS
+        ${PC_${_component}_LIBDIR}
+        ${PC_${_component}_LIBRARY_DIRS}
+    )
+  endif()
 
   set(${_component}_DEFINITIONS  ${PC_${_component}_CFLAGS_OTHER} CACHE STRING "The ${_component} CFLAGS.")
   set(${_component}_VERSION      ${PC_${_component}_VERSION}      CACHE STRING "The ${_component} version number.")
@@ -189,6 +221,87 @@ if(TARGET postproc)
   endif()
 endif()
 
+# The SDK's libav* are static archives built against a pile of codec and
+# protocol libraries that live elsewhere in the SDK: dav1d, x264, x265, opus,
+# vpx, webp, SVT-JPEG-XS, mp3lame, libxml2, SRT (itself linking the SDK's
+# openssl), freetype+harfbuzz for the drawtext filter, and the compression
+# libraries libavformat demuxes with. pkg-config lists them all -- libavcodec.pc
+# ends in "-ldav1d ... -lsrt" -- but this module imports only the av* archives,
+# so nothing puts them on the link line.
+#
+# They belong on an imported ffmpeg target, NOT on a consumer such as
+# score_plugin_media. A static link resolves left to right and CMake orders a
+# target's dependencies *after* it, so with score_plugin_gfx naming
+# "avcodec avformat ... score_plugin_media", the av* archives are pushed past
+# score_plugin_media's entire interface: anything added over there lands
+# *before* libavcodec.a and every symbol it carries stays undefined. avutil is
+# the sink of the ffmpeg graph -- every other libav* links it -- so its
+# interface is the one position guaranteed to come after all of them.
+#
+# Each entry is looked up, never required: SDK 36 has none of these, and some
+# are target-dependent (Windows-on-ARM has no OpenSSL mingw target, so libsrt is
+# built there without encryption). Found => linked, missing => nothing changes,
+# which is what keeps a single tree building against several SDKs. The whole
+# block is inert for a distro or homebrew ffmpeg, which resolves its own deps.
+if(OSSIA_SDK AND TARGET avutil)
+  set(_ffmpeg_sdk_libdirs
+    "${OSSIA_SDK}/sysroot/lib"     # Linux + Windows: shared dep prefix
+    "${OSSIA_SDK}/sysroot/lib64"   # Linux, RedHat layout
+    "${OSSIA_SDK}/lib"             # macOS: media-deps installs into the prefix
+    "${OSSIA_SDK}/openssl/lib"
+    "${OSSIA_SDK}/openssl/lib64"
+    "${OSSIA_SDK}/freetype/lib"    # macOS keeps these in their own prefixes
+    "${OSSIA_SDK}/harfbuzz/lib"
+  )
+
+  # Ordered for a single left-to-right pass: dependants before dependencies.
+  # webpmux -> webp -> sharpyuv, srt -> ssl -> crypto, xml2 -> lzma, and bz2 /
+  # lzma are libavformat's, not libavcodec's, so they trail the codecs.
+  #
+  # jpeg: the SDK builds libjpeg-turbo (Qt is configured -system-libjpeg), and
+  # on aarch64 Linux libavdevice reaches it too -- ffmpeg's --enable-libv4l2
+  # resolves libv4l2.pc statically, whose Libs.private ends in "-ljpeg".
+  foreach(_sdk_lib
+      dav1d x264 x265 opus vpx webpmux webp sharpyuv SvtJpegxs mp3lame
+      srt xml2 freetype harfbuzz jpeg bz2 lzma ssl crypto)
+    # NO_DEFAULT_PATH is deliberate: these have to be the SDK's own copies.
+    # Silently linking a system libssl or libfreetype here is exactly the kind
+    # of leak the SDK exists to prevent, and it would only show up as a crash
+    # on someone else's machine.
+    find_library(FFMPEG_SDK_LIB_${_sdk_lib}
+      NAMES ${_sdk_lib}
+      PATHS ${_ffmpeg_sdk_libdirs}
+      NO_DEFAULT_PATH
+    )
+    mark_as_advanced(FFMPEG_SDK_LIB_${_sdk_lib})
+    if(FFMPEG_SDK_LIB_${_sdk_lib})
+      imported_link_libraries(avutil "${FFMPEG_SDK_LIB_${_sdk_lib}}")
+    endif()
+  endforeach()
+
+  # libvpx, libwebp, libsrt and x265 all use pthreads. Being raw archive paths
+  # they carry no dependency information for CMake to order around, so name this
+  # after them. No-op where the compiler driver already implies it.
+  find_package(Threads)
+  if(TARGET Threads::Threads)
+    imported_link_libraries(avutil Threads::Threads)
+  endif()
+
+  if(WIN32)
+    # System import libraries the SDK's ffmpeg pulls in, taken from the Libs:
+    # lines of the .pc files it installs:
+    #   libavcodec   mediafoundation -> mfuuid, ole32, strmiids
+    #   libavformat  schannel        -> secur32, ncrypt, crypt32
+    #                srt             -> ws2_32, wsock32, advapi32, shell32
+    #   libavdevice                  -> psapi, uuid, oleaut32, shlwapi, gdi32
+    # All are OS import libraries present in both mingw and MSVC, so listing
+    # them costs nothing where they were already coming in via Qt.
+    imported_link_libraries(avutil
+      mfuuid ole32 oleaut32 uuid shlwapi psapi gdi32 advapi32 shell32
+      secur32 ncrypt crypt32 ws2_32 wsock32
+    )
+  endif()
+endif()
 if(TARGET avutil)
   if(UNIX OR MSYS OR MINGW)
     if(NOT APPLE)
@@ -246,7 +359,7 @@ mark_as_advanced(FFMPEG_INCLUDE_DIRS
 
 
 # Now set the noncached _FOUND vars for the components.
-foreach (_component AVCODEC AVDEVICE AVFORMAT AVUTIL POSTPROCESS SWSCALE SWRESAMPLE)
+foreach (_component AVCODEC AVDEVICE AVFILTER AVFORMAT AVUTIL POSTPROC SWSCALE SWRESAMPLE)
   set_component_found(${_component})
 endforeach ()
 

--- a/src/plugins/score-plugin-media/CMakeLists.txt
+++ b/src/plugins/score-plugin-media/CMakeLists.txt
@@ -5,7 +5,11 @@ score_common_setup()
 
 # Packages
 find_package(${QT_VERSION} REQUIRED COMPONENTS Core Widgets)
-find_package(FFmpeg COMPONENTS AVCODEC AVFORMAT AVDEVICE AVUTIL SWRESAMPLE SWSCALE POSTPROC)
+# POSTPROC is not requested: libpostproc was removed in ffmpeg 8, so naming it
+# as a component only makes find_package report FFmpeg missing. FindFFmpeg still
+# looks it up opportunistically for an older distro ffmpeg, and every use of it
+# below is guarded by if(TARGET postproc).
+find_package(FFmpeg COMPONENTS AVCODEC AVFORMAT AVDEVICE AVUTIL SWRESAMPLE SWSCALE)
 
 if(UNIX AND NOT APPLE)
   find_package(ZLIB QUIET)
@@ -236,113 +240,21 @@ elseif(TARGET avcodec)
     endif()
   endif()
 
-  # If we build against homebrew's ffmpeg we do not need those
+  # If we build against homebrew's ffmpeg we do not need those.
+  # Everything the SDK's static libav* need themselves -- the codec and protocol
+  # archives, zlib/bzip2/lzma, the Windows import libraries -- hangs off the
+  # imported avutil target in cmake/modules/FindFFmpeg.cmake, which is the only
+  # place a static link orders them *after* libavcodec.a and libavformat.a.
   if(OSSIA_SDK)
-    find_package(ZLIB)
-    if(TARGET ZLIB::ZLIB)
-      target_link_libraries(${PROJECT_NAME} PRIVATE
-        ZLIB::ZLIB
-      )
-    endif()
-
-    find_package(BZip2)
-    if(TARGET BZip2::BZip2)
-      target_link_libraries(${PROJECT_NAME} PRIVATE
-        BZip2::BZip2
-      )
-    endif()
-
-    find_package(LibLZMA)
-    if(TARGET LibLZMA::LibLZMA)
-      target_link_libraries(${PROJECT_NAME} PRIVATE
-        LibLZMA::LibLZMA
-      )
-    endif()
-
     if(UNIX AND NOT APPLE AND NOT WIN32)
+      # libavdevice enumerates v4l2 devices through libudev. Shared, so its
+      # position on the line does not matter.
       find_library(UDEV_LIBRARY udev REQUIRED)
       if(UDEV_LIBRARY)
           target_link_libraries(${PROJECT_NAME} PRIVATE
             ${UDEV_LIBRARY}
           )
       endif()
-    endif()
-
-    # ossia SDK 39 (ffmpeg 9) builds libavcodec / libavformat against a set of
-    # codec and protocol libraries that earlier SDKs did not have: dav1d, x264,
-    # x265, opus, vpx, webp, SVT-JPEG-XS, mp3lame, libxml2, SRT (which itself
-    # links the SDK's openssl) and freetype+harfbuzz for the drawtext filter.
-    #
-    # FindFFmpeg.cmake imports only the av* archives: it asks pkg-config for the
-    # include and library DIRECTORIES but never for Libs.private, so none of the
-    # above reaches the link line on its own and a static score dies in a wall of
-    # undefined references.
-    #
-    # Every entry is looked up rather than required. SDK 36 has none of them, and
-    # even in 37 some are target-dependent -- Windows-on-ARM has no OpenSSL mingw
-    # target, so libsrt is built there without encryption. Found => linked,
-    # missing => nothing changes; that is what keeps this file building against
-    # both SDKs, and it is inert for a distro/homebrew ffmpeg since the whole
-    # block is under if(OSSIA_SDK).
-    set(SCORE_SDK_LIBDIRS
-      "${OSSIA_SDK}/sysroot/lib"     # Linux + Windows: shared dep prefix
-      "${OSSIA_SDK}/sysroot/lib64"   # Linux, RedHat layout
-      "${OSSIA_SDK}/lib"             # macOS: media-deps installs into the prefix
-      "${OSSIA_SDK}/openssl/lib"
-      "${OSSIA_SDK}/openssl/lib64"
-      "${OSSIA_SDK}/freetype/lib"    # macOS keeps these in their own prefixes
-      "${OSSIA_SDK}/harfbuzz/lib"
-    )
-    # Ordered for a static link: dependants before their dependencies.
-    # libwebp needs sharpyuv, libsrt needs ssl+crypto, freetype needs harfbuzz.
-    #
-    # jpeg: the SDK builds libjpeg-turbo (Qt is configured -system-libjpeg), and
-    # on aarch64 Linux libavdevice reaches it too -- ffmpeg's --enable-libv4l2
-    # resolves libv4l2.pc statically, whose Libs.private ends in "-ljpeg".
-    foreach(_sdk_lib
-        dav1d x264 x265 opus vpx webpmux webp sharpyuv SvtJpegxs mp3lame xml2
-        srt ssl crypto freetype harfbuzz jpeg)
-      # NO_DEFAULT_PATH is deliberate: these have to be the SDK's own copies.
-      # Silently linking a system libssl or libfreetype here is exactly the kind
-      # of leak the SDK exists to prevent, and it would only show up as a crash
-      # on someone else's machine.
-      find_library(SCORE_SDK_LIB_${_sdk_lib}
-        NAMES ${_sdk_lib}
-        PATHS ${SCORE_SDK_LIBDIRS}
-        NO_DEFAULT_PATH
-      )
-      mark_as_advanced(SCORE_SDK_LIB_${_sdk_lib})
-      if(SCORE_SDK_LIB_${_sdk_lib})
-        # PUBLIC: score-plugin-gfx links avcodec/avformat directly and picks
-        # these up through this target's interface, after them, which is the
-        # order a static link needs.
-        target_link_libraries(${PROJECT_NAME} PUBLIC "${SCORE_SDK_LIB_${_sdk_lib}}")
-      endif()
-    endforeach()
-
-    # libvpx, libwebp, libsrt and x265 all use pthreads. Being raw archive paths
-    # they carry no dependency information for CMake to order around, so name
-    # this last rather than relying on whatever libossia's find_package(Threads)
-    # happens to place earlier in the line. No-op where the compiler implies it.
-    find_package(Threads)
-    if(TARGET Threads::Threads)
-      target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
-    endif()
-
-    if(WIN32)
-      # System import libraries the SDK's ffmpeg now pulls in, taken from the
-      # Libs: lines of the .pc files it installs:
-      #   libavcodec   mediafoundation -> mfuuid, ole32, strmiids
-      #   libavformat  schannel        -> secur32, ncrypt, crypt32
-      #                srt             -> ws2_32, wsock32, advapi32, shell32
-      #   libavutil                    -> bcrypt
-      #   libavdevice                  -> psapi, uuid, oleaut32, shlwapi, gdi32
-      # All are OS import libraries present in both mingw and MSVC, so listing
-      # them costs nothing where they were already coming in via Qt.
-      target_link_libraries(${PROJECT_NAME} PRIVATE
-        mfuuid ole32 oleaut32 uuid shlwapi psapi gdi32 advapi32 shell32
-        secur32 ncrypt crypt32 bcrypt ws2_32 wsock32
-      )
     endif()
   endif()
   target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_DL_LIBS})


### PR DESCRIPTION
Fixes the static link against ossia SDK 39. On a clean `master` + SDK 39 build,
`ossia-score` fails with hundreds of undefined references spread over `srt`,
`xml2`, `vpx`, `opus`, `x264`, `mp3lame`, `dav1d`, `SvtJpegxs`, `x265`, `bz2` and
`lzma`:

```
/usr/bin/ld: /opt/ossia-sdk-x86_64/ffmpeg/lib/libavcodec.a(libdav1d.o): in function `libdav1d_receive_frame':
libdav1d.c:(.text+0x7c): undefined reference to `dav1d_send_data'
/usr/bin/ld: /opt/ossia-sdk-x86_64/ffmpeg/lib/libavformat.a(libsrt.o): in function `libsrt_network_wait_fd_timeout':
libsrt.c:(.text+0x1449): undefined reference to `srt_epoll_wait'
```

## Diagnosis

Not missing libraries — **wrong order**. Every archive was already on the link
line, just ahead of the ffmpeg archives that reference it, and a static link
resolves left to right in one pass:

```
before:  … libdav1d.a … libxml2.a  libsrt.a … │ libavformat.a  libavcodec.a … libavutil.a
after:   … libavformat.a  libavcodec.a … libavutil.a │ libdav1d.a … libxml2.a  libsrt.a …
```

af9171b49c attached them to `score_plugin_media`, assuming that naming them after
`avcodec`/`avformat` in that target's own list is enough. It is not, across target
boundaries: `score-plugin-gfx/CMakeLists.txt` links
`avcodec avformat … score_plugin_media`, and because CMake must order a target's
dependencies *after* the target itself, the `av*` archives get pushed past the
entire `score_plugin_media` interface — past the very libraries added there.

## Fix

Move them onto an imported ffmpeg target, where the dependency graph does the
ordering instead of source-line position. `avutil` is the sink of that graph —
every other `libav*` links it — so its interface is the one position guaranteed
to come after all seven archives.

Side effects of the same move:

- `zlib`/`bzip2`/`lzma` come along: `bz2` and `lzma` are libavformat's and were
  landing ahead of it too.
- `webp`, `jpeg`, `freetype`, `harfbuzz`, `ssl`, `crypto`, `z` were only
  resolving *by accident*, because Qt's static libs happen to appear later on
  the line. They no longer depend on that coincidence.
- Windows import libs move to the same place. `bcrypt` is deliberately omitted —
  `FindFFmpeg` already handles it via the `winbcrypt` target — and
  `evr`/`mf`/`mfplat`/`strmiids`/`quartz`/`vfw32` stay in the media plugin's own
  `WIN32` block, unchanged.

## Second defect this uncovered: host ffmpeg leaking into the build

ffmpeg 8 removed `libpostproc` and the SDK no longer ships it, so
`find_component(POSTPROC …)` fell through to pkg-config and the platform paths
and imported the host's copy:

```
POSTPROC_LIBRARIES    = /usr/lib/x86_64-linux-gnu/libpostproc.so   # NEEDED libavutil.so.59
POSTPROC_INCLUDE_DIRS = /usr/include/x86_64-linux-gnu              # ffmpeg 7 headers
FFMPEG_INCLUDE_DIRS   = /opt/ossia-sdk-x86_64/ffmpeg/include;/usr/include/x86_64-linux-gnu
```

That is a second libavutil ABI beside the statically linked v61, plus ffmpeg 7
headers reachable through a `PUBLIC` target interface — a runtime-only failure on
someone else's machine. With `OSSIA_SDK` set, the SDK is now the only provider
consulted, and a hit cached by an earlier configure from outside the SDK is
purged so existing build directories heal themselves rather than needing a wipe.

`POSTPROC` also stops being *requested* as a component, which was the only reason
`find_package(FFmpeg)` reported failure. `find_component` still looks it up
opportunistically for an older distro ffmpeg, and every use of the target stays
behind `if(TARGET postproc)`.

## Compatibility

Every lookup is optional and the whole block is under `if(OSSIA_SDK)`, so this is
inert against SDK 36/37/38 (which ship none of these) and against a distro or
Homebrew ffmpeg, which resolves its own dependencies.

## Verification

Debian host with a system ffmpeg 7 installed, SDK 39, clang/libc++,
`-DSCORE_DYNAMIC_PLUGINS=0 -DCMAKE_BUILD_TYPE=Debug -DSCORE_PCH=1`:

| Check | Result |
|---|---|
| `rm ossia-score && cmake --build build` | `[7/7] Linking CXX executable ossia-score` |
| Link order in `build.ninja` | `libav*`/`libsw*` at items 827-833, private deps at 834-852 |
| `nm --defined-only` | `dav1d_send_data`, `srt_epoll_wait`, `xmlFreeDoc`, `BZ2_bzDecompress`, `lzma_code` all `T` |
| `readelf -d ossia-score` | 0 `libav*` / `libsw*` / `libpostproc` NEEDED entries |
| Configure | `-- Found FFmpeg: …/ffmpeg/lib/libavcodec.a;…` — SDK paths only, no "Could NOT find FFmpeg" |
| Run | `./ossia-score --version` → `score 3.8.2` |

**Verified on Linux x86_64 only.** The macOS and Windows legs of the change are
path/ordering-symmetric but rely on CI to confirm.

## Also

Spells `POSTPROC` correctly in the redundant `set_component_found` loop, which had
been asking about `POSTPROCESS`, and completes that list with `AVFILTER` and
`SWRESAMPLE`. No behavior change — `find_component` already sets those `_FOUND`
vars; the loop is pure redundancy, left in place rather than deleted.

## Disclosure

The implementation in this PR was produced with an AI coding 
agent (Anthropic's Claude Opus 5) using [omp](https://omp.sh/).
I directed the work, reviewed every change, and ran the verification
described above; I take responsibility for its correctness and licensing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


## Second gap: libplacebo (fixed in 63446f37)

The first commit made the SDK's private archives reachable but did not supply
one the current SDK needs at all. The SDK's ffmpeg is configured
`--enable-libplacebo`, so `libavfilter.a` carries undefined `pl_*` symbols and
nothing on score's link line resolved them. This surfaced on Windows against the
`ossia/sdk` `continuous` release, assets dated 2026-09-03 (`sdk-mingw-x86_64.7z`,
the full 14-component SDK, not `sdk-core-`): clang 23.1.0,
`x86_64-w64-windows-gnu`, Ninja/Release, `-DSCORE_TESTING=0`. The build reached
105/108 and lld stopped at the LINK step on `pl_cache_create`, `pl_find_fmt`,
`pl_log_create_360`, `pl_lut_free`, `pl_mpv_user_shader_destroy` and others.

Measured across the three platforms of that same release:

| | Windows (`sdk-mingw-x86_64`) | Linux (`sdk-linux-x86_64`) | macOS (`sdk-macOS-aarch64` / `-x86_64`) |
|---|---|---|---|
| ships libplacebo | yes, `sysroot/lib/libplacebo.a` | yes, `sysroot/lib64/libplacebo.a` | no, absent from the archive |
| undefined `pl_` in `libavfilter.a` | 80 | 80 | 0 |
| `pl_` defined by `libplacebo.a` | 645 | 637 | n/a |
| undefined `pl_` in `libavcodec` / `libavutil` / `libavformat` | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 |
| verdict | **affected** | **affected** | **not affected** |

Two earlier readings needed correcting. Only `ReadbackTester.exe` and
`EncoderTester.exe` were seen to fail, but `build.ninja` named `libavfilter` on
6 link lines belonging to exactly three outputs — those two and `score.exe` — so
the main application was equally broken and had simply not been reached. And
`libplacebo.a` needs no Vulkan loader at link time: subtracting the symbols it
defines itself from the ones it references leaves 101 externals on Windows (91
on Linux), all libc/libc++/Win32, plus `glslang::*` and `GetDefaultResources`.
The `vk*` names are its own internal ones; its Vulkan backend is dispatched at
runtime.

`63446f37` therefore adds `placebo glslang glslang-default-resource-limits` to
the same lookup this PR introduces, in that order, and adds nothing for Vulkan.
Of the six glslang archives in the SDK sysroot only `libglslang.a` has content
(5.4 MB, 2863 symbols, including `GlslangToSpv`); `libSPIRV.a`,
`libMachineIndependent.a`, `libGenericCodeGen.a` and `libOSDependent.a` are
942-byte stubs holding one `stub_library_function()` each, so there is nothing
to link from them. The entries are looked up and never required, so this stays
inert on the macOS SDK and on older SDKs.

Verified on the Windows box, same SDK and configuration:

| Check | Result |
|---|---|
| `placebo` in `build.ninja` | 0 before, 6 after — one per libavfilter link line |
| Archive order on a link line | `libavfilter.a` → `libavutil.a` → `libplacebo.a` → `libglslang.a` → `libglslang-default-resource-limits.a` |
| Link | `score.exe`, `ReadbackTester.exe`, `EncoderTester.exe` all link; 0 unresolved symbols |
| Filter present at runtime | `avfilter_get_by_name("libplacebo")` → non-null, `"Apply various GPU filters from libplacebo"` |

The point is that the libplacebo filters stay available, not that the symbols go
away: they are a property of `libavfilter.a` and are still there, now resolved.

Sweeping every undefined symbol of the SDK's `libav*` against every archive the
SDK ships turned up no other unsatisfied third-party family — the remainder is
libc, libc++, compiler builtins and OS import libraries.