### PR TITLE
jit: adapt to LLVM 23 APIs

### DIFF
--- a/src/plugins/score-plugin-jit/JitCpp/Compiler/Compiler.cpp
+++ b/src/plugins/score-plugin-jit/JitCpp/Compiler/Compiler.cpp
@@ -65,10 +65,12 @@ void setTargetOptions(
   opts.AllowFPOpFusion = llvm::FPOpFusion::Fast;
 #endif
 
+#if LLVM_VERSION_MAJOR < 23
   opts.NoInfsFPMath = true;
   opts.NoNaNsFPMath = true;
-  opts.NoTrappingFPMath = true;
   opts.NoSignedZerosFPMath = true;
+#endif
+  opts.NoTrappingFPMath = true;
   opts.HonorSignDependentRoundingFPMathOption = false;
   opts.EnableIPRA = true;
   opts.EnableFastISel = true;
@@ -210,16 +212,31 @@ static std::unique_ptr<llvm::orc::LLJIT> jitBuilder(JitCompiler& self)
   builder.setJITTargetMachineBuilder(std::move(*JTMB));
   builder.setNumCompileThreads(4);
 
+#if LLVM_VERSION_MAJOR >= 23
+  builder.setMemoryManagerCreator(
+      [&](llvm::orc::ExecutionSession&)
+          -> llvm::Expected<std::unique_ptr<llvm::jitlink::JITLinkMemoryManager>> {
+    return std::move(self.m_memmgr);
+  });
+#endif
+
   // Configure to use JITLink via ObjectLinkingLayer
   builder.setObjectLinkingLayerCreator(
       [&](llvm::orc::ExecutionSession& ES
-            #if LLVM_VERSION_MAJOR < 21
+            #if LLVM_VERSION_MAJOR >= 23
+              , llvm::jitlink::JITLinkMemoryManager& memmgr
+            #elif LLVM_VERSION_MAJOR < 21
               , const llvm::Triple& TT
             #endif
               ) {
     // Create ObjectLinkingLayer with JITLink
+#if LLVM_VERSION_MAJOR >= 23
+    auto ObjLinkingLayer
+        = std::make_unique<llvm::orc::ObjectLinkingLayer>(ES, memmgr);
+#else
     auto ObjLinkingLayer
         = std::make_unique<llvm::orc::ObjectLinkingLayer>(ES, *self.m_memmgr);
+#endif
 
     // COFF needs the same responsibility setup LLJIT applies to its own COFF
     // object layer; a hand-built ObjectLinkingLayer omits it, so JIT-linking COFF

--- a/src/plugins/score-plugin-jit/JitCpp/cc1_main.cpp
+++ b/src/plugins/score-plugin-jit/JitCpp/cc1_main.cpp
@@ -61,7 +61,9 @@ class QtDiagnosticConsumer final : public DiagnosticConsumer
 
   // DiagnosticConsumer interface
 public:
+#if LLVM_VERSION_MAJOR < 23
   void finish() override { std::cerr << " == finish == \n"; }
+#endif
   void
   HandleDiagnostic(DiagnosticsEngine::Level DiagLevel, const Diagnostic& Info) override
   {


### PR DESCRIPTION
## Changes
- adapt JIT `TargetOptions` to LLVM 23's removed fast-math fields
- pass the LLVM 23-owned JITLink memory manager into the object layer while preserving score's contiguous COFF manager
- remove the deleted `DiagnosticConsumer::finish()` override on Clang 23
- pick the VST3 `<exception>` include from jcelerier/vst3_public_sdk#1

## Validation
- clean recursive worktree at `7795c60d45`
- configured with Clang/LLVM 23.1.0 and Qt 6.12 from the updated ossia SDK
- complete `ci/win32.build.sh` build and package succeeded on Windows x86_64