### PR TITLE
core: tear plug-ins down in reverse creation order when closing a document

### DIFF
--- a/src/lib/core/presenter/DocumentManager.cpp
+++ b/src/lib/core/presenter/DocumentManager.cpp
@@ -288,10 +288,15 @@ bool DocumentManager::closeDocument(
 void DocumentManager::forceCloseDocument(
     const score::GUIApplicationContext& ctx, Document& doc)
 {
-  // Clear the plug-ins
-  for(auto plug : doc.model().pluginModels())
+  // Clear the plug-ins, in reverse creation order: same rule as ~DocumentModel
+  // and ~DocumentManager. The execution plug-in has to be torn down before the
+  // device explorer one, whose on_documentClosing() disconnects every device --
+  // which destroys the ossia parameters that the still-running execution graph
+  // holds raw pointers to in ossia::inlet::address.
+  auto& plugs = doc.model().pluginModels();
+  for(auto it = plugs.rbegin(); it != plugs.rend(); ++it)
   {
-    plug->on_documentClosing();
+    (*it)->on_documentClosing();
   }
 
   // Clear the app plugins


### PR DESCRIPTION
Quitting while a document is playing crashes on the audio thread, dereferencing a freed `ossia::net::generic_parameter`.

## Measured

AddressSanitizer, with a document whose control inlet is bound to a device address, quit driven by a real `WM_DELETE_WINDOW`:

```
heap-use-after-free, thread T41 (audio)
  ossia::net::parameter_base::get_node()        parameter.hpp:62
  ossia::execution_state::unregister_parameter  execution_state.cpp:97
  Execution::SetupContext::unregister_node      ExecutionSetup.cpp:668
  Dataflow::Clock::play_impl                    DataflowClock.cpp:113
freed by thread T38:
  ossia::net::generic_device::~generic_device   generic_device.cpp:36
  Device::releaseDevice                         DeviceInterface.cpp:1109
```

| plug-in teardown order | runs | ASan errors |
|---|---|---|
| creation order (as shipped) | 4 | **4 × heap-use-after-free** |
| reverse creation order | 5 | **0** |

## Why

`ExecutionSetup.cpp:321` stores a raw `ossia::net::parameter_base*` in `ossia::inlet::address`, and `dataflow.hpp:24` calls straight through it for the `parameter_base` alternative — it never consults `exec_devices()`, so `execution_state::unregister_device`, deferred to `begin_tick`, offers no protection.

`forceCloseDocument` walked `pluginModels()` in **creation order**, so `Explorer::DeviceDocumentPlugin::on_documentClosing()` disconnected every device — destroying their parameters — while `Execution::DocumentPlugin` had not yet stopped the clock. Between those two the audio thread keeps ticking over inlets whose `address` is dangling.

`~DocumentModel` and `~DocumentManager` already walk that list in reverse and carry comments saying the execution plug-in must go first. `forceCloseDocument` — the path a GUI quit actually takes — was the only one that did not. It became reachable when af65b43a25 gave the device explorer an `on_documentClosing()`; before that the forward loop was harmless.

## Scope

This closes the systematic quit-time case. It is **not** the whole family: removing a device from the explorer during playback frees the same parameters and produces an identical use-after-free via `DeviceList::removeDevice`. Fixing that properly means giving `ossia::inlet::address` a lifetime guarantee — deferring device destruction past a `set_tick`/`sync` barrier, or holding the device alive from the execution state — which is a libossia change and needs its own PR.