### PR TITLE
js: make the scripting API and --script able to drive a .mjs module

### DIFF
--- a/src/plugins/score-plugin-js/JS/ApplicationPlugin.cpp
+++ b/src/plugins/score-plugin-js/JS/ApplicationPlugin.cpp
@@ -117,26 +117,52 @@ ApplicationPlugin::ApplicationPlugin(const score::GUIApplicationContext& ctx)
   parser.addOption(script_opt);
 
   parser.parse(ctx.applicationSettings.arguments);
-  const auto script = parser.value(script_opt);
-  if(stringIsScript(script))
+  for(const QString& script : parser.values(script_opt))
   {
-    this->m_start_script = script;
-  }
-  else if(!script.isEmpty())
-  {
-    QFile f{script};
-    if(f.open(QIODevice::ReadOnly))
+    if(script.isEmpty())
+      continue;
+
+    if(stringIsScript(script))
     {
-      this->m_start_script = f.readAll();
-      this->m_start_script_name = script;
-      this->m_start_script_path = QFileInfo{f}.canonicalPath();
+      this->m_start_scripts.push_back(StartScript{.source = script});
+      continue;
     }
-    else
+
+    QFile f{script};
+    if(!f.open(QIODevice::ReadOnly))
     {
       qCritical() << "--script: cannot open" << script << ":" << f.errorString();
       this->m_start_script_failed = true;
+      continue;
     }
+
+    const QFileInfo fi{f};
+    StartScript s;
+    s.name = script;
+    s.file = fi.canonicalFilePath();
+    s.dir = fi.canonicalPath();
+    // .mjs is what the rest of score calls an ES module (see the library's
+    // ModuleLibraryHandler); only those go through importModule().
+    s.module = fi.suffix().compare(QStringLiteral("mjs"), Qt::CaseInsensitive) == 0;
+    if(!s.module)
+      s.source = QString::fromUtf8(f.readAll());
+
+    this->m_start_scripts.push_back(std::move(s));
   }
+}
+
+QJSValue ApplicationPlugin::importModule(QQmlEngine& engine, const QString& path)
+{
+  QJSValue mod = engine.importModule(path);
+  if(mod.isError())
+    return mod;
+
+  if(auto init = mod.property("initialize"); init.isCallable())
+    if(const auto res = init.call(); res.isError())
+      return res;
+
+  engine.globalObject().setProperty(QFileInfo{path}.baseName(), mod);
+  return mod;
 }
 
 void ApplicationPlugin::on_newDocument(score::Document& doc)
@@ -185,24 +211,28 @@ void ApplicationPlugin::on_createdDocument(score::Document& doc)
     return;
   }
 
-  if(!m_start_script.isEmpty())
+  if(!m_start_scripts.empty())
   {
     QTimer::singleShot(100, this, [this] {
-      if(!m_start_script_path.isEmpty())
-        m_consoleEngine.addImportPath(m_start_script_path);
-
-      // Report a throwing --script: an unresolvable readFile returns an empty
-      // string and eval("") is a no-op, so the process would otherwise exit
-      // reporting success and a harness could not tell that from a pass.
-      const auto res = m_consoleEngine.evaluate(m_start_script, m_start_script_name);
-      if(res.isError())
+      for(const StartScript& s : m_start_scripts)
       {
-        qCritical().noquote()
-            << "--script:"
-            << (m_start_script_name.isEmpty() ? QStringLiteral("<inline>")
-                                              : m_start_script_name)
-            << "line" << res.property("lineNumber").toInt() << ":" << res.toString();
-        qGuiApp->exit(3);
+        if(!s.dir.isEmpty())
+          m_consoleEngine.addImportPath(s.dir);
+
+        // Report a throwing --script: an unresolvable readFile returns an empty
+        // string and eval("") is a no-op, so the process would otherwise exit
+        // reporting success and a harness could not tell that from a pass.
+        const auto res = s.module ? importModule(m_consoleEngine, s.file)
+                                  : m_consoleEngine.evaluate(s.source, s.name);
+        if(res.isError())
+        {
+          qCritical().noquote()
+              << "--script:"
+              << (s.name.isEmpty() ? QStringLiteral("<inline>") : s.name) << "line"
+              << res.property("lineNumber").toInt() << ":" << res.toString();
+          qGuiApp->exit(3);
+          return;
+        }
       }
     });
   }
@@ -216,6 +246,10 @@ void ApplicationPlugin::afterStartup()
   for(auto& p : this->context.settings<Library::Settings::Model>().getIncludePaths())
   {
     m_scriptProcessUIEngine.addImportPath(p);
+    // The console engine runs --script, the console panel and every library
+    // .mjs; without this they could not import what a JS process can, which
+    // made the same `import` line work in a process and fail in a script.
+    m_consoleEngine.addImportPath(p);
   }
 
 #if __has_include(<QQuickWindow>)

--- a/src/plugins/score-plugin-js/JS/ApplicationPlugin.hpp
+++ b/src/plugins/score-plugin-js/JS/ApplicationPlugin.hpp
@@ -4,11 +4,13 @@
 #include <core/application/ApplicationSettings.hpp>
 
 #include <QFileInfo>
+#include <QJSValue>
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlEngine>
 
 #include <thread>
+#include <vector>
 
 namespace ossia::net
 {
@@ -31,6 +33,21 @@ public:
   void afterStartup() override;
   void on_newDocument(score::Document& doc) override;
 
+  /** Load an ES module and give it a chance to set itself up.
+   *
+   * ES modules cannot go through QJSEngine::evaluate, which parses its input
+   * as a script: a top-level `export` is a syntax error there. They must be
+   * imported, which is why loading one is a function of its own.
+   *
+   * The module's `initialize()` is called if it has one, and the module is
+   * left on the global object under its base name so that whatever runs next
+   * -- another --script, the console, a menu action -- can call into it.
+   *
+   * Returns the module, or the error value the caller should report: either
+   * the import failing, or `initialize()` throwing.
+   */
+  static QJSValue importModule(QQmlEngine& engine, const QString& path);
+
   // Used for processing whatever comes from the console
   QQmlEngine m_consoleEngine;
 
@@ -44,9 +61,19 @@ public:
   std::thread m_asioThread;
   ossia::net::network_context_ptr m_asioContext;
 
-  QString m_start_script;
-  QString m_start_script_name; //!< path as given, for error messages
-  QString m_start_script_path; //!< directory, added as a QML import path
+  //! One --script argument.
+  struct StartScript
+  {
+    QString source; //!< inline source or file contents; empty for a module
+    QString name;   //!< path as given, for diagnostics; empty when inline
+    QString file;   //!< canonical path, what importModule() is given
+    QString dir;    //!< the script's folder, added as a QML import path
+    bool module{};  //!< load with importModule() rather than evaluate()
+  };
+
+  //! --script may be repeated; entries run in order. That is what lets a run
+  //! load a module and then drive it: `--script mod.mjs --script "mod.go()"`.
+  std::vector<StartScript> m_start_scripts;
   bool m_start_script_failed{};
 };
 }

--- a/src/plugins/score-plugin-js/JS/ConsolePanel.cpp
+++ b/src/plugins/score-plugin-js/JS/ConsolePanel.cpp
@@ -139,9 +139,9 @@ QMenu* PanelDelegate::addMenu(QMenu* cur, QStringList names)
 
 void PanelDelegate::importModule(const QString& path)
 {
-  QJSValue mod = m_engine.importModule(path);
-  if(auto init = mod.property("initialize"); init.isCallable())
-    init.call();
+  // Shared with --script so that both agree on what loading a module means:
+  // import, run initialize(), publish under the base name.
+  QJSValue mod = ApplicationPlugin::importModule(m_engine, path);
   if(auto init = mod.property("actions"); init.isArray())
   {
     QJSValueIterator it(init);

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.hpp
@@ -106,6 +106,26 @@ public:
   QObject* createProcess(QObject* interval, QString name, QString data);
   W_SLOT(createProcess)
 
+  //! Number of processes hosted by an interval or a state.
+  int processes(QObject* obj);
+  W_SLOT(processes)
+
+  //! The index-th process of an interval or a state. Index 0 is the most
+  //! recently added one; the order is stable but is not timeline order.
+  QObject* process(QObject* obj, int index);
+  W_SLOT(process)
+
+  //! The process an object belongs to: the process itself if given one, else
+  //! the closest process ancestor. Ports, layers and cable endpoints all
+  //! resolve through this.
+  QObject* parentProcess(QObject* obj);
+  W_SLOT(parentProcess)
+
+  //! The interval an object belongs to, or null. A process gives the interval
+  //! hosting it; an interval gives itself.
+  QObject* parentInterval(QObject* obj);
+  W_SLOT(parentInterval)
+
   void loadPreset(QObject* process, QString json);
   W_SLOT(loadPreset)
   QString savePreset(QObject* process);
@@ -141,23 +161,49 @@ public:
   void setIntervalSpeed(QObject* object, double);
   W_SLOT(setIntervalSpeed)
 
+  //! A port of a process by name, inlets first. Prefer inlet() / outlet() when
+  //! a process has an input and an output sharing a name.
   QObject* port(QObject* obj, QString name);
   W_SLOT(port)
 
   QObject* inlet(QObject* obj, int index);
-  W_SLOT(inlet)
+  W_SLOT(inlet, (QObject*, int))
+
+  //! An inlet of a process by name, or null.
+  QObject* inlet(QObject* obj, QString name);
+  W_SLOT(inlet, (QObject*, QString))
 
   int inlets(QObject* obj);
   W_SLOT(inlets)
 
   QObject* outlet(QObject* obj, int index);
-  W_SLOT(outlet)
+  W_SLOT(outlet, (QObject*, int))
+
+  //! An outlet of a process by name, or null.
+  QObject* outlet(QObject* obj, QString name);
+  W_SLOT(outlet, (QObject*, QString))
 
   int outlets(QObject* obj);
   W_SLOT(outlets)
 
   QObject* createCable(QObject* outlet, QObject* inlet);
   W_SLOT(createCable)
+
+  //! The index-th cable attached to a port. Works for inlets and outlets alike.
+  QObject* cable(QObject* port, int index);
+  W_SLOT(cable)
+
+  //! Number of cables attached to a port. Works for inlets and outlets alike.
+  int cables(QObject* port);
+  W_SLOT(cables)
+
+  //! The outlet a cable starts from, or null if it no longer resolves.
+  QObject* source(QObject* cable);
+  W_SLOT(source)
+
+  //! The inlet a cable ends at, or null if it no longer resolves.
+  QObject* sink(QObject* cable);
+  W_SLOT(sink)
 
   void setAddress(QObject* obj, QString addr);
   W_SLOT(setAddress)
@@ -243,10 +289,14 @@ public:
   void replaceAddress(QObjectList objects, QString before, QString after);
   W_SLOT(replaceAddress)
 
-  void automate(QObject* interval, QString addr);
+  //! Create automations for every parameter matching `addr` in `interval`.
+  //! Returns the created processes: an address may expand to several curves.
+  QVariantList automate(QObject* interval, QString addr);
   W_SLOT(automate, (QObject*, QString))
 
-  void automate(QObject* interval, QObject* port);
+  //! Create an automation in `interval` driving `port`, and cable it up.
+  //! Returns the created process, whose default curve is a 0 -> 1 ramp.
+  QObject* automate(QObject* interval, QObject* port);
   W_SLOT(automate, (QObject*, QObject*))
 
   /////////////////

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.port.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.port.cpp
@@ -1,6 +1,8 @@
 #include <State/Domain.hpp>
 
 #include <Process/Commands/EditPort.hpp>
+#include <Process/Dataflow/Cable.hpp>
+#include <Process/Dataflow/Port.hpp>
 
 #include <Scenario/Commands/CommandAPI.hpp>
 #include <Scenario/Document/Interval/IntervalModel.hpp>
@@ -10,24 +12,26 @@
 
 #include <ossia/network/domain/domain.hpp>
 
+#include <vector>
+
 namespace JS
 {
-void EditJsContext::automate(QObject* interval, QObject* port)
+QObject* EditJsContext::automate(QObject* interval, QObject* port)
 {
   auto doc = ctx();
   if(!doc)
-    return;
+    return nullptr;
   auto itv = qobject_cast<Scenario::IntervalModel*>(interval);
   if(!itv)
-    return;
+    return nullptr;
   auto ctl = qobject_cast<Process::Inlet*>(port);
   if(!ctl)
-    return;
+    return nullptr;
   if(ctl->type() != Process::PortType::Message)
-    return;
+    return nullptr;
 
   auto [m, _] = macro(*doc);
-  m->automate(*itv, *ctl);
+  return m->automate(*itv, *ctl);
 }
 
 QObject* EditJsContext::port(QObject* obj, QString name)
@@ -66,6 +70,21 @@ QObject* EditJsContext::inlet(QObject* obj, int index)
   return proc->inlets()[index];
 }
 
+QObject* EditJsContext::inlet(QObject* obj, QString name)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  auto proc = qobject_cast<Process::ProcessModel*>(obj);
+  if(!proc)
+    return nullptr;
+
+  for(auto p : proc->inlets())
+    if(p->name() == name)
+      return p;
+  return nullptr;
+}
+
 int EditJsContext::inlets(QObject* obj)
 {
   auto doc = ctx();
@@ -89,6 +108,21 @@ QObject* EditJsContext::outlet(QObject* obj, int index)
     return nullptr;
 
   return proc->outlets()[index];
+}
+
+QObject* EditJsContext::outlet(QObject* obj, QString name)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  auto proc = qobject_cast<Process::ProcessModel*>(obj);
+  if(!proc)
+    return nullptr;
+
+  for(auto p : proc->outlets())
+    if(p->name() == name)
+      return p;
+  return nullptr;
 }
 
 int EditJsContext::outlets(QObject* obj)
@@ -120,6 +154,71 @@ QObject* EditJsContext::createCable(QObject* outlet, QObject* inlet)
   auto [m, _] = macro(*doc);
   auto& c = m->createCable(root, *src, *sink, Process::CableType::ImmediateGlutton);
   return &c;
+}
+
+// A port stores its cables as paths, which may not resolve while a document is
+// being torn down or if the other end was just removed. Both accessors below
+// skip what does not resolve, so a script never sees a dangling cable and the
+// indices of cable(port, i) stay in step with the count from cables(port).
+static void
+resolvedCables(const Process::Port& port, const score::DocumentContext& ctx,
+               std::vector<Process::Cable*>& out)
+{
+  for(const auto& path : port.cables())
+    if(auto c = path.try_find(ctx))
+      out.push_back(c);
+}
+
+int EditJsContext::cables(QObject* port)
+{
+  auto doc = ctx();
+  if(!doc)
+    return 0;
+  auto p = qobject_cast<Process::Port*>(port);
+  if(!p)
+    return 0;
+
+  std::vector<Process::Cable*> found;
+  resolvedCables(*p, *doc, found);
+  return std::ssize(found);
+}
+
+QObject* EditJsContext::cable(QObject* port, int index)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  auto p = qobject_cast<Process::Port*>(port);
+  if(!p)
+    return nullptr;
+
+  std::vector<Process::Cable*> found;
+  resolvedCables(*p, *doc, found);
+  if(index < 0 || index >= std::ssize(found))
+    return nullptr;
+  return found[index];
+}
+
+QObject* EditJsContext::source(QObject* cable)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  auto c = qobject_cast<Process::Cable*>(cable);
+  if(!c)
+    return nullptr;
+  return c->source().try_find(*doc);
+}
+
+QObject* EditJsContext::sink(QObject* cable)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  auto c = qobject_cast<Process::Cable*>(cable);
+  if(!c)
+    return nullptr;
+  return c->sink().try_find(*doc);
 }
 
 void EditJsContext::setAddress(QObject* obj, QString addr)

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
@@ -1,20 +1,26 @@
 #include <Process/Preset.hpp>
+#include <Process/Process.hpp>
 #include <Process/ProcessList.hpp>
 
 #include <Scenario/Commands/CommandAPI.hpp>
 #include <Scenario/Commands/Metadata/ChangeElementName.hpp>
 #include <Scenario/Commands/State/AddMessagesToState.hpp>
+#include <Scenario/Document/Interval/IntervalModel.hpp>
 #include <Scenario/Document/ScenarioDocument/ScenarioDocumentModel.hpp>
+#include <Scenario/Document/State/StateModel.hpp>
 #include <Scenario/Process/Algorithms/Accessors.hpp>
 
 #include <JS/Commands/ScriptMacro.hpp>
 #include <JS/Qml/EditContext.hpp>
 
 #include <score/application/GUIApplicationContext.hpp>
+#include <score/model/EntityMap.hpp>
 
 #include <ossia-qt/js_utilities.hpp>
 
 #include <QTime>
+
+#include <iterator>
 namespace JS
 {
 
@@ -53,17 +59,22 @@ QObject* EditJsContext::rootInterval()
   return &root.baseInterval();
 }
 
-void EditJsContext::automate(QObject* interval, QString addr)
+QVariantList EditJsContext::automate(QObject* interval, QString addr)
 {
   auto doc = ctx();
   if(!doc)
-    return;
+    return {};
   auto itv = qobject_cast<Scenario::IntervalModel*>(interval);
   if(!itv)
-    return;
+    return {};
 
   auto [m, _] = macro(*doc);
-  m->automate(*itv, addr);
+
+  QVariantList created;
+  for(auto proc : m->automate(*itv, addr))
+    if(proc)
+      created.push_back(QVariant::fromValue(static_cast<QObject*>(proc)));
+  return created;
 }
 
 EditJsContext::MacroClear EditJsContext::macro(const score::DocumentContext& doc)
@@ -171,6 +182,66 @@ QObject* EditJsContext::createProcess(QObject* interval, QString name, QString d
     return m->createProcess(*st, f->concreteKey(), data);
   }
   return nullptr;
+}
+
+// Intervals and states both host processes in an ordered EntityMap, so the
+// same pair of accessors serves both. The order is the map's own, which
+// inserts at the front: index 0 is the most recently added process. It is
+// stable for a given document, which is what an index-based accessor needs;
+// scripts that care about timeline order should sort on what they need.
+static const score::EntityMap<Process::ProcessModel, true>*
+hostedProcesses(QObject* obj)
+{
+  if(auto itv = qobject_cast<Scenario::IntervalModel*>(obj))
+    return &itv->processes;
+  if(auto st = qobject_cast<Scenario::StateModel*>(obj))
+    return &st->stateProcesses;
+  return nullptr;
+}
+
+int EditJsContext::processes(QObject* obj)
+{
+  auto doc = ctx();
+  if(!doc)
+    return 0;
+  auto procs = hostedProcesses(obj);
+  if(!procs)
+    return 0;
+  return std::ssize(*procs);
+}
+
+QObject* EditJsContext::process(QObject* obj, int index)
+{
+  auto doc = ctx();
+  if(!doc)
+    return nullptr;
+  auto procs = hostedProcesses(obj);
+  if(!procs)
+    return nullptr;
+  if(index < 0 || index >= std::ssize(*procs))
+    return nullptr;
+
+  auto it = procs->begin();
+  std::advance(it, index);
+  return &*it;
+}
+
+QObject* EditJsContext::parentProcess(QObject* obj)
+{
+  if(!obj)
+    return nullptr;
+  if(auto proc = qobject_cast<Process::ProcessModel*>(obj))
+    return proc;
+  return Process::parentProcess(obj);
+}
+
+QObject* EditJsContext::parentInterval(QObject* obj)
+{
+  if(!obj)
+    return nullptr;
+  if(auto itv = qobject_cast<Scenario::IntervalModel*>(obj))
+    return itv;
+  return Scenario::closestParentInterval(obj);
 }
 
 void EditJsContext::loadPreset(QObject* process, QString json)

--- a/src/plugins/score-plugin-scenario/Scenario/Commands/CommandAPI.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Commands/CommandAPI.cpp
@@ -485,7 +485,7 @@ Macro::automate(const IntervalModel& parent, const Process::Inlet& inl)
   auto outl = static_cast<Automation::ProcessModel*>(autom)->outlet.get();
   createCable(plug, *outl, inl, Process::CableType::ImmediateGlutton);
 
-  return {};
+  return autom;
 }
 
 Process::ProcessModel& Macro::automate(

--- a/tests/integration/ScriptExitCodeTest.cpp
+++ b/tests/integration/ScriptExitCodeTest.cpp
@@ -36,7 +36,7 @@ struct Run
   QString output;
 };
 
-Run runScript(const QString& scriptArg, const QString& configHome = {})
+Run runScripts(const QStringList& scriptArgs, const QString& configHome = {})
 {
   auto env = QProcessEnvironment::systemEnvironment();
   env.remove("DISPLAY");
@@ -44,15 +44,25 @@ Run runScript(const QString& scriptArg, const QString& configHome = {})
   env.insert("QT_QPA_PLATFORM", "offscreen");
   env.insert("SCORE_AUDIO_BACKEND", "dummy");
   env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  // Every message this test reads -- the script's own console.log, and the
+  // "--script:" diagnostics -- is a qDebug/qCritical, and the child's stderr is
+  // a pipe. Where Qt is built against journald it then logs to the journal and
+  // the pipe stays empty, so the assertions below read nothing and fail for a
+  // reason that has nothing to do with the code under test. Same pair, and the
+  // same reason, as JsGraphE2ETest.
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
   if(!configHome.isEmpty())
     env.insert("XDG_CONFIG_HOME", configHome);
+
+  QStringList args{"--no-gui", "--no-restore", "--wait", "0"};
+  for(const QString& s : scriptArgs)
+    args << "--script" << s;
 
   QProcess p;
   p.setProcessEnvironment(env);
   p.setProcessChannelMode(QProcess::MergedChannels);
-  p.start(
-      appBinary(),
-      {"--no-gui", "--no-restore", "--wait", "0", "--script", scriptArg});
+  p.start(appBinary(), args);
 
   Run r;
   if(!p.waitForStarted(30000) || !p.waitForFinished(90000))
@@ -66,6 +76,11 @@ Run runScript(const QString& scriptArg, const QString& configHome = {})
   r.crashed = p.exitStatus() != QProcess::NormalExit;
   r.exitCode = p.exitCode();
   return r;
+}
+
+Run runScript(const QString& scriptArg, const QString& configHome = {})
+{
+  return runScripts(QStringList{scriptArg}, configHome);
 }
 
 QString write(const QTemporaryDir& dir, const QString& name, const QByteArray& body)
@@ -178,5 +193,75 @@ TEST_CASE("--script reports what happened to it", "[integration][js][script]")
     // else, which is the case a plain missing path must not be confused with.
     CHECK(r.output.contains("<LIBRARY>:/definitely/absent.js ->"));
     CHECK(r.output.contains("Score.readFile: cannot read /definitely/absent-plain.js"));
+  }
+
+  // --script used to hand everything to QJSEngine::evaluate, which parses its
+  // input as a script: a top-level `export` was a syntax error, so none of the
+  // .mjs modules score ships in packages/default/Scripts could be run or
+  // tested headlessly. They now go through importModule.
+  SECTION("a .mjs module is imported rather than evaluated")
+  {
+    const auto path = write(
+        dir, "mod.mjs",
+        "export function initialize() { console.log(\"INIT-RAN\"); }\n"
+        "console.log(\"TOPLEVEL-RAN\");\n"
+        "Qt.exit(0);\n");
+
+    auto r = runScript(path);
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    CHECK_FALSE(r.output.contains("SyntaxError"));
+    CHECK(r.output.contains("TOPLEVEL-RAN"));
+    // The console panel calls initialize() when it loads a library module;
+    // --script has to mean the same thing or a module behaves differently
+    // depending on how it was loaded.
+    CHECK(r.output.contains("INIT-RAN"));
+  }
+
+  SECTION("a module that throws while initialising exits 3")
+  {
+    const auto path = write(
+        dir, "badinit.mjs",
+        "export function initialize() { throw new Error(\"initboom\"); }\n");
+
+    auto r = runScript(path);
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 3);
+    CHECK(r.output.contains("--script:"));
+    CHECK(r.output.contains("initboom"));
+  }
+
+  SECTION("a module that fails to parse exits 3 and names itself")
+  {
+    const auto path = write(dir, "syntax.mjs", "export const = ;\n");
+
+    auto r = runScript(path);
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 3);
+    CHECK(r.output.contains("--script:"));
+    CHECK(r.output.contains(path));
+  }
+
+  // A module that only exports things needs something to call into it: that is
+  // the whole point of shipping .mjs actions, and the only way to exercise one
+  // without a Scripts menu.
+  SECTION("--script repeats, so a module can be loaded and then driven")
+  {
+    const auto mod = write(
+        dir, "driven.mjs", "export function go(n) { Qt.exit(n); }\n");
+
+    auto r = runScripts({mod, "driven.go(4);"});
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 4);
+  }
+
+  SECTION("a failing entry stops the ones after it")
+  {
+    const auto boom = write(dir, "first.js", "throw new Error(\"first\");\n");
+
+    auto r = runScripts({boom, "Qt.exit(0);"});
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 3);
+    CHECK(r.output.contains("first"));
   }
 }


### PR DESCRIPTION
Two things stood between a script and the model it is meant to edit. Both were
found by writing an ordinary script -- assemble a patch, wire two clips into a
mixer, ramp a control -- and running out of API halfway through.

### The scripting API could not name what it had just made

`Macro::automate(interval, inlet)` built the `Automation`, cabled it up, and
returned `{}` rather than the pointer it had in hand, so `EditJsContext` had
nothing to expose. A script could create a ramp but never shape it: the default
linear 0 → 1 curve was the only one reachable. It now returns the process; the
address overload returns a list, since one address can expand to several curves.

The rest are new, each a pair so neither direction is the awkward one:

| | |
|---|---|
| `processes(obj)` / `process(obj, i)` | follows the `inlets`/`inlet` convention; serves intervals and states alike |
| `cables(port)` / `cable(port, i)` | valid on an inlet or an outlet, since `cables()` is on `Process::Port` |
| `source(cable)` / `sink(cable)` | named after `Process::Cable`'s own accessors; rerouting has no other expression |
| `inlet(obj, name)` / `outlet(obj, name)` | `port(obj, name)` searches inlets then outlets, ambiguous for an ISF shader with an image in *and* an image out |
| `parentProcess(obj)` / `parentInterval(obj)` | get back from a port to what contains it |

A port keeps its cables as `Path`s that need not resolve while a document is
being torn down, so both cable accessors skip what does not: the indices stay in
step with the count, and a script never sees a dangling cable.

### `--script` could not run any of the .mjs modules we ship

`--script` handed everything to `QJSEngine::evaluate`, which parses its input as
a *script*. A top-level `export` is a syntax error there, so every module in
`packages/default/Scripts` failed on its first line:

```
--script: Crossfade.mjs line 1 : SyntaxError: Unexpected token `export'
```

- Modules now go through `importModule()`; the `.mjs` suffix is the rule, matching `ModuleLibraryHandler`.
- Import, `initialize()` and publishing under the base name are one function shared with the console panel, which did all three and which `--script` did none of. The panel keeps only its own half: turning an exported `actions` array into Scripts-menu entries.
- `--script` may be repeated, entries running in order — a module that only exports things needs something to call into it, and a headless run has no Scripts menu:
  ```
  ossia-score --no-gui --script Crossfade.mjs --script "Crossfade.run()"
  ```
- Library include paths reached the process-script engine only, so the same `import` line worked inside a JS process and failed in a `--script`. The console engine gets them too.

### A note on the test environment

The new sections set `QT_ASSUME_STDERR_HAS_CONSOLE` / `QT_FORCE_STDERR_LOGGING`.
Everything these tests read out of the child is a `qDebug`/`qCritical` and the
child's stderr is a pipe; where Qt is built against journald it logs to the
journal instead and the pipe stays empty, so the assertions read nothing and
fail for a reason unrelated to the code under test. `JsGraphE2ETest` sets the
same pair for the same reason. Worth knowing more widely: a *negative*
assertion on such a log (`REQUIRE_FALSE(log.contains(...))`) passes vacuously,
so a real regression reads as green.

### Testing

Full build clean (2227/2227, clang, Debug). `test_integration_script_exit_code`
passes 69/69, including five new sections: module imported rather than
evaluated, `initialize()` runs, a throwing `initialize()` exits 3, a module
parse error names itself, repeat-and-drive, and a failing entry stopping the
ones after it. The API additions were additionally verified end to end against
this build through a two-part `--script` run — import, `initialize()`,
`automate()` returning the process, cable counts on both ends, `source`/`sink`
resolving, name and parent lookups, out-of-range nulls — and against ~29 hostile
inputs (nulls, dangling handles, out-of-range indices) with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8nefvG3ArFjF2WEJNxxzz
