### PR TITLE
Restore /exit s force on windowed instances, and two video format guards

### DIFF
--- a/src/lib/core/presenter/Presenter.cpp
+++ b/src/lib/core/presenter/Presenter.cpp
@@ -75,8 +75,13 @@ bool Presenter::exit()
   // deletions); a second exit request arriving meanwhile — e.g. the OSC
   // /exit callback firing again, or a queued quit timer — would re-enter
   // closeAllDocuments and tear down half-destroyed documents.
+  // Already tearing down: report that closing may proceed, without re-entering
+  // closeAllDocuments. Returning false here vetoes the shutdown -- View::closeEvent
+  // calls ev->ignore() on false, and QCoreApplication::quit() closes the top-level
+  // windows, so the latch that exists to prevent re-entrancy would cancel the very
+  // quit that forceExit() had just scheduled.
   if(m_exiting)
-    return false;
+    return true;
   m_exiting = true;
   const bool closed = m_docManager.closeAllDocuments(m_context);
   if(!closed)

--- a/src/plugins/score-plugin-media/Video/GpuFormats.hpp
+++ b/src/plugins/score-plugin-media/Video/GpuFormats.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <Media/Libav.hpp>
 
+#include <QtGlobal>
+
 #include <string>
 #include <vector>
 
@@ -175,10 +177,21 @@ inline constexpr bool formatNeedsDecoding(AVPixelFormat fmt) noexcept
     case AV_PIX_FMT_P410LE:
 #endif
 
-#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(60, 8, 100)
+    // These guards must match GPUVideoDecoderFactory.cpp: a format whose decoder
+    // is compiled in but whose case here is compiled out gets routed through
+    // swscale even though it has a direct GPU path.
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(58, 29, 100)
     case AV_PIX_FMT_RGBAF32LE:
     case AV_PIX_FMT_VUYA:
     case AV_PIX_FMT_VUYX:
+    case AV_PIX_FMT_P012LE:
+    case AV_PIX_FMT_RGBAF16LE:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+    case AV_PIX_FMT_XV30LE:
+#endif
+#endif
+
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(60, 8, 100)
     case AV_PIX_FMT_GRAYF16LE:
     case AV_PIX_FMT_GRAYF16BE:
 #endif


### PR DESCRIPTION
Two independent defects on master, both found while running the gfx/integration suite against a stack branch. Neither is reachable from the tests master currently has.

### `/exit s force` is vetoed by `Presenter::exit()`'s re-entrancy latch

`b4cdf3ef85` added the `force` argument to the local-tree `/exit` so a **windowed** instance can be shut down without a save prompt: it marks every command stack as saved, then calls `forceExit()`. That escape hatch no longer works.

`Presenter::exit()` latches `m_exiting` so a second exit request cannot re-enter `closeAllDocuments`. It returns `false` for that second call — and `false` is also how `View::closeEvent` learns a close must be refused:

```cpp
if(m_presenter->exit()) ev->accept(); else ev->ignore();
```

Since Qt 6.6 `QCoreApplication::quit()` closes the top-level windows and honours that refusal. `forceExit()` does `requestExit()` — which runs `Presenter::exit()` and sets the latch — then a queued `quit()` 500 ms later. So with `force`, the documents close successfully, the latch stays set, and the subsequent `closeEvent` gets `false` and vetoes the very quit that `forceExit()` had just scheduled. The app stays up with a healthy event loop and an ordinary main-thread stack, which reads as a hang rather than a refused close.

Traced by instrumenting the path; every step ran, on the main thread, and `closeAllDocuments` returned true — then `quit()` did nothing while `QCoreApplication::exit(0)` immediately worked.

`exit()` now returns `true` when a shutdown is already in progress: closing may proceed. It still does not re-enter `closeAllDocuments`, so the re-entrancy the latch exists to prevent is still prevented.

**The save-prompt protection is deliberate and is preserved.** A plain `/exit` on a modified document still goes through `closeAllDocuments`, and if the user cancels, `closed == false` clears the latch and the session continues exactly as before. The only changed behaviour is a *second* `exit()` call after a *successful* close.

Only reachable with a GUI: headless has no `Presenter`, so `requestExit()` is a no-op and the queued `quit()` has no window to be refused by. That is why `ossia-score --no-gui` exits on `/exit` and a windowed instance does not.

### Six pixel formats are rescaled although they have a GPU decoder

`formatNeedsDecoding()` and `createGPUVideoDecoder()` must agree; they disagreed twice.

`RGBAF32LE`, `VUYA`, `VUYX` were guarded at libavutil `>= 60.8.100` while the factory builds their decoders at `>= 58.29.100`. Between those versions — 58.29.100 is what Ubuntu 24.04 ships — the decoder is compiled in but the whitelist case is compiled out, so the frame goes through swscale despite having a direct upload path.

`P012LE`, `RGBAF16LE`, `XV30LE` were missing outright, though the factory has built `P016Decoder`, `RGBA64Decoder` and `XV30Decoder` for them all along. `XV30LE` keeps the factory's Qt 6.4 condition. `GRAYF16LE/BE` stay at 60.8.100, which is when they appeared.

### Verification

- Full clang-22 build of this branch, Qt 6.13, `SCORE_TESTING=1`: 0 errors.
- GUI shutdown: `ossia-score --no-restore` under xcb/llvmpipe now exits `RC=0` on `/exit s force`; before, it ran to the harness timeout.
- The format fix is covered by `test_unit_gpu_formats`, which lives on a not-yet-merged branch. There it went from 3150 assertions / 6 failed to **3156 / 0**. Master has no test that reaches either defect, which is why both survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZgzE8JjWvHDtaVUhxpLE
