### PR TITLE
tests: a latched-out exit reports that closing may proceed

### DIFF
--- a/tests/integration/RegressionDoubleExitTest.cpp
+++ b/tests/integration/RegressionDoubleExitTest.cpp
@@ -4,10 +4,11 @@
 // again, or an already-queued quit timer — re-entered closeAllDocuments and
 // tore down half-destroyed documents, aborting the process.
 //
-// Presenter::exit() now latches: the first call closes the documents, any
-// further call while exiting (or after a completed exit) is a no-op returning
-// false. A cancelled close (user said no to a save prompt) resets the latch so
-// the session can exit later. GUIApplicationInterface::requestExit() also
+// Presenter::exit() latches: the first call closes the documents, any further
+// call while exiting (or after a completed exit) is a no-op. It answers true --
+// closing may proceed -- because the return also gates View::closeEvent, and a
+// refusal there vetoes the shutdown. A cancelled close (user said no to a save
+// prompt) resets the latch so the session can exit later. GUIApplicationInterface::requestExit() also
 // tolerates the presenter being gone.
 
 #include <score_test/App.hpp>
@@ -39,9 +40,14 @@ TEST_CASE(
   // First request closes every document and reports success.
   CHECK(pres->exit() == true);
 
-  // Any further request is latched out instead of re-entering the close.
-  CHECK(pres->exit() == false);
-  CHECK(pres->exit() == false);
+  // Any further request is latched out instead of re-entering the close, and
+  // reports that closing may proceed. It must NOT report a refusal: the return
+  // is what View::closeEvent turns into accept/ignore, and since Qt 6.6
+  // QCoreApplication::quit() closes the top-level windows and honours that
+  // refusal -- so answering false here made the latch veto the very quit
+  // forceExit() had just scheduled, and a windowed instance never exited.
+  CHECK(pres->exit() == true);
+  CHECK(pres->exit() == true);
 
   // The full request path stays safe too (this is what the OSC /exit
   // callback and the quit timer end up calling).


### PR DESCRIPTION
**Master is red.** `test_regression_double_exit` fails 2 of 4 assertions since #2248 merged, and it is my fault: I changed `Presenter::exit()`'s return value there without running this test.

### What happened

`RegressionDoubleExitTest` asserted that a second `Presenter::exit()` returns `false`, and its header documented that as the contract:

> *"any further call while exiting (or after a completed exit) is a no-op returning false"*

But that return is also what `View::closeEvent` turns into accept/ignore:

```cpp
if(m_presenter->exit()) ev->accept(); else ev->ignore();
```

and since Qt 6.6 `QCoreApplication::quit()` closes the top-level windows and honours that refusal. So `false` made the latch veto the very quit `forceExit()` had just scheduled — no windowed instance could be shut down over OSC `/exit`, which is the defect `fe3fd08a64` fixed by answering `true`. That left this test asserting the behaviour the fix had just removed.

### What changes

Only the answer the latch gives its caller: from "refuse the close" to "closing may proceed". The property the test is named for is untouched and still asserted — a second request is a no-op that does not re-enter `closeAllDocuments`, and a cancelled save prompt still resets the latch so the session survives.

### Verification

Built and run against this branch:

- `== true` → **4/4 assertions pass**
- `== false` restored → **2 of 4 fail** (negative control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZgzE8JjWvHDtaVUhxpLE
