### PR TITLE
js: make time and cable removal usable from a script

### DIFF
--- a/src/plugins/score-lib-process/Process/Process.hpp
+++ b/src/plugins/score-lib-process/Process/Process.hpp
@@ -106,6 +106,9 @@ public:
 
   void setDuration(const TimeVal& other) noexcept;
   const TimeVal& duration() const noexcept;
+  //! The process's length in flicks. Read-only: the duration follows the
+  //! parent interval, and is changed through it.
+  double durationInFlicks() const noexcept { return duration().impl; }
 
   /// Nodal things
   QPointF position() const noexcept;
@@ -216,6 +219,8 @@ public:
 
   void durationChanged(const TimeVal& arg_1)
       E_SIGNAL(SCORE_LIB_PROCESS_EXPORT, durationChanged, arg_1)
+
+  PROPERTY(double, duration W_READ durationInFlicks W_NOTIFY durationChanged)
   void useParentDurationChanged(bool arg_1)
       E_SIGNAL(SCORE_LIB_PROCESS_EXPORT, useParentDurationChanged, arg_1)
 

--- a/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/EditContext.scenario.cpp
@@ -562,6 +562,16 @@ void EditJsContext::remove(QObject* obj)
     if(auto itv = qobject_cast<Scenario::IntervalModel*>(proc->parent()))
       m->removeProcess(*itv, proc->id());
   }
+  else if(auto cable = qobject_cast<Process::Cable*>(obj))
+  {
+    // Cables are parented to the document-level cable map rather than to a
+    // scenario, so the generic branch below never matched one: removing a cable
+    // from a script silently did nothing, which is what a script has to do to
+    // reroute an existing connection.
+    auto& root = score::IDocument::get<Scenario::ScenarioDocumentModel>(doc->document);
+    auto [m, _] = macro(*doc);
+    m->removeCable(root, *cable);
+  }
   else if(auto p = obj->parent())
   {
     if(auto scenar = qobject_cast<Scenario::ProcessModel*>(p))

--- a/src/plugins/score-plugin-js/JS/Qml/Utils.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/Utils.cpp
@@ -382,6 +382,11 @@ double JsUtils::toMilliseconds(TimeVal v)
 {
   return v.msec();
 }
+
+double JsUtils::toSeconds(TimeVal v)
+{
+  return v.impl / double(ossia::flicks_per_second<int64_t>);
+}
 bool JsUtils::isInfinite(TimeVal v)
 {
   return v.infinite();

--- a/src/plugins/score-plugin-js/JS/Qml/Utils.hpp
+++ b/src/plugins/score-plugin-js/JS/Qml/Utils.hpp
@@ -76,6 +76,10 @@ public:
   W_SLOT(toTime)
   double toMilliseconds(TimeVal v);
   W_SLOT(toMilliseconds)
+  //! Seconds, for the common case. Accepts anything that converts to a
+  //! TimeVal, including the raw flicks that itv.date and proc.duration give.
+  double toSeconds(TimeVal v);
+  W_SLOT(toSeconds)
   bool isInfinite(TimeVal v);
   W_SLOT(isInfinite)
 

--- a/src/plugins/score-plugin-js/score_plugin_js.cpp
+++ b/src/plugins/score-plugin-js/score_plugin_js.cpp
@@ -52,6 +52,22 @@ score_plugin_js::score_plugin_js()
       [](int64_t qval) -> TimeVal { return TimeVal{qval}; });
   QMetaType::registerConverter<double, TimeVal>(
       [](double qval) -> TimeVal { return TimeVal{(int64_t)qval}; });
+
+  // A Javascript number reaches a TimeVal parameter as whichever C++ type it
+  // fits in, and an integral one that fits in 32 bits arrives as `int` -- a
+  // type nothing above converts. The effect was that a duration passed as a
+  // whole number worked only above INT32_MAX flicks, i.e. above ~3.04 seconds,
+  // and threw "Passing incompatible arguments to C++ functions" below it:
+  //
+  //     Score.setIntervalDuration(itv, 7056000000)  // 10 s: fine
+  //     Score.setIntervalDuration(itv, 1411200000)  //  2 s: TypeError
+  //
+  // Registering the narrower integral types can only turn that error into the
+  // call the script already meant.
+  QMetaType::registerConverter<int, TimeVal>(
+      [](int qval) -> TimeVal { return TimeVal{int64_t(qval)}; });
+  QMetaType::registerConverter<unsigned int, TimeVal>(
+      [](unsigned int qval) -> TimeVal { return TimeVal{int64_t(qval)}; });
   QMetaType::registerConverter<QTime, TimeVal>([](const QTime& qval) -> TimeVal {
     int64_t ms = 0;
     ms += qval.hour() * 60 * 60 * 1000;

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Event/EventModel.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Event/EventModel.hpp
@@ -69,6 +69,8 @@ public:
   const State::Expression& condition() const noexcept;
   OffsetBehavior offsetBehavior() const noexcept;
   const TimeVal& date() const noexcept;
+  //! The event's position in flicks, relative to its parent scenario.
+  double dateInFlicks() const noexcept { return date().impl; }
   void translate(const TimeVal& deltaTime);
   ExecutionStatus status() const noexcept;
 
@@ -103,6 +105,8 @@ private:
 
   ExecutionStatusProperty m_status{};
   OffsetBehavior m_offset{};
+
+  PROPERTY(double, date READ dateInFlicks NOTIFY dateChanged)
 
   W_PROPERTY(
       Scenario::OffsetBehavior,

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModel.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModel.hpp
@@ -95,6 +95,14 @@ public:
   void setStartDate(const TimeVal& start);
   void translate(const TimeVal& deltaTime);
 
+  //! The interval's start, in flicks, relative to its parent scenario.
+  //!
+  //! Read-only and in flicks: that is how time is already spelled on the
+  //! Javascript side (TokenRequestValueType::date and friends return a raw
+  //! .impl), and leaving it read-only keeps every position change going through
+  //! a command, so undo still works.
+  double dateInFlicks() const noexcept { return date().impl; }
+
   double heightPercentage() const noexcept;
 
   void startExecution();
@@ -207,6 +215,7 @@ public:
 
   void setStartMarker(TimeVal t);
   TimeVal startMarker() const noexcept;
+  double startMarkerInFlicks() const noexcept { return startMarker().impl; }
   inline IntervalDurations* getDurations() noexcept { return &duration; }
 
   void hasTimeSignatureChanged(bool arg_1)
@@ -286,6 +295,10 @@ public:
       ossia::musical_sync, quantizationRate READ quantizationRate WRITE
                                setQuantizationRate NOTIFY quantizationRateChanged)
   W_PROPERTY(IntervalDurations*, durations READ getDurations CONSTANT)
+
+  PROPERTY(double, date READ dateInFlicks NOTIFY dateChanged)
+  PROPERTY(
+      double, startMarker READ startMarkerInFlicks NOTIFY startMarkerChanged)
 
 private:
   void on_addProcess(Process::ProcessModel&);

--- a/src/plugins/score-plugin-scenario/Scenario/Document/TimeSync/TimeSyncModel.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/TimeSync/TimeSyncModel.hpp
@@ -52,6 +52,9 @@ public:
 
   // Data of the TimeSync
   const TimeVal& date() const noexcept;
+  //! The sync's position in flicks, relative to its parent scenario.
+  //! Read-only, in flicks, like IntervalModel::dateInFlicks.
+  double dateInFlicks() const noexcept { return date().impl; }
   void setDate(const TimeVal&);
 
   void addEvent(const Id<EventModel>&);
@@ -109,6 +112,7 @@ public:
   PROPERTY(
       ossia::musical_sync,
       musicalSync READ musicalSync WRITE setMusicalSync NOTIFY musicalSyncChanged)
+  PROPERTY(double, date READ dateInFlicks NOTIFY dateChanged)
   PROPERTY(bool, active READ active WRITE setActive NOTIFY activeChanged)
   PROPERTY(
       bool, autotrigger READ autotrigger WRITE setAutotrigger NOTIFY autotriggerChanged)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -182,6 +182,17 @@ if(TARGET score AND NOT EMSCRIPTEN)
     TIMEOUT 900 RUN_SERIAL TRUE)
 endif()
 
+# Time in the scripting API: the flicks-as-a-number representation scripts
+# already depend on, and the positions that were added beside it.
+if(TARGET score AND NOT EMSCRIPTEN)
+  score_add_test(test_integration_js_time_api
+    SOURCES JsTimeApiTest.cpp)
+  target_compile_definitions(test_integration_js_time_api PRIVATE
+    "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\"")
+  set_tests_properties(test_integration_js_time_api PROPERTIES
+    TIMEOUT 900 RUN_SERIAL TRUE)
+endif()
+
 # Closing a MODIFIED document with applicationSettings.gui false must not
 # raise the save prompt: nothing can answer it and QMessageBox::exec() aborts.
 score_add_test(test_regression_headless_close_modified

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -171,6 +171,17 @@ if(TARGET score AND NOT EMSCRIPTEN)
     TIMEOUT 900 RUN_SERIAL TRUE)
 endif()
 
+# Score.remove() on a cable, which used to be a silent no-op. A subprocess test
+# for the same reason: what is under test is the effect on a live document.
+if(TARGET score AND NOT EMSCRIPTEN)
+  score_add_test(test_integration_js_remove_cable
+    SOURCES JsRemoveCableTest.cpp)
+  target_compile_definitions(test_integration_js_remove_cable PRIVATE
+    "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\"")
+  set_tests_properties(test_integration_js_remove_cable PROPERTIES
+    TIMEOUT 900 RUN_SERIAL TRUE)
+endif()
+
 # Closing a MODIFIED document with applicationSettings.gui false must not
 # raise the save prompt: nothing can answer it and QMessageBox::exec() aborts.
 score_add_test(test_regression_headless_close_modified

--- a/tests/integration/JsRemoveCableTest.cpp
+++ b/tests/integration/JsRemoveCableTest.cpp
@@ -1,0 +1,185 @@
+// Score.remove() on a cable.
+//
+// A cable is parented to the document-level cable map rather than to a
+// scenario, so EditJsContext::remove matched neither its ProcessModel branch
+// nor the generic parent-based one: the call returned having done nothing, and
+// said nothing about it. That is the one operation a script needs to reroute an
+// existing connection -- take what an outlet already feeds and feed it from
+// somewhere else instead -- so the failure showed up as a patch that was built
+// correctly and then left wired to both destinations.
+//
+// A subprocess test because the behaviour under test is what the scripting API
+// does to a live document, which is only reachable through a real --script run.
+
+#include <QByteArray>
+#include <QFile>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+QString appBinary()
+{
+#if defined(SCORE_APP_BINARY)
+  return QStringLiteral(SCORE_APP_BINARY);
+#else
+  return {};
+#endif
+}
+
+struct Run
+{
+  int exitCode{-1};
+  bool crashed{true};
+  QString output;
+};
+
+Run runScript(const QString& path)
+{
+  auto env = QProcessEnvironment::systemEnvironment();
+  env.remove("DISPLAY");
+  env.remove("WAYLAND_DISPLAY");
+  env.insert("QT_QPA_PLATFORM", "offscreen");
+  env.insert("SCORE_AUDIO_BACKEND", "dummy");
+  env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  // The script reports through console.log, which is a qDebug, and the child's
+  // stderr here is a pipe: where Qt is built against journald it would log to
+  // the journal instead and every check below would read an empty string.
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
+
+  QProcess p;
+  p.setProcessEnvironment(env);
+  p.setProcessChannelMode(QProcess::MergedChannels);
+  p.start(
+      appBinary(), {"--no-gui", "--no-restore", "--wait", "0", "--script", path});
+
+  Run r;
+  if(!p.waitForStarted(30000) || !p.waitForFinished(120000))
+  {
+    p.kill();
+    p.waitForFinished(5000);
+    return r;
+  }
+  r.output = QString::fromUtf8(p.readAll());
+  r.crashed = p.exitStatus() != QProcess::NormalExit;
+  r.exitCode = p.exitCode();
+  return r;
+}
+
+QString write(const QTemporaryDir& dir, const QString& name, const QByteArray& body)
+{
+  const QString path = dir.filePath(name);
+  QFile f{path};
+  REQUIRE(f.open(QIODevice::WriteOnly));
+  f.write(body);
+  f.close();
+  return path;
+}
+
+// Two processes carrying a texture outlet and a texture inlet, so that a cable
+// between them is type-compatible. Any transition shader will do; Fade is the
+// smallest of the ones the default package ships.
+const char* prelude = R"JS(
+var SHADER = "<LIBRARY>:/packages/default/Presets/GLSL_shaders/basic/blend/Fade.fs";
+var root = Score.rootInterval();
+var a = Score.createProcess(root, "ISF Shader", SHADER);
+var b = Score.createProcess(root, "ISF Shader", SHADER);
+var c = Score.createProcess(root, "ISF Shader", SHADER);
+if(!a || !b || !c) { console.log("NO-SHADER"); Qt.exit(0); }
+var out = Score.outlet(a, 0);
+var inB = Score.inlet(b, "startImage");
+var inC = Score.inlet(c, "startImage");
+)JS";
+}
+
+TEST_CASE("Score.remove() on a cable", "[integration][js][scripting]")
+{
+  if(appBinary().isEmpty() || !QFile::exists(appBinary()))
+    SKIP("the score application binary was not built");
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  SECTION("a removed cable is gone from both of its ports")
+  {
+    auto r = runScript(write(
+        dir, "remove.js",
+        QByteArray(prelude)
+            + R"JS(
+Score.createCable(out, inB);
+console.log("BEFORE " + Score.cables(out) + " " + Score.cables(inB));
+Score.remove(Score.cable(out, 0));
+console.log("AFTER " + Score.cables(out) + " " + Score.cables(inB));
+Qt.exit(0);
+)JS"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    if(r.output.contains("NO-SHADER"))
+      SKIP("the default package's shaders are not installed");
+    CHECK(r.output.contains("BEFORE 1 1"));
+    // Was "AFTER 1 1": the call did nothing at all.
+    CHECK(r.output.contains("AFTER 0 0"));
+  }
+
+  SECTION("removal takes effect inside a macro, as a reroute needs")
+  {
+    auto r = runScript(write(
+        dir, "macro.js",
+        QByteArray(prelude)
+            + R"JS(
+Score.createCable(out, inB);
+Score.startMacro();
+Score.remove(Score.cable(out, 0));
+console.log("INSIDE " + Score.cables(out));
+Score.createCable(out, inC);
+Score.endMacro();
+console.log("AFTER " + Score.cables(out));
+var moved = Score.cables(out) === 1
+         && Score.parentProcess(Score.sink(Score.cable(out, 0))) === c;
+console.log("REROUTED " + moved);
+Qt.exit(0);
+)JS"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    if(r.output.contains("NO-SHADER"))
+      SKIP("the default package's shaders are not installed");
+    CHECK(r.output.contains("INSIDE 0"));
+    CHECK(r.output.contains("AFTER 1"));
+    CHECK(r.output.contains("REROUTED true"));
+  }
+
+  SECTION("removing something that is not a cable leaves the cable alone")
+  {
+    // A number cannot become a QObject*, and the engine refuses the call rather
+    // than passing null: that is a JS exception the script has to catch, not a
+    // crash and not a removal. The port is the interesting case -- it has a
+    // parent, so it reaches the generic branch -- and must also be left alone.
+    auto r = runScript(write(
+        dir, "notacable.js",
+        QByteArray(prelude)
+            + R"JS(
+Score.createCable(out, inB);
+function tryRemove(what, v) {
+  try { Score.remove(v); console.log("RETURNED " + what); }
+  catch(e) { console.log("THREW " + what); }
+}
+tryRemove("null", null);
+tryRemove("outlet", out);
+tryRemove("number", 42);
+console.log("SURVIVED " + Score.cables(out));
+Qt.exit(0);
+)JS"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    if(r.output.contains("NO-SHADER"))
+      SKIP("the default package's shaders are not installed");
+    CHECK(r.output.contains("RETURNED null"));
+    CHECK(r.output.contains("RETURNED outlet"));
+    CHECK(r.output.contains("THREW number"));
+    CHECK(r.output.contains("SURVIVED 1"));
+  }
+}

--- a/tests/integration/JsTimeApiTest.cpp
+++ b/tests/integration/JsTimeApiTest.cpp
@@ -1,0 +1,212 @@
+// Time in the Javascript scripting API.
+//
+// Two halves. The first pins the representation that already existed, because
+// scripts in the wild depend on it and none of it may shift: a Javascript
+// number reaching a TimeVal parameter means *flicks*, Util.toMilliseconds
+// converts the other way, and durations are readable off the objects that
+// carry them. The second covers what was added -- positions, which were
+// reachable from C++ and from nowhere else.
+//
+// The number/TimeVal conversion in the middle used to depend on magnitude. A
+// Javascript number arrives as whichever C++ type it fits in, so an integral
+// one below INT32_MAX came through as `int`, which nothing converted to
+// TimeVal: every duration under ~3.04 seconds threw, longer ones worked, and
+// so did anything fractional. The boundary cases below are that bug.
+
+#include <QByteArray>
+#include <QFile>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+QString appBinary()
+{
+#if defined(SCORE_APP_BINARY)
+  return QStringLiteral(SCORE_APP_BINARY);
+#else
+  return {};
+#endif
+}
+
+struct Run
+{
+  int exitCode{-1};
+  bool crashed{true};
+  QString output;
+};
+
+Run runScript(const QString& path)
+{
+  auto env = QProcessEnvironment::systemEnvironment();
+  env.remove("DISPLAY");
+  env.remove("WAYLAND_DISPLAY");
+  env.insert("QT_QPA_PLATFORM", "offscreen");
+  env.insert("SCORE_AUDIO_BACKEND", "dummy");
+  env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  // Every value this test checks is reported through console.log, i.e. a
+  // qDebug, and the child's stderr is a pipe: where Qt is built against
+  // journald it logs there instead and the checks all read an empty string.
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
+
+  QProcess p;
+  p.setProcessEnvironment(env);
+  p.setProcessChannelMode(QProcess::MergedChannels);
+  p.start(
+      appBinary(), {"--no-gui", "--no-restore", "--wait", "0", "--script", path});
+
+  Run r;
+  if(!p.waitForStarted(30000) || !p.waitForFinished(120000))
+  {
+    p.kill();
+    p.waitForFinished(5000);
+    return r;
+  }
+  r.output = QString::fromUtf8(p.readAll());
+  r.crashed = p.exitStatus() != QProcess::NormalExit;
+  r.exitCode = p.exitCode();
+  return r;
+}
+
+QString write(const QTemporaryDir& dir, const QString& name, const QByteArray& body)
+{
+  const QString path = dir.filePath(name);
+  QFile f{path};
+  REQUIRE(f.open(QIODevice::WriteOnly));
+  f.write(body);
+  f.close();
+  return path;
+}
+
+// A: 3 s -> 9 s, B: 4 s -> 10 s, so they overlap by 5 s.
+const char* prelude = R"JS(
+var FL = 705600000;
+var root = Score.rootInterval();
+var scen = Score.process(root, 0);
+var a = Score.createBox(scen, 3*FL, 6*FL, 0.15);
+var b = Score.createBox(scen, 4*FL, 6*FL, 0.55);
+function say(k, v) { console.log(k + "=" + v); }
+function attempt(k, f) { try { f(); say(k, "ok"); } catch(e) { say(k, "threw"); } }
+)JS";
+}
+
+TEST_CASE("time is readable and writable from Javascript", "[integration][js][time]")
+{
+  if(appBinary().isEmpty() || !QFile::exists(appBinary()))
+    SKIP("the score application binary was not built");
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  SECTION("the existing representation is unchanged")
+  {
+    auto r = runScript(write(
+        dir, "contract.js",
+        QByteArray(prelude)
+            + R"JS(
+say("durationMs", Util.toMilliseconds(a.durations.default));
+say("minMs", Util.toMilliseconds(a.durations.min));
+say("speed", a.durations.speed);
+say("rigid", a.durations.isRigid);
+say("infinite", Util.isInfinite(a.durations.default));
+say("roundtrip", Util.toMilliseconds(Util.timevalFromMilliseconds(4000)));
+var p = Score.createProcess(a, "Video", "");
+say("startOffsetMs", Util.toMilliseconds(p.startOffset));
+say("loopDurationMs", Util.toMilliseconds(p.loopDuration));
+Qt.exit(0);
+)JS"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    // A number handed to a TimeVal parameter is flicks, and toMilliseconds is
+    // the way back. Changing either would silently rescale every script that
+    // sets a duration.
+    CHECK(r.output.contains("durationMs=6000"));
+    CHECK(r.output.contains("minMs=6000"));
+    CHECK(r.output.contains("speed=1"));
+    CHECK(r.output.contains("rigid=true"));
+    CHECK(r.output.contains("infinite=false"));
+    CHECK(r.output.contains("roundtrip=4000"));
+    CHECK(r.output.contains("startOffsetMs=0"));
+    CHECK(r.output.contains("loopDurationMs=6000"));
+  }
+
+  SECTION("a number means flicks whatever its magnitude")
+  {
+    auto r = runScript(write(
+        dir, "magnitude.js",
+        QByteArray(prelude)
+            + R"JS(
+attempt("small", function() { Score.setIntervalDuration(a, 1411200000); });
+say("smallMs", Util.toMilliseconds(a.durations.default));
+attempt("large", function() { Score.setIntervalDuration(a, 10*FL); });
+say("largeMs", Util.toMilliseconds(a.durations.default));
+attempt("fractional", function() { Score.setIntervalDuration(a, 1000.5); });
+say("utilSmall", Util.toMilliseconds(705600));
+Qt.exit(0);
+)JS"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    // 1411200000 flicks is 2 s and fits in an int: this threw.
+    CHECK(r.output.contains("small=ok"));
+    CHECK(r.output.contains("smallMs=2000"));
+    CHECK(r.output.contains("large=ok"));
+    CHECK(r.output.contains("largeMs=10000"));
+    CHECK(r.output.contains("fractional=ok"));
+    CHECK(r.output.contains("utilSmall=1"));
+  }
+
+  SECTION("positions are readable")
+  {
+    auto r = runScript(write(
+        dir, "positions.js",
+        QByteArray(prelude)
+            + R"JS(
+say("aDate", a.date);
+say("bDate", b.date);
+say("aMarker", a.startMarker);
+say("syncDate", Score.startSync(b).date);
+say("eventDate", Score.startEvent(b).date);
+var p = Score.createProcess(a, "Video", "");
+say("procDuration", p.duration);
+Qt.exit(0);
+)JS"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    CHECK(r.output.contains("aDate=2116800000"));   // 3 s
+    CHECK(r.output.contains("bDate=2822400000"));   // 4 s
+    CHECK(r.output.contains("aMarker=0"));
+    CHECK(r.output.contains("syncDate=2822400000"));
+    CHECK(r.output.contains("eventDate=2822400000"));
+    CHECK(r.output.contains("procDuration=4233600000")); // 6 s
+  }
+
+  SECTION("toSeconds accepts both a position and a duration")
+  {
+    // The point of the helper: positions come back as raw flicks and durations
+    // as a TimeVal, and a script should not have to care which it is holding.
+    auto r = runScript(write(
+        dir, "seconds.js",
+        QByteArray(prelude)
+            + R"JS(
+say("dateS", Util.toSeconds(a.date));
+say("durS", Util.toSeconds(a.durations.default));
+var aStart = Util.toSeconds(a.date), aEnd = aStart + Util.toSeconds(a.durations.default);
+var bStart = Util.toSeconds(b.date), bEnd = bStart + Util.toSeconds(b.durations.default);
+say("earlier", aStart <= bStart ? "A" : "B");
+say("overlap", Math.min(aEnd, bEnd) - Math.max(aStart, bStart));
+Qt.exit(0);
+)JS"));
+    CHECK_FALSE(r.crashed);
+    CHECK(r.exitCode == 0);
+    CHECK(r.output.contains("dateS=3"));
+    CHECK(r.output.contains("durS=6"));
+    // Which clip is outgoing, and by how much they overlap: the two questions a
+    // transition has to answer, and neither was answerable before.
+    CHECK(r.output.contains("earlier=A"));
+    CHECK(r.output.contains("overlap=5"));
+  }
+}


### PR DESCRIPTION
Two gaps that a script hits as soon as it tries to build something, both found
by writing an ordinary one — assemble a patch, wire two clips into a mixer, ramp
a control across their overlap — and running out of API partway through.

### Removing a cable did nothing, and said nothing

`EditJsContext::remove` tests for a `ProcessModel`, then falls back to a branch
that looks the object's parent up as a `Scenario::ProcessModel`. A
`Process::Cable` is parented to the document-level cable map, so neither matched
and the call returned having done nothing — no error, no message.

That is the one operation needed to *reroute* a connection: take what an outlet
already feeds and feed it from somewhere else. So the failure did not look like
a missing feature. A script that built a patch and moved an existing cable onto
it produced a document wired to both destinations, which for video means the
output is composited twice.

### A script could read how long something lasts, but never when it happens

Durations were already reachable. Positions were not: `date()` on an interval, a
time sync and an event, and `duration()` on a process, all exist in C++ with a
change signal each and no property, so from Javascript they read `undefined`.
A script could not tell which of two intervals comes first, nor whether they
overlap.

They are now exposed **read-only, in flicks as a plain number** — how time is
already spelled on this side of the boundary, since `TokenRequestValueType::date`
and its neighbours return a raw `.impl` and `token.date` is used throughout the
Javascript presets we ship. Read-only keeps every position change going through
a command, so undo still works.

Passing a number to a `TimeVal` parameter also only worked above a threshold. A
Javascript number arrives as whichever C++ type it fits in, so an integral one
below `INT32_MAX` came through as `int`, which no registered converter accepted:

```js
Score.setIntervalDuration(itv, 7056000000)  // 10 s: fine
Score.setIntervalDuration(itv, 1411200000)  //  2 s: TypeError
```

Every duration under about 3.04 seconds threw; longer ones worked, and so did
anything fractional. Registering the narrower integral types can only turn that
error into the call the script already meant.

`Util.toSeconds` is added beside `toMilliseconds`, and deliberately takes a
`TimeVal`: the double-to-TimeVal converter means it accepts both a position
(a raw number) and a duration (not), so a script needn't know which it holds.

### Compatibility

Nothing existing changes meaning — every name added is new, and no existing
signature, unit or representation moved. In particular `setIntervalDuration`
still reads a bare number as flicks; changing that to seconds would silently
rescale every script in the wild by 705600000 with no error, so it was left
alone and a separate helper added instead.

The time test pins the representation that was *already* there — a number means
flicks, `toMilliseconds` converts back, `durations.*` and `startOffset` /
`loopDuration` stay readable — so a later change that rescales any of it fails
loudly instead of shifting every script that sets a duration.

### Testing

Both tests drive a real `--script` run, because what is under test is the effect
on a live document.

- `test_integration_js_time_api` — 40 assertions: the preserved representation, the magnitude boundary, the new positions, and the two questions a transition has to answer (`earlier=A`, `overlap=5`).
- `test_integration_js_remove_cable` — 21 assertions: removal, removal inside the macro a reroute uses, and three shapes of wrong argument (null and a port return quietly, a number raises the engine's type error, the cable survives all three).
- `test_integration_script_exit_code` — 69 assertions, unchanged.

Also re-ran against the wider suites for regressions: `js_presets` (the
shipped-corpus sweep) 21/21 and `js_process` 5/5, both unchanged.

Both tests set `QT_ASSUME_STDERR_HAS_CONSOLE` / `QT_FORCE_STDERR_LOGGING`:
everything they read out of the child is a `qDebug` and the child's stderr is a
pipe, so where Qt is built against journald it logs there instead and every
assertion reads an empty string. `JsGraphE2ETest` sets the same pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8nefvG3ArFjF2WEJNxxzz
