### PR TITLE
avnd: consume impulses on the GFX node path like the CPU path does

### DIFF
--- a/src/plugins/score-plugin-avnd/Crousti/CpuAnalysisNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/CpuAnalysisNode.hpp
@@ -153,6 +153,7 @@ struct GfxRenderer<Node_T> final
     // Run the processor
     if_possible(state->runInitialPasses(renderer, commands, res, edge));
     if_possible((*state)());
+    parent.clearControlIn(*state);
 
     // Copy the data to the model node
     parent.processControlOut(*this->state);

--- a/src/plugins/score-plugin-avnd/Crousti/CpuFilterNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/CpuFilterNode.hpp
@@ -226,6 +226,7 @@ struct GfxRenderer<Node_T> final
     // Run the processor
     if_possible(state->runInitialPasses(renderer, commands, res, edge));
     if_possible((*state)());
+    parent.clearControlIn(*state);
 
     // Upload output buffers
     if constexpr(avnd::buffer_output_introspection<Node_T>::size > 0)

--- a/src/plugins/score-plugin-avnd/Crousti/GpuComputeNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuComputeNode.hpp
@@ -424,6 +424,7 @@ struct GpuComputeRenderer final : ComputeRendererBaseType<Node_T>
 
     // Copy the data to the model node
     parent.processControlOut(*this->state);
+    parent.clearControlIn(*this->state);
   }
 
   void runInitialPasses(

--- a/src/plugins/score-plugin-avnd/Crousti/GpuNode.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuNode.hpp
@@ -412,6 +412,8 @@ struct CustomGpuRenderer final
     // Copy the data to the model node
     if(!this->states.empty())
       parent.processControlOut(*this->states[0]);
+    for(auto& state : states)
+      parent.clearControlIn(*state);
   }
 };
 

--- a/src/plugins/score-plugin-avnd/Crousti/GpuUtils.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/GpuUtils.hpp
@@ -148,10 +148,29 @@ struct GpuProcessIns
     return true;
   }
 
-  void operator()(avnd::parameter_port auto& t, auto field_index)
+  // The same message is handed to the renderer more than once (init, update, every frame between
+  // two execution ticks).
+  bool is_new_message() const noexcept
   {
-    if(!can_process_message(field_index))
+    return prev_mess.node_id != mess.node_id || prev_mess.token.date != mess.token.date
+           || prev_mess.input.size() != mess.input.size();
+  }
+
+  template <avnd::parameter_port Field, std::size_t NField>
+  void operator()(Field& t, avnd::field_index<NField> field_index)
+  {
+    if constexpr(avnd::optional_ish<decltype(Field::value)>)
+    {
+      // Impulses and other one-shot values are events, not states: a value equal to the previous
+      // one is a new event, but the same message must not fire it twice. Mirrors the CPU path
+      // (which sees each port's data stream once per tick).
+      if(mess.input.size() <= NField || !is_new_message())
+        return;
+    }
+    else if(!can_process_message(field_index))
+    {
       return;
+    }
 
     if(auto val = ossia::get_if<ossia::value>(&mess.input[field_index]))
     {
@@ -255,6 +274,19 @@ struct GpuControlIns
         avnd::get_inputs<Node_T>(state),
         GpuProcessIns<Self, Node_T>{self, state, renderer_mess, mess, ctx});
     renderer_mess = mess;
+  }
+
+  // Once the processor has run, the impulses and other one-shot values it received this tick are
+  // consumed, exactly as oscr::process_after_run does on the CPU path. Without this an impulse
+  // would stay set until the next message touches the port.
+  template <typename Node_T>
+  static void clearControlIn(Node_T& state) noexcept
+  {
+    avnd::parameter_input_introspection<Node_T>::for_all(
+        avnd::get_inputs<Node_T>(state), []<typename Field>(Field& t) {
+          if constexpr(avnd::optional_ish<decltype(Field::value)>)
+            t.value.reset();
+        });
   }
 };
 


### PR DESCRIPTION
## Problem

An Avendish texture/GPU node with a `halp::val_port<"Bang", std::optional<halp::impulse>>` input sees the impulse **on every tick** after the first one: the GFX path (`CpuFilterNode` / `GpuNode` / `GpuComputeNode`) applies controls from the execution engine's `score::gfx::Message` through `GpuProcessIns` and never resets them, whereas the CPU path clears one-shot values in `oscr::process_after_run` after the processor ran. `GpuProcessIns` also deduplicates messages by value, which is right for stateful controls but would drop a second impulse equal to the previous one.

Found while wiring the `Trigger` / `Build` impulses of the StreamDiffusion node (score-addon-librediffusion): one press of `Build` restarted the engine build every tick, forever.

## Fix (mirrors the CPU path)

- `GpuProcessIns`: optional-valued ports are events — applied once per execution message (the same message is handed to the renderer several times between ticks: `init`, `update`, every frame), never deduplicated by value.
- `GpuControlIns::clearControlIn` resets those ports after the processor ran; called from the three renderers after `operator()` / `dispatch()` / the render pass, next to `processControlOut`.

Stateful controls are untouched (same dedup as before).

## Validation

- Windows, ossia-sdk clang 22, CI flags (`-DOSSIA_SDK -DCMAKE_UNITY_BUILD=1 -DOSSIA_STATIC_EXPORT=1 -DSCORE_DEPLOYMENT_BUILD=1`): `score_plugin_avnd` and `score_addon_librediffusion` build clean.
- Behaviour traced against `gfx_exec_node::run` (an impulse inlet's slot is filled only on the tick it arrives) and `oscr::process_after_run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SV6BNsGfa18QxBcaaWoe7m
