### PR TITLE
dataflow: tell a port's own unit apart from the one its address asks for

### DIFF
--- a/src/plugins/score-lib-process/Process/Dataflow/Port.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/Port.cpp
@@ -166,6 +166,16 @@ const State::AddressAccessor& Port::address() const noexcept
   return m_address;
 }
 
+const State::Unit& Port::unit() const noexcept
+{
+  return m_unit;
+}
+
+void Port::setUnit(State::Unit u) noexcept
+{
+  m_unit = std::move(u);
+}
+
 const std::vector<Path<Cable>>& Port::cables() const noexcept
 {
   return m_cables;

--- a/src/plugins/score-lib-process/Process/Dataflow/Port.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/Port.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <State/Address.hpp>
 #include <State/Domain.hpp>
+#include <State/Unit.hpp>
 
 #include <Device/Address/AddressSettings.hpp>
 
@@ -121,6 +122,13 @@ public:
   const QString& exposed() const noexcept;
   const QString& description() const noexcept;
 
+  //! The unit the process expects on this port, overridden by the @[unit] of its
+  //! address. Not serialized: the process declares it again when its ports are
+  //! built, which is why a port with a fixed unit overrides this rather than
+  //! calling setUnit().
+  virtual const State::Unit& unit() const noexcept;
+  void setUnit(State::Unit u) noexcept;
+
   virtual PortType type() const noexcept = 0;
 
   virtual Device::FullAddressAccessorSettings settings() const noexcept;
@@ -174,6 +182,7 @@ protected:
   QString m_exposed;
   QString m_description;
   State::AddressAccessor m_address;
+  State::Unit m_unit;
 };
 
 class SCORE_LIB_PROCESS_EXPORT Inlet : public Port

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -135,9 +135,10 @@ HSVSlider::HSVSlider(
 
 HSVSlider::~HSVSlider() { }
 
-void HSVSlider::setupExecution(ossia::inlet& i, QObject* exec_context) const noexcept
+const State::Unit& HSVSlider::unit() const noexcept
 {
-  safe_cast<ossia::value_inlet*>(&i)->data.type = ossia::rgba_u{};
+  static const State::Unit u{ossia::unit_t{ossia::rgba_u{}}};
+  return u;
 }
 
 FloatSlider::FloatSlider(

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
@@ -515,7 +515,8 @@ struct SCORE_LIB_PROCESS_EXPORT HSVSlider : public Process::ControlInlet
       ossia::vec4f init, const QString& name, Id<Process::Port> id, QObject* parent);
   ~HSVSlider();
 
-  void setupExecution(ossia::inlet& inl, QObject* exec_context) const noexcept override;
+  //! rgba, however the port was constructed.
+  const State::Unit& unit() const noexcept override;
   auto getMin() const noexcept { return ossia::vec4f{0., 0., 0., 0.}; }
   auto getMax() const noexcept { return ossia::vec4f{1., 1., 1., 1.}; }
   using Process::ControlInlet::ControlInlet;

--- a/src/plugins/score-lib-process/Process/ExecutionSetup.cpp
+++ b/src/plugins/score-lib-process/Process/ExecutionSetup.cpp
@@ -167,6 +167,29 @@ void SetupContext::connect_cable_impl(Process::Cable& cable, Impl&& impl)
   }
 }
 
+// Pushed once, when the node is registered; the address machinery never touches
+// `type` afterwards.
+template <typename T, typename Impl>
+static void set_declared_unit_impl(
+    const Process::Port& proc_port, const T& port, Impl&& append)
+{
+  OSSIA_ENSURE_CURRENT_THREAD_KIND(ossia::thread_type::Ui);
+  const ossia::unit_t& u = proc_port.unit().get();
+  if(!u)
+    return;
+
+  append([port, u] {
+    OSSIA_ENSURE_CURRENT_THREAD_KIND(ossia::thread_type::Audio);
+    if(ossia::value_port* dat = port->template target<ossia::value_port>())
+    {
+      // A unit the node declared is more precise than the widget's and wins; a
+      // plain value type does not.
+      if(!dat->type.target<ossia::unit_t>())
+        dat->type = u;
+    }
+  });
+}
+
 template <typename Impl>
 void SetupContext::register_inlet_impl(
     Process::Inlet& proc_port, const ossia::inlet_ptr& ossia_port,
@@ -185,16 +208,13 @@ void SetupContext::register_inlet_impl(
     OSSIA_ENSURE_CURRENT_THREAD_KIND(ossia::thread_type::Ui);
     set_destination(address, ossia_port);
   });
+  set_declared_unit_impl(proc_port, ossia_port, impl);
+
+  // Also registers the port with the execution state, once, when the address
+  // resolves.
   set_destination_impl(context, proc_port.address(), ossia_port, impl);
 
   inlets.insert({&proc_port, std::make_pair(node, ossia_port)});
-
-  std::weak_ptr<ossia::execution_state> ws = context.execState;
-  impl([ws, ossia_port] {
-    OSSIA_ENSURE_CURRENT_THREAD_KIND(ossia::thread_type::Audio);
-    if(auto state = ws.lock())
-      state->register_port(*ossia_port);
-  });
 }
 
 template <typename Impl>
@@ -294,7 +314,7 @@ void set_destination_impl(
         port->address = {};
         if(ossia::value_port* dat = port->template target<ossia::value_port>())
         {
-          dat->type = {};
+          dat->address_unit = {};
           dat->index = {};
         }
         g->mark_dirty();
@@ -321,8 +341,9 @@ void set_destination_impl(
         port->address = p;
         if(ossia::value_port* dat = port->template target<ossia::value_port>())
         {
-          if(qual.unit)
-            dat->type = qual.unit;
+          // Unconditionally, like the index: dropping the qualifier has to give
+          // the process's declaration back.
+          dat->address_unit = qual.unit;
           dat->index = qual.accessors;
         }
         s->register_port(*port);
@@ -365,7 +386,7 @@ void set_destination_impl(
         port->address = std::move(p);
         if(ossia::value_port* dat = port->template target<ossia::value_port>())
         {
-          dat->type = {};
+          dat->address_unit = {};
           dat->index.clear();
         }
         s->register_port(*port);
@@ -386,7 +407,7 @@ void set_destination_impl(
         port->address = {};
         if(ossia::value_port* dat = port->template target<ossia::value_port>())
         {
-          dat->type = {};
+          dat->address_unit = {};
           dat->index.clear();
         }
         s->register_port(*port);
@@ -507,6 +528,8 @@ void SetupContext::register_outlet_impl(
     OSSIA_ENSURE_CURRENT_THREAD_KIND(ossia::thread_type::Ui);
     set_destination(address, ossia_port);
   });
+  set_declared_unit_impl(proc_port, ossia_port, impl);
+
   set_destination_impl(context, proc_port.address(), ossia_port, impl);
 
   outlets.insert({&proc_port, std::make_pair(node, ossia_port)});

--- a/src/plugins/score-plugin-avnd/CMakeLists.txt
+++ b/src/plugins/score-plugin-avnd/CMakeLists.txt
@@ -1246,6 +1246,8 @@ target_include_directories(Avnd_point_tracker_Test PRIVATE "${CMAKE_CURRENT_SOUR
 addAvndTest(entity_to_midi_Test
              "${CMAKE_CURRENT_SOURCE_DIR}/Tests/EntityToMidi_Test.cpp")
 target_include_directories(Avnd_entity_to_midi_Test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+addAvndTest(port_unit_Test
+             "${CMAKE_CURRENT_SOURCE_DIR}/Tests/port_unit_Test.cpp")
 endif()
 
 set(CMAKE_AUTOMOC OFF)

--- a/src/plugins/score-plugin-avnd/Tests/port_unit_Test.cpp
+++ b/src/plugins/score-plugin-avnd/Tests/port_unit_Test.cpp
@@ -1,0 +1,164 @@
+// The ossia binding deduces a port's unit from the shape of its value. Those
+// concepts nest, so each overload has to exclude the wider ones.
+
+#include <ossia/dataflow/port.hpp>
+#include <ossia/network/dataspace/dataspace_visitors.hpp>
+
+#include <avnd/introspection/port.hpp>
+
+#include <avnd/binding/ossia/port_setup.hpp>
+#include <halp/controls.hpp>
+
+#include <catch2/catch_all.hpp>
+
+namespace
+{
+template <typename Field>
+ossia::value_port port_for()
+{
+  ossia::value_port p;
+  oscr::setup_value_port::setup_port<Field>(p);
+  return p;
+}
+
+// As the address panel spells it.
+std::string unit_of(const ossia::value_port& p)
+{
+  if(auto u = p.type.target<ossia::unit_t>())
+    return std::string(ossia::get_pretty_unit_text(*u));
+  return "<not a unit>";
+}
+
+ossia::val_type type_of(const ossia::value_port& p)
+{
+  auto t = p.type.target<ossia::val_type>();
+  REQUIRE(t);
+  return *t;
+}
+}
+
+TEST_CASE("A port's unit follows the arity of its value", "[avnd][port][unit]")
+{
+  SECTION("two components are a 2D position")
+  {
+    auto p = port_for<halp::xy_spinboxes_f32<"P", halp::range{0., 1., 0.}>>();
+    CHECK(unit_of(p) == "position.cart2D");
+  }
+
+  SECTION("three components are a 3D position")
+  {
+    auto p = port_for<halp::xyz_spinboxes_f32<"P", halp::range{0., 1., 0.}>>();
+    CHECK(unit_of(p) == "position.cart3D");
+  }
+
+  SECTION("four components have no position unit, only their arity")
+  {
+    struct xyzw_port
+    {
+      static consteval auto name() { return "P"; }
+      struct
+      {
+        float x, y, z, w;
+      } value;
+    };
+    auto p = port_for<xyzw_port>();
+    CHECK(p.type.target<ossia::unit_t>() == nullptr);
+    CHECK(type_of(p) == ossia::val_type::VEC4F);
+  }
+
+  SECTION("an xy pad is still a 2D position")
+  {
+    auto p = port_for<halp::xy_pad_f32<"P", halp::range{0., 1., 0.}>>();
+    CHECK(unit_of(p) == "position.cart2D");
+  }
+
+  SECTION("scalars are untouched")
+  {
+    auto p = port_for<halp::hslider_f32<"F", halp::range{0., 1., 0.}>>();
+    CHECK(type_of(p) == ossia::val_type::FLOAT);
+  }
+}
+
+TEST_CASE("A colour port's unit follows its arity too", "[avnd][port][unit]")
+{
+  // rgba_value satisfies rgb_value, exactly as xyzw does xy.
+  SECTION("three components are rgb")
+  {
+    struct rgb_port
+    {
+      static consteval auto name() { return "C"; }
+      struct
+      {
+        float r, g, b;
+      } value;
+    };
+    CHECK(unit_of(port_for<rgb_port>()) == "color.rgb");
+  }
+
+  SECTION("four components are rgba")
+  {
+    struct rgba_port
+    {
+      static consteval auto name() { return "C"; }
+      struct
+      {
+        float r, g, b, a;
+      } value;
+    };
+    CHECK(unit_of(port_for<rgba_port>()) == "color.rgba");
+  }
+}
+
+TEST_CASE("A unit a process declares itself", "[avnd][port][unit]")
+{
+  SECTION("a unit name resolves")
+  {
+    struct pitch_port
+    {
+      static consteval auto name() { return "out"; }
+      static consteval auto unit() { return "midipitch"; }
+      int value;
+    };
+    CHECK(unit_of(port_for<pitch_port>()) == "time.midinote");
+  }
+
+  SECTION("a qualified unit name resolves")
+  {
+    struct mm_port
+    {
+      static consteval auto name() { return "out"; }
+      static consteval auto unit() { return "distance.mm"; }
+      float value;
+    };
+    CHECK(unit_of(port_for<mm_port>()) == "distance.mm");
+  }
+
+  SECTION("a dataspace name gives its neutral unit, not an empty dataspace")
+  {
+    struct pos_port
+    {
+      static consteval auto name() { return "out"; }
+      static consteval auto unit() { return "position"; }
+      float value;
+    };
+    auto p = port_for<pos_port>();
+    auto u = p.type.target<ossia::unit_t>();
+    REQUIRE(u);
+    CHECK(bool(*u));
+    CHECK(unit_of(p) == "position.cart3D");
+  }
+
+  SECTION("what a process declares wins over the shape of its value")
+  {
+    struct declared
+    {
+      static consteval auto name() { return "P"; }
+      static consteval auto unit() { return "position.opengl"; }
+      struct
+      {
+        float x, y, z;
+      } value;
+    };
+    CHECK(unit_of(port_for<declared>()) == "position.openGL");
+  }
+}

--- a/src/plugins/score-plugin-controlsurface/ControlSurface/Executor.cpp
+++ b/src/plugins/score-plugin-controlsurface/ControlSurface/Executor.cpp
@@ -22,7 +22,7 @@ std::function<void(T&)> set_destination_impl(
         port.address = {};
         if(ossia::value_port* dat = port.template target<ossia::value_port>())
         {
-          dat->type = {};
+          dat->address_unit = {};
           dat->index = {};
         }
         g.mark_dirty();
@@ -41,8 +41,7 @@ std::function<void(T&)> set_destination_impl(
         port.address = p;
         if(ossia::value_port* dat = port.template target<ossia::value_port>())
         {
-          if(qual.unit)
-            dat->type = qual.unit;
+          dat->address_unit = qual.unit;
           dat->index = qual.accessors;
         }
         s.register_port(port);
@@ -69,7 +68,7 @@ std::function<void(T&)> set_destination_impl(
         port.address = std::move(*path);
         if(ossia::value_port* dat = port.template target<ossia::value_port>())
         {
-          dat->type = {};
+          dat->address_unit = {};
           dat->index.clear();
         }
         s.register_port(port);
@@ -83,7 +82,7 @@ std::function<void(T&)> set_destination_impl(
         port.address = {};
         if(ossia::value_port* dat = port.template target<ossia::value_port>())
         {
-          dat->type = {};
+          dat->address_unit = {};
           dat->index.clear();
         }
         g.mark_dirty();
@@ -191,10 +190,12 @@ ProcessExecutorComponent::ProcessExecutorComponent(
     system().setup.set_destination(addr, &outlet);
     ctrl->setupExecution(inlet, this);
 
-    // set_destination sets the domain / type in the exec thread, so since
-    // we override it we have to schedul the change after to make sure it does
-    // not get overwritten:
-    in_exec([&in_port, &out_port] {
+    // The outlet is the port that carries an address here, and register_node()
+    // only pushes the declaration to the inlet.
+    const ossia::unit_t declared = ctrl->unit().get();
+    in_exec([&in_port, &out_port, declared] {
+      if(declared)
+        in_port.type = declared;
       out_port.domain = in_port.domain;
       out_port.type = in_port.type;
     });
@@ -226,9 +227,11 @@ void ProcessExecutorComponent::inletAdded(Process::ControlInlet& inl)
   auto set_addr
       = ossia::set_destination_impl<ossia::outlet>(*ctx.execState, *ctx.execGraph, addr);
 
+  const ossia::unit_t declared = inl.unit().get();
+
   std::weak_ptr<ossia::control_surface_node> weak_node
       = std::dynamic_pointer_cast<ossia::control_surface_node>(this->node);
-  in_exec([v, weak_node, set_addr, fake = std::move(fake)]() mutable {
+  in_exec([v, weak_node, set_addr, declared, fake = std::move(fake)]() mutable {
     if(auto node = weak_node.lock())
     {
       std::pair<ossia::value*, bool>& p = node->add_control();
@@ -243,9 +246,9 @@ void ProcessExecutorComponent::inletAdded(Process::ControlInlet& inl)
 
       auto& fake_port = *fake->target<ossia::value_port>();
       in_port.domain = fake_port.domain;
-      in_port.type = fake_port.type;
+      in_port.type = declared ? ossia::complex_type{declared} : fake_port.type;
       out_port.domain = fake_port.domain;
-      out_port.type = fake_port.type;
+      out_port.type = in_port.type;
     }
   });
 

--- a/tests/unit/DataflowValueTest.cpp
+++ b/tests/unit/DataflowValueTest.cpp
@@ -6,6 +6,7 @@
 #include <Process/Dataflow/Port.hpp>
 #include <Process/Dataflow/PortFactory.hpp>
 #include <Process/Dataflow/PortSerialization.hpp>
+#include <Process/Dataflow/WidgetInlets.hpp>
 
 #include <Dataflow/AudioInletItem.hpp>
 #include <Dataflow/AudioOutletItem.hpp>
@@ -15,6 +16,9 @@
 #include <Dataflow/MidiOutletItem.hpp>
 #include <Dataflow/ValueInletItem.hpp>
 #include <Dataflow/ValueOutletItem.hpp>
+#include <Dataflow/WidgetInletFactory.hpp>
+
+#include <Process/Dataflow/ControlWidgets.hpp>
 
 #include <score/application/ApplicationComponents.hpp>
 #include <score/application/ApplicationContext.hpp>
@@ -121,6 +125,9 @@ struct TestApplication final : public score::ApplicationInterface
     ports->insert(std::make_unique<Dataflow::MidiOutletFactory>());
     ports->insert(std::make_unique<Dataflow::AudioInletFactory>());
     ports->insert(std::make_unique<Dataflow::AudioOutletFactory>());
+    ports->insert(
+        std::make_unique<Dataflow::WidgetInletFactory<
+            Process::HSVSlider, WidgetFactory::HSVSlider>>());
     m_compData.factories.emplace(ports->interfaceKey(), std::move(ports));
   }
 
@@ -569,5 +576,58 @@ TEST_CASE("fuzz: corrupt port and cable buffers are handled gracefully",
       }
     }
     SUCCEED("no crash on truncated polymorphic port buffers");
+  }
+}
+
+// unit() is virtual because a port loaded from a document is built by the
+// inherited deserializing constructors, which run no subclass code.
+TEST_CASE("A port's declared unit", "[dataflow][port][unit]")
+{
+  testApp();
+
+  const State::Unit rgba{ossia::unit_t{ossia::rgba_u{}}};
+
+  SECTION("an ordinary control declares nothing")
+  {
+    Process::ControlInlet inl{"ctl", Id<Process::Port>{0}, nullptr};
+    CHECK(!inl.unit().get());
+  }
+
+  SECTION("a colour control declares rgba")
+  {
+    Process::HSVSlider col{
+        ossia::vec4f{0.f, 0.f, 0.f, 1.f}, "col", Id<Process::Port>{0}, nullptr};
+    CHECK(col.unit() == rgba);
+
+    // including through the base class, which is how the execution setup asks
+    const Process::Port& base = col;
+    CHECK(base.unit() == rgba);
+  }
+
+  SECTION("and still declares it when it comes back from a document")
+  {
+    Process::HSVSlider src{
+        ossia::vec4f{0.f, 0.f, 0.f, 1.f}, "col", Id<Process::Port>{7}, nullptr};
+
+    QByteArray arr;
+    {
+      DataStream::Serializer s{&arr};
+      s.stream() << src;
+    }
+    DataStream::Deserializer des{arr};
+    auto loaded = Process::load_inlet(des, nullptr);
+    REQUIRE(loaded);
+
+    auto col = dynamic_cast<Process::HSVSlider*>(loaded.get());
+    REQUIRE(col);
+    CHECK(col->name() == "col");
+    CHECK(col->unit() == rgba);
+  }
+
+  SECTION("a port that picks its unit per instance")
+  {
+    Process::ControlInlet inl{"gain", Id<Process::Port>{0}, nullptr};
+    inl.setUnit(State::Unit{ossia::unit_t{ossia::decibel_u{}}});
+    CHECK(inl.unit() == State::Unit{ossia::unit_t{ossia::decibel_u{}}});
   }
 }


### PR DESCRIPTION
The score half of a three-repo change. **Needs ossia/libossia#934 and
celtera/avendish#200 first** — the submodule pointers are deliberately not bumped
here, so this branch does not build until those two land.

## Where this started

A report of "an occasional bug when setting an OSC address that has a unit
(`orientation.quaternion`) as the input of a micromap". Reproduced with the JS
scripting API and `oscsend`: two processes reading one OSC address, re-point
either one, and the other silently stops receiving for the rest of the session.
The root cause is a reference count in libossia; this repo contributed to it.

## What changes here

**`register_inlet_impl` registered its port with the execution state twice** — once
inside `set_destination_impl`, once explicitly — while teardown unregisters once.
That happened to compensate for the off-by-one in `message_queue::reg()`, so the
common case balanced and the bug only showed when an address was bound while
playing. With libossia fixed, the extra registration is simply wrong and is
removed.

**A port had two opinions about its unit and one field to hold them.** What the
process declares and what the address asks for with `@[unit]` were both written
into the execution port's `type`, so setting an address destroyed the declaration,
clearing one wiped it entirely, and a new address without a qualifier kept the old
unit. `set_destination_impl` now writes `address_unit` — unconditionally, the way
it already did for the index — so dropping a qualifier gives the declaration back.

**`Process::Port` gains a declared unit**, held as a `State::Unit` so `Port.hpp`
does not pull in the dataspace headers. It is virtual because a port loaded from a
saved document is built by the inherited deserializing constructors, which run no
subclass code. `HSVSlider` overrides it and its `setupExecution` is deleted;
`register_inlet` / `register_outlet` push the declaration to the execution port
once. A unit the node declared for itself wins over the widget's — an avnd colour
port knows whether it is rgb or rgba — while a plain value type does not.

**ControlSurface** reads the declaration from the model port instead of from
whatever `setupExecution` left behind. That gives its *outlet* — the port that
actually carries an address there — the unit it never had, and removes the
`in_exec` scheduling hack whose comment said it existed only because
`set_destination` overwrote the type.

## Testing

- `test_unit_dataflow_value` gains *A port's declared unit*: a plain control
  declares nothing; a colour control declares rgba, including through a
  `Process::Port&`, which is how the execution setup asks for it; `setUnit` for
  per-instance units; and an `HSVSlider` serialized and reloaded through
  `Process::load_inlet` still declares rgba.
- `Avnd_port_unit_Test` (new) pins the avendish-side deduction: arity for
  xy / xyz / xyzw and rgb / rgba, and `halp_meta(unit, …)` resolving.
- End to end through `--script`: two micromaps on `osc:/q@[orientation.quaternion]`,
  re-point one, the other keeps receiving (it did not, before); a colour control
  bound to a `color.hsv` address converts, and **still converts after its address
  is cleared and re-bound**, which is the declaration surviving; an outlet in
  metres into a millimetre address sends 2000 where it sent 2; 1900 address
  changes under OSC traffic with no crash.
- Green: `test_unit_dataflow_value` (70), `Avnd_port_unit_Test` (16),
  `Avnd_point_tracker_Test` (535), `Avnd_ossia_value_Test`,
  `test_unit_port_address_list`, `test_unit_port_drop`, and
  `test_unit_automation_values` / `test_unit_mapping_values` case by case (the
  whole-binary SIGSEGV there is the known pre-existing multiple-`run_in_app`
  problem on Windows, unrelated).

## Known and not addressed

- `State::Unit`'s constructor heap-allocates, so this costs one small allocation
  per port. Dropping `m_unit` and leaving `unit()` purely virtual would remove it —
  every current user is a fixed-unit port — at the cost of the per-instance case.
- The new virtual changes `Process::Port`'s vtable: out-of-tree addons built
  against an older SDK need a rebuild.
- The Gradient process still smuggles its declared unit through a qualifier on an
  otherwise empty address, which *is* serialized. Migrating it to `setUnit()` is a
  model change and is left out.
- The score-side wiring above is covered by the end-to-end scripts rather than by
  the test suite; a real test needs an `Execution::Context`, which nothing in
  `tests/` builds today. `Execution::DocumentPlugin::setupContext` and
  `SetupContext::inlets` are public, so it is reachable — it just needs playback
  and one case per binary here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197hSihNtB1bPw9WDUV3SR2
