### PR TITLE
Runtime-populated comboboxes and avnd UI file paths (reviewed #2110 + #2114)

### DIFF
--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -1394,15 +1394,15 @@ struct ComboBox
   static auto make_widget(
       T& inlet, const score::DocumentContext& ctx, QWidget* parent, QObject* context)
   {
-    const auto& values = inlet.getValues();
     auto sl = new score::ComboBox{parent};
-    for(auto& e : values)
+    for(auto& e : inlet.getValues())
     {
       sl->addItem(e.first);
     }
     sl->setContentsMargins(0, 0, 0, 0);
 
-    auto set_index = [values, sl](const ossia::value& val) {
+    auto set_index = [&inlet, sl](const ossia::value& val) {
+      const auto& values = inlet.getValues();
       auto it
           = ossia::find_if(values, [&](const auto& pair) { return pair.second == val; });
       if(it != values.end())
@@ -1414,13 +1414,27 @@ struct ComboBox
 
     QObject::connect(
         sl, SignalUtils::QComboBox_currentIndexChanged_int(), context,
-        [values, &inlet, &ctx](int idx) {
-      CommandDispatcher<>{ctx.commandStack}.submit<SetControlValue<T>>(
-          inlet, values[idx].second);
+        [&inlet, &ctx](int idx) {
+      const auto& values = inlet.getValues();
+      if(idx >= 0 && idx < std::ssize(values))
+        CommandDispatcher<>{ctx.commandStack}.submit<SetControlValue<T>>(
+            inlet, values[idx].second);
     });
 
     QObject::connect(
         &inlet, &T::valueChanged, sl, [=](const ossia::value& val) { set_index(val); });
+
+    if constexpr(requires { &T::alternativesChanged; })
+    {
+      QObject::connect(
+          &inlet, &T::alternativesChanged, sl, [&inlet, sl, set_index] {
+        QSignalBlocker b{sl};
+        sl->clear();
+        for(auto& e : inlet.getValues())
+          sl->addItem(e.first);
+        set_index(inlet.value());
+      });
+    }
 
     return sl;
   }
@@ -1441,7 +1455,8 @@ struct ComboBox
     auto sl = new score::QGraphicsCombo{arr, nullptr};
     initWidgetProperties(inlet, *sl);
 
-    auto set_index = [values, sl](const ossia::value& val) {
+    auto set_index = [&slider, sl](const ossia::value& val) {
+      const auto& values = slider.getValues();
       auto it
           = ossia::find_if(values, [&](const auto& pair) { return pair.second == val; });
       if(it != values.end())
@@ -1452,10 +1467,12 @@ struct ComboBox
     set_index(inlet.value());
 
     QObject::connect(
-        sl, &score::QGraphicsCombo::sliderMoved, context, [values, sl, &inlet, &ctx] {
+        sl, &score::QGraphicsCombo::sliderMoved, context, [&slider, sl, &inlet, &ctx] {
           sl->moving = true;
-          ctx.dispatcher.submit<SetControlValue<Control_T>>(
-              inlet, values[sl->value()].second);
+          const auto& values = slider.getValues();
+          if(sl->value() >= 0 && sl->value() < std::ssize(values))
+            ctx.dispatcher.submit<SetControlValue<Control_T>>(
+                inlet, values[sl->value()].second);
         });
     QObject::connect(sl, &score::QGraphicsCombo::sliderReleased, context, [sl, &ctx] {
       ctx.dispatcher.commit();
@@ -1478,6 +1495,18 @@ struct ComboBox
 
       set_index(val);
     });
+
+    if constexpr(requires { &Control_T::alternativesChanged; })
+    {
+      QObject::connect(
+          &inlet, &Control_T::alternativesChanged, sl, [&slider, sl, set_index, &inlet] {
+        sl->array.clear();
+        for(auto& e : slider.getValues())
+          sl->array.push_back(e.first);
+        set_index(inlet.value());
+        sl->update();
+      });
+    }
 
     return sl;
   }

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -8,6 +8,7 @@
 #include <ossia-qt/invoke.hpp>
 
 #include <QCoreApplication>
+#include <QDir>
 
 #include <wobjectimpl.h>
 
@@ -105,6 +106,24 @@ void ComboBox::setupExecution(ossia::inlet& inl, QObject* exec_context) const no
 {
   auto& port = **safe_cast<ossia::value_inlet*>(&inl);
   port.domain = domain().get();
+}
+
+void ComboBox::repopulateFromFolder(const QString& folderPath)
+{
+  std::vector<std::pair<QString, ossia::value>> alts;
+  if(!folderPath.isEmpty())
+  {
+    QDir dir(folderPath);
+    const auto files = fileExtensions.isEmpty()
+                           ? dir.entryList(QDir::Files, QDir::Name)
+                           : dir.entryList(fileExtensions, QDir::Files, QDir::Name);
+    int i = 0;
+    for(const auto& f : files)
+      alts.emplace_back(f, i++);
+  }
+  if(alts.empty())
+    alts.emplace_back(QStringLiteral("-"), 0);
+  setAlternatives(std::move(alts));
 }
 
 void ComboBox::setAlternatives(std::vector<std::pair<QString, ossia::value>> values)

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -11,6 +11,7 @@
 
 #include <wobjectimpl.h>
 
+W_OBJECT_IMPL(Process::ComboBox)
 W_OBJECT_IMPL(Process::FileChooserBase)
 W_OBJECT_IMPL(Process::FileChooser)
 W_OBJECT_IMPL(Process::FolderChooser)
@@ -104,6 +105,30 @@ void ComboBox::setupExecution(ossia::inlet& inl, QObject* exec_context) const no
 {
   auto& port = **safe_cast<ossia::value_inlet*>(&inl);
   port.domain = domain().get();
+}
+
+void ComboBox::setAlternatives(std::vector<std::pair<QString, ossia::value>> values)
+{
+  if(values == alternatives)
+    return;
+  alternatives = std::move(values);
+
+  std::vector<ossia::value> vals;
+  for(auto& v : alternatives)
+    vals.push_back(v.second);
+  setDomain(State::Domain{ossia::make_domain(vals)});
+
+  // re-clamp the current value if the list shrank past it
+  if(!alternatives.empty())
+  {
+    const auto& cur = value();
+    auto it = ossia::find_if(
+        alternatives, [&](const auto& pair) { return pair.second == cur; });
+    if(it == alternatives.end())
+      setValue(alternatives.back().second);
+  }
+
+  alternativesChanged();
 }
 
 ComboBox::~ComboBox() { }

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -9,6 +9,7 @@
 
 #include <QCoreApplication>
 #include <QDir>
+#include <QFileSystemWatcher>
 
 #include <wobjectimpl.h>
 
@@ -123,6 +124,25 @@ void ComboBox::repopulateFromFolder(const QString& folderPath)
   if(alts.empty())
     alts.emplace_back(QStringLiteral("-"), std::string("-"));
   setAlternatives(std::move(alts));
+
+  // Watch the folder so files created while the document is open (e.g. by an
+  // upstream process writing its analysis) appear in the list right away.
+  if(folderPath != m_watchedFolder)
+  {
+    if(m_folderWatcher)
+    {
+      delete m_folderWatcher;
+      m_folderWatcher = nullptr;
+    }
+    m_watchedFolder = folderPath;
+    if(!folderPath.isEmpty() && QDir{folderPath}.exists())
+    {
+      m_folderWatcher = new QFileSystemWatcher{{folderPath}, this};
+      connect(
+          m_folderWatcher, &QFileSystemWatcher::directoryChanged, this,
+          [this](const QString& path) { repopulateFromFolder(path); });
+    }
+  }
 }
 
 void ComboBox::setAlternatives(std::vector<std::pair<QString, ossia::value>> values)
@@ -136,14 +156,20 @@ void ComboBox::setAlternatives(std::vector<std::pair<QString, ossia::value>> val
     vals.push_back(v.second);
   setDomain(State::Domain{ossia::make_domain(vals)});
 
-  // re-clamp the current value if the list shrank past it
+  // Keep the current value if it is still in the list; otherwise fall back to
+  // the init value when available. A value absent from the list is left
+  // untouched: for folder-backed comboboxes it may name a file that simply
+  // does not exist *yet* — it becomes selectable (and shows up as selected)
+  // once the file appears.
   if(!alternatives.empty())
   {
-    const auto& cur = value();
-    auto it = ossia::find_if(
-        alternatives, [&](const auto& pair) { return pair.second == cur; });
-    if(it == alternatives.end())
-      setValue(alternatives.back().second);
+    auto in_list = [this](const ossia::value& v) {
+      return ossia::find_if(
+                 alternatives, [&](const auto& pair) { return pair.second == v; })
+             != alternatives.end();
+    };
+    if(!in_list(value()) && in_list(init()))
+      setValue(init());
   }
 
   alternativesChanged();

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -117,12 +117,11 @@ void ComboBox::repopulateFromFolder(const QString& folderPath)
     const auto files = fileExtensions.isEmpty()
                            ? dir.entryList(QDir::Files, QDir::Name)
                            : dir.entryList(fileExtensions, QDir::Files, QDir::Name);
-    int i = 0;
     for(const auto& f : files)
-      alts.emplace_back(f, i++);
+      alts.emplace_back(f, f.toStdString()); // value = the file name itself
   }
   if(alts.empty())
-    alts.emplace_back(QStringLiteral("-"), 0);
+    alts.emplace_back(QStringLiteral("-"), std::string("-"));
   setAlternatives(std::move(alts));
 }
 

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -1372,13 +1372,13 @@ SCORE_LIB_PROCESS_EXPORT void
 DataStreamReader::read(const Process::ComboBox& p)
 {
   read((const Process::ControlInlet&)p);
-  m_stream << p.alternatives;
+  m_stream << p.alternatives << p.folderPortName << p.fileExtensions;
 }
 template <>
 SCORE_LIB_PROCESS_EXPORT void
 DataStreamWriter::write(Process::ComboBox& p)
 {
-  m_stream >> p.alternatives;
+  m_stream >> p.alternatives >> p.folderPortName >> p.fileExtensions;
 }
 template <>
 SCORE_LIB_PROCESS_EXPORT void
@@ -1386,11 +1386,27 @@ JSONReader::read(const Process::ComboBox& p)
 {
   read((const Process::ControlInlet&)p);
   obj["Values"] = p.alternatives;
+  // Folder-backed combobox metadata (empty for a plain combobox). Persisted so
+  // a loaded document can re-scan the folder and re-establish live refresh;
+  // see ProcessModel::init_folder_comboboxes. Extensions are stored as one
+  // space-joined string ("*.json *.wav"), like FileChooser's filters.
+  obj["FolderPort"] = p.folderPortName;
+  obj["FileExtensions"] = p.fileExtensions.join(QChar(' '));
 }
 template <>
 SCORE_LIB_PROCESS_EXPORT void JSONWriter::write(Process::ComboBox& p)
 {
   p.alternatives <<= obj["Values"];
+  // Guarded for documents saved before these fields existed.
+  if(obj.tryGet("FolderPort"))
+    p.folderPortName <<= obj["FolderPort"];
+  if(obj.tryGet("FileExtensions"))
+  {
+    QString exts;
+    exts <<= obj["FileExtensions"];
+    p.fileExtensions
+        = exts.isEmpty() ? QStringList{} : exts.split(QChar(' '), Qt::SkipEmptyParts);
+  }
 }
 template <>
 SCORE_LIB_PROCESS_EXPORT void

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
@@ -5,6 +5,8 @@
 
 #include <ossia/network/domain/domain.hpp>
 
+class QFileSystemWatcher;
+
 namespace Process
 {
 struct FloatSlider;
@@ -456,10 +458,19 @@ public:
 
   // Folder-backed combobox (halp::folder_combobox): items are the files of the
   // sibling port named folderPortName, filtered by fileExtensions ("*.wav"…).
-  // Empty folderPortName = plain combobox. Populated at edit/load time.
+  // Empty folderPortName = plain combobox. Populated at edit/load time, and
+  // refreshed by a filesystem watcher while the document is open so that files
+  // written by other processes (an upstream analysis, a recorder…) show up
+  // without reloading.
   QString folderPortName;
   QStringList fileExtensions;
   void repopulateFromFolder(const QString& folderPath);
+
+private:
+  QFileSystemWatcher* m_folderWatcher{};
+  QString m_watchedFolder;
+
+public:
 
   const auto& getValues() const noexcept { return alternatives; }
   auto count() const noexcept { return alternatives.size(); }

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
@@ -454,6 +454,13 @@ public:
   void setAlternatives(std::vector<std::pair<QString, ossia::value>> values);
   void alternativesChanged() W_SIGNAL(alternativesChanged);
 
+  // Folder-backed combobox (halp::folder_combobox): items are the files of the
+  // sibling port named folderPortName, filtered by fileExtensions ("*.wav"…).
+  // Empty folderPortName = plain combobox. Populated at edit/load time.
+  QString folderPortName;
+  QStringList fileExtensions;
+  void repopulateFromFolder(const QString& folderPath);
+
   const auto& getValues() const noexcept { return alternatives; }
   auto count() const noexcept { return alternatives.size(); }
 

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
@@ -442,12 +442,17 @@ struct SCORE_LIB_PROCESS_EXPORT ProgramEdit : public Process::ControlInlet
 
 struct SCORE_LIB_PROCESS_EXPORT ComboBox : public Process::ControlInlet
 {
+  W_OBJECT(ComboBox)
+public:
   MODEL_METADATA_IMPL(ComboBox)
   std::vector<std::pair<QString, ossia::value>> alternatives;
   ComboBox(
       std::vector<std::pair<QString, ossia::value>> values, ossia::value init,
       const QString& name, Id<Process::Port> id, QObject* parent);
   ~ComboBox();
+
+  void setAlternatives(std::vector<std::pair<QString, ossia::value>> values);
+  void alternativesChanged() W_SIGNAL(alternativesChanged);
 
   const auto& getValues() const noexcept { return alternatives; }
   auto count() const noexcept { return alternatives.size(); }

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
@@ -454,7 +454,11 @@ public:
   ~ComboBox();
 
   void setAlternatives(std::vector<std::pair<QString, ossia::value>> values);
-  void alternativesChanged() W_SIGNAL(alternativesChanged);
+  // E_SIGNAL, not W_SIGNAL: the widgets and the avnd executor connect to this
+  // from other plug-ins, and a non-exported signal silently never fires across
+  // a shared-library boundary.
+  void alternativesChanged()
+      E_SIGNAL(SCORE_LIB_PROCESS_EXPORT, alternativesChanged)
 
   // Folder-backed combobox (halp::folder_combobox): items are the files of the
   // sibling port named folderPortName, filtered by fileExtensions ("*.wav"…).

--- a/src/plugins/score-plugin-avnd/Crousti/Concepts.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Concepts.hpp
@@ -410,6 +410,34 @@ make_control_in(avnd::field_index<N>, Id<Process::Port>&& id, QObject* parent)
             "", qname, id, parent};
     }
   }
+  else if constexpr(avnd::folder_items_parameter<T>)
+  {
+    // Folder-backed, string-valued combobox: the value IS the selected file
+    // name, so an object uses it directly like a file-name string. Items are
+    // filled from the sibling folder port at edit time by the model.
+    static constexpr auto c = avnd::get_range<T>();
+    const std::string initv{c.init};
+    std::vector<std::pair<QString, ossia::value>> initAlts;
+    initAlts.emplace_back(QString::fromStdString(initv), initv);
+    auto combo = new Process::ComboBox{
+        std::move(initAlts), ossia::value{initv}, qname, id, parent};
+    combo->folderPortName
+        = QString::fromUtf8(T::folder_port().data(), T::folder_port().size());
+    // extensions(): space-separated suffixes ("wav aif json") -> "*.wav" ...
+    const std::string_view ex = T::extensions();
+    std::size_t pos = 0;
+    while(pos < ex.size())
+    {
+      auto sp = ex.find(' ', pos);
+      if(sp == std::string_view::npos)
+        sp = ex.size();
+      if(sp > pos)
+        combo->fileExtensions.push_back(
+            "*." + QString::fromUtf8(ex.data() + pos, int(sp - pos)));
+      pos = sp + 1;
+    }
+    return combo;
+  }
   else if constexpr(widg.widget == avnd::widget_type::combobox)
   {
     static constexpr auto c = avnd::get_range<T>();
@@ -419,27 +447,8 @@ make_control_in(avnd::field_index<N>, Id<Process::Port>&& id, QObject* parent)
       init = static_cast<int>(c.init);
     else
       init = c.init;
-    auto combo = new Process::ComboBox{
+    return new Process::ComboBox{
         to_combobox_range(c.values), std::move(init), qname, id, parent};
-    if constexpr(avnd::folder_items_parameter<T>)
-    {
-      combo->folderPortName
-          = QString::fromUtf8(T::folder_port().data(), T::folder_port().size());
-      // extensions(): space-separated suffixes ("wav aif json") -> "*.wav" ...
-      const std::string_view ex = T::extensions();
-      std::size_t pos = 0;
-      while(pos < ex.size())
-      {
-        auto sp = ex.find(' ', pos);
-        if(sp == std::string_view::npos)
-          sp = ex.size();
-        if(sp > pos)
-          combo->fileExtensions.push_back(
-              "*." + QString::fromUtf8(ex.data() + pos, int(sp - pos)));
-        pos = sp + 1;
-      }
-    }
-    return combo;
   }
   else if constexpr(widg.widget == avnd::widget_type::choices)
   {

--- a/src/plugins/score-plugin-avnd/Crousti/Concepts.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Concepts.hpp
@@ -23,6 +23,7 @@
 #include <avnd/concepts/audio_port.hpp>
 #include <avnd/concepts/channels.hpp>
 #include <avnd/concepts/curve.hpp>
+#include <avnd/concepts/folder_items.hpp>
 #include <avnd/concepts/gfx.hpp>
 #include <avnd/concepts/midi_port.hpp>
 #include <avnd/concepts/parameter.hpp>
@@ -418,8 +419,27 @@ make_control_in(avnd::field_index<N>, Id<Process::Port>&& id, QObject* parent)
       init = static_cast<int>(c.init);
     else
       init = c.init;
-    return new Process::ComboBox{
+    auto combo = new Process::ComboBox{
         to_combobox_range(c.values), std::move(init), qname, id, parent};
+    if constexpr(avnd::folder_items_parameter<T>)
+    {
+      combo->folderPortName
+          = QString::fromUtf8(T::folder_port().data(), T::folder_port().size());
+      // extensions(): space-separated suffixes ("wav aif json") -> "*.wav" ...
+      const std::string_view ex = T::extensions();
+      std::size_t pos = 0;
+      while(pos < ex.size())
+      {
+        auto sp = ex.find(' ', pos);
+        if(sp == std::string_view::npos)
+          sp = ex.size();
+        if(sp > pos)
+          combo->fileExtensions.push_back(
+              "*." + QString::fromUtf8(ex.data() + pos, int(sp - pos)));
+        pos = sp + 1;
+      }
+    }
+    return combo;
   }
   else if constexpr(widg.widget == avnd::widget_type::choices)
   {

--- a/src/plugins/score-plugin-avnd/Crousti/Concepts.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Concepts.hpp
@@ -432,8 +432,15 @@ make_control_in(avnd::field_index<N>, Id<Process::Port>&& id, QObject* parent)
       if(sp == std::string_view::npos)
         sp = ex.size();
       if(sp > pos)
-        combo->fileExtensions.push_back(
-            "*." + QString::fromUtf8(ex.data() + pos, int(sp - pos)));
+      {
+        auto suffix = QString::fromUtf8(ex.data() + pos, int(sp - pos));
+        // Both "wav" and ".wav" are natural to write; normalise so neither
+        // turns into the glob "*..wav", which matches nothing.
+        while(suffix.startsWith('.'))
+          suffix.remove(0, 1);
+        if(!suffix.isEmpty())
+          combo->fileExtensions.push_back("*." + suffix);
+      }
       pos = sp + 1;
     }
     return combo;

--- a/src/plugins/score-plugin-avnd/Crousti/Executor.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Executor.hpp
@@ -50,9 +50,12 @@
 #include <avnd/binding/ossia/ossia_audio_node.hpp>
 #include <avnd/binding/ossia/ossia_dynamic_audio_node.hpp>
 #include <avnd/binding/ossia/poly_audio_node.hpp>
+#include <avnd/concepts/dynamic_items.hpp>
 #include <avnd/concepts/temporality.hpp>
 #include <avnd/concepts/ui.hpp>
 #include <avnd/concepts/worker.hpp>
+
+#include <QPointer>
 
 namespace oscr
 {
@@ -177,7 +180,10 @@ public:
 
     if constexpr(requires { ptr->impl.effect; })
       if constexpr(std::is_same_v<std::decay_t<decltype(ptr->impl.effect)>, Node>)
+      {
         connect_message_bus(element, ctx, ptr->impl.effect);
+        connect_dynamic_items(element, ptr->impl.effect);
+      }
     connect_worker(ctx, ptr->impl);
 
     node->dynamic_ports = element.dynamic_ports;
@@ -681,6 +687,44 @@ public:
         }
       });
     };
+  }
+
+  void connect_dynamic_items(ProcessModel<Node>& element, Node& eff)
+  {
+    // type-only inputs: get_inputs would hard-error
+    if constexpr(
+        avnd::inputs_is_type<Node>
+        || avnd::control_input_introspection<Node>::size == 0)
+      return;
+    else
+    avnd::control_input_introspection<Node>::for_all_n2(
+        avnd::get_inputs<Node>(eff),
+        [&element]<std::size_t Idx, typename F>(
+            F& field, auto pred_index, avnd::field_index<Idx>) {
+      if constexpr(avnd::dynamic_items_parameter<F>)
+      {
+        auto ports = element.avnd_input_idx_to_model_ports(Idx);
+        if(ports.size() != 1)
+          return;
+        if(auto combo = qobject_cast<Process::ComboBox*>(ports[0]))
+        {
+          field.update_items = [p = QPointer<Process::ComboBox>{combo}](
+                                   std::vector<std::string> items) {
+            std::vector<std::pair<QString, ossia::value>> alts;
+            alts.reserve(items.size());
+            for(std::size_t i = 0; i < items.size(); i++)
+              alts.emplace_back(QString::fromStdString(items[i]), (int)i);
+            QMetaObject::invokeMethod(
+                qApp,
+                [p, alts = std::move(alts)]() mutable {
+              if(p)
+                p->setAlternatives(std::move(alts));
+            },
+                Qt::QueuedConnection);
+          };
+        }
+      }
+    });
   }
 
   void connect_message_bus(

--- a/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
@@ -9,12 +9,15 @@
 #include <Crousti/Painter.hpp>
 #include <Crousti/ProcessModel.hpp>
 
+#include <Process/Dataflow/WidgetInlets.hpp>
+
 #include <score/command/Dispatchers/CommandDispatcher.hpp>
 #include <score/graphics/layouts/GraphicsBoxLayout.hpp>
 #include <score/graphics/layouts/GraphicsGridLayout.hpp>
 #include <score/graphics/layouts/GraphicsSplitLayout.hpp>
 #include <score/graphics/layouts/GraphicsTabLayout.hpp>
 #include <score/graphics/widgets/QGraphicsLineEdit.hpp>
+#include <score/tools/File.hpp>
 
 #include <avnd/common/aggregates.hpp>
 #include <avnd/concepts/layout.hpp>
@@ -143,6 +146,22 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       const Process::ControlLayout& lay, Item& item)
       = delete; // TODO
 
+  // File paths are stored in the document as templates (<PROJECT>:...,
+  // <LIBRARY>:..., or document-relative); resolve them so the ui items
+  // always receive a usable absolute path, like the score-side file
+  // widgets do.
+  static ossia::value resolveFilePath(
+      const ossia::value& v, Process::ControlInlet* inl,
+      const score::DocumentContext& ctx) noexcept
+  {
+    if(qobject_cast<Process::FileChooserBase*>(inl)
+       || qobject_cast<Process::FolderChooser*>(inl))
+      if(auto str = v.target<std::string>(); str && !str->empty())
+        return score::locateFilePath(QString::fromStdString(*str), ctx)
+            .toStdString();
+    return v;
+  }
+
   template <typename Item>
   void setupControl(
       QGraphicsItem* parent, Process::ControlInlet* inl,
@@ -152,14 +171,16 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
     {
       using avnd_port_type = pmf_member_type_t<decltype(item.model)>;
       avnd_port_type p;
-      oscr::from_ossia_value(p, inl->value(), item.value);
+      oscr::from_ossia_value(p, resolveFilePath(inl->value(), inl, doc), item.value);
       if constexpr(requires { rootUi->on_control_update(); })
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [rui = rootUi, layout = this->layout, &item](const ossia::value& v) {
+            [rui = rootUi, layout = this->layout, &item, inl,
+             &ctx = static_cast<const score::DocumentContext&>(this->doc)](
+                const ossia::value& v) {
           avnd_port_type p;
-          oscr::from_ossia_value(p, v, item.value);
+          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
 
           rui->on_control_update();
           layout->update();
@@ -169,9 +190,11 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [layout = this->layout, &item](const ossia::value& v) {
+            [layout = this->layout, &item, inl,
+             &ctx = static_cast<const score::DocumentContext&>(this->doc)](
+                const ossia::value& v) {
           avnd_port_type p;
-          oscr::from_ossia_value(p, v, item.value);
+          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
           layout->update();
         });
       }

--- a/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
@@ -9,8 +9,6 @@
 #include <Crousti/Painter.hpp>
 #include <Crousti/ProcessModel.hpp>
 
-#include <Process/Dataflow/WidgetInlets.hpp>
-
 #include <score/command/Dispatchers/CommandDispatcher.hpp>
 #include <score/graphics/layouts/GraphicsBoxLayout.hpp>
 #include <score/graphics/layouts/GraphicsGridLayout.hpp>
@@ -20,7 +18,10 @@
 #include <score/tools/File.hpp>
 
 #include <avnd/common/aggregates.hpp>
+#include <avnd/concepts/file_port.hpp>
 #include <avnd/concepts/layout.hpp>
+#include <avnd/concepts/midifile.hpp>
+#include <avnd/concepts/soundfile.hpp>
 
 namespace oscr
 {
@@ -130,6 +131,41 @@ struct pmf_member_type<V T::*>
 template <typename T>
 using pmf_member_type_t = typename pmf_member_type<T>::type;
 
+template <typename T>
+struct SetGUIValue
+{
+  const score::DocumentContext& ctx;
+  void operator()(const ossia::value& v, auto& dst) const
+  {
+    T p;
+    oscr::from_ossia_value(p, v, dst);
+  }
+};
+
+// File & folder ports: paths are stored in the document as templates
+// (<PROJECT>:..., <LIBRARY>:..., or document-relative); resolve them so the
+// ui items always receive a usable absolute path.
+template <typename T>
+  requires(
+      avnd::soundfile_port<T> || avnd::midifile_port<T> || avnd::file_port<T>
+      || requires { T::widget::folder; })
+struct SetGUIValue<T>
+{
+  const score::DocumentContext& ctx;
+  void operator()(const ossia::value& v, auto& dst) const
+  {
+    T p;
+    if(auto str = v.target<std::string>(); str && !str->empty())
+      oscr::from_ossia_value(
+          p,
+          ossia::value{
+              score::locateFilePath(QString::fromStdString(*str), ctx).toStdString()},
+          dst);
+    else
+      oscr::from_ossia_value(p, v, dst);
+  }
+};
+
 template <typename Info>
 struct LayoutBuilder final : Process::LayoutBuilderBase
 {
@@ -146,22 +182,6 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       const Process::ControlLayout& lay, Item& item)
       = delete; // TODO
 
-  // File paths are stored in the document as templates (<PROJECT>:...,
-  // <LIBRARY>:..., or document-relative); resolve them so the ui items
-  // always receive a usable absolute path, like the score-side file
-  // widgets do.
-  static ossia::value resolveFilePath(
-      const ossia::value& v, Process::ControlInlet* inl,
-      const score::DocumentContext& ctx) noexcept
-  {
-    if(qobject_cast<Process::FileChooserBase*>(inl)
-       || qobject_cast<Process::FolderChooser*>(inl))
-      if(auto str = v.target<std::string>(); str && !str->empty())
-        return score::locateFilePath(QString::fromStdString(*str), ctx)
-            .toStdString();
-    return v;
-  }
-
   template <typename Item>
   void setupControl(
       QGraphicsItem* parent, Process::ControlInlet* inl,
@@ -170,17 +190,15 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
     if constexpr(requires { sizeof(Item::value); })
     {
       using avnd_port_type = pmf_member_type_t<decltype(item.model)>;
-      avnd_port_type p;
-      oscr::from_ossia_value(p, resolveFilePath(inl->value(), inl, doc), item.value);
+      SetGUIValue<avnd_port_type>{doc}(inl->value(), item.value);
       if constexpr(requires { rootUi->on_control_update(); })
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [rui = rootUi, layout = this->layout, &item, inl,
+            [rui = rootUi, layout = this->layout, &item,
              &ctx = static_cast<const score::DocumentContext&>(this->doc)](
                 const ossia::value& v) {
-          avnd_port_type p;
-          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
+          SetGUIValue<avnd_port_type>{ctx}(v, item.value);
 
           rui->on_control_update();
           layout->update();
@@ -190,11 +208,10 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
       {
         QObject::connect(
             inl, &Process::ControlInlet::valueChanged, &context,
-            [layout = this->layout, &item, inl,
+            [layout = this->layout, &item,
              &ctx = static_cast<const score::DocumentContext&>(this->doc)](
                 const ossia::value& v) {
-          avnd_port_type p;
-          oscr::from_ossia_value(p, resolveFilePath(v, inl, ctx), item.value);
+          SetGUIValue<avnd_port_type>{ctx}(v, item.value);
           layout->update();
         });
       }

--- a/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/Layer.hpp
@@ -166,6 +166,32 @@ struct SetGUIValue<T>
   }
 };
 
+// The inverse of SetGUIValue: an item hands back the absolute path it was
+// given, and the document must keep storing a template, or the project stops
+// being relocatable. Non-file ports pass through untouched.
+template <typename T>
+struct GetGUIValue
+{
+  const score::DocumentContext& ctx;
+  ossia::value operator()(ossia::value v) const { return v; }
+};
+
+template <typename T>
+  requires(
+      avnd::soundfile_port<T> || avnd::midifile_port<T> || avnd::file_port<T>
+      || requires { T::widget::folder; })
+struct GetGUIValue<T>
+{
+  const score::DocumentContext& ctx;
+  ossia::value operator()(ossia::value v) const
+  {
+    if(auto str = v.target<std::string>(); str && !str->empty())
+      return ossia::value{
+          score::relativizeFilePath(QString::fromStdString(*str), ctx).toStdString()};
+    return v;
+  }
+};
+
 template <typename Info>
 struct LayoutBuilder final : Process::LayoutBuilderBase
 {
@@ -218,7 +244,10 @@ struct LayoutBuilder final : Process::LayoutBuilderBase
 
       if constexpr(requires { item.set = {}; })
       {
-        item.set = [inl](const auto& val) { inl->setValue(oscr::to_ossia_value(val)); };
+        item.set = [inl, &ctx = static_cast<const score::DocumentContext&>(this->doc)](
+                       const auto& val) {
+          inl->setValue(GetGUIValue<avnd_port_type>{ctx}(oscr::to_ossia_value(val)));
+        };
       }
     }
 

--- a/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
@@ -20,6 +20,7 @@
 #include <ossia/detail/type_if.hpp>
 #include <ossia/detail/typelist.hpp>
 
+#include <QFileInfo>
 #include <QTimer>
 
 #include <avnd/binding/ossia/data_node.hpp>
@@ -205,7 +206,14 @@ private:
         if(!p)
           return {};
         if(auto s = p->value().target<std::string>())
-          return QString::fromStdString(*s);
+        {
+          // The sibling port may name a folder, or a file (e.g. a sound-file
+          // port): in the latter case list the file's containing folder.
+          auto path = QString::fromStdString(*s);
+          if(QFileInfo fi{path}; fi.isFile())
+            return fi.absolutePath();
+          return path;
+        }
         return {};
       };
 

--- a/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
@@ -172,7 +172,52 @@ private:
   }
 
   void init_before_port_creation() { init_dynamic_ports(); }
-  void init_after_port_creation() { init_controller_ports(); }
+  void init_after_port_creation()
+  {
+    init_controller_ports();
+    init_folder_comboboxes();
+  }
+
+  // Folder-backed comboboxes (halp::folder_combobox): each carries the name of
+  // a sibling folder port; list that folder's files as the combobox items, at
+  // edit/load time, and refresh whenever the folder value changes. Runs after
+  // deserialization, so a loaded document's folder value is already in place.
+  void init_folder_comboboxes()
+  {
+    for(auto* inl : m_inlets)
+    {
+      auto combo = qobject_cast<Process::ComboBox*>(inl);
+      if(!combo || combo->folderPortName.isEmpty())
+        continue;
+
+      Process::ControlInlet* folderPort = nullptr;
+      for(auto* other : m_inlets)
+      {
+        auto ci = qobject_cast<Process::ControlInlet*>(other);
+        if(ci && ci != combo && ci->name() == combo->folderPortName)
+        {
+          folderPort = ci;
+          break;
+        }
+      }
+
+      auto pathOf = [](Process::ControlInlet* p) -> QString {
+        if(!p)
+          return {};
+        if(auto s = p->value().target<std::string>())
+          return QString::fromStdString(*s);
+        return {};
+      };
+
+      combo->repopulateFromFolder(pathOf(folderPort));
+      if(folderPort)
+        QObject::connect(
+            folderPort, &Process::ControlInlet::valueChanged, combo,
+            [combo, folderPort, pathOf](const ossia::value&) {
+          combo->repopulateFromFolder(pathOf(folderPort));
+        });
+    }
+  }
   void check_all_ports()
   {
     if(std::ssize(m_inlets) != expected_input_ports()

--- a/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
+++ b/src/plugins/score-plugin-avnd/Crousti/ProcessModel.hpp
@@ -20,6 +20,8 @@
 #include <ossia/detail/type_if.hpp>
 #include <ossia/detail/typelist.hpp>
 
+#include <score/tools/File.hpp>
+
 #include <QFileInfo>
 #include <QTimer>
 
@@ -202,14 +204,27 @@ private:
         }
       }
 
-      auto pathOf = [](Process::ControlInlet* p) -> QString {
+      auto pathOf = [this](Process::ControlInlet* p) -> QString {
         if(!p)
           return {};
         if(auto s = p->value().target<std::string>())
         {
+          // Stored paths are templates (<PROJECT>:..., <LIBRARY>:..., or
+          // document-relative); resolve before touching the filesystem, or a
+          // project-relative folder lists nothing.
+          auto path = QString::fromStdString(*s);
+          if(path.isEmpty())
+            return {};
+          // Walk up rather than score::IDocument::documentFromObject, which
+          // throws when there is no document -- ports are built before the
+          // process is attached to one.
+          score::Document* doc{};
+          for(QObject* o = this->parent(); o && !doc; o = o->parent())
+            doc = qobject_cast<score::Document*>(o);
+          if(doc)
+            path = score::locateFilePath(path, doc->context());
           // The sibling port may name a folder, or a file (e.g. a sound-file
           // port): in the latter case list the file's containing folder.
-          auto path = QString::fromStdString(*s);
           if(QFileInfo fi{path}; fi.isFile())
             return fi.absolutePath();
           return path;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -181,6 +181,13 @@ score_add_test(test_unit_port_visibility
   SOURCES PortVisibilityTest.cpp
   PLUGINS score_lib_process score_lib_state score_lib_device)
 
+# Runtime-populated combobox items: what happens to the selection when the list
+# changes under it, folder listing, and loading documents written before it.
+score_add_test(test_unit_combobox_alternatives
+  SOURCES ComboBoxAlternativesTest.cpp
+  APP
+  PLUGINS score_lib_process score_lib_state score_lib_device)
+
 score_add_test(test_unit_curve_sample
   SOURCES CurveSampleTest.cpp
   PLUGINS score_plugin_curve)

--- a/tests/unit/ComboBoxAlternativesTest.cpp
+++ b/tests/unit/ComboBoxAlternativesTest.cpp
@@ -1,0 +1,198 @@
+// Unit test: Process::ComboBox's runtime-populated item list.
+//
+// A combobox port's items used to be fixed once, at construction. They can now
+// be replaced at run time -- by an avnd object calling update_items, or by
+// listing a sibling folder port. That makes three things worth pinning:
+//  * what happens to the selected value when the list changes under it,
+//  * that a folder listing filters, sorts and degrades predictably,
+//  * that a document written before any of this existed still loads.
+
+#include <score_test/App.hpp>
+
+#include <Process/Dataflow/WidgetInlets.hpp>
+
+#include <score/serialization/DataStreamVisitor.hpp>
+#include <score/serialization/JSONVisitor.hpp>
+#include <score/serialization/VisitorCommon.hpp>
+
+#include <QDir>
+#include <QFile>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+using Alts = std::vector<std::pair<QString, ossia::value>>;
+
+Alts alts(std::initializer_list<const char*> names)
+{
+  Alts a;
+  for(auto* n : names)
+    a.emplace_back(QString::fromUtf8(n), std::string(n));
+  return a;
+}
+
+Process::ComboBox make_combo(QObject& parent, Alts a, const char* init)
+{
+  return Process::ComboBox{
+      std::move(a), ossia::value{std::string(init)}, "combo", Id<Process::Port>{0},
+      &parent};
+}
+
+void touch(const QString& dir, const char* name)
+{
+  QFile f{dir + "/" + QString::fromUtf8(name)};
+  REQUIRE(f.open(QIODevice::WriteOnly));
+  f.write("x");
+}
+}
+
+TEST_CASE("Replacing the items keeps a selection that is still there", "[combobox]")
+{
+  QObject parent;
+  auto combo = make_combo(parent, alts({"a", "b", "c"}), "a");
+  combo.setValue(ossia::value{std::string("b")});
+
+  int changed = 0;
+  QObject::connect(
+      &combo, &Process::ComboBox::alternativesChanged, &parent, [&] { changed++; });
+
+  combo.setAlternatives(alts({"b", "c", "d"}));
+  CHECK(changed == 1);
+  CHECK(combo.value() == ossia::value{std::string("b")});
+  CHECK(combo.count() == 3);
+}
+
+TEST_CASE("A selection that disappears falls back to the init value", "[combobox]")
+{
+  QObject parent;
+  auto combo = make_combo(parent, alts({"a", "b", "c"}), "a");
+  combo.setValue(ossia::value{std::string("c")});
+
+  combo.setAlternatives(alts({"a", "b"}));
+  CHECK(combo.value() == ossia::value{std::string("a")});
+}
+
+// Folder-backed comboboxes name a file that an upstream process may not have
+// written yet: such a selection must survive a refresh rather than snap away.
+TEST_CASE("A selection absent from the list and from init is left alone", "[combobox]")
+{
+  QObject parent;
+  auto combo = make_combo(parent, alts({"a", "b"}), "zzz");
+  combo.setValue(ossia::value{std::string("not-yet.wav")});
+
+  combo.setAlternatives(alts({"a", "b"}));
+  CHECK(combo.value() == ossia::value{std::string("not-yet.wav")});
+}
+
+TEST_CASE("Setting the same items again changes nothing and is silent", "[combobox]")
+{
+  QObject parent;
+  auto combo = make_combo(parent, alts({"a", "b"}), "a");
+
+  int changed = 0;
+  QObject::connect(
+      &combo, &Process::ComboBox::alternativesChanged, &parent, [&] { changed++; });
+
+  combo.setAlternatives(alts({"a", "b"}));
+  CHECK(changed == 0);
+}
+
+TEST_CASE("A folder listing is filtered, sorted, and never empty", "[combobox][folder]")
+{
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+  touch(dir.path(), "b.wav");
+  touch(dir.path(), "a.wav");
+  touch(dir.path(), "notes.txt");
+
+  QObject parent;
+  auto combo = make_combo(parent, alts({"-"}), "-");
+
+  SECTION("no filter lists everything, sorted by name")
+  {
+    combo.repopulateFromFolder(dir.path());
+    REQUIRE(combo.count() == 3);
+    CHECK(combo.getValues()[0].first == "a.wav");
+    CHECK(combo.getValues()[1].first == "b.wav");
+    CHECK(combo.getValues()[2].first == "notes.txt");
+  }
+
+  SECTION("an extension filter keeps only what matches")
+  {
+    combo.fileExtensions = QStringList{"*.wav"};
+    combo.repopulateFromFolder(dir.path());
+    REQUIRE(combo.count() == 2);
+    CHECK(combo.getValues()[0].first == "a.wav");
+    CHECK(combo.getValues()[1].first == "b.wav");
+  }
+
+  SECTION("the value of an item is the bare file name")
+  {
+    combo.repopulateFromFolder(dir.path());
+    CHECK(combo.getValues()[0].second == ossia::value{std::string("a.wav")});
+  }
+
+  SECTION("an empty or missing folder degrades to a single placeholder")
+  {
+    QTemporaryDir empty;
+    combo.repopulateFromFolder(empty.path());
+    REQUIRE(combo.count() == 1);
+    CHECK(combo.getValues()[0].first == "-");
+
+    combo.repopulateFromFolder("/does/not/exist");
+    REQUIRE(combo.count() == 1);
+    CHECK(combo.getValues()[0].first == "-");
+
+    combo.repopulateFromFolder({});
+    REQUIRE(combo.count() == 1);
+  }
+}
+
+TEST_CASE("Folder-combobox metadata survives a JSON round-trip", "[combobox][serialization]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QObject parent;
+    auto combo = make_combo(parent, alts({"a.wav"}), "a.wav");
+    combo.folderPortName = "Folder";
+    combo.fileExtensions = QStringList{"*.wav", "*.aif"};
+
+    JSONReader r;
+    r.readFrom(combo);
+    const rapidjson::Document doc = toValue(r);
+    JSONObject::Deserializer des{doc};
+    Process::ComboBox reloaded{des, &parent};
+
+    CHECK(reloaded.folderPortName == "Folder");
+    CHECK(reloaded.fileExtensions == QStringList{"*.wav", "*.aif"});
+    CHECK(reloaded.count() == 1);
+  });
+}
+
+// A .score written before folder-comboboxes existed has no FolderPort key.
+TEST_CASE("A JSON document without the new keys still loads", "[combobox][serialization]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QObject parent;
+    auto combo = make_combo(parent, alts({"a", "b"}), "a");
+
+    JSONReader r;
+    r.readFrom(combo);
+    rapidjson::Document doc = toValue(r);
+    doc.RemoveMember("FolderPort");
+    doc.RemoveMember("FileExtensions");
+
+    JSONObject::Deserializer des{doc};
+    Process::ComboBox reloaded{des, &parent};
+    CHECK(reloaded.folderPortName.isEmpty());
+    CHECK(reloaded.fileExtensions.isEmpty());
+    CHECK(reloaded.count() == 2);
+  });
+}
+
+// Note: the binary (.scorebin) path is deliberately not covered here. A port
+// cannot be marshalled standalone through DataStream in this harness -- a plain
+// ControlInlet round-trip aborts in checkDelimiter() on unmodified code too,
+// because ports are written through the port factory's own framing. Covering it
+// needs a document-level fixture.


### PR DESCRIPTION
Supersedes #2110 and #2114, which come from a fork and so could not take the
review fixes directly. Their commits are here unchanged, with authorship
intact; the four commits on top are the result of reviewing them, and the
avendish bump they depend on is first.

Depends on celtera/avendish#204 (merged), which supersedes celtera/avendish#171.

## What the review found

**The dynamic-combobox feature did not work at all.** `alternativesChanged` was
declared with `W_SIGNAL`, which emits nothing for connections made from another
shared library — and every consumer is in one: the inspector and canvas
comboboxes live in `score_lib_process`'s headers, the executor in
`score_plugin_avnd`. The item list would be replaced and nothing would redraw.
Every other signal on these ports already uses `E_SIGNAL` for exactly this
reason. The first new test catches it.

**Folder-backed comboboxes listed nothing in ordinary documents.** The sibling
folder port's value is a stored template (`<PROJECT>:…`, `<LIBRARY>:…`, or
document-relative) and was handed to `QDir` raw. Resolved now — via a walk up
the parent chain rather than `IDocument::documentFromObject`, which throws when
a process is not attached to a document yet.

**`#2114` resolved paths one way only.** `item.set` writes straight back to the
inlet, so a custom widget echoing the absolute path it was just given would
store that path in the document and the project would stop being relocatable.
score's own file widgets have always paired `locateFilePath` with
`relativizeFilePath`; the other half is restored.

**Extensions written as `".wav"` matched nothing**, becoming the glob `"*..wav"`.
Both spellings are accepted now.

**One commit from #2110 is not included.** `QGraphicsCombo: open a popup menu on
click` replaces drag-selection with `QMenu::exec()` — a nested event loop inside
`mousePressEvent` on a graphics item, which has no precedent in this codebase,
and which the `QEvent::UngrabMouse` handling in the sliders/knobs/choosers
exists precisely to avoid. It also silently neuters
`TEST_CASE("degenerate combo boxes survive being dragged")`, the regression test
for a divide-by-zero on single-entry combos. It is unrelated to the feature and
the remaining seven commits rebase cleanly without it, so it is left out; worth
its own PR if the popup behaviour is wanted.

## On the DataStream change

`ComboBox`'s DataStream layout gains two fields (`folderPortName`,
`fileExtensions`). I originally flagged this as a backwards-compatibility
hazard for `.scorebin`; that was wrong. The binary format is only used to
serialize in and out of a live score instance, so reader and writer are always
the same build and there is no older stream to desynchronise. No version guard
is needed. The JSON path is guarded with `tryGet` regardless.

## Tests

`tests/unit/ComboBoxAlternativesTest.cpp` (7 cases, 41 assertions): the selected
value survives the list being replaced under it, falls back to init when it
disappears, and is left alone when it names a file an upstream process has not
written yet; folder listings are filtered, sorted, and degrade to a placeholder;
JSON round-trips preserve the new metadata and documents without it still load.

celtera/avendish#204 added the matching compile-time tests on the avendish side.

## Verification

Built clean and run against master: **145/150**. The five failures
(`analysis_gist`, `beat_tracker`, `media_trim`, `unused_files`,
`explorer_editor_look`) reproduce identically on an unmodified `origin/master`
build and are pre-existing. `test_unit_graphics_combo` still passes, which it
would not with the popup commit included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oUFSPD1bswcWtvrsq25t3
