### PR TITLE
ci: build score-addon-videoio

### DIFF
--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -172,6 +172,7 @@ then
   clone_addon     https://github.com/ossia/score-addon-spatgris
   clone_addon    https://github.com/ossia/score-addon-ultraleap
   clone_addon      https://github.com/ossia/score-addon-sysinfo
+  clone_addon https://github.com/ossia/score-addon-videoio
   clone_addon https://github.com/sat-mtl/carto-tcp-avendish.git update-avendish-packaging
   NO_SUBMODULES=1 clone_addon https://github.com/ossia/score-addon-orbbec
 fi


### PR DESCRIPTION
Adds `score-addon-videoio` to the addons CI clones.

Capture and playout for SDI and USB devices — V4L2, AJA, DeckLink, DELTACAST,
Bluefish444, Magewell and NVIDIA Argus. Every backend sits behind a check for
its SDK, so a machine without one just builds without that backend rather than
failing.

### The AJA SDK and unity builds

The addon vendors `libajantv2`, which is not unity-safe: `ntv2anc.cpp` and
`ntv2aux.cpp` each define `kNumDIDRegisters` and `extractorInitParamsTable` at
file scope, and `extractorInitParamsTable` is a *different struct type* in each,
so merging them into one translation unit is a redefinition. `ntv2regvpid.cpp`
collides the same way on `gChannelToSDIInput3GStatusRegNum`. Built standalone
with `-DCMAKE_UNITY_BUILD=1` it fails with 7 errors, and roughly a dozen jobs
here pass that flag.

Fixed in the addon rather than worked around here — ossia/score-addon-videoio
`00949d705d` wraps the SDK's `add_subdirectory` in a `block()` that sets
`CMAKE_UNITY_BUILD OFF`, so the SDK's own targets read it as they are created
and the rest of the build stays unity. Same shape as
`tests/corpus/CMakeLists.txt:44`. The clone here is therefore plain, submodules
included, and AJA is enabled.

### Verified

Configured and built against this tree with `-DCMAKE_UNITY_BUILD=1` and AJA on:

    score-addon-videoio: AJA enabled (SDK: .../3rdparty/libajantv2)
    ninja ajantv2               exit 0, 0 errors
    ninja score_addon_videoio   exit 0, 0 errors -> libscore_addon_videoio.so

The addon's own V4L2/DeckLink/Magewell test harness stays out of CI: it is
behind `option(SCORE_VIDEOIO_BUILD_TESTS ... OFF)` and no job sets it. Were it
enabled, both binaries return 77 (`SKIP_RETURN_CODE`) on a machine with no
capture device.
