### PR TITLE
ci: build score-addon-lavfi

### DIFF
--- a/ci/common.deps.sh
+++ b/ci/common.deps.sh
@@ -166,6 +166,7 @@ then
   clone_addon    https://github.com/ossia/score-addon-deuterium
   clone_addon         https://github.com/ossia/score-addon-hdf5
   clone_addon          https://github.com/ossia/score-addon-led
+  clone_addon          https://github.com/ossia/score-addon-lavfi
   clone_addon          https://github.com/ossia/score-addon-lsl
   clone_addon          https://github.com/ossia/score-addon-ndi
   clone_addon      https://github.com/ossia/score-addon-openzen


### PR DESCRIPTION
Adds `score-addon-lavfi` to the addons CI clones. The repository was created
for this: https://github.com/ossia/score-addon-lavfi

An **FFmpeg filter** process whose program is a libavfilter graph — audio
effects and analyzers, video filters, generators, and audio-to-video
visualisers. On the Vulkan backend video frames stay on the GPU.

### Self-disabling

The addon returns early rather than failing when it cannot build:

- on Emscripten;
- without `score_plugin_gfx` or `score_plugin_media`;
- when `FindFFmpeg` does not turn up `libavfilter`, which it deliberately keeps
  out of `FFMPEG_TARGETS` since nothing else in score links it —
  `score-addon-lavfi: libavfilter not found, skipping`.

It has no submodules, so the clone is plain.

### What is in it

11 commits, 752 KB. The libavfilter wrapper is Qt-free and ossia-free so it can
be tested on its own; `tests/` holds headless CPU/Vulkan/CUDA graph tests, a
Vulkan transport test that checks pixels through `hflip_vulkan`, and
`presets.js`, which drives every shipped preset through score itself.
