### PR TITLE
PipeWire video I/O, graphics output fixes, and a batch of UI/scenario bugs

### DIFF
--- a/cmake/ScoreExpectedRedGuard.cmake
+++ b/cmake/ScoreExpectedRedGuard.cmake
@@ -70,9 +70,8 @@ set(SCORE_EXPECTED_RED
   "shouldfail@tests/threedim/SceneApproximationPins.cpp@DEFECT: the render-thread light encoder collapses area lights onto point, and dome onto directional@light-type information is lost in the render-thread encoder"
   "shouldfail@tests/threedim/SceneApproximationPins.cpp@DEFECT: SceneFilterNode mode 2 has no Name port, so it cannot be configured at all@mode 2 exposes no Name port"
 
-  "shouldfail@tests/integration/PipewireVideoOutputTest.cpp@a PipeWire video output can hand over DMA-BUF memory@the dma-buf modifier handshake ends in \"no more output formats\": nothing survives the modifier intersection with this consumer, and score errors instead of falling back to host memory. The shm path in the same file is green, pixels and rate both"
 
-  "shouldfail@tests/integration/PipewireVideoOutputTest.cpp@a PipeWire video output keeps up at 7680x4320@the readback path copies 132 MB per frame through host memory and delivers 3.5 distinct frames a second against the 60 the device asks for. Spout and Syphon carry 8K because they hand over a texture; this goes green when the dma-buf path negotiates with an outside consumer"
+  "shouldfail@tests/integration/PipewireVideoOutputTest.cpp@a PipeWire video output keeps up at 7680x4320@the readback path copies 132 MB per frame through host memory and delivers 3.5 distinct frames a second against the 60 the device asks for. Spout and Syphon carry 8K because they hand over a texture -- this goes green when the dma-buf path negotiates with an outside consumer"
 
   # -- CMake WILL_FAIL ------------------------------------------------------
   # Cannot be a Catch2 tag: the defect aborts, so Catch2 never reports.

--- a/cmake/ScoreExpectedRedGuard.cmake
+++ b/cmake/ScoreExpectedRedGuard.cmake
@@ -70,6 +70,8 @@ set(SCORE_EXPECTED_RED
   "shouldfail@tests/threedim/SceneApproximationPins.cpp@DEFECT: the render-thread light encoder collapses area lights onto point, and dome onto directional@light-type information is lost in the render-thread encoder"
   "shouldfail@tests/threedim/SceneApproximationPins.cpp@DEFECT: SceneFilterNode mode 2 has no Name port, so it cannot be configured at all@mode 2 exposes no Name port"
 
+  "shouldfail@tests/integration/PipewireVideoOutputTest.cpp@a PipeWire video output can hand over DMA-BUF memory@the dma-buf modifier handshake ends in \"no more output formats\": nothing survives the modifier intersection with this consumer, and score errors instead of falling back to host memory. The shm path in the same file is green, pixels and rate both"
+
   # -- CMake WILL_FAIL ------------------------------------------------------
   # Cannot be a Catch2 tag: the defect aborts, so Catch2 never reports.
   "will_fail@tests/integration/CMakeLists.txt@test_integration_js_rootpath_static@rootPath()'s function-local static caches a dangling reference. ASAN-ONLY -- off ASan the freed read trips Qt's own Q_ASSERT only when the garbage is unlucky (measured 8 red / 2 green in 10 runs), so the entry is WILL_FAIL under -fsanitize=address and DISABLED otherwise"

--- a/cmake/ScoreExpectedRedGuard.cmake
+++ b/cmake/ScoreExpectedRedGuard.cmake
@@ -72,6 +72,8 @@ set(SCORE_EXPECTED_RED
 
   "shouldfail@tests/integration/PipewireVideoOutputTest.cpp@a PipeWire video output can hand over DMA-BUF memory@the dma-buf modifier handshake ends in \"no more output formats\": nothing survives the modifier intersection with this consumer, and score errors instead of falling back to host memory. The shm path in the same file is green, pixels and rate both"
 
+  "shouldfail@tests/integration/PipewireVideoOutputTest.cpp@a PipeWire video output keeps up at 7680x4320@the readback path copies 132 MB per frame through host memory and delivers 3.5 distinct frames a second against the 60 the device asks for. Spout and Syphon carry 8K because they hand over a texture; this goes green when the dma-buf path negotiates with an outside consumer"
+
   # -- CMake WILL_FAIL ------------------------------------------------------
   # Cannot be a Catch2 tag: the defect aborts, so Catch2 never reports.
   "will_fail@tests/integration/CMakeLists.txt@test_integration_js_rootpath_static@rootPath()'s function-local static caches a dangling reference. ASAN-ONLY -- off ASan the freed read trips Qt's own Q_ASSERT only when the garbage is unlucky (measured 8 red / 2 green in 10 runs), so the entry is WILL_FAIL under -fsanitize=address and DISABLED otherwise"

--- a/cmake/ScoreHardwareTests.cmake
+++ b/cmake/ScoreHardwareTests.cmake
@@ -182,13 +182,16 @@ function(score_add_media_test)
   # SCORE_MEDIA_TEST_WRAPPER is with-virtual-media.sh. ctest cannot exec a .sh
   # directly on Windows. msys2 supplies bash, ffmpeg and the GStreamer stack,
   # so the harnesses run once they are invoked through it.
+  # These harnesses open real windows, so keep them off the developer's session
+  # the same way score_add_test(GUI) does.
+  score_test_display_wrapper(_display_wrapper)
   if(SCORE_MEDIA_TEST_SHELL)
     add_test(NAME ${ARG_NAME}
-      COMMAND "${SCORE_MEDIA_TEST_SHELL}" "${SCORE_MEDIA_TEST_WRAPPER}"
+      COMMAND ${_display_wrapper} "${SCORE_MEDIA_TEST_SHELL}" "${SCORE_MEDIA_TEST_WRAPPER}"
               ${_flags} -- "${_exe}" ${ARG_ARGS})
   elseif(SCORE_HAS_SHELL_HARNESS)
     add_test(NAME ${ARG_NAME}
-      COMMAND "${SCORE_MEDIA_TEST_WRAPPER}" ${_flags} -- "${_exe}" ${ARG_ARGS})
+      COMMAND ${_display_wrapper} "${SCORE_MEDIA_TEST_WRAPPER}" ${_flags} -- "${_exe}" ${ARG_ARGS})
   else()
     # No shell at all: registering it would report BAD_COMMAND, which reads as a
     # failure of the test rather than of the machine.
@@ -201,6 +204,9 @@ function(score_add_media_test)
     RUN_SERIAL TRUE
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}"
     ENVIRONMENT "SCORE_AUDIO_BACKEND=dummy;SCORE_DISABLE_AUDIOPLUGINS=1")
+
+  set_property(TEST ${ARG_NAME} APPEND PROPERTY
+    ENVIRONMENT_MODIFICATION ${SCORE_TEST_HARNESS_ENVIRONMENT})
 
   # Only an explicitly OPTIONAL test may skip; everything else must run.
   if(ARG_OPTIONAL)

--- a/cmake/ScoreTestRegistrationGuard.cmake
+++ b/cmake/ScoreTestRegistrationGuard.cmake
@@ -51,6 +51,11 @@ set(SCORE_TEST_GUARD_ALLOWED_HARNESSES
   hardware/probe-aja.sh
   hardware/probe-decklink.sh
   hardware/probe-magewell.sh
+  # A single-file Vulkan probe, built by hand with the g++ line in its header:
+  # it needs no score, no Qt and no pipewire, and it answers "how fast can this
+  # driver write into an exported dma-buf image" on a machine that may not have
+  # a score build at all.
+  hardware/dmabuf-export-bandwidth.cpp
   # Developer tools rather than tests: they were never registered, drive a
   # built score by hand and report to the terminal. Registering them is a
   # separate piece of work, not a regression.

--- a/cmake/ScoreTests.cmake
+++ b/cmake/ScoreTests.cmake
@@ -8,6 +8,7 @@
 #     PLUGINS   score_lib_state          # extra score libs/plugins to link
 #     APP                                # needs the full headless app (run from build root)
 #     GUI                                # needs a GUI QApplication (links Qt Widgets/Gui)
+#                                      # and a display: runs under a private Xvfb
 #     STANDALONE                         # do not link score_lib_base, only use its headers
 #     NO_CTEST                           # build the executable, register it elsewhere
 #     LIBS      some_other_lib)          # arbitrary extra link libraries
@@ -39,6 +40,60 @@ if(WIN32)
 else()
   set(SCORE_HAS_SHELL_HARNESS 1 CACHE INTERNAL "shell harnesses are runnable")
 endif()
+
+# A GUI test maps real windows. Left on the developer's display they flash over
+# their session, take focus, and -- for the ones that drive input -- grab the
+# pointer and the keyboard. Run them against a throwaway X server instead.
+#
+# Vulkan is unaffected: its ICD enumerates devices without the X server, so the
+# GPU tests still run on real hardware. OpenGL drops to llvmpipe.
+find_program(SCORE_XVFB_EXECUTABLE Xvfb)
+if(UNIX AND NOT APPLE AND NOT EMSCRIPTEN AND SCORE_XVFB_EXECUTABLE)
+  set(_score_xvfb_default ON)
+else()
+  set(_score_xvfb_default OFF)
+endif()
+option(SCORE_TESTS_XVFB
+  "Run tests that need a display against a private Xvfb" ${_score_xvfb_default})
+
+# Prefix that puts a ctest COMMAND behind that private X server, or nothing when
+# the feature is off. For score_add_test(GUI) below and for the handful of shell
+# harnesses in tests/integration that register themselves.
+function(score_test_display_wrapper OUT)
+  if(SCORE_TESTS_XVFB)
+    set(${OUT} "${SCORE_ROOT_SOURCE_DIR}/tests/tools/run-with-display.sh" PARENT_SCOPE)
+  else()
+    set(${OUT} "" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# The identity a test process runs under. The application name decides the
+# QSettings file, the standard paths and -- see score::OpenDocumentsFile -- the
+# crash-recovery list the start screen offers to restore, so a test that leaves
+# a document open does not put it in front of the developer at their next real
+# start. Same pair of variables that lets two people share one machine; see
+# setQApplicationMetadata().
+#
+# On the ctest entry as well as in the C++ fixture, so a test that spawns a
+# score process of its own hands the name down to it.
+# TMPDIR alongside the name because the crash-recovery list lives in the temp
+# directory: a child that loses one of the two is still isolated by the other.
+set(SCORE_TEST_ENVIRONMENT
+  "SCORE_CUSTOM_APP_APPLICATION_NAME=set:score-test"
+  "XDG_CONFIG_HOME=set:${SCORE_ROOT_BINARY_DIR}/test-home/config"
+  "TMPDIR=set:${SCORE_ROOT_BINARY_DIR}/test-home/tmp"
+  CACHE INTERNAL "hermetic identity for test processes")
+file(MAKE_DIRECTORY "${SCORE_ROOT_BINARY_DIR}/test-home/config")
+
+# The shell harnesses cannot take that name: each writes its own score.conf and
+# runs the real binary against it, and under another name score would read a
+# file that is not there. Isolate the one thing that reaches the developer
+# instead -- the crash-recovery list lives in the temp directory, and a harness
+# that kills score leaves entries in it.
+set(SCORE_TEST_HARNESS_ENVIRONMENT
+  "TMPDIR=set:${SCORE_ROOT_BINARY_DIR}/test-home/tmp"
+  CACHE INTERNAL "temp isolation for harnesses that spawn score")
+file(MAKE_DIRECTORY "${SCORE_ROOT_BINARY_DIR}/test-home/tmp")
 
 # Make the Catch2 target (Catch2::Catch2WithMain) available. Catch2 is vendored
 # inside libossia's 3rdparty tree; we add it ourselves (rather than relying on
@@ -168,13 +223,16 @@ function(score_add_test NAME)
   # A test that exercises code which deletes or overwrites media files runs
   # with the filesystem read-only apart from /tmp, so a bug in it cannot reach
   # anything of the developer's. See tests/tools/sandboxed-test.sh.
+  set(_cmd "$<TARGET_FILE:${NAME}>")
   if(ARG_SANDBOXED AND UNIX AND NOT APPLE AND NOT EMSCRIPTEN)
-    add_test(NAME ${NAME}
-      COMMAND "${SCORE_ROOT_SOURCE_DIR}/tests/tools/sandboxed-test.sh"
-              "$<TARGET_FILE:${NAME}>")
-  else()
-    add_test(NAME ${NAME} COMMAND ${NAME})
+    set(_cmd "${SCORE_ROOT_SOURCE_DIR}/tests/tools/sandboxed-test.sh" ${_cmd})
   endif()
+  # Outermost: the X server belongs to the test, not to the sandbox it runs in.
+  if(ARG_GUI)
+    score_test_display_wrapper(_display_wrapper)
+    set(_cmd ${_display_wrapper} ${_cmd})
+  endif()
+  add_test(NAME ${NAME} COMMAND ${_cmd})
 
   # Record the target this ctest entry actually runs, so the registration guard
   # can check association instead of guessing it from names. See
@@ -186,6 +244,9 @@ function(score_add_test NAME)
   # precondition is absent -- no display, no shader library, no capture device --
   # is not a defect, and counting it as one silently inflates the failure count.
   set_tests_properties(${NAME} PROPERTIES SKIP_RETURN_CODE 4)
+
+  set_property(TEST ${NAME} APPEND PROPERTY
+    ENVIRONMENT_MODIFICATION ${SCORE_TEST_ENVIRONMENT})
 
   # Sanitizer builds: hand every test the suppression file. ENVIRONMENT_MODIFICATION
   # rather than ENVIRONMENT so this does not fight the ENVIRONMENT values set
@@ -217,8 +278,9 @@ function(score_add_test NAME)
     set_tests_properties(${NAME} PROPERTIES
       ENVIRONMENT "QT_QPA_PLATFORM=offscreen;SCORE_AUDIO_BACKEND=dummy;SCORE_DISABLE_AUDIOPLUGINS=1")
   elseif(ARG_GUI)
-    # GUI tests need a real display (X11 locally, Xvfb in CI): do NOT force
-    # offscreen. Labelled "gui" so CI can gate them behind a display.
+    # GUI tests need a real X server -- the private one from
+    # score_test_display_wrapper() -- so do NOT force offscreen. Labelled "gui"
+    # so CI can gate them behind a display.
     set_tests_properties(${NAME} PROPERTIES
       ENVIRONMENT "SCORE_AUDIO_BACKEND=dummy;SCORE_DISABLE_AUDIOPLUGINS=1"
       LABELS "gui")

--- a/src/lib/core/application/OpenDocumentsFile.cpp
+++ b/src/lib/core/application/OpenDocumentsFile.cpp
@@ -2,6 +2,7 @@
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 #include "OpenDocumentsFile.hpp"
 
+#include <QCoreApplication>
 #include <QFile>
 #include <QStandardPaths>
 
@@ -16,8 +17,16 @@ QString OpenDocumentsFile::path()
         username = qEnvironmentVariable("USERNAME");
       return username;
     }();
+    // Keyed on the application name, not the literal "score", so the two
+    // SCORE_CUSTOM_APP_* variables that already separate one user's settings
+    // from another's separate their crash-recovery lists too. Default is
+    // "score", so the path is unchanged for a normal run.
+    auto app = QCoreApplication::applicationName();
+    if(app.isEmpty())
+      app = QStringLiteral("score");
+
     const auto paths = QStandardPaths::standardLocations(QStandardPaths::TempLocation);
-    return paths.first() + "/score_open_docs." + username;
+    return paths.first() + "/" + app + "_open_docs." + username;
   }();
 
   return path;

--- a/src/lib/score/graphics/layouts/GraphicsGridLayout.cpp
+++ b/src/lib/score/graphics/layouts/GraphicsGridLayout.cpp
@@ -1,5 +1,7 @@
 #include "GraphicsGridLayout.hpp"
 
+#include <algorithm>
+
 #include <score/graphics/layouts/Constants.hpp>
 
 #include <QPainter>
@@ -229,6 +231,10 @@ void GraphicsDefaultInletLayout::layout()
 }
 
 GraphicsDefaultOutletLayout::~GraphicsDefaultOutletLayout() { }
+void GraphicsDefaultOutletLayout::setMinimumWidth(double w)
+{
+  m_minimumWidth = w;
+}
 void GraphicsDefaultOutletLayout::layout()
 {
   const auto items = this->childItems();
@@ -239,15 +245,18 @@ void GraphicsDefaultOutletLayout::layout()
     if(auto ww = items[i]->boundingRect().width(); ww > w)
       w = ww;
 
-  double cur_x = 0;
+  // Right edge of the column: the node's width when it is the wider of the
+  // two. A node with outlets and no inlets used to leave this at the column's
+  // own width, which put its outlets against the LEFT edge of the node.
+  const double right = std::max(w, m_minimumWidth);
+
   double cur_y = 0;
 
   for(int i = 0; i < items.size(); i++)
   {
     auto it = items[i];
     auto rect = it->boundingRect();
-    cur_x = w - rect.width();
-    it->setPos(cur_x, cur_y);
+    it->setPos(right - rect.width(), cur_y);
     cur_y += rect.height();
   }
 }

--- a/src/lib/score/graphics/layouts/GraphicsGridLayout.hpp
+++ b/src/lib/score/graphics/layouts/GraphicsGridLayout.hpp
@@ -57,7 +57,14 @@ public:
   using GraphicsLayout::GraphicsLayout;
   ~GraphicsDefaultOutletLayout();
 
+  //! Outlets belong against the right-hand edge of the node. The column lays
+  //! itself out against this width when the node is wider than the column,
+  //! which is what GraphicsIORootLayout does for a node that also has inlets.
+  void setMinimumWidth(double w);
   void layout() override;
+
+private:
+  double m_minimumWidth{};
 };
 
 class SCORE_LIB_BASE_EXPORT GraphicsIORootLayout : public GraphicsLayout

--- a/src/lib/score/graphics/widgets/QGraphicsIntSlider.cpp
+++ b/src/lib/score/graphics/widgets/QGraphicsIntSlider.cpp
@@ -90,6 +90,11 @@ void QGraphicsIntSlider::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   DefaultGraphicsSliderImpl::mouseReleaseEvent(*this, event);
 }
 
+void QGraphicsIntSlider::mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event)
+{
+  DefaultGraphicsSliderImpl::mouseDoubleClickEvent(*this, event);
+}
+
 bool QGraphicsIntSlider::sceneEvent(QEvent* event)
 {
   if(event->type() == QEvent::UngrabMouse)

--- a/src/lib/score/graphics/widgets/QGraphicsIntSlider.hpp
+++ b/src/lib/score/graphics/widgets/QGraphicsIntSlider.hpp
@@ -50,6 +50,7 @@ private:
   void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
   void mouseMoveEvent(QGraphicsSceneMouseEvent* event) override;
   void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
+  void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* event) override;
   bool sceneEvent(QEvent* event) override;
   void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
       override;

--- a/src/lib/score/widgets/ControlWidgets.hpp
+++ b/src/lib/score/widgets/ControlWidgets.hpp
@@ -60,6 +60,7 @@ protected:
 
   void paintEvent(QPaintEvent* event) override;
   void mousePressEvent(QMouseEvent*) override;
+  void mouseDoubleClickEvent(QMouseEvent*) override;
   void createPopup(QPoint pos) override;
 };
 

--- a/src/lib/score/widgets/DoubleSlider.cpp
+++ b/src/lib/score/widgets/DoubleSlider.cpp
@@ -58,12 +58,14 @@ void DoubleSlider::setValue(double val)
 
 double DoubleSlider::map(double v) const
 {
-  return min + m_value * (max - min);
+  return min + v * (max - min);
 }
 
 double DoubleSlider::unmap(double v) const
 {
-  return (v / (max - min)) - min;
+  if(max == min)
+    return 0.;
+  return (v - min) / (max - min);
 }
 
 void DoubleSlider::updateValue(QPointF mousePos)
@@ -104,6 +106,25 @@ void DoubleSlider::mouseMoveEvent(QMouseEvent* event)
 void DoubleSlider::mouseReleaseEvent(QMouseEvent* event)
 {
   sliderReleased();
+}
+
+void DoubleSlider::mouseDoubleClickEvent(QMouseEvent* event)
+{
+  // Same gesture as the graphics-view controls: back to the default the
+  // process declared. The press that opened the double click already moved the
+  // value under the cursor, so this has to overwrite it.
+  if(max == min)
+  {
+    // No domain was ever set on this slider: there is no default to go to.
+    event->ignore();
+    return;
+  }
+  m_value = clamp(unmap(init), 0., 1.);
+  repaint();
+  valueChanged(m_value);
+  sliderMoved(m_value);
+  sliderReleased();
+  event->accept();
 }
 void DoubleSlider::createPopup(QPoint pos)
 {

--- a/src/lib/score/widgets/DoubleSlider.hpp
+++ b/src/lib/score/widgets/DoubleSlider.hpp
@@ -41,6 +41,7 @@ public:
   void mousePressEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
+  void mouseDoubleClickEvent(QMouseEvent* event) override;
   virtual void createPopup(QPoint pos);
   virtual void setRange(double min, double max, double init) noexcept;
 

--- a/src/lib/score/widgets/IntSlider.cpp
+++ b/src/lib/score/widgets/IntSlider.cpp
@@ -97,6 +97,22 @@ void IntSlider::mouseReleaseEvent(QMouseEvent* event)
 {
   sliderReleased();
 }
+
+void IntSlider::mouseDoubleClickEvent(QMouseEvent* event)
+{
+  // See DoubleSlider::mouseDoubleClickEvent: reset to the declared default.
+  if(m_max == m_min)
+  {
+    event->ignore();
+    return;
+  }
+  m_value = clamp(m_init, m_min, m_max);
+  repaint();
+  valueChanged(m_value);
+  sliderMoved(m_value);
+  sliderReleased();
+  event->accept();
+}
 void IntSlider::createPopup(QPoint pos)
 {
   auto w = new QSpinBox();

--- a/src/lib/score/widgets/IntSlider.hpp
+++ b/src/lib/score/widgets/IntSlider.hpp
@@ -39,6 +39,7 @@ public:
   void mousePressEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
+  void mouseDoubleClickEvent(QMouseEvent* event) override;
   virtual void createPopup(QPoint pos);
 
 protected:

--- a/src/lib/score/widgets/SpinBoxes.cpp
+++ b/src/lib/score/widgets/SpinBoxes.cpp
@@ -627,6 +627,15 @@ SpeedSlider::~SpeedSlider()
   ossia::remove_one(speedSliders, this);
 }
 
+void SpeedSlider::mouseDoubleClickEvent(QMouseEvent* event)
+{
+  // The speed slider has no declared domain -- its default is simply x1.
+  setSpeed(1.0);
+  sliderMoved(value());
+  sliderReleased();
+  event->accept();
+}
+
 double SpeedSlider::speed() const noexcept
 {
   return std::round(1000 * speedFromValue(value())) / 1000;

--- a/src/plugins/score-lib-process/Control/DefaultEffectItem.cpp
+++ b/src/plugins/score-lib-process/Control/DefaultEffectItem.cpp
@@ -300,7 +300,13 @@ void DefaultEffectItem::recreate_onlyOutlets()
 {
   auto& portFactory = m_ctx.app.interfaces<Process::PortFactoryList>();
 
-  m_layout = new score::GraphicsDefaultOutletLayout{this};
+  auto outlet_layout = new score::GraphicsDefaultOutletLayout{this};
+  // Against the right-hand edge, as GraphicsIORootLayout puts it when the node
+  // also has inlets. Without this a node with outlets only -- a generator such
+  // as the Random Characters shader, folded -- drew its texture outlet on the
+  // left.
+  outlet_layout->setMinimumWidth(m_minimumWidth);
+  m_layout = outlet_layout;
   m_allLayouts.push_back(m_layout);
   LayoutBuilderBase b{*this,       m_effect,          m_ctx,
                       portFactory, m_effect.inlets(), m_effect.outlets(),

--- a/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/ControlWidgets.hpp
@@ -1042,14 +1042,39 @@ struct ProgramEdit
 // dialog); `onPicked` then receives a real, readable path. On desktop it is the
 // usual synchronous getOpenFileName, opened in `startDir` (see
 // score::pickerStartFolder). `onPicked(const QString& path)`.
+//! True while a file or folder dialog is up. One flag for the whole process:
+//! these dialogs are modal and only one should ever be on screen.
+inline bool& pickerInFlight() noexcept
+{
+  static bool b = false;
+  return b;
+}
+
 template <typename F>
 inline void openFileToImport(const QString& filters, const QString& startDir, F onPicked)
 {
+  // One picker at a time, process-wide.
+  //
+  // getOpenFileName runs a nested event loop, and that loop keeps delivering
+  // clicks to the widget underneath the dialog: clicking a file control a
+  // second time while its dialog was up opened another one the instant the
+  // first closed. The wasm branch is asynchronous rather than nested, and has
+  // the same problem for the same reason, so the flag is cleared from its
+  // callback instead of on the way out.
+  //
+  // The flag lives outside this template on purpose. A static inside it would
+  // be one flag per callable type, so only a repeat click on the SAME control
+  // would be caught, and two different controls could still stack dialogs.
+  if(pickerInFlight())
+    return;
+  pickerInFlight() = true;
+
 #if defined(__EMSCRIPTEN__)
   QFileDialog::getOpenFileContent(
       filters,
       [onPicked = std::move(onPicked)](
           const QString& name, const QByteArray& data) mutable {
+    pickerInFlight() = false;
     if(name.isEmpty() || data.isEmpty())
       return;
     if(QString staged = score::stageImportedFile(name, data); !staged.isEmpty())
@@ -1058,9 +1083,26 @@ inline void openFileToImport(const QString& filters, const QString& startDir, F 
 #else
   const QString fn
       = QFileDialog::getOpenFileName(nullptr, QObject::tr("Open File"), startDir, filters);
+  pickerInFlight() = false;
   if(!fn.isEmpty())
     onPicked(fn);
 #endif
+}
+
+//! Same re-entrancy guard as openFileToImport, for the folder pickers.
+//! getExistingDirectory nests an event loop too, so a second click while it is
+//! up queues a second dialog.
+template <typename F>
+inline void
+openFolderToImport(const QString& title, const QString& startDir, F onPicked)
+{
+  if(pickerInFlight())
+    return;
+  pickerInFlight() = true;
+  const QString dir = QFileDialog::getExistingDirectory(nullptr, title, startDir);
+  pickerInFlight() = false;
+  if(!dir.isEmpty())
+    onPicked(dir);
 }
 
 struct FileChooser
@@ -1190,15 +1232,13 @@ struct FolderChooser
     act->setIcon(QIcon(":/icons/search.png"));
     sl->setPlaceholderText(QObject::tr("Open Folder"));
     auto on_open = [=, &ctx, &inlet] {
-      auto filename
-          = QFileDialog::getExistingDirectory(
-              nullptr, "Open Folder",
-              score::pickerStartFolder(
-                  QString::fromStdString(ossia::convert<std::string>(inlet.value())), ctx));
-      if(filename.isEmpty())
-        return;
-      auto path = score::relativizeFilePath(filename, ctx);
-      sl->setText(path);
+      openFolderToImport(
+          "Open Folder",
+          score::pickerStartFolder(
+              QString::fromStdString(ossia::convert<std::string>(inlet.value())), ctx),
+          [=, &ctx](const QString& filename) {
+        sl->setText(score::relativizeFilePath(filename, ctx));
+      });
     };
 
     QObject::connect(sl, &QLineEdit::returnPressed, on_open);
@@ -1228,17 +1268,14 @@ struct FolderChooser
     auto bt = new score::QGraphicsTextButton{"Choose a folder...", parent};
     initWidgetProperties(inlet, *bt);
     auto on_open = [&inlet, &ctx] {
-      auto filename
-          = QFileDialog::getExistingDirectory(
-              nullptr, "Open Folder",
-              score::pickerStartFolder(
-                  QString::fromStdString(ossia::convert<std::string>(inlet.value())), ctx));
-      if(filename.isEmpty())
-        return;
-
-      auto path = score::relativizeFilePath(filename, ctx);
-      CommandDispatcher<>{ctx.commandStack}.submit<SetControlValue<Control_T>>(
-          inlet, path.toStdString());
+      openFolderToImport(
+          "Open Folder",
+          score::pickerStartFolder(
+              QString::fromStdString(ossia::convert<std::string>(inlet.value())), ctx),
+          [&inlet, &ctx](const QString& filename) {
+        CommandDispatcher<>{ctx.commandStack}.submit<SetControlValue<Control_T>>(
+            inlet, score::relativizeFilePath(filename, ctx).toStdString());
+      });
     };
     auto on_set = [&inlet, &ctx](const QString& filename) {
       if(filename.isEmpty())

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -429,7 +429,16 @@ TimeChooser::TimeChooser(
     : ControlInlet{name, id, parent}
 {
   displayHandledExplicitly = true;
-  setValue(ossia::vec2f{init, 1.f});
+  // The second component is the mode: 0 is a time in seconds, anything else is
+  // a musical denomination. It starts at 0, which is what the object declaring
+  // the control says too -- halp::time_chooser_t has `bool sync{false}`.
+  //
+  // It used to start synced, and that made every such control's default wrong:
+  // the value the process declared as its init was read as a number of quarter
+  // notes and converted to seconds against the tempo, so a control asking for
+  // two seconds got two quarters instead. Deuterium's sampler carries a
+  // work-around for exactly this.
+  setValue(ossia::vec2f{init, 0.f});
   setInit(value());
   setDomain(ossia::make_domain(ossia::vec2f{min, 0.f}, ossia::vec2f{max, 1.f}));
 }

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.cpp
@@ -215,6 +215,16 @@ const State::Unit& HSVSlider::unit() const noexcept
   return u;
 }
 
+void HSVSlider::setupExecution(ossia::inlet& inl, QObject* exec_context) const noexcept
+{
+  // The unit, not just the value type: it is what makes an address declared
+  // color.rgb (or hsv, or any other colour unit) arrive here as the rgba this
+  // control reads. Without it value_port::effective_type() is empty and
+  // adapt_value() has nothing to convert towards.
+  auto& port = **safe_cast<ossia::value_inlet*>(&inl);
+  port.type = unit().get();
+}
+
 FloatSlider::FloatSlider(
     float min, float max, float init, const QString& name, Id<Port> id, QObject* parent)
     : ControlInlet{name, id, parent}

--- a/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
+++ b/src/plugins/score-lib-process/Process/Dataflow/WidgetInlets.hpp
@@ -565,6 +565,7 @@ struct SCORE_LIB_PROCESS_EXPORT HSVSlider : public Process::ControlInlet
 
   //! rgba, however the port was constructed.
   const State::Unit& unit() const noexcept override;
+  void setupExecution(ossia::inlet& inl, QObject* exec_context) const noexcept override;
   auto getMin() const noexcept { return ossia::vec4f{0., 0., 0., 0.}; }
   auto getMax() const noexcept { return ossia::vec4f{1., 1., 1., 1.}; }
   using Process::ControlInlet::ControlInlet;

--- a/src/plugins/score-plugin-curve/Curve/CurveConversion.hpp
+++ b/src/plugins/score-plugin-curve/Curve/CurveConversion.hpp
@@ -41,12 +41,13 @@ std::shared_ptr<ossia::curve<X_T, Y_T>> curve(
   auto curve = std::make_shared<ossia::curve<X_T, Y_T>>();
   curve->reserve(segments.size() + 1);
 
+  // Where the curve begins, wherever that is. The first segment is not
+  // required to start at 0: leaving x0/y0 at their defaults there made the
+  // ossia curve ramp from (0, 0) to the first segment's end, which throws that
+  // segment away and shifts everything after it.
   auto start = segments[0]->start();
-  if(start.x() == 0.)
-  {
-    curve->set_x0(scale_x(start.x()));
-    curve->set_y0(scale_y(start.y()));
-  }
+  curve->set_x0(scale_x(start.x()));
+  curve->set_y0(scale_y(start.y()));
 
   for(const auto& score_segment : segments)
   {
@@ -70,12 +71,10 @@ floatCurve(const Segments& segments, const std::optional<ossia::destination>& tw
 {
   ossia::curve<double, float> curve;
 
+  // See above: the first segment need not start at 0.
   auto start = segments[0]->start();
-  if(start.x() == 0.)
-  {
-    curve.set_x0(start.x());
-    curve.set_y0(start.y());
-  }
+  curve.set_x0(start.x());
+  curve.set_y0(start.y());
 
   for(const auto& score_segment : segments)
   {

--- a/src/plugins/score-plugin-deviceexplorer/CMakeLists.txt
+++ b/src/plugins/score-plugin-deviceexplorer/CMakeLists.txt
@@ -40,6 +40,7 @@ set(HDRS
     "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/ValueEditors.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/DeviceExplorerView.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/DeviceExplorerWidget.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/LearnRollback.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/ExplorationWorker.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/ExplorationWorkerWrapper.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/ListeningManager.hpp"
@@ -102,6 +103,7 @@ set(SRCS
 "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/DeviceExplorerDelegate.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/ValueEditors.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/DeviceExplorerWidget.cpp"
+"${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/LearnRollback.cpp"
 "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Explorer/ListeningManager.cpp"
 
 "${CMAKE_CURRENT_SOURCE_DIR}/Explorer/Listening/ListeningHandler.cpp"

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/DeviceExplorerWidget.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/DeviceExplorerWidget.cpp
@@ -21,6 +21,7 @@
 
 #include <Explorer/Commands/Add/AddAddress.hpp>
 #include <Explorer/Commands/Add/LoadDevice.hpp>
+#include <Explorer/Explorer/LearnRollback.hpp>
 #include <Explorer/Commands/Remove.hpp>
 #include <Explorer/Commands/RemoveNodes.hpp>
 #include <Explorer/Commands/ReplaceDevice.hpp>
@@ -1363,12 +1364,13 @@ void DeviceExplorerWidget::learn()
   }
   else
   {
-    // We still have to rollback the messages that may have been received
-    Explorer::Command::ReloadWholeDevice cmd{
-        m->deviceModel(), std::move(oldDevice), std::move(newDevice)};
-
-    // No need to push anything
-    cmd.undo(m_cmdDispatcher->stack().context());
+    // Take back what the learn added, one address at a time. Rolling back with
+    // ReloadWholeDevice::undo instead removes the device and builds a new one,
+    // which drops everything the outside world had attached to it -- with
+    // PipeWire, cancelling a learn that added nothing at all still cost the
+    // user their MIDI cable.
+    rollbackLearnedNodes(
+        m->deviceModel(), n.get<Device::DeviceSettings>().name, oldDevice);
   }
 }
 

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/LearnRollback.cpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/LearnRollback.cpp
@@ -1,0 +1,74 @@
+#include "LearnRollback.hpp"
+
+#include <Device/Node/DeviceNode.hpp>
+
+#include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
+#include <Explorer/DocumentPlugin/NodeUpdateProxy.hpp>
+#include <Explorer/Explorer/DeviceExplorerModel.hpp>
+
+namespace Explorer
+{
+namespace
+{
+//! The shallowest node of \p now that \p before did not have.
+const Device::Node* firstAdded(const Device::Node& before, const Device::Node& now)
+{
+  for(const auto& child : now)
+    if(!findChildNode(before, child.displayName()))
+      return &child;
+
+  for(const auto& child : now)
+    if(const auto* old = findChildNode(before, child.displayName()))
+      if(const auto* deeper = firstAdded(*old, child))
+        return deeper;
+
+  return nullptr;
+}
+
+int countNodes(const Device::Node& n)
+{
+  int c = 1;
+  for(const auto& child : n)
+    c += countNodes(child);
+  return c;
+}
+
+Device::Node* deviceNode(DeviceDocumentPlugin& plug, const QString& name)
+{
+  for(auto& n : plug.rootNode())
+    if(n.is<Device::DeviceSettings>() && n.get<Device::DeviceSettings>().name == name)
+      return &n;
+  return nullptr;
+}
+}
+
+void rollbackLearnedNodes(
+    DeviceDocumentPlugin& plug, const QString& deviceName, const Device::Node& before)
+{
+  Device::Node* live = deviceNode(plug, deviceName);
+  if(!live)
+    return;
+
+  // A learn adds a handful of addresses. The bound is only here so that a
+  // protocol which declines to remove one cannot spin forever.
+  for(int guard = 0, n = countNodes(*live); guard < n; guard++)
+  {
+    const Device::Node* added = firstAdded(before, *live);
+    if(!added)
+      return;
+
+    Device::Node* parent = added->parent();
+    if(!parent)
+      return;
+
+    const auto settings = added->get<Device::AddressSettings>();
+    const int was = countNodes(*live);
+
+    plug.updateProxy.removeNode(Device::NodePath{*parent}, settings);
+
+    // The protocol refused: stop rather than ask again for the same node.
+    if(countNodes(*live) >= was)
+      return;
+  }
+}
+}

--- a/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/LearnRollback.hpp
+++ b/src/plugins/score-plugin-deviceexplorer/Explorer/Explorer/LearnRollback.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#include <Device/Node/DeviceNode.hpp>
+
+#include <score_plugin_deviceexplorer_export.h>
+
+#include <QString>
+
+namespace Explorer
+{
+class DeviceDocumentPlugin;
+
+/**
+ * @brief Undo what a learn added, leaving the device itself alone.
+ *
+ * Cancelling a learn used to roll back with ReloadWholeDevice::undo, which
+ * removes the device and builds a new one from the saved tree. Everything the
+ * outside world had attached to the old one goes with it: a PipeWire MIDI link,
+ * an open socket, a connected client. Cancelling a learn that added nothing at
+ * all still cost the user their cable.
+ *
+ * The addresses a learn added are few and known, so they are taken out one by
+ * one instead -- from the device and from the explorer both, which is what
+ * NodeUpdateProxy::removeNode does.
+ *
+ * @param before The device's node as it was before learning started.
+ */
+SCORE_PLUGIN_DEVICEEXPLORER_EXPORT
+void rollbackLearnedNodes(
+    DeviceDocumentPlugin& plug, const QString& deviceName, const Device::Node& before);
+}

--- a/src/plugins/score-plugin-fx/CMakeLists.txt
+++ b/src/plugins/score-plugin-fx/CMakeLists.txt
@@ -40,6 +40,7 @@ set(HDRS
   "${CMAKE_CURRENT_SOURCE_DIR}/Fx/Quantifier.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Fx/RateLimiter.hpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/Fx/VelToNote.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Fx/VelToNoteCore.hpp"
 
   "${CMAKE_CURRENT_SOURCE_DIR}/score_plugin_fx.hpp"
  )

--- a/src/plugins/score-plugin-fx/Fx/VelToNote.hpp
+++ b/src/plugins/score-plugin-fx/Fx/VelToNote.hpp
@@ -110,6 +110,20 @@ inline double canonical_quarters(double q) noexcept
   return q;
 }
 
+// One duration bound off its own chooser. Each bound syncs independently, so
+// each carries its own unit. A synchronized chooser with no usable tempo
+// yields no bound rather than a wrong one.
+inline Bound bound_from_time_chooser(double value, bool sync, double tempo) noexcept
+{
+  if(!std::isfinite(value) || value <= 0.)
+    return {};
+  if(!sync)
+    return {value, DurationUnit::model_seconds};
+  if(!(std::isfinite(tempo) && tempo > 0.))
+    return {};
+  return {canonical_quarters(value * tempo / 60.), DurationUnit::quarters};
+}
+
 // The ossia binding passes free values through. In synchronized mode it gives
 // q * 60 / tempo, where q is the selected quarter-note duration. Recover q ONCE.
 inline Settings
@@ -145,6 +159,8 @@ struct Node
       "[pitch, integer velocity]: MIDI velocity; float velocity: normalized 0..1. "
       "Zero velocity releases owned notes for that source pitch. "
       "Starts may be quantized; ends use a grid or a duration. "
+      "In quantized mode, min duration extends to the next grid point and "
+      "max duration caps the hold exactly. "
       "Tightness blends from immediate (0) to the next grid point (1).")
 
   struct
@@ -163,6 +179,9 @@ struct Node
     halp::toggle<"Fixed duration"> fixed_duration;
     halp::time_chooser<"Duration", halp::range{0., 10., 0.}> duration;
     halp::enum_t<detail::PitchDirection, "Pitch direction"> pitch_direction;
+    // Quantized mode only; zero disables. Appended, like the rest.
+    halp::time_chooser<"Min duration", halp::range{0., 10., 0.}> min_duration;
+    halp::time_chooser<"Max duration", halp::range{0., 10., 0.}> max_duration;
   } inputs;
   struct
   {
@@ -313,6 +332,10 @@ struct Node
         .pitch_random = inputs.note_random.value,
         .velocity_random = inputs.vel_random.value,
         .pitch_direction = inputs.pitch_direction.value};
+    settings.min_duration = detail::bound_from_time_chooser(
+        inputs.min_duration.value, inputs.min_duration.sync, tk.tempo);
+    settings.max_duration = detail::bound_from_time_chooser(
+        inputs.max_duration.value, inputs.max_duration.sync, tk.tempo);
     settings = detail::settings_from_time_chooser(
         settings, inputs.duration.value, inputs.duration.sync, tk.tempo);
     auto sink = [this](const detail::MidiEvent& e) noexcept { emit(e); };

--- a/src/plugins/score-plugin-fx/Fx/VelToNote.hpp
+++ b/src/plugins/score-plugin-fx/Fx/VelToNote.hpp
@@ -1,50 +1,156 @@
 #pragma once
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "VelToNoteCore.hpp"
+
 #include <Fx/Types.hpp>
 
+#include <ossia/dataflow/exec_state_facade.hpp>
+#include <ossia/dataflow/token_request.hpp>
 #include <ossia/dataflow/value_port.hpp>
-#include <ossia/detail/math.hpp>
 
 #include <halp/controls.hpp>
 #include <halp/meta.hpp>
-#include <halp/midi.hpp>
 #include <libremidi/message.hpp>
-#include <rnd/random.hpp>
 
-#include <iostream>
-inline std::ostream&
-operator<<(std::ostream& s, decltype(halp::tick_musical::signature) sig)
+#include <cmath>
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <vector>
+
+namespace Nodes::PulseToNote
 {
-  return s << sig.num << " / " << sig.denom;
+namespace detail
+{
+struct NumericValue
+{
+  std::optional<double> operator()() const noexcept { return std::nullopt; }
+  std::optional<double> operator()(int x) const noexcept { return x; }
+  std::optional<double> operator()(char x) const noexcept { return x; }
+  std::optional<double> operator()(float x) const noexcept { return x; }
+  template <typename T>
+  std::optional<double> operator()(const T&) const noexcept
+  {
+    return std::nullopt;
+  }
+};
+
+struct ValueDecoder
+{
+  int base_pitch{}, base_velocity{};
+  std::optional<DecodedNote> operator()() const noexcept { return std::nullopt; }
+  std::optional<DecodedNote> operator()(ossia::impulse) const noexcept
+  {
+    return decode_pair(base_pitch, base_velocity, false);
+  }
+  std::optional<DecodedNote> operator()(int pitch) const noexcept
+  {
+    return decode_pair(pitch, base_velocity, false);
+  }
+  std::optional<DecodedNote> operator()(char pitch) const noexcept
+  {
+    return decode_pair(pitch, base_velocity, false);
+  }
+  std::optional<DecodedNote> operator()(float pitch) const noexcept
+  {
+    return decode_pair(pitch, base_velocity, false);
+  }
+  template <typename T>
+  std::optional<DecodedNote> operator()(const T&) const noexcept
+  {
+    return std::nullopt;
+  }
+  std::optional<DecodedNote>
+  operator()(const std::vector<ossia::value>& list) const noexcept
+  {
+    if(list.empty())
+      return operator()(ossia::impulse{});
+    const auto pitch = list[0].apply(NumericValue{});
+    if(!pitch)
+      return std::nullopt;
+    if(list.size() == 1)
+      return decode_pair(*pitch, base_velocity, false);
+    const auto velocity = list[1].apply(NumericValue{});
+    if(!velocity)
+      return std::nullopt;
+    // Extra elements are ignored, but NEVER change how the first pair is decoded.
+    return decode_pair(*pitch, *velocity, list[1].get_type() == ossia::val_type::FLOAT);
+  }
+  template <std::size_t N>
+  std::optional<DecodedNote>
+  operator()(const std::array<float, N>& vector) const noexcept
+  {
+    if constexpr(N >= 2)
+      return decode_pair(vector[0], vector[1], true);
+    else if constexpr(N == 1)
+      return decode_pair(vector[0], base_velocity, false);
+    else
+      return operator()(ossia::impulse{});
+  }
+};
+
+// Recover the chooser's exact notated durations from its float round-trip.
+// Without this, e.g. a quarter at 90 BPM becomes 1.00000003 quarters and the
+// conservative duration-to-sample ceil schedules its release one sample late.
+// These are the 22 score QGraphicsTimeChooser detents, expressed in quarters.
+// Arbitrary automated values outside float rounding error are NOT snapped.
+inline double canonical_quarters(double q) noexcept
+{
+  constexpr double notes[]{1. / 16, 1. / 12, 1. / 8, 1. / 6, 3. / 16, 1. / 4,
+                           1. / 3,  3. / 8,  1. / 2, 2. / 3, 3. / 4,  1.,
+                           4. / 3,  3. / 2,  2.,     8. / 3, 3.,      4.,
+                           6.,      8.,      12.,    16.};
+  if(!std::isfinite(q) || q <= 0.)
+    return q;
+  for(const auto n : notes)
+    if(std::abs(q - n) <= 4. * std::numeric_limits<float>::epsilon() * n)
+      return n;
+  return q;
 }
-namespace Nodes
+
+// The ossia binding passes free values through. In synchronized mode it gives
+// q * 60 / tempo, where q is the selected quarter-note duration. Recover q ONCE.
+inline Settings
+settings_from_time_chooser(Settings s, double value, bool sync, double tempo) noexcept
 {
-namespace PulseToNote
-{
+  s.duration_unit = sync ? DurationUnit::quarters : DurationUnit::model_seconds;
+  s.duration = sync ? (std::isfinite(tempo) && tempo > 0.
+                           ? canonical_quarters(value * tempo / 60.)
+                           : 0.)
+                    : value;
+  return sanitize(s);
+}
+} // namespace detail
+
 struct Node
 {
   halp_meta(name, "Pulse to Midi")
   halp_meta(c_name, "VelToNote")
   halp_meta(category, "Midi")
   halp_meta(author, "ossia score")
-  halp_meta(manual_url, "https://ossia.io/score-docs/processes/midi-utilities.html#pulse-to-note")
+  halp_meta(
+      manual_url,
+      "https://ossia.io/score-docs/processes/midi-utilities.html#pulse-to-note")
+  halp_meta(uuid, "2c6493c3-5449-4e52-ae04-9aee3be5fb6a")
+  halp_meta(process_exec, true)
+  // Aggregate already-produced slices until the graph's begin_execution boundary.
+  // Pending notes and future releases remain exclusively in engine_.
+  halp_meta(local_midi_tick_batch, true)
+  halp_meta(local_midi_tick_batch_reserve, detail::Engine<>::max_output_events)
   halp_meta(
       description,
-      "Converts a message into MIDI.\n"
-      "If the input is an impulse, the output will be the default pitch "
-      "at the default velocity.\n"
-      "If the input is a single integer in [0; 127], the output will be "
-      "the relevant note at the default velocity"
-      "If the input is an array of two values between [0; 127], the "
-      "output will be the relevant note.")
-
-  halp_meta(uuid, "2c6493c3-5449-4e52-ae04-9aee3be5fb6a")
+      "Impulse: default pitch and velocity. Scalar number: pitch. "
+      "[pitch, integer velocity]: MIDI velocity; float velocity: normalized 0..1. "
+      "Zero velocity releases owned notes for that source pitch. "
+      "Starts may be quantized; ends use a grid or a duration. "
+      "Tightness blends from immediate (0) to the next grid point (1).")
 
   struct
   {
-    // FIXME is_event
-    // FIXME all incorrect when token_request smaller than tick
-    // Implement polyphonic behaviour at the avendish level?
-    ossia_port<"in", ossia::value_port> port{};
+    // Existing port order is retained. New controls are appended, not inserted.
+    ossia_port<"in", ossia::value_port, true> port{};
     quant_selector<"Start quant."> start_quant;
     halp::hslider_f32<"Tightness", halp::range{0.f, 1.f, 0.8f}> tightness;
     quant_selector<"End quant."> end_quant;
@@ -54,280 +160,198 @@ struct Node
     octave_slider<"Pitch random", 0, 2> note_random;
     octave_slider<"Vel. random", 0, 2> vel_random;
     midi_channel<"Channel"> channel;
-
+    halp::toggle<"Fixed duration"> fixed_duration;
+    halp::time_chooser<"Duration", halp::range{0., 10., 0.}> duration;
+    halp::enum_t<detail::PitchDirection, "Pitch direction"> pitch_direction;
   } inputs;
   struct
   {
     midi_out midi;
   } outputs;
 
-  struct Note
+  // score's Crousti::Executor injects this member. A native token plus the
+  // facade gives the EXACT executed sample span, including partial callbacks.
+  // Avendish explicitly supports using ossia::token_request as T::tick.
+  using tick = ossia::token_request;
+  ossia::exec_state_facade ossia_state{};
+  struct Setup
   {
-    uint8_t pitch{};
-    uint8_t vel{};
-    uint8_t chan{};
+    int frames{};
+    double rate{};
+    std::uint64_t instance{};
   };
 
-  struct NoteIn
+  void prepare(Setup setup)
   {
-    Note note{};
-    int64_t date{};
-    bool fresh{};
-  };
-  std::vector<NoteIn> to_start;
-  std::vector<NoteIn> running_notes;
-
-  struct val_visitor
-  {
-    Node& st;
-    uint8_t base_note{};
-    uint8_t base_vel{};
-
-    Note operator()() { return {base_note, base_vel}; }
-    Note operator()(ossia::impulse) { return {base_note, base_vel}; }
-    template <typename T>
-    Note operator()(const T&)
+    // Reserve the outer message buffer off the audio thread. Allocation-free
+    // publication additionally requires inline short-message storage in
+    // libremidi and adequately reserved buffers in the host binding.
+    outputs.midi.midi_messages.reserve(detail::Engine<>::max_output_events);
+    if(rate_ != setup.rate)
+      engine_.request_reset();
+    rate_ = setup.rate;
+    if(!seeded_)
     {
-      return {base_note, base_vel};
-    }
-    Note operator()(float note) { return {(uint8_t)note, base_vel}; }
-    Note operator()(char note) { return {(uint8_t)note, base_vel}; }
-    Note operator()(int note) { return {(uint8_t)note, base_vel}; }
-    Note operator()(int note, int vel) { return {(uint8_t)note, (uint8_t)vel}; }
-    Note operator()(int note, float vel) { return {(uint8_t)note, (uint8_t)(vel * 127.f)}; }
-    Note operator()(const std::vector<ossia::value>& v)
-    {
-      switch(v.size())
-      {
-        case 0:
-          return operator()();
-        case 1:
-          return operator()(ossia::convert<int>(v[0]));
-        case 2: {
-          int note = ossia::convert<int>(v[0]);
-          switch(v[1].get_type())
-          {
-            case ossia::val_type::FLOAT:
-              return operator()(note, *v[1].v.target<float>());
-            case ossia::val_type::INT:
-              return operator()(note, *v[1].v.target<int>());
-            default:
-              return operator()(note, ossia::convert<int>(v[1]));
-          }
-        }
-        default:
-          return operator()(ossia::convert<int>(v[0]), ossia::convert<int>(v[1]));
-      }
-    }
-    template <std::size_t N>
-    Note operator()(const std::array<float, N>& v)
-    {
-      static_assert(N >= 2);
-      return operator()(v[0], v[1]);
-    }
-  };
-
-  static constexpr uint8_t midi_clamp(int num) { return (uint8_t)ossia::clamp(num, 0, 127); }
-
-  using tick = halp::tick_flicks;
-  void operator()(const tick& tk)
-  {
-    // TODO : when arrays like [ 1, 25, 12, 37, 10, 40 ] are received
-    // send relevant chords
-
-    // When a message is received, we have three cases :
-    // 1. Just an impulse: use base note & base vel
-    // 2. Just an int: it's the velocity, use base note
-    // 3. A tuple [int, int]: it's note and velocity
-
-    // Then once we have a pair [int, int] we randomize and we output a note
-    // on.
-
-    // At the end, scan running_notes: if any is going to end in this buffer,
-    // end it too.
-
-    // FIXME next version choose between these behaviours
-
-#define STOP_AT_NEXT_SAMPLE_FOR_ZERO_END_QUANT 1
-
-    const auto& start = inputs.start_quant.value;
-    // TODO double precision = tightness.rbegin()->second;
-    const auto& end = inputs.end_quant.value;
-    const auto& shiftnote = inputs.shift_note.value;
-    const auto& base_note = midi_clamp(inputs.basenote.value);
-    const auto& base_vel = midi_clamp(inputs.basevel.value);
-    const auto& rand_note = inputs.note_random.value;
-    const auto& rand_vel = inputs.vel_random.value;
-    const auto& chan = inputs.channel.value;
-
-    for(auto& in : inputs.port.value->get_data())
-    {
-      auto note = in.value.apply(val_visitor{*this, base_note, base_vel});
-
-      if(rand_note != 0)
-        note.pitch = std::clamp(
-            (int)note.pitch + (int)rnd::rand(-rand_note, rand_note), 0, 127);
-
-      if(rand_vel != 0)
-        note.vel
-            = std::clamp((int)note.vel + (int)rnd::rand(-rand_vel, rand_vel), 0, 127);
-
-      note.pitch = ossia::clamp((int)note.pitch + shiftnote, 0, 127);
-      note.vel = ossia::clamp((int)note.vel, 0, 127);
-
-      if(note.vel != 0.)
-      {
-        if(start == 0.f) // No quantification, start directly
-        {
-          outputs.midi.note_on(chan, note.pitch, note.vel).timestamp = in.timestamp;
-          if(end > 0.f)
-          {
-            this->running_notes.push_back(
-                {note, tk.position_in_frames + in.timestamp, true});
-          }
-          else if(end == 0.f)
-          {
-            // Stop at the next sample
-#if STOP_AT_NEXT_SAMPLE_FOR_ZERO_END_QUANT
-            outputs.midi.note_off(chan, note.pitch, note.vel).timestamp = in.timestamp;
-#endif
-          }
-          else
-          {
-            // else do nothing and just wait for a note off
-          }
-        }
-        else
-        {
-          // Find next time that matches the requested quantification
-          this->to_start.push_back({note, {}});
-        }
-      }
-      else
-      {
-        // Just stop
-        outputs.midi.note_off(chan, note.pitch, note.vel).timestamp = in.timestamp;
-      }
-    }
-    std::optional<int> start_quant_date{};
-
-    if(!to_start.empty())
-    {
-      if(start != 0.f)
-      {
-        for(auto [date, q] : tk.get_quantification_date(4. * start))
-        {
-          start_all_notes(tk.position_in_frames + date, date, chan, end);
-          start_quant_date = date;
-          break;
-        }
-      }
-      else
-      {
-        start_all_notes(tk.position_in_frames, 0, chan, end);
-        start_quant_date = 0;
-      }
-    }
-
-    if(end != 0.f)
-    {
-      for(auto [date, q] : tk.get_quantification_date(4. * end))
-      {
-        if(!start_quant_date || date > start_quant_date)
-        {
-          stop_notes(date, chan);
-        }
-      }
-    }
-    else
-    {
-      // FIXME this means that the notes cannot run ? instead we should just rely on note off maybe? but it's an impulse...
-      // we should do this for "impulses" and individual ints, but let the normal note off
-#if STOP_AT_NEXT_SAMPLE_FOR_ZERO_END_QUANT
-      stop_notes(0, chan);
-#endif
+      engine_.seed(setup.instance ^ 0xa35371f99772b987ULL);
+      seeded_ = true;
     }
   }
 
-  void start_all_notes(
-      ossia::physical_time abs_date, ossia::physical_time date_phys, int chan,
-      float endq) noexcept
+  // Processing-thread hooks only: never write, retain, or read output messages.
+  void start() noexcept
   {
-    for(auto& note : this->to_start)
-    {
-      outputs.midi.note_on(chan, note.note.pitch, note.note.vel).timestamp = date_phys;
-
-      if(endq > 0.f)
-      {
-        this->running_notes.push_back({{note.note}, abs_date});
-      }
-      else if(endq == 0.f)
-      {
-        // Stop at the next sample
-
-#if STOP_AT_NEXT_SAMPLE_FOR_ZERO_END_QUANT
-        outputs.midi.note_off(chan, note.note.pitch, note.note.vel).timestamp
-            = date_phys;
-#endif
-      }
-    }
-    this->to_start.clear();
+    running_ = true;
+    engine_.request_reset();
+  }
+  void stop() noexcept
+  {
+    running_ = false;
+    engine_.request_reset();
+  }
+  void pause() noexcept { stop(); }
+  void resume() noexcept { start(); }
+  template <typename Time>
+  void transport(Time) noexcept
+  {
+    engine_.request_reset();
   }
 
-  void stop_notes(ossia::physical_time date_phys, int chan)
+  [[nodiscard]] const detail::Statistics& statistics() const noexcept
   {
-    for(auto it = this->running_notes.begin(); it != this->running_notes.end();)
+    return engine_.statistics();
+  }
+  [[nodiscard]] bool needs_service() const noexcept { return engine_.needs_service(); }
+
+  // A host with no normal tick after stop/removal must provide one final writable
+  // cleanup tick before destroying the node or its route. This is a TICK API,
+  // not an out-of-band write from stop(). No output survives as deferred state.
+  void cleanup_tick(const tick& tk) noexcept
+  {
+    outputs.midi.midi_messages.clear();
+    engine_.begin_input();
+    engine_.request_reset();
+    if(const auto span = execution_span(tk); span && span->length > 0)
     {
-      auto& note = *it;
-      if(!note.fresh)
-      {
-        it = this->running_notes.erase(it);
-        outputs.midi.note_off(chan, note.note.pitch, note.note.vel).timestamp
-            = date_phys;
-      }
-      else
-      {
-        note.fresh = false;
-        ++it;
-      }
+      auto sink = [this](const detail::MidiEvent& e) noexcept { emit(e); };
+      engine_.drain_releases(0, static_cast<int>(span->length), sink);
     }
-    /*
-    for(auto it = this->running_notes.begin(); it != this->running_notes.end();)
+  }
+
+  void operator()(const tick& tk) noexcept
+  {
+    // A stop may leave graph tokens already requested by the interval. They
+    // may publish cleanup, but cannot trigger again until start or resume.
+    if(!running_)
     {
-      auto& note = *it;
-      // note.date is the date at which the note was started.
+      cleanup_tick(tk);
+      return;
+    }
+    // Output ports are scratch space for this invocation only. Host code may
+    // clear/move/destroy their message contents immediately after publication.
+    outputs.midi.midi_messages.clear();
+    engine_.begin_input();
+    const auto span = execution_span(tk);
+    if(!span)
+    {
+      engine_.request_reset();
+      return;
+    }
 
-      if(note.date.impl > tk.date.impl)
-      {
-        // Note was started "in the future", stop it right now as it means  we went back in time
-        p2.note_off(chan, note.note.pitch, note.note.vel).timestamp
-            = tk.to_physical_time_in_tick(tk.prev_date, sampleRatio);
-        it = this->running_notes.erase(it);
-      }
-      else if(note.date.impl < tk.prev_date.impl)
-      {
-        // if we're
-        it = this->running_notes.erase(it);
-      }
+    const auto total = ossia_state.samplesSinceStart();
+    const auto size = ossia_state.bufferSize();
+    // In score's buffer_tick and precise_score_tick, the counter has already
+    // advanced to the END of the current buffer when a dataflow node runs.
+    if(total < std::numeric_limits<std::int64_t>::min() + size
+       || total - size > std::numeric_limits<std::int64_t>::max() - span->start_sample)
+    {
+      engine_.request_reset();
+      return;
+    }
+    const detail::Block b{
+        .frames = static_cast<int>(span->length),
+        .first_frame = total - size + span->start_sample,
+        .quarters_begin = tk.musical_start_position,
+        .quarters_end = tk.musical_end_position,
+        .numerator = tk.signature.upper,
+        .denominator = tk.signature.lower,
+        .bar_begin = tk.musical_start_last_bar,
+        .bar_end = tk.musical_end_last_bar,
+        .last_signature = tk.musical_start_last_signature,
+        .model_begin = tk.prev_date.impl,
+        .model_end = tk.date.impl,
+        .discontinuity = tk.start_discontinuous,
+        .end_discontinuity = tk.end_discontinuous};
+
+    const detail::ValueDecoder decoder{inputs.basenote.value, inputs.basevel.value};
+    if(inputs.port.value && b.frames > 0)
+    {
+      const auto& data = inputs.port.value->get_data();
+      // Bounded scanning, including malformed and out-of-slice inputs. A
+      // discarded suffix could contain a release; fail closed on overload.
+      if(data.size() > detail::Engine<>::max_inputs)
+        engine_.input_overflow();
       else
-      {
-        ++it;
-      }
-
-      if(note.date > tk.prev_date && note.date.impl < tk.date.impl)
-      {
-        p2.note_off(chan, note.note.pitch, note.note.vel).timestamp
-            = (note.date - tk.prev_date).impl * st.modelToSamples();
-
-        it = this->running_notes.erase(it);
-      }
-      else
-      {
-        ++it;
-      }
+        for(const auto& input : data)
+        {
+          if(input.timestamp < span->start_sample
+             || input.timestamp - span->start_sample >= span->length)
+            continue;
+          if(const auto note = input.value.apply(decoder))
+            if(!engine_.push(
+                   static_cast<int>(input.timestamp - span->start_sample), *note))
+              break;
         }
-*/
+    }
+    detail::Settings settings{
+        .start_quant = inputs.start_quant.value,
+        .tightness = inputs.tightness.value,
+        .end_quant = inputs.end_quant.value,
+        .end_mode = inputs.fixed_duration.value ? detail::EndMode::duration
+                                                : detail::EndMode::quantized,
+        .channel = inputs.channel.value,
+        .pitch_shift = inputs.shift_note.value,
+        .pitch_random = inputs.note_random.value,
+        .velocity_random = inputs.vel_random.value,
+        .pitch_direction = inputs.pitch_direction.value};
+    settings = detail::settings_from_time_chooser(
+        settings, inputs.duration.value, inputs.duration.sync, tk.tempo);
+    auto sink = [this](const detail::MidiEvent& e) noexcept { emit(e); };
+    engine_.process(b, settings, sink);
+  }
+
+  // Public data preserve aggregate reflection. Only these local members survive
+  // invocations; none is a pointer/reference/iterator into a message port.
+  detail::Engine<> engine_{};
+  bool running_{true};
+  double rate_{};
+  bool seeded_{};
+
+  std::optional<ossia::exec_state_facade::sample_timings>
+  execution_span(const tick& tk) const noexcept
+  {
+    if(!ossia_state.impl || ossia_state.bufferSize() < 0)
+      return std::nullopt;
+    const auto size = ossia_state.bufferSize();
+    // Do not rescale the full model interval into a host-clipped physical span.
+    // A malformed carried span is rejected, leaving releases local for retry.
+    if(tk.start_sample >= 0 && tk.length_sample >= 0
+       && (tk.start_sample > size || tk.length_sample > size - tk.start_sample))
+      return std::nullopt;
+    const auto span = ossia_state.timings(tk);
+    if(span.start_sample < 0 || span.length < 0 || span.start_sample > size
+       || span.length > size - span.start_sample)
+      return std::nullopt;
+    return span;
+  }
+
+  void emit(const detail::MidiEvent& e) noexcept
+  {
+    auto& msg = outputs.midi.midi_messages.emplace_back();
+    msg.bytes.assign(
+        {static_cast<unsigned char>((e.on ? 0x90 : 0x80) | e.channel), e.pitch,
+         e.velocity});
+    // Slice-relative. Avendish's MIDI postprocessor adds the slice start once.
+    msg.timestamp = e.frame;
   }
 };
-}
-}
+} // namespace Nodes::PulseToNote

--- a/src/plugins/score-plugin-fx/Fx/VelToNoteCore.hpp
+++ b/src/plugins/score-plugin-fx/Fx/VelToNoteCore.hpp
@@ -64,6 +64,16 @@ decode_pair(double pitch, double velocity, bool normalized_velocity) noexcept
   return DecodedNote{static_cast<std::uint8_t>(*p), static_cast<std::uint8_t>(iv)};
 }
 
+// A duration bound in whichever unit the chooser was in. Zero disables it.
+// Each bound carries its own unit because the two choosers sync independently.
+struct Bound
+{
+  double value{};
+  DurationUnit unit{DurationUnit::quarters};
+
+  friend bool operator==(const Bound&, const Bound&) = default;
+};
+
 struct Settings
 {
   // The score selectors contain fractions of a whole note, NOT rates.
@@ -72,6 +82,12 @@ struct Settings
   double start_quant{0.25};
   double tightness{1.};
   double end_quant{0.25}; // > 0: grid; == 0: one sample; < 0: explicit release.
+  // Quantized mode only: a floor and a ceiling on how long a note may hold.
+  // The floor extends to the first grid point at or after it, so a bounded
+  // note still lands on the grid. The ceiling clamps exactly -- snapping back
+  // to the previous grid point can land before the note started.
+  Bound min_duration{};
+  Bound max_duration{};
   EndMode end_mode{EndMode::quantized};
   DurationUnit duration_unit{DurationUnit::model_seconds};
   double duration{}; // Already converted to the unit above by the host adapter.
@@ -139,6 +155,8 @@ inline Settings sanitize(Settings s) noexcept
   s.end_quant
       = std::isfinite(s.end_quant) && s.end_quant < 0. ? -1. : quant(s.end_quant);
   s.duration = finite_clamp(s.duration, 0., 86400., 0.);
+  s.min_duration.value = finite_clamp(s.min_duration.value, 0., 86400., 0.);
+  s.max_duration.value = finite_clamp(s.max_duration.value, 0., 86400., 0.);
   s.channel = std::clamp(s.channel, 1, 16);
   s.pitch_shift = std::clamp(s.pitch_shift, -127, 127);
   s.pitch_random = std::clamp(s.pitch_random, 0, 127);
@@ -303,7 +321,12 @@ class Engine
     frame_t arrival_frame{}, not_before{};
     std::int64_t model_anchor{}; // end_target is relative to this for model durations.
     position_t arrival_quarter{}, start_target{}, end_target{};
+    // Where the note actually began, and its bounds resolved into quarters.
+    // Both are fixed when the note starts: a bound asked for in seconds must
+    // not move later because the tempo did.
+    position_t activation_quarter{}, min_quarters{}, max_quarters{};
     double start_quant{}, tightness{}, end_quant{}, duration{};
+    Bound min_duration{}, max_duration{};
     int direction{};
     int due{}; // Slice-local deadline; Block::frames means not in this slice.
   };
@@ -479,7 +502,9 @@ public:
         set_start_target(v, grid, b, qd);
       if(v.state == State::active && v.end_kind == EndKind::grid && meter_changed && qd
          && qd * (v.end_target - b.quarters_begin) > 0.L)
-        v.end_target = grid.next(b.quarters_begin, v.end_quant, qd);
+        v.end_target = clamp_grid_end(
+            v, v.activation_quarter, grid.next(b.quarters_begin, v.end_quant, qd),
+            grid);
       if(v.state != State::free)
         v.due = deadline(v, b, grid);
     }
@@ -630,6 +655,47 @@ private:
   {
     return at(b.quarters_begin, b.quarters_end, f, b.frames);
   }
+  // A bound in quarters, or zero when it is disabled or cannot be resolved.
+  // A seconds bound needs a tempo, and the slice is the only place one is
+  // known; a slice that advances no musical time cannot supply it, so the
+  // bound is dropped rather than guessed.
+  static position_t resolve_bound(const Bound& bound, const Block& b) noexcept
+  {
+    if(!(bound.value > 0.))
+      return 0.L;
+    if(bound.unit == DurationUnit::quarters)
+      return position_t(bound.value);
+    const auto seconds
+        = std::abs(model_delta(b.model_end, b.model_begin)) / flicks_per_second;
+    const auto quarters = std::abs(position_t(b.quarters_end) - position_t(b.quarters_begin));
+    if(!(seconds > 0.L) || !(quarters > 0.L))
+      return 0.L;
+    return position_t(bound.value) * (quarters / seconds);
+  }
+  // Apply the quantized-mode bounds to a grid deadline. `from` is where the
+  // note began. Order matters: the floor moves the target out to a grid point,
+  // then the ceiling caps it, so a ceiling below the floor yields exactly the
+  // floor rather than cancelling the note.
+  static position_t clamp_grid_end(
+      const Voice& v, position_t from, position_t target, const Grid& grid) noexcept
+  {
+    const int dir = v.direction;
+    if(dir == 0)
+      return target;
+    if(v.min_quarters > 0.L)
+    {
+      const auto floor_at = from + dir * v.min_quarters;
+      if(dir * (floor_at - target) > 0.L)
+        target = grid.next(floor_at, v.end_quant, dir);
+    }
+    if(v.max_quarters > 0.L)
+    {
+      const auto ceil_at = from + dir * std::max(v.max_quarters, v.min_quarters);
+      if(dir * (target - ceil_at) > 0.L)
+        target = ceil_at;
+    }
+    return target;
+  }
   // Cast AFTER unsigned subtraction. This handles the complete int64 range
   // without signed overflow or losing small deltas at a large model origin on
   // platforms where long double has only double precision (notably MSVC).
@@ -764,6 +830,8 @@ private:
     v.tightness = s.tightness;
     v.end_quant = s.end_quant;
     v.duration = s.duration;
+    v.min_duration = s.min_duration;
+    v.max_duration = s.max_duration;
     v.end_kind
         = s.end_mode == EndMode::duration
               ? (s.duration == 0.                                 ? EndKind::sample
@@ -799,7 +867,14 @@ private:
     else if(v.end_kind == EndKind::musical)
       v.end_target = quarter_at(b, frame) + v.direction * v.duration;
     else if(v.end_kind == EndKind::grid)
-      v.end_target = grid.next(quarter_at(b, frame), v.end_quant, v.direction, true);
+    {
+      v.activation_quarter = quarter_at(b, frame);
+      v.min_quarters = resolve_bound(v.min_duration, b);
+      v.max_quarters = resolve_bound(v.max_duration, b);
+      v.end_target = clamp_grid_end(
+          v, v.activation_quarter,
+          grid.next(v.activation_quarter, v.end_quant, v.direction, true), grid);
+    }
     v.due = deadline(v, b, grid);
     return true;
   }

--- a/src/plugins/score-plugin-fx/Fx/VelToNoteCore.hpp
+++ b/src/plugins/score-plugin-fx/Fx/VelToNoteCore.hpp
@@ -1,0 +1,835 @@
+#pragma once
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Allocation-free, host-independent scheduling for Nodes::PulseToNote::Node.
+
+#include <cmath>
+
+#include <algorithm>
+#include <array>
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+namespace Nodes::PulseToNote::detail
+{
+using frame_t = std::int64_t;
+using position_t = long double;
+inline constexpr position_t flicks_per_second = 705600000.L;
+
+enum class EndMode
+{
+  quantized,
+  duration
+};
+enum class DurationUnit
+{
+  model_seconds,
+  quarters
+};
+enum class PitchDirection
+{
+  Both,
+  Higher,
+  Lower
+};
+
+struct DecodedNote
+{
+  std::uint8_t pitch{};    // Source identity, BEFORE transposition / randomization.
+  std::uint8_t velocity{}; // Zero is an explicit release.
+};
+
+inline std::optional<int> midi_number(double x) noexcept
+{
+  if(!std::isfinite(x))
+    return std::nullopt;
+  return static_cast<int>(std::clamp(x, 0., 127.));
+}
+
+// Float velocities are normalized; integer velocities use the MIDI range.
+// A positive normalized velocity remains a note-on, even below 1 / 127.
+inline std::optional<DecodedNote>
+decode_pair(double pitch, double velocity, bool normalized_velocity) noexcept
+{
+  const auto p = midi_number(pitch);
+  if(!p || !std::isfinite(velocity))
+    return std::nullopt;
+  const double v = normalized_velocity ? std::clamp(velocity, 0., 1.) * 127.
+                                       : std::clamp(velocity, 0., 127.);
+  const int iv = v > 0. ? std::max(1, static_cast<int>(v)) : 0;
+  return DecodedNote{static_cast<std::uint8_t>(*p), static_cast<std::uint8_t>(iv)};
+}
+
+struct Settings
+{
+  // The score selectors contain fractions of a whole note, NOT rates.
+  // For compatibility with score, 1 and above mean one bar and multiples
+  // of a bar. Fractions below 1 mean 4 * value quarter notes, reset per bar.
+  double start_quant{0.25};
+  double tightness{1.};
+  double end_quant{0.25}; // > 0: grid; == 0: one sample; < 0: explicit release.
+  EndMode end_mode{EndMode::quantized};
+  DurationUnit duration_unit{DurationUnit::model_seconds};
+  double duration{}; // Already converted to the unit above by the host adapter.
+  int channel{1};    // User-facing, one-based.
+  int pitch_shift{};
+  int pitch_random{};
+  int velocity_random{};
+  PitchDirection pitch_direction{PitchDirection::Both};
+};
+
+struct Block
+{
+  int frames{};
+  frame_t first_frame{}; // Absolute AUDIO clock of this slice's first sample.
+  double quarters_begin{};
+  double quarters_end{}; // One-past-end musical position.
+  int numerator{4};
+  int denominator{4};
+  double bar_begin{}; // Last bar line at slice start.
+  double bar_end{};   // Last bar line at slice end.
+  double last_signature{};
+  std::int64_t model_begin{}; // Logical flicks; NOT the wall / sample clock.
+  std::int64_t model_end{};
+  bool discontinuity{};
+  bool end_discontinuity{};
+};
+
+struct MidiEvent
+{
+  int frame{};            // Slice-relative; always in [0, Block::frames).
+  std::uint8_t channel{}; // Wire format, ZERO-based.
+  std::uint8_t pitch{};
+  std::uint8_t velocity{}; // Release velocity is deliberately zero.
+  bool on{};
+  friend bool operator==(const MidiEvent&, const MidiEvent&) = default;
+};
+
+struct Statistics
+{
+  std::uint64_t input_overflows{};
+  std::uint64_t rejected_inputs{};
+  std::uint64_t dropped_triggers{};
+  std::uint64_t coalesced_starts{};
+  std::uint64_t retriggers{};
+  std::uint64_t resets{};
+  std::uint64_t invalid_blocks{};
+  std::uint64_t output_failures{};
+};
+
+inline double finite_clamp(double x, double lo, double hi, double fallback) noexcept
+{
+  return std::isfinite(x) ? std::clamp(x, lo, hi) : fallback;
+}
+
+inline Settings sanitize(Settings s) noexcept
+{
+  // Explicit lower bound prevents unrepresentable / denormal grid spacing.
+  auto quant = [](double q) {
+    if(!std::isfinite(q) || q <= 0.)
+      return 0.;
+    return std::clamp(q, 1. / 1024., 64.);
+  };
+  s.start_quant = quant(s.start_quant);
+  s.tightness = finite_clamp(s.tightness, 0., 1., 1.);
+  s.end_quant
+      = std::isfinite(s.end_quant) && s.end_quant < 0. ? -1. : quant(s.end_quant);
+  s.duration = finite_clamp(s.duration, 0., 86400., 0.);
+  s.channel = std::clamp(s.channel, 1, 16);
+  s.pitch_shift = std::clamp(s.pitch_shift, -127, 127);
+  s.pitch_random = std::clamp(s.pitch_random, 0, 127);
+  s.velocity_random = std::clamp(s.velocity_random, 0, 127);
+  return s;
+}
+
+// Correct only rounding noise at a sample boundary, never quantize a duration
+// to a grid. Interpolation uses wide arithmetic; endpoint inputs may be doubles.
+inline position_t clean_integer(position_t x) noexcept
+{
+  const auto n = std::round(x);
+  const auto eps = std::clamp(
+      64.L * std::numeric_limits<double>::epsilon() * std::max(1.L, std::abs(x)), 1e-9L,
+      1e-5L);
+  return std::abs(x - n) <= eps ? n : x;
+}
+template <typename T>
+inline int direction(T a, T z) noexcept
+{
+  return (z > a) - (z < a);
+}
+
+// Analytic grid: no per-block grid allocation and no arbitrary event-count cap.
+// Fractions < 1 are whole-note fractions, reset at every bar. Values >= 1
+// denote multiples of a bar counted from the last signature change, as in score.
+class Grid
+{
+public:
+  explicit Grid(const Block& b) noexcept
+      : length_{
+            b.numerator > 0 && b.denominator > 0 ? 4.L * b.numerator / b.denominator
+                                                 : 4.L}
+      , near_{std::min(b.bar_begin, b.bar_end)}
+      , far_{std::max(b.bar_begin, b.bar_end)}
+      , origin_{b.last_signature}
+  {
+    const auto lo = std::min(b.quarters_begin, b.quarters_end);
+    const auto hi = std::max(b.quarters_begin, b.quarters_end);
+    // Defensive fallback only for missing/inconsistent bar metadata.
+    if(near_ > lo || near_ + length_ < lo)
+      near_ = origin_ + std::floor((lo - origin_) / length_) * length_;
+    if(far_ < near_ || far_ > hi)
+      far_ = near_;
+  }
+
+  [[nodiscard]] position_t
+  next(position_t q, double selection, int dir, bool strict = false) const noexcept
+  {
+    if(selection >= 1.)
+    {
+      const auto unit = length_ * selection;
+      const auto x = clean_integer((q - origin_) / unit);
+      const auto k = dir > 0 ? (strict ? std::floor(x) + 1.L : std::ceil(x))
+                             : (strict ? std::ceil(x) - 1.L : std::floor(x));
+      return origin_ + k * unit;
+    }
+    const auto unit = 4.L * selection;
+    const auto anchor = q >= far_ ? far_ : near_;
+    const auto bar
+        = anchor + std::floor(clean_integer((q - anchor) / length_)) * length_;
+    auto end = bar + length_;
+    if(bar < far_ && end > far_)
+      end = far_; // An irregular reported bar line.
+    const auto x = clean_integer((q - bar) / unit);
+    if(dir > 0)
+    {
+      const auto k = strict ? std::floor(x) + 1.L : std::ceil(x);
+      return std::min(bar + k * unit, end);
+    }
+    const auto k = strict ? std::ceil(x) - 1.L : std::floor(x);
+    if(k >= 0.L)
+      return bar + k * unit;
+    // We crossed the start of this bar. The preceding bar can be truncated.
+    const auto previous
+        = bar == far_ && far_ > near_
+              ? near_
+                    + (std::ceil(clean_integer((far_ - near_) / length_)) - 1.L)
+                          * length_
+              : bar - length_;
+    const auto last = std::ceil(clean_integer((bar - previous) / unit)) - 1.L;
+    return previous + std::max(0.L, last) * unit;
+  }
+
+private:
+  position_t length_, near_, far_, origin_;
+};
+
+// Directed phase uses the actual adjacent points, including the short cell at
+// an odd-meter bar boundary. Every target is causal in either travel direction.
+inline position_t onset_target(
+    const Grid& grid, position_t arrival, double quant, double tightness,
+    int dir) noexcept
+{
+  if(quant <= 0. || tightness <= 0.)
+    return arrival;
+  const auto next = grid.next(arrival, quant, dir);
+  if(next == arrival)
+    return arrival;
+  if(tightness >= 1.)
+    return next;
+  const auto previous = grid.next(arrival, quant, -dir);
+  const auto phase = (arrival - previous) / (next - previous);
+  const auto grace = (1.L - tightness) / 2.L;
+  const auto x = std::clamp((phase - grace) / grace, 0.L, 1.L);
+  const auto weight = tightness * x * x * (3.L - 2.L * x);
+  return arrival + weight * (next - arrival);
+}
+
+// Not a source of cryptographic randomness. Instance-owned, reproducible, no
+// locking / allocation / process-global random generator on the audio thread.
+class Random
+{
+public:
+  void seed(std::uint64_t value) noexcept { state_ = value; }
+  int between(int low, int high) noexcept
+  {
+    if(low == high)
+      return low;
+    state_ += 0x9e3779b97f4a7c15ULL;
+    auto z = state_;
+    z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+    z ^= z >> 31;
+    // At most 255 outcomes. The modulo bias is negligible (less than 2^-56).
+    return low + static_cast<int>(z % static_cast<unsigned>(high - low + 1));
+  }
+  int symmetric(int radius) noexcept { return between(-radius, radius); }
+
+private:
+  std::uint64_t state_{0x71cc53a295a3b2e1ULL};
+};
+
+// Single execution thread. The sink accepts only CURRENT-slice messages.
+// A void sink promises delivery; a bool sink can refuse a message. Refused
+// note-offs are retained locally and must succeed before any more note-ons.
+template <std::size_t MaxVoices = 256, std::size_t MaxInputs = 4096>
+class Engine
+{
+  static_assert(MaxVoices > 0 && MaxInputs > 0);
+  static constexpr frame_t frame_limit = std::numeric_limits<frame_t>::max() / 4;
+  enum class State : std::uint8_t
+  {
+    free,
+    pending,
+    active
+  };
+  enum class EndKind : std::uint8_t
+  {
+    grid,
+    sample,
+    model,
+    musical,
+    hold
+  };
+  struct Voice
+  {
+    State state{};
+    EndKind end_kind{};
+    std::uint8_t source{}, pitch{}, velocity{}, channel{};
+    std::uint64_t serial{};
+    frame_t arrival_frame{}, not_before{};
+    std::int64_t model_anchor{}; // end_target is relative to this for model durations.
+    position_t arrival_quarter{}, start_target{}, end_target{};
+    double start_quant{}, tightness{}, end_quant{}, duration{};
+    int direction{};
+    int due{}; // Slice-local deadline; Block::frames means not in this slice.
+  };
+  struct Input
+  {
+    int frame{};
+    DecodedNote note{};
+    std::size_t order{};
+  };
+
+public:
+  static constexpr std::size_t max_voices = MaxVoices;
+  static constexpr std::size_t max_inputs = MaxInputs;
+  static constexpr std::size_t wire_notes = 16 * 128;
+  // Two messages per new/carried voice, plus every locally owed wire release.
+  static constexpr std::size_t max_output_events
+      = 2 * MaxInputs + 2 * MaxVoices + wire_notes;
+
+  void seed(std::uint64_t value) noexcept { random_.seed(value); }
+  [[nodiscard]] const Statistics& statistics() const noexcept { return stats_; }
+  [[nodiscard]] std::size_t active_count() const noexcept
+  {
+    return count(State::active);
+  }
+  [[nodiscard]] std::size_t pending_count() const noexcept
+  {
+    return count(State::pending);
+  }
+  [[nodiscard]] std::size_t deferred_release_count() const noexcept
+  {
+    return owed_offs_.count();
+  }
+  [[nodiscard]] bool needs_service() const noexcept
+  {
+    return active_count() || pending_count() || owed_offs_.any();
+  }
+
+  // NO port access here. Lifecycle, transport, and end-of-tick calls can safely
+  // retire voices even if no output sample currently exists. Repeated calls
+  // preserve the locally stored releases. Pending starts are discarded.
+  void request_reset() noexcept
+  {
+    for(auto& v : voices_)
+    {
+      if(v.state == State::active)
+        owe_off(v);
+      v.state = State::free;
+    }
+    have_previous_ = false;
+    ++stats_.resets;
+  }
+
+  void begin_input() noexcept
+  {
+    input_count_ = 0;
+    overflow_ = false;
+  }
+  bool push(int frame, DecodedNote note) noexcept
+  {
+    if(input_count_ == MaxInputs)
+    {
+      overflow_ = true;
+      return false;
+    }
+    inputs_[input_count_] = {frame, note, input_count_};
+    ++input_count_;
+    return true;
+  }
+  void input_overflow() noexcept { overflow_ = true; }
+
+  // Service a real writable window without triggering or advancing any notes.
+  // May be used by a host that gives stopped nodes a final cleanup tick.
+  template <typename Sink>
+  bool drain_releases(int frame, int frames, Sink&& sink) noexcept
+  {
+    if(frame < 0 || frame >= frames)
+      return !owed_offs_.any();
+    for(std::size_t k = 0; k < wire_notes; ++k)
+    {
+      if(!owed_offs_[k])
+        continue;
+      if(!send(
+             MidiEvent{
+                 frame, static_cast<std::uint8_t>(k / 128),
+                 static_cast<std::uint8_t>(k % 128), 0, false},
+             sink))
+        return false;
+      owed_offs_.reset(k);
+    }
+    return true;
+  }
+
+  template <typename Sink>
+  void process(const Block& b, Settings settings, Sink&& sink) noexcept
+  {
+    // Inspect transport even when there is no writable frame. Never emit an
+    // out-of-range message and never consume locally owed releases in this case.
+    if(b.frames <= 0)
+    {
+      if(b.frames < 0 || b.discontinuity || b.end_discontinuity
+         || b.model_begin != b.model_end || b.quarters_begin != b.quarters_end
+         || changed_position(b))
+        request_reset();
+      begin_input();
+      return;
+    }
+    if(!valid(b))
+    {
+      ++stats_.invalid_blocks;
+      request_reset();
+      drain_releases(0, b.frames, sink);
+      begin_input();
+      return;
+    }
+    const int md = direction(b.model_begin, b.model_end);
+    const int qd = direction(b.quarters_begin, b.quarters_end);
+    const bool reversed
+        = have_previous_
+          && ((md && previous_model_direction_ && md != previous_model_direction_)
+              || (qd && previous_quarter_direction_
+                  && qd != previous_quarter_direction_));
+    if(b.discontinuity || changed_position(b) || reversed)
+      request_reset();
+
+    // Stationary scrubs audition no new triggers. Retire all previous voices.
+    // A continuous reverse tick, unlike a stationary tick, is fully playable.
+    if(md == 0)
+      request_reset();
+    if(!drain_releases(0, b.frames, sink))
+    {
+      begin_input();
+      return; // Backpressure: do not permit a new on before its owed off.
+    }
+    if(md == 0)
+    {
+      begin_input();
+      remember(b);
+      return;
+    }
+    if(overflow_)
+    {
+      ++stats_.input_overflows;
+      request_reset(); // A discarded input suffix could contain explicit offs.
+      drain_releases(0, b.frames, sink);
+      begin_input();
+      remember(b);
+      return;
+    }
+
+    settings = sanitize(settings);
+    std::size_t kept = 0;
+    for(std::size_t i = 0; i < input_count_; ++i)
+      if(inputs_[i].frame >= 0 && inputs_[i].frame < b.frames
+         && inputs_[i].note.pitch <= 127 && inputs_[i].note.velocity <= 127)
+        inputs_[kept++] = inputs_[i];
+      else
+        ++stats_.rejected_inputs;
+    input_count_ = kept;
+    std::sort(
+        inputs_.begin(), inputs_.begin() + input_count_,
+        [](const Input& a, const Input& c) {
+      return a.frame != c.frame ? a.frame < c.frame : a.order < c.order;
+    });
+
+    const Grid grid{b};
+    const bool meter_changed = have_previous_
+                               && (b.numerator != previous_numerator_
+                                   || b.denominator != previous_denominator_
+                                   || b.last_signature != previous_signature_);
+    for(auto& v : voices_)
+    {
+      if(v.state == State::pending && meter_changed && v.start_quant > 0. && qd)
+        set_start_target(v, grid, b, qd);
+      if(v.state == State::active && v.end_kind == EndKind::grid && meter_changed && qd
+         && qd * (v.end_target - b.quarters_begin) > 0.L)
+        v.end_target = grid.next(b.quarters_begin, v.end_quant, qd);
+      if(v.state != State::free)
+        v.due = deadline(v, b, grid);
+    }
+
+    bool ok = true;
+    std::size_t input = 0;
+    while(ok)
+    {
+      int now = input < input_count_ ? inputs_[input].frame : b.frames;
+      for(const auto& v : voices_)
+        if(v.state != State::free)
+          now = std::min(now, v.due);
+      if(now >= b.frames)
+        break;
+
+      // Automatic offs, then timestamp-stable inputs, then surviving ons.
+      for(auto& v : voices_)
+        if(v.state == State::active && v.due == now)
+          if(!release(v, now, sink))
+          {
+            ok = false;
+            break;
+          }
+      if(!ok)
+        break;
+      while(input < input_count_ && inputs_[input].frame == now)
+      {
+        const auto note = inputs_[input++].note;
+        if(note.velocity == 0)
+          ok = cancel_source(note.pitch, now, sink);
+        else
+          enqueue(note, now, settings, b, grid);
+        if(!ok)
+          break;
+      }
+      if(!ok)
+        break;
+
+      // One voice per wire (channel,pitch); last arrival wins on equal samples.
+      for(auto& v : voices_)
+      {
+        if(v.state != State::pending || v.due != now)
+          continue;
+        for(const auto& other : voices_)
+          if(other.state == State::pending && other.due == now
+             && other.channel == v.channel && other.pitch == v.pitch
+             && other.serial > v.serial)
+          {
+            v.state = State::free;
+            ++stats_.coalesced_starts;
+            break;
+          }
+      }
+      // Release collisions before ANY new on at this timestamp.
+      for(const auto& p : voices_)
+      {
+        if(p.state != State::pending || p.due != now)
+          continue;
+        for(auto& a : voices_)
+          if(a.state == State::active && a.channel == p.channel && a.pitch == p.pitch)
+          {
+            ok = release(a, now, sink);
+            ++stats_.retriggers;
+            if(!ok)
+              break;
+          }
+        if(!ok)
+          break;
+      }
+      if(!ok)
+        break;
+      for(;;)
+      {
+        Voice* next = nullptr;
+        for(auto& v : voices_)
+          if(v.state == State::pending && v.due == now
+             && (!next || v.serial < next->serial))
+            next = &v;
+        if(!next)
+          break;
+        if(!activate(*next, now, b, grid, sink))
+        {
+          ok = false;
+          break;
+        }
+      }
+    }
+    begin_input();
+    if(!ok)
+    {
+      request_reset();
+      return;
+    }
+    remember(b);
+    // The next tick owns this boundary. Do not emit at frame == b.frames or
+    // append a speculative future timestamp to the output port.
+    if(b.end_discontinuity)
+      request_reset();
+  }
+
+private:
+  [[nodiscard]] std::size_t count(State state) const noexcept
+  {
+    return std::count_if(voices_.begin(), voices_.end(), [state](const Voice& v) {
+      return v.state == state;
+    });
+  }
+  void owe_off(const Voice& v) noexcept
+  {
+    owed_offs_.set(std::size_t(v.channel) * 128 + v.pitch);
+  }
+  template <typename Sink>
+  bool send(const MidiEvent& e, Sink& sink) noexcept
+  {
+    if constexpr(std::is_void_v<std::invoke_result_t<Sink&, const MidiEvent&>>)
+    {
+      sink(e);
+      return true;
+    }
+    else
+    {
+      if(sink(e))
+        return true;
+      ++stats_.output_failures;
+      return false;
+    }
+  }
+  static bool valid(const Block& b) noexcept
+  {
+    auto position = [](double q) { return std::isfinite(q) && std::abs(q) <= 1e9; };
+    return b.first_frame >= -frame_limit && b.first_frame <= frame_limit - b.frames
+           && position(b.quarters_begin) && position(b.quarters_end)
+           && position(b.bar_begin) && position(b.bar_end) && position(b.last_signature)
+           && b.numerator >= 0 && b.numerator <= 1024 && b.denominator >= 0
+           && b.denominator <= 1024;
+  }
+  bool changed_position(const Block& b) const noexcept
+  {
+    return have_previous_
+           && (b.first_frame != previous_frame_ || b.model_begin != previous_model_
+               || std::abs(position_t(b.quarters_begin) - previous_quarter_) > 1e-8L);
+  }
+  static position_t at(position_t a, position_t z, int f, int frames) noexcept
+  {
+    return a + (z - a) * (position_t(f) / frames);
+  }
+  static position_t quarter_at(const Block& b, int f) noexcept
+  {
+    return at(b.quarters_begin, b.quarters_end, f, b.frames);
+  }
+  // Cast AFTER unsigned subtraction. This handles the complete int64 range
+  // without signed overflow or losing small deltas at a large model origin on
+  // platforms where long double has only double precision (notably MSVC).
+  static position_t model_delta(std::int64_t to, std::int64_t from) noexcept
+  {
+    if(to >= from)
+      return position_t(std::uint64_t(to) - std::uint64_t(from));
+    return -position_t(std::uint64_t(from) - std::uint64_t(to));
+  }
+  static int
+  frame_of(position_t a, position_t z, position_t target, int frames, bool ceil) noexcept
+  {
+    if(a == z)
+      return frames;
+    const auto x = clean_integer((target - a) / (z - a) * frames);
+    if(!std::isfinite(x) || x >= frames)
+      return frames;
+    if(x <= 0.L)
+      return 0;
+    return static_cast<int>(ceil ? std::ceil(x) : std::floor(x));
+  }
+  static int local_frame(const Block& b, frame_t absolute) noexcept
+  {
+    if(absolute <= b.first_frame)
+      return 0;
+    if(absolute >= b.first_frame + b.frames)
+      return b.frames;
+    return static_cast<int>(absolute - b.first_frame);
+  }
+  static void
+  set_start_target(Voice& v, const Grid& grid, const Block& b, int dir) noexcept
+  {
+    const auto from = dir > 0
+                          ? std::max(v.arrival_quarter, position_t(b.quarters_begin))
+                          : std::min(v.arrival_quarter, position_t(b.quarters_begin));
+    v.start_target = onset_target(grid, from, v.start_quant, v.tightness, dir);
+  }
+  int deadline(const Voice& v, const Block& b, const Grid& grid) const noexcept
+  {
+    if(v.state == State::pending)
+    {
+      const int earliest = local_frame(b, v.arrival_frame);
+      if(v.start_quant == 0. || v.tightness == 0.)
+        return earliest;
+      return std::max(
+          earliest,
+          frame_of(b.quarters_begin, b.quarters_end, v.start_target, b.frames, true));
+    }
+    const int earliest = local_frame(b, v.not_before);
+    switch(v.end_kind)
+    {
+      case EndKind::sample:
+        return earliest;
+      case EndKind::model:
+        return std::max(
+            earliest, frame_of(
+                          0.L, model_delta(b.model_end, b.model_begin),
+                          model_delta(v.model_anchor, b.model_begin) + v.end_target,
+                          b.frames, true));
+      case EndKind::musical:
+        return std::max(
+            earliest,
+            frame_of(b.quarters_begin, b.quarters_end, v.end_target, b.frames, true));
+      case EndKind::grid:
+        return std::max(
+            earliest,
+            frame_of(b.quarters_begin, b.quarters_end, v.end_target, b.frames, true));
+      case EndKind::hold:
+        return b.frames;
+    }
+    return b.frames;
+  }
+  template <typename Sink>
+  bool release(Voice& v, int frame, Sink& sink) noexcept
+  {
+    const bool ok = send(MidiEvent{frame, v.channel, v.pitch, 0, false}, sink);
+    if(!ok)
+      owe_off(v);
+    v.state = State::free;
+    return ok;
+  }
+  template <typename Sink>
+  bool cancel_source(std::uint8_t source, int frame, Sink& sink) noexcept
+  {
+    for(auto& v : voices_)
+      if(v.state != State::free && v.source == source)
+      {
+        if(v.state == State::active)
+        {
+          if(!release(v, frame, sink))
+            return false;
+        }
+        else
+          v.state = State::free;
+      }
+    return true; // Unmatched releases never stop notes owned by other processors.
+  }
+  void enqueue(
+      DecodedNote note, int frame, const Settings& s, const Block& b,
+      const Grid& grid) noexcept
+  {
+    // A full pool rejects the trigger; it never silently evicts an unrelated
+    // active note or forgets that note's eventual release.
+    Voice* free = nullptr;
+    for(auto& v : voices_)
+    {
+      if(v.state == State::free && !free)
+        free = &v;
+    }
+    if(!free)
+    {
+      ++stats_.dropped_triggers;
+      return;
+    }
+    auto& v = *free;
+    v = {};
+    v.state = State::pending;
+    v.source = note.pitch;
+    v.pitch = static_cast<std::uint8_t>(std::clamp(
+        int(note.pitch) + s.pitch_shift
+            + random_.between(
+                s.pitch_direction == PitchDirection::Higher ? 0 : -s.pitch_random,
+                s.pitch_direction == PitchDirection::Lower ? 0 : s.pitch_random),
+        0, 127));
+    v.velocity = static_cast<std::uint8_t>(
+        std::clamp(int(note.velocity) + random_.symmetric(s.velocity_random), 1, 127));
+    v.channel = static_cast<std::uint8_t>(s.channel - 1);
+    v.serial = ++serial_;
+    v.arrival_frame = b.first_frame + frame;
+    v.arrival_quarter = quarter_at(b, frame);
+    v.start_quant = s.start_quant;
+    v.tightness = s.tightness;
+    v.end_quant = s.end_quant;
+    v.duration = s.duration;
+    v.end_kind
+        = s.end_mode == EndMode::duration
+              ? (s.duration == 0.                                 ? EndKind::sample
+                 : s.duration_unit == DurationUnit::model_seconds ? EndKind::model
+                                                                  : EndKind::musical)
+              : (s.end_quant > 0.   ? EndKind::grid
+                 : s.end_quant < 0. ? EndKind::hold
+                                    : EndKind::sample);
+    const int qd = direction(b.quarters_begin, b.quarters_end);
+    v.direction = qd ? qd : direction(b.model_begin, b.model_end);
+    if(s.start_quant > 0.)
+      set_start_target(v, grid, b, v.direction);
+    v.due = deadline(v, b, grid);
+  }
+  template <typename Sink>
+  bool
+  activate(Voice& v, int frame, const Block& b, const Grid& grid, Sink& sink) noexcept
+  {
+    if(!send(MidiEvent{frame, v.channel, v.pitch, v.velocity, true}, sink))
+    {
+      v.state = State::free;
+      return false;
+    }
+    v.state = State::active;
+    v.not_before = b.first_frame + frame + 1;
+    if(v.end_kind == EndKind::model)
+    {
+      v.model_anchor = b.model_begin;
+      v.end_target
+          = model_delta(b.model_end, b.model_begin) * (position_t(frame) / b.frames)
+            + direction(b.model_begin, b.model_end) * v.duration * flicks_per_second;
+    }
+    else if(v.end_kind == EndKind::musical)
+      v.end_target = quarter_at(b, frame) + v.direction * v.duration;
+    else if(v.end_kind == EndKind::grid)
+      v.end_target = grid.next(quarter_at(b, frame), v.end_quant, v.direction, true);
+    v.due = deadline(v, b, grid);
+    return true;
+  }
+  void remember(const Block& b) noexcept
+  {
+    previous_frame_ = b.first_frame + b.frames;
+    previous_model_ = b.model_end;
+    previous_quarter_ = b.quarters_end;
+    previous_model_direction_ = direction(b.model_begin, b.model_end);
+    previous_quarter_direction_ = direction(b.quarters_begin, b.quarters_end);
+    previous_numerator_ = b.numerator;
+    previous_denominator_ = b.denominator;
+    previous_signature_ = b.last_signature;
+    have_previous_ = true;
+  }
+
+  std::array<Voice, MaxVoices> voices_{};
+  std::array<Input, MaxInputs> inputs_{};
+  // Owed MIDI bytes are exactly determined by this key; release velocity is 0.
+  // This is LOCAL STORAGE, not a retained output-port buffer or reference.
+  std::bitset<wire_notes> owed_offs_{};
+  std::size_t input_count_{};
+  std::uint64_t serial_{};
+  Random random_{};
+  Statistics stats_{};
+  frame_t previous_frame_{};
+  std::int64_t previous_model_{};
+  double previous_quarter_{}, previous_signature_{};
+  int previous_model_direction_{}, previous_quarter_direction_{};
+  int previous_numerator_{}, previous_denominator_{};
+  bool have_previous_{}, overflow_{};
+};
+} // namespace Nodes::PulseToNote::detail

--- a/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
+++ b/src/plugins/score-plugin-gfx/3rdparty/libisf/src/isf.cpp
@@ -1560,9 +1560,53 @@ static void parse_input(audioFFT_input& inp, const sajson::value& v)
   parse_audio_sampler_config(inp.sampler, v);
 }
 
+//! Position of \p needle in \p values, comparing numbers numerically and
+//! strings by name.
+static std::optional<std::size_t> index_of_value(
+    const std::vector<ossia::variant<int64_t, double, std::string>>& values,
+    const ossia::variant<int64_t, double, std::string>& needle) noexcept
+{
+  const auto* wanted_str = ossia::get_if<std::string>(&needle);
+  double wanted_num = 0.;
+  if(!wanted_str)
+  {
+    if(auto* i = ossia::get_if<int64_t>(&needle))
+      wanted_num = double(*i);
+    else if(auto* d = ossia::get_if<double>(&needle))
+      wanted_num = *d;
+  }
+
+  for(std::size_t i = 0; i < values.size(); i++)
+  {
+    const auto& v = values[i];
+    if(wanted_str)
+    {
+      if(auto* s = ossia::get_if<std::string>(&v); s && *s == *wanted_str)
+        return i;
+    }
+    else if(auto* iv = ossia::get_if<int64_t>(&v))
+    {
+      if(double(*iv) == wanted_num)
+        return i;
+    }
+    else if(auto* dv = ossia::get_if<double>(&v))
+    {
+      if(*dv == wanted_num)
+        return i;
+    }
+  }
+  return std::nullopt;
+}
+
 static void parse_input(long_input& inp, const sajson::value& v)
 {
   std::size_t N = v.get_length();
+
+  // ISF says a long input's DEFAULT names one of VALUES, not a position in it.
+  // long_input::def stays an index because every input libisf synthesizes
+  // fills it in as one, so the value is resolved here, once, at parse time.
+  bool has_default = false;
+  ossia::variant<int64_t, double, std::string> raw_default{int64_t{}};
 
   for(std::size_t i = 0; i < N; i++)
   {
@@ -1612,6 +1656,22 @@ static void parse_input(long_input& inp, const sajson::value& v)
     else if(k == "DEFAULT")
     {
       auto val = v.get_object_value(i);
+      has_default = true;
+      switch(val.get_type())
+      {
+        case sajson::TYPE_INTEGER:
+          raw_default = int64_t(val.get_integer_value());
+          break;
+        case sajson::TYPE_DOUBLE:
+          raw_default = val.get_double_value();
+          break;
+        case sajson::TYPE_STRING:
+          raw_default = std::string(val.as_string());
+          break;
+        default:
+          raw_default = int64_t(parse_input_impl(val, int64_t{}));
+          break;
+      }
       inp.def = parse_input_impl(val, int64_t{});
     }
     else if(k == "MIN")
@@ -1632,9 +1692,17 @@ static void parse_input(long_input& inp, const sajson::value& v)
     }
   }
 
-  // If we have VALUES/LABELS (enum mode), clamp def to valid index
+  // If we have VALUES/LABELS (enum mode), resolve DEFAULT and clamp the index
   if(!inp.values.empty())
   {
+    if(has_default)
+    {
+      if(auto idx = index_of_value(inp.values, raw_default))
+        inp.def = *idx;
+      // Otherwise DEFAULT names nothing in VALUES: shaders in the wild do
+      // write a position there, so keep reading it as one rather than
+      // dropping what the author asked for.
+    }
     inp.def = std::min((int64_t)inp.def, (int64_t)(inp.values.size()) - 1);
     auto min_size = std::min(inp.labels.size(), inp.values.size());
     if(min_size > 0)
@@ -5233,6 +5301,19 @@ std::string parser::write_isf() const
           oss << "      \"DEFAULT\": " << f.def << "\n";
         }
 
+        //! One entry of VALUES as JSON: numbers bare, strings quoted.
+        void write_value(const ossia::variant<int64_t, double, std::string>& v)
+        {
+          if(auto* i = ossia::get_if<int64_t>(&v))
+            oss << *i;
+          else if(auto* d = ossia::get_if<double>(&v))
+            oss << *d;
+          else if(auto* str = ossia::get_if<std::string>(&v))
+            oss << "\"" << escape_json(*str) << "\"";
+          else
+            oss << 0;
+        }
+
         void operator()(const long_input& l)
         {
           oss << "      \"TYPE\": \"long\",\n";
@@ -5241,7 +5322,7 @@ std::string parser::write_isf() const
             oss << "      \"VALUES\": [";
             for(size_t i = 0; i < l.values.size(); ++i)
             {
-              oss << l.values[i];
+              write_value(l.values[i]);
               if(i < l.values.size() - 1)
                 oss << ", ";
             }
@@ -5262,7 +5343,18 @@ std::string parser::write_isf() const
             oss << "      \"MIN\": " << *l.min << ",\n";
           if(l.max)
             oss << "      \"MAX\": " << *l.max << ",\n";
-          oss << "      \"DEFAULT\": " << l.def << "\n";
+          // Enum mode: DEFAULT is one of VALUES, so write the entry `def`
+          // points at rather than the position itself.
+          if(!l.values.empty() && l.def < l.values.size())
+          {
+            oss << "      \"DEFAULT\": ";
+            write_value(l.values[l.def]);
+            oss << "\n";
+          }
+          else
+          {
+            oss << "      \"DEFAULT\": " << l.def << "\n";
+          }
         }
 
         void operator()(const bool_input& b)

--- a/src/plugins/score-plugin-gfx/Gfx/Filter/Library.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Filter/Library.cpp
@@ -129,10 +129,16 @@ LibraryHandler::previewWidget(const QString& path, QWidget* parent) const noexce
 }
 
 QWidget* LibraryHandler::previewWidget(
-    const Process::Preset& path, QWidget* parent) const noexcept
+    const Process::Preset& preset, QWidget* parent) const noexcept
 {
+  // The library asks every interface in turn and takes the first widget it is
+  // handed, so a preset of some other process used to get a shader preview --
+  // an empty black one -- from here.
+  if(preset.key.key != Metadata<ConcreteKey_k, Filter::Model>::get())
+    return nullptr;
+
   if(!qEnvironmentVariableIsSet("SCORE_DISABLE_SHADER_PREVIEW"))
-    return new ShaderPreviewWidget{path, parent};
+    return new ShaderPreviewWidget{preset, parent};
   else
     return nullptr;
 }

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
@@ -452,16 +452,22 @@ void GfxContext::add_preview_output(score::gfx::OutputNode& node)
 
   m_graph->createSingleRenderList(node, api);
 
-  // rate in fps
-  double rate = m_context.app.settings<Gfx::Settings::Model>().getRate();
-
-  // Timer for graph update
-  if(m_no_vsync_timer == nullptr) {
-    m_no_vsync_timer = m_timers.acquireTimer(this, rate);
-    connect(m_no_vsync_timer, &score::HighResolutionTimer::timeout, this, &GfxContext::on_no_vsync_timer, Qt::UniqueConnection);
-  }
-
-  // Render is done in the widget
+  // Then the clocks, but ONLY for a preview that expects to be driven from
+  // here. The old preview widget rendered its own node off its own 16ms timer
+  // -- hence "render is done in the widget" -- and the QML texture source
+  // still does; those declare no manualRenderingRate and must be left exactly
+  // as they were, because recomputeTimers rebuilds the whole timer pool and
+  // would, as a side effect, drop a lone window off its vsync clock the moment
+  // a second output appeared.
+  //
+  // The inspector's texture-port preview is the other kind: a BackgroundNode
+  // that declares a rate and needs its TimerClock to be rendered at all. It
+  // used to obtain one by registering through the generic node path, which
+  // rebuilt every render list to get there and blinked whatever was already on
+  // screen. recomputeTimers touches no render list, so it gets its clock and
+  // the outputs already running keep theirs.
+  if(node.configuration().manualRenderingRate)
+    recomputeTimers();
 }
 
 void GfxContext::recompute_connections()
@@ -767,9 +773,17 @@ void GfxContext::run_commands()
           break;
         }
         case NodeCommand::REMOVE_PREVIEW_NODE: {
-          auto& node = nodes.at(cmd.index);
-          auto n = dynamic_cast<score::gfx::OutputNode*>(node.get());
-          SCORE_ASSERT(n);
+          // find, not at(): the inspector's preview widget outlives its
+          // GfxContext on a queued DeferredDelete (see RhiPreviewWidget's
+          // liveNode()), so a removal can arrive for a node some other
+          // teardown path has already taken out. That is a no-op, not a
+          // std::out_of_range in the middle of a tick.
+          auto node_it = nodes.find(cmd.index);
+          if(node_it == nodes.end())
+            break;
+          auto n = dynamic_cast<score::gfx::OutputNode*>(node_it->second.get());
+          if(!n)
+            break;
           {
             // recompute_edges snapshots preview_edges under edges_lock,
             // so guard reads/mutations of it here too. remove_edge only
@@ -794,8 +808,17 @@ void GfxContext::run_commands()
               this->preview_edges.erase(to_remove);
             }
           }
+          // Whether this output was on a clock decides if the pool has to be
+          // rebuilt once it is gone: a rate-driven preview leaving restores
+          // the single-output case, and with it the vsync clock the window
+          // gave up when the preview arrived. Read it before remove_node,
+          // which destroys the node.
+          const bool wasClocked = bool(n->configuration().manualRenderingRate);
+
           m_graph->destroyOutputRenderList(*n);
           remove_node(nursery, cmd.index);
+          if(wasClocked)
+            recomputeTimers();
           break;
         }
         case NodeCommand::REMOVE_NODE: {

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
@@ -51,15 +51,28 @@ GfxContext::GfxContext(const score::DocumentContext& ctx)
   rate = qBound(1.0, rate, 1000.);
 
 
+  // Queued, both of these, and it matters. Both callbacks call updateGraph(),
+  // updateGraph() can reach recomputeTimers(), and recomputeTimers() destroys
+  // the timer pool -- including the very timer whose timerEvent() is on the
+  // stack, since HighResolutionTimer emits timeout() synchronously from it and
+  // the pool owns its timers by unique_ptr. A direct connection therefore
+  // returns into freed memory. recomputeTimers() already reconnects the
+  // no-vsync timer queued; these two were the ones left direct.
   {
     m_no_vsync_timer = m_timers.acquireTimer(this, rate);
-    connect(m_no_vsync_timer, &score::HighResolutionTimer::timeout, this, &GfxContext::on_no_vsync_timer, Qt::UniqueConnection);
+    connect(
+        m_no_vsync_timer, &score::HighResolutionTimer::timeout, this,
+        &GfxContext::on_no_vsync_timer,
+        Qt::ConnectionType(Qt::UniqueConnection | Qt::QueuedConnection));
   }
 
   // A safety timer necessary to handle graph updates in case we had vsync and lost it
   {
     m_watchdog_timer = m_timers.acquireTimer(this, 20.);
-    connect(m_watchdog_timer, &score::HighResolutionTimer::timeout, this, &GfxContext::on_watchdog_timer, Qt::UniqueConnection);
+    connect(
+        m_watchdog_timer, &score::HighResolutionTimer::timeout, this,
+        &GfxContext::on_watchdog_timer,
+        Qt::ConnectionType(Qt::UniqueConnection | Qt::QueuedConnection));
   }
 }
 
@@ -299,7 +312,12 @@ void GfxContext::recomputeTimers()
   std::construct_at(&m_timers);
   {
     m_watchdog_timer = m_timers.acquireTimer(this, 20.);
-    connect(m_watchdog_timer, &score::HighResolutionTimer::timeout, this, &GfxContext::on_watchdog_timer, Qt::UniqueConnection);
+    // Queued for the same reason as the constructor's: on_watchdog_timer calls
+    // updateGraph(), which can reach back into here and destroy this timer.
+    connect(
+        m_watchdog_timer, &score::HighResolutionTimer::timeout, this,
+        &GfxContext::on_watchdog_timer,
+        Qt::ConnectionType(Qt::UniqueConnection | Qt::QueuedConnection));
   }
   m_no_vsync_timer = nullptr;
   delete m_freewheel_timer;

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.cpp
@@ -488,6 +488,13 @@ void GfxContext::add_preview_output(score::gfx::OutputNode& node)
     recomputeTimers();
 }
 
+std::span<score::gfx::OutputNode* const> GfxContext::outputs() const noexcept
+{
+  if(!m_graph)
+    return {};
+  return m_graph->outputs();
+}
+
 void GfxContext::recompute_connections()
 {
   recompute_graph();

--- a/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/GfxContext.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <span>
 #include <Process/Dataflow/CableData.hpp>
 
 #include <Gfx/AssetTable.hpp>
@@ -87,6 +88,10 @@ public:
   // is drained — without this the graph is left with a dangling output pointer
   // and a RenderList referencing an already-freed QRhi.
   void destroyOutput(score::gfx::OutputNode* node);
+
+  //! The outputs the render clocks will drive. An output missing from here
+  //! is never rendered, whatever else was built for it.
+  std::span<score::gfx::OutputNode* const> outputs() const noexcept;
 
   void recompute_edges();
   void recompute_graph();

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/Graph.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/Graph.cpp
@@ -221,6 +221,15 @@ void Graph::createSingleRenderList(
   }
 #endif
 
+  // Promote it into m_outputs before bringing it up. That vector is what
+  // outputs() returns, and GfxContext::recomputeTimers() walks it to decide
+  // what to put on a render clock. Only createAllRenderLists used to fill it,
+  // so an output brought up through this function was invisible to the clocks:
+  // it got a render list, a renderer and an edge, and then nothing ever called
+  // render() on it. That is the inspector's texture-port preview, black.
+  if(!ossia::contains(m_outputs, &output))
+    m_outputs.push_back(&output);
+
   initializeOutput(&output, graphicsApi);
   output.startRendering();
 }
@@ -1202,6 +1211,11 @@ void Graph::addNode(Node* n)
 void Graph::removeNode(Node* n)
 {
   ossia::remove_erase(m_nodes, n);
+  // m_outputs holds raw pointers and is no longer rebuilt from scratch on
+  // every topology change: createSingleRenderList adds to it directly, so a
+  // node leaving has to leave it too or the clocks keep rendering a corpse.
+  if(auto* out = dynamic_cast<OutputNode*>(n))
+    ossia::remove_erase(m_outputs, out);
 }
 
 void Graph::clearEdges()

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/MultiWindowNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/MultiWindowNode.cpp
@@ -1056,8 +1056,15 @@ void MultiWindowNode::createOutput(score::gfx::OutputConfiguration conf)
     {
       if(targetScreen)
         wo.window->setScreen(targetScreen);
-      wo.window->setGeometry(QRect(mapping.windowPosition, mapping.windowSize));
+      const QRect geom(mapping.windowPosition, mapping.windowSize);
+      wo.window->setGeometry(geom);
       wo.window->show();
+      // Ask again now that the platform window exists. A tiling window
+      // manager is free to ignore a geometry set before the window is mapped,
+      // and on i3 the first output window stayed invisible until it was moved
+      // by one pixel; asking after show() is what makes it configure it.
+      if(wo.window->geometry() != geom)
+        wo.window->setGeometry(geom);
     }
   }
 

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/MultiWindowNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/MultiWindowNode.cpp
@@ -244,20 +244,27 @@ public:
           // Soft-edge blending
           // v_texcoord.y is Y-up on both GL and Vulkan (Qt RHI normalizes this),
           // so tc.y=0 is screen bottom and tc.y=1 is screen top.
+          // pow() of a negative base is undefined in GLSL, and the drivers
+          // that answer NaN turn it into a fully lit pixel on the way into a
+          // UNORM attachment: that is the one-pixel bright fringe that used to
+          // reappear along a blended border. The ramp coordinate leaves [0;1]
+          // whenever the fragment centre of an edge pixel falls outside the
+          // triangle, which multisampling makes routine, so it is clamped.
           float alpha = 1.0;
           // Left edge
           if(blendWidths.x > 0.0 && tc.x < blendWidths.x)
-              alpha *= pow(tc.x / blendWidths.x, blendGammas.x);
+              alpha *= pow(clamp(tc.x / blendWidths.x, 0.0, 1.0), blendGammas.x);
           // Right edge
           if(blendWidths.y > 0.0 && tc.x > 1.0 - blendWidths.y)
-              alpha *= pow((1.0 - tc.x) / blendWidths.y, blendGammas.y);
+              alpha *= pow(clamp((1.0 - tc.x) / blendWidths.y, 0.0, 1.0), blendGammas.y);
           // Top edge (tc.y near 1.0 = screen top)
           if(blendWidths.z > 0.0 && tc.y > 1.0 - blendWidths.z)
-              alpha *= pow((1.0 - tc.y) / blendWidths.z, blendGammas.z);
+              alpha *= pow(clamp((1.0 - tc.y) / blendWidths.z, 0.0, 1.0), blendGammas.z);
           // Bottom edge (tc.y near 0.0 = screen bottom)
           if(blendWidths.w > 0.0 && tc.y < blendWidths.w)
-              alpha *= pow(tc.y / blendWidths.w, blendGammas.w);
+              alpha *= pow(clamp(tc.y / blendWidths.w, 0.0, 1.0), blendGammas.w);
 
+          alpha = clamp(alpha, 0.0, 1.0);
           fragColor = vec4(fragColor.rgb * alpha, alpha);
       }
       )_";

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/Node.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/Node.cpp
@@ -49,30 +49,58 @@ void ProcessNode::process(Timings tk)
   UBO.passIndex = 0;
 }
 
+namespace
+{
+//! Take what the list supplies and leave the rest of the uniform alone.
+//!
+//! ossia::convert<vec4f>(list) starts from a zeroed vector and fills only the
+//! components the list has, so three floats arriving at a four-component
+//! uniform wrote a zero into the fourth. On a colour that is alpha, and the
+//! shape went black: an OSC address carrying rgb, or anything else that sends
+//! a colour without its alpha. A cable never showed it because it carries all
+//! four components.
+//!
+//! Leaving the missing components untouched is also the right answer for a
+//! non-colour uniform: a partial update should not silently zero what it did
+//! not mention.
+template <std::size_t N>
+void assign_prefix(
+    std::array<float, N>& val, const std::vector<ossia::value>& v) noexcept
+{
+  const std::size_t n = std::min(v.size(), N);
+  for(std::size_t i = 0; i < n; i++)
+    val[i] = ossia::convert<float>(v[i]);
+}
+}
+
 void ProcessNode::process(int32_t port, const ossia::value& v)
 {
   using namespace score::gfx;
   struct vec_visitor
   {
     const std::vector<ossia::value>& v;
+
+    //! Take what the list supplies and leave the rest of the uniform alone.
+    //!
+    //! ossia::convert<vec4f>(list) starts from a zeroed vector and fills the
+    //! components the list has, so three floats arriving at a four-component
+    //! uniform wrote a zero into the fourth. On a colour that is alpha, and
+    //! the shape went black: an OSC address carrying rgb, or anything else
+    //! that sends a colour without its alpha. A cable did not show it because
+    //! it carries all four.
+    //!
+    //! Leaving the missing components untouched is also the right answer for
+    //! a non-colour uniform: a partial update should not silently zero what
+    //! it did not mention.
     void operator()(ossia::monostate) const noexcept { }
     void operator()(float& val) const noexcept
     {
       if(!v.empty())
         val = ossia::convert<float>(v[0]);
     }
-    void operator()(ossia::vec2f& val) const noexcept
-    {
-      val = ossia::convert<ossia::vec2f>(v);
-    }
-    void operator()(ossia::vec3f& val) const noexcept
-    {
-      val = ossia::convert<ossia::vec3f>(v);
-    }
-    void operator()(ossia::vec4f& val) const noexcept
-    {
-      val = ossia::convert<ossia::vec4f>(v);
-    }
+    void operator()(ossia::vec2f& val) const noexcept { assign_prefix(val, v); }
+    void operator()(ossia::vec3f& val) const noexcept { assign_prefix(val, v); }
+    void operator()(ossia::vec4f& val) const noexcept { assign_prefix(val, v); }
     void operator()(image& val) const noexcept { }
   };
 

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/ScreenNode.cpp
@@ -894,6 +894,10 @@ void ScreenNode::setFullScreen(bool b)
   {
     if(b)
     {
+      // Same as at show time: land on the screen's top-left pixel at its full
+      // size first, or the platform may keep the offset the window had.
+      if(auto* scr = m_screen ? m_screen : m_window->screen())
+        m_window->setGeometry(scr->geometry());
       m_window->showFullScreen();
     }
     else
@@ -1084,6 +1088,13 @@ void ScreenNode::createOutput(score::gfx::OutputConfiguration conf)
 
     if(m_fullScreen)
     {
+      // Put the window exactly on its screen before asking for full screen.
+      // Windows honours the window's existing geometry when it goes full
+      // screen, so a window that was anywhere else stays offset by that much
+      // and paints outside the display. The screen's own geometry is the
+      // answer: its top-left pixel in the virtual desktop, and its size.
+      if(auto* scr = m_screen ? m_screen : m_window->screen())
+        m_window->setGeometry(scr->geometry());
       m_window->showFullScreen();
     }
     else

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/TexgenNode.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/TexgenNode.hpp
@@ -29,7 +29,12 @@ struct TexgenNode : NodeModel
   {
     v_texcoord = texcoord;
     gl_Position = renderer.clipSpaceCorrMatrix * vec4(position.xy, 0.0, 1.);
-#if !(defined(QSHADER_SPIRV) || defined(QSHADER_HLSL) || defined(QSHADER_MSL))
+// The uploaded buffer's row 0 is its top, and it must come out at the top on
+// every backend. Vulkan was left out of this correction, so a JIT Texgen -- and
+// anything else painting a texture from C++ -- came out upside down there,
+// through every sink: the window, the readback outputs and the GPU encoders
+// alike.
+#if !(defined(QSHADER_HLSL) || defined(QSHADER_MSL))
   gl_Position.y = - gl_Position.y;
 #endif
   }

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/decoders/DRMPrime.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/decoders/DRMPrime.hpp
@@ -22,8 +22,10 @@
 //   I420 / YUV420P                                  3 samplers, all R8, the
 //               YUV420.hpp shader
 //
-// A 2-slot import ring per plane keeps the GPU from being handed a slot it has
-// not finished sampling.
+// Imports are cached by the inode of the dma-buf, so a producer rotating a
+// fixed pool -- which is what pipewire negotiates -- imports each buffer once
+// instead of once a frame. Planes that cannot be cached fall back to a 2-slot
+// ring, so the GPU is never handed a slot it has not finished sampling.
 
 #if defined(__linux__)
 #include <Gfx/Graph/decoders/ColorSpace.hpp>
@@ -38,6 +40,11 @@
 #include <Video/VideoInterface.hpp>
 
 #include <score/gfx/Vulkan.hpp>
+
+#include <sys/stat.h>
+
+#include <optional>
+#include <unordered_map>
 
 extern "C" {
 #include <libavformat/avformat.h>
@@ -83,27 +90,107 @@ struct DRMPrimeDecoder : GPUVideoDecoder
   Family m_family{Family::PackedRGB};
   bool m_is_10bit{false}; // P010 vs NV12
 
+  /** Identifies one imported dma-buf.
+   *
+   *  Keyed on the INODE, not the file descriptor: descriptor numbers are
+   *  recycled as soon as one is closed, an inode is not reused while the
+   *  dma-buf lives. The rest is layout -- the same buffer at a different
+   *  offset, stride or format is a different image.
+   *
+   *  Importing is a vkCreateImage plus an external-memory import on Vulkan,
+   *  an eglCreateImage on GL, and it is most of what a frame costs here:
+   *  PipewireRoundtrip's s2sgpu-vk-rgba dma-buf cell measures more than twice
+   *  the per-frame cost without this cache.
+   */
+  struct DmaBufImportKey
+  {
+    unsigned long long ino{};
+    unsigned long long dev{};
+    uint64_t modifier{};
+    long long offset{};
+    long long pitch{};
+    int w{}, h{};
+    uint32_t fmt{};
+
+    friend bool operator==(const DmaBufImportKey&, const DmaBufImportKey&)
+        = default;
+  };
+  struct DmaBufImportKeyHash
+  {
+    std::size_t operator()(const DmaBufImportKey& k) const noexcept
+    {
+      std::size_t h = std::hash<unsigned long long>{}(k.ino);
+      auto mix = [&h](std::size_t v) { h ^= v + 0x9e3779b9 + (h << 6) + (h >> 2); };
+      mix(std::hash<unsigned long long>{}(k.dev));
+      mix(std::hash<uint64_t>{}(k.modifier));
+      mix(std::hash<long long>{}(k.offset));
+      mix(std::hash<long long>{}(k.pitch));
+      mix(std::hash<int>{}(k.w));
+      mix(std::hash<int>{}(k.h));
+      mix(std::hash<uint32_t>{}(k.fmt));
+      return h;
+    }
+  };
+
+  /** Nothing when the kernel will not name the dma-buf; the caller then
+   *  imports into the scratch rotation instead of the cache. */
+  static std::optional<DmaBufImportKey> importKey(
+      int fd, uint64_t modifier, long long offset, long long pitch, int w, int h,
+      uint32_t fmt) noexcept
+  {
+    struct ::stat st
+    {
+    };
+    if(fd < 0 || ::fstat(fd, &st) != 0)
+      return std::nullopt;
+
+    DmaBufImportKey key{};
+    key.ino = st.st_ino;
+    key.dev = st.st_dev;
+    key.modifier = modifier;
+    key.offset = offset;
+    key.pitch = pitch;
+    key.w = w;
+    key.h = h;
+    key.fmt = fmt;
+    return key;
+  }
+
+  //! Cached imports are never evicted, only released with the decoder, so
+  //! nothing can be destroyed while the GPU still reads it. Past this bound a
+  //! plane goes to the scratch rotation. A sane producer never comes close.
+  static constexpr std::size_t kMaxImports = 32;
+
+  //! Two, so the import a frame is sampling is not the one the next frame
+  //! destroys.
+  static constexpr int kNumScratchSlots = 2;
+
 #if QT_HAS_VULKAN && defined(VK_EXT_image_drm_format_modifier) \
     && defined(VK_KHR_external_memory_fd)
   DMABufPlaneImporter m_vk_importer;
-  static constexpr int kNumVkSlots = 2;
-  struct VkSlot
+
+  std::unordered_map<DmaBufImportKey, DMABufPlaneImporter::PlaneImport,
+                     DmaBufImportKeyHash>
+      m_vk_imports;
+  struct VkScratch
   {
     DMABufPlaneImporter::PlaneImport planes[3]{};
   };
-  VkSlot m_vk_slots[kNumVkSlots]{};
-  int m_vk_slotIdx{0};
+  VkScratch m_vk_scratch[kNumScratchSlots]{};
+  int m_vk_scratchIdx{0};
   VkFormat m_vk_plane_fmt[3]{}; // per-plane VkFormat
 #endif
 
   EglDmaBufImporter m_gl_importer;
-  static constexpr int kNumGlSlots = 2;
-  struct GlSlot
+  std::unordered_map<DmaBufImportKey, EglDmaBufImporter::PlaneImport,
+                     DmaBufImportKeyHash>
+      m_gl_imports;
+  struct GlScratch
   {
     EglDmaBufImporter::PlaneImport planes[3]{};
   };
-  GlSlot m_gl_slots[kNumGlSlots]{};
-  int m_gl_slotIdx{0};
+  GlScratch m_gl_scratch[kNumScratchSlots]{};
+  int m_gl_scratchIdx{0};
   unsigned int m_gl_textures[3]{0, 0, 0}; // persistent GL ids per plane
   uint32_t m_gl_plane_fourcc[3]{};        // per-plane DRM fourcc
 
@@ -146,22 +233,61 @@ struct DRMPrimeDecoder : GPUVideoDecoder
     }
   }
 
-  ~DRMPrimeDecoder() override
+  /** Drop every imported dma-buf. Idempotent.
+   *
+   *  The caller must first drop anything referencing these images: the sampler
+   *  textures adopted them through createFrom and hold image views on them,
+   *  and destroying an image under a live view segfaults inside the driver's
+   *  vkDestroyImage. release() below does that. */
+  void releaseImports() noexcept
   {
 #if QT_HAS_VULKAN && defined(VK_EXT_image_drm_format_modifier) \
     && defined(VK_KHR_external_memory_fd)
     if(m_backend == Backend::Vulkan)
     {
-      for(auto& slot : m_vk_slots)
+      // The GPU may still be reading the frames that sampled these.
+      m_vk_importer.waitIdle();
+      for(auto& [k, pl] : m_vk_imports)
+        m_vk_importer.cleanupPlane(pl);
+      m_vk_imports.clear();
+      for(auto& slot : m_vk_scratch)
         for(auto& p : slot.planes)
           m_vk_importer.cleanupPlane(p);
     }
 #endif
     if(m_backend == Backend::OpenGL)
     {
-      for(auto& slot : m_gl_slots)
+      for(auto& [k, pl] : m_gl_imports)
+        m_gl_importer.cleanupPlane(pl);
+      m_gl_imports.clear();
+      for(auto& slot : m_gl_scratch)
         for(auto& p : slot.planes)
           m_gl_importer.cleanupPlane(p);
+    }
+  }
+
+  void release(RenderList& r) override
+  {
+    // The base only deleteLater()s the sampler textures, leaving their image
+    // views alive past this call. Drop them and let the RHI run its deferred
+    // releases first.
+    for(auto& s : samplers)
+      if(s.texture)
+        s.texture->destroy();
+    if(r.state.rhi)
+      r.state.rhi->finish();
+
+    releaseImports();
+    GPUVideoDecoder::release(r);
+  }
+
+  ~DRMPrimeDecoder() override
+  {
+    // Normally already done by release(); this covers a decoder that is
+    // dropped without one.
+    releaseImports();
+    if(m_backend == Backend::OpenGL)
+    {
       if(auto* ctx = QOpenGLContext::currentContext())
       {
         if(auto* funcs = ctx->extraFunctions())
@@ -249,7 +375,10 @@ struct DRMPrimeDecoder : GPUVideoDecoder
     switch(m_family)
     {
       case Family::PackedRGB:
-        // Placeholder format; createFrom replaces the native handle.
+        // Placeholder until the first frame's DRM fourcc gives the real
+        // channel order; exec() fixes the format before adopting the image.
+        // createFrom keeps the texture's format, and Qt builds the image view
+        // from it, so a BGRA8 view over an R8G8B8A8 image swaps red and blue.
         makeSamplerTexture(QRhiTexture::BGRA8, QSize{w, h});
 #if QT_HAS_VULKAN && defined(VK_EXT_image_drm_format_modifier) \
     && defined(VK_KHR_external_memory_fd)
@@ -353,6 +482,29 @@ struct DRMPrimeDecoder : GPUVideoDecoder
 
 #if QT_HAS_VULKAN && defined(VK_EXT_image_drm_format_modifier) \
     && defined(VK_KHR_external_memory_fd)
+  /** Packed RGB DRM fourcc → the QRhi format with the same channel order.
+   *  UnknownFormat leaves the texture as it was. */
+  static QRhiTexture::Format qrhiPackedFmtFromDrmFourcc(uint32_t fourcc) noexcept
+  {
+    switch(fourcc)
+    {
+      case 0x34325241: // ARGB8888
+      case 0x34325258: // XRGB8888
+        return QRhiTexture::BGRA8;
+      case 0x34324241: // ABGR8888
+      case 0x34324258: // XBGR8888
+        return QRhiTexture::RGBA8;
+      case 0x30334241: // ABGR2101010
+      case 0x30334258: // XBGR2101010
+        return QRhiTexture::RGB10A2;
+      case 0x48344241: // ABGR16161616F
+      case 0x48344258: // XBGR16161616F
+        return QRhiTexture::RGBA16F;
+      // ARGB2101010 has no QRhi equivalent: RGB10A2 is A2B10G10R10.
+      default: return QRhiTexture::UnknownFormat;
+    }
+  }
+
   /** Packed RGB DRM fourcc → Vulkan packed RGB format. */
   static VkFormat vkPackedFmtFromDrmFourcc(uint32_t fourcc) noexcept
   {
@@ -450,33 +602,65 @@ struct DRMPrimeDecoder : GPUVideoDecoder
          && m_vk_plane_fmt[0] == VK_FORMAT_UNDEFINED)
       {
         m_vk_plane_fmt[0] = vkPackedFmtFromDrmFourcc(desc->layers[0].format);
+        if(const auto qfmt = qrhiPackedFmtFromDrmFourcc(desc->layers[0].format);
+           qfmt != QRhiTexture::UnknownFormat && !samplers.empty()
+           && samplers[0].texture)
+        {
+          // Before the createFrom below, which is what builds the view.
+          samplers[0].texture->setFormat(qfmt);
+        }
         if(m_vk_plane_fmt[0] == VK_FORMAT_UNDEFINED)
         {
-          qDebug()
-              << "DRMPrimeDecoder: unsupported packed DRM fourcc"
-              << Qt::hex << desc->layers[0].format;
+          qDebug() << "DRMPrimeDecoder: unsupported packed DRM fourcc" << Qt::hex
+                   << desc->layers[0].format;
           return;
         }
       }
 
-      auto& slot = m_vk_slots[m_vk_slotIdx];
-      for(auto& pl : slot.planes)
-        m_vk_importer.cleanupPlane(pl);
-      m_vk_slotIdx = (m_vk_slotIdx + 1) % kNumVkSlots;
-
       for(int i = 0; i < np; ++i)
       {
         const auto& obj = desc->objects[p[i].obj_idx];
-        if(!m_vk_importer.importPlane(
-               slot.planes[i], obj.fd, obj.format_modifier, p[i].offset,
-               p[i].pitch, m_vk_plane_fmt[i], p[i].w, p[i].h))
+        const auto key = importKey(
+            obj.fd, obj.format_modifier, p[i].offset, p[i].pitch, p[i].w, p[i].h,
+            uint32_t(m_vk_plane_fmt[i]));
+
+        if(key)
         {
-          qDebug() << "DRMPrimeDecoder: Vulkan importPlane failed for plane"
-                   << i << "fd" << obj.fd;
+          if(auto it = m_vk_imports.find(*key); it != m_vk_imports.end())
+          {
+            samplers[i].texture->createFrom(QRhiTexture::NativeTexture{
+                quint64(it->second.image), VK_IMAGE_LAYOUT_GENERAL});
+            continue;
+          }
+        }
+
+        DMABufPlaneImporter::PlaneImport imported{};
+        if(!m_vk_importer.importPlane(
+               imported, obj.fd, obj.format_modifier, p[i].offset, p[i].pitch,
+               m_vk_plane_fmt[i], p[i].w, p[i].h))
+        {
+          qDebug() << "DRMPrimeDecoder: Vulkan importPlane failed for plane" << i
+                   << "fd" << obj.fd;
           return;
         }
+
+        if(key && m_vk_imports.size() < kMaxImports)
+        {
+          m_vk_imports.emplace(*key, imported);
+        }
+        else
+        {
+          // Uncacheable or cache full: park it in the rotation, where the
+          // slot two frames old is the one destroyed.
+          auto& slot = m_vk_scratch[m_vk_scratchIdx];
+          m_vk_importer.cleanupPlane(slot.planes[i]);
+          slot.planes[i] = imported;
+          if(i == np - 1)
+            m_vk_scratchIdx = (m_vk_scratchIdx + 1) % kNumScratchSlots;
+        }
+
         samplers[i].texture->createFrom(QRhiTexture::NativeTexture{
-            quint64(slot.planes[i].image), VK_IMAGE_LAYOUT_UNDEFINED});
+            quint64(imported.image), VK_IMAGE_LAYOUT_GENERAL});
       }
       hasFrame = true;
       return;
@@ -490,22 +674,50 @@ struct DRMPrimeDecoder : GPUVideoDecoder
       if(m_family == Family::PackedRGB)
         m_gl_plane_fourcc[0] = desc->layers[0].format;
 
-      auto& slot = m_gl_slots[m_gl_slotIdx];
-      for(auto& pl : slot.planes)
-        m_gl_importer.cleanupPlane(pl);
-      m_gl_slotIdx = (m_gl_slotIdx + 1) % kNumGlSlots;
-
       for(int i = 0; i < np; ++i)
       {
         const auto& obj = desc->objects[p[i].obj_idx];
+        const auto key = importKey(
+            obj.fd, obj.format_modifier, p[i].offset, p[i].pitch, p[i].w, p[i].h,
+            m_gl_plane_fourcc[i]);
+
+        if(key)
+        {
+          if(auto it = m_gl_imports.find(*key); it != m_gl_imports.end())
+          {
+            // The EGLImage is still good but the texture points at the last
+            // frame's buffer, so re-bind it. A pointer swap, not an import.
+            if(!m_gl_importer.bindPlane(m_gl_textures[i], it->second))
+            {
+              qDebug() << "DRMPrimeDecoder: EGL bindPlane failed for plane" << i;
+              return;
+            }
+            continue;
+          }
+        }
+
+        EglDmaBufImporter::PlaneImport imported{};
         if(!m_gl_importer.importPlane(
-               slot.planes[i], m_gl_textures[i], obj.fd, obj.format_modifier,
+               imported, m_gl_textures[i], obj.fd, obj.format_modifier,
                p[i].offset, p[i].pitch, m_gl_plane_fourcc[i], p[i].w, p[i].h))
         {
-          qDebug() << "DRMPrimeDecoder: EGL importPlane failed for plane"
-                   << i << "fd" << obj.fd << "fourcc" << Qt::hex
+          qDebug() << "DRMPrimeDecoder: EGL importPlane failed for plane" << i
+                   << "fd" << obj.fd << "fourcc" << Qt::hex
                    << m_gl_plane_fourcc[i];
           return;
+        }
+
+        if(key && m_gl_imports.size() < kMaxImports)
+        {
+          m_gl_imports.emplace(*key, imported);
+        }
+        else
+        {
+          auto& slot = m_gl_scratch[m_gl_scratchIdx];
+          m_gl_importer.cleanupPlane(slot.planes[i]);
+          slot.planes[i] = imported;
+          if(i == np - 1)
+            m_gl_scratchIdx = (m_gl_scratchIdx + 1) % kNumScratchSlots;
         }
       }
       hasFrame = true;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/decoders/DRMPrime.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/decoders/DRMPrime.hpp
@@ -245,6 +245,21 @@ struct DRMPrimeDecoder : GPUVideoDecoder
     && defined(VK_KHR_external_memory_fd)
     if(m_backend == Backend::Vulkan)
     {
+      const bool scratch_held = std::any_of(
+          std::begin(m_vk_scratch), std::end(m_vk_scratch), [](const VkScratch& s) {
+        return std::any_of(
+            std::begin(s.planes), std::end(s.planes),
+            [](const DMABufPlaneImporter::PlaneImport& p) {
+          return p.image != VK_NULL_HANDLE;
+        });
+      });
+      // Nothing to free means nothing to wait for. The destructor calls this
+      // after release() already emptied it, and by then the device is being
+      // torn down: waiting on it there is not just wasted, it is a call the
+      // validation layer rejects.
+      if(m_vk_imports.empty() && !scratch_held)
+        return;
+
       // The GPU may still be reading the frames that sampled these.
       m_vk_importer.waitIdle();
       for(auto& [k, pl] : m_vk_imports)

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/decoders/GPUVideoDecoder.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/decoders/GPUVideoDecoder.hpp
@@ -151,9 +151,13 @@ public:
  */
 struct EmptyDecoder : GPUVideoDecoder
 {
+  // Writing nothing leaves the attachment undefined: NVIDIA hands back black,
+  // llvmpipe hands back white. Write the black the callers expect.
   static const constexpr auto hashtag_no_filter = R"_(#version 450
+    layout(location = 0) out vec4 fragColor;
     void main ()
     {
+      fragColor = vec4(0.0, 0.0, 0.0, 1.0);
     }
   )_";
 

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/BGRA.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/BGRA.hpp
@@ -43,7 +43,12 @@ struct BGRAEncoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
 
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/BGRACompute.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/BGRACompute.hpp
@@ -43,7 +43,10 @@ struct BGRAComputeEncoder final : ComputeEncoder
       if (int(x) >= src_size.x || int(y) >= src_size.y)
         return;
 
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // See GPUVideoEncoder::y_flip_glsl: only OpenGL. The rest of the engine
+    // negates Y through renderer.clipSpaceCorrMatrix on Vulkan; this pass
+    // indexes texels directly and does not, so it must not flip there.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       int src_y = int(y);
     #else
       int src_y = src_size.y - 1 - int(y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/GPUVideoEncoder.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/GPUVideoEncoder.hpp
@@ -102,7 +102,12 @@ struct GPUVideoEncoder
   /// Fragment shader Y-flip: on GL, flip v_texcoord.y. On Metal/HLSL, no flip.
   static constexpr const char* y_flip_glsl = R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/I420.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/I420.hpp
@@ -27,7 +27,12 @@ struct I420Encoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -46,7 +51,12 @@ struct I420Encoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -65,7 +75,12 @@ struct I420Encoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/NV12.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/NV12.hpp
@@ -40,7 +40,12 @@ struct NV12Encoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -60,7 +65,12 @@ struct NV12Encoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -83,7 +93,10 @@ struct NV12Encoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     int flip_y_int(int y, int h) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // See GPUVideoEncoder::y_flip_glsl: only OpenGL. The rest of the engine
+    // negates Y through renderer.clipSpaceCorrMatrix on Vulkan; this pass
+    // indexes texels directly and does not, so it must not flip there.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return y;
     #else
       return h - 1 - y;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/P010.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/P010.hpp
@@ -43,7 +43,12 @@ struct P010Encoder : GPUVideoEncoder
     )_" "%1" R"_(
     )_" "%2" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -64,7 +69,12 @@ struct P010Encoder : GPUVideoEncoder
     )_" "%1" R"_(
     )_" "%2" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -209,7 +219,10 @@ struct P010Encoder : GPUVideoEncoder
 {
   static constexpr const char* common = R"_(
     int flip_y_int(int y, int h) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // See GPUVideoEncoder::y_flip_glsl: only OpenGL. The rest of the engine
+    // negates Y through renderer.clipSpaceCorrMatrix on Vulkan; this pass
+    // indexes texels directly and does not, so it must not flip there.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return y;
     #else
       return h - 1 - y;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/PackedRGB.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/PackedRGB.hpp
@@ -38,7 +38,12 @@ struct PackedRGBEncoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
 
     vec2 flip_y_uv(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/UYVY.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/UYVY.hpp
@@ -23,7 +23,12 @@ struct UYVYEncoder : GPUVideoEncoder
     )_" "%1" R"_(
 
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/UYVYCompute.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/UYVYCompute.hpp
@@ -45,7 +45,10 @@ struct UYVYComputeEncoder final : ComputeEncoder
       if (pair_x >= pairs_per_row || int(y) >= src_size.y)
         return;
 
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // See GPUVideoEncoder::y_flip_glsl: only OpenGL. The rest of the engine
+    // negates Y through renderer.clipSpaceCorrMatrix on Vulkan; this pass
+    // indexes texels directly and does not, so it must not flip there.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       int src_y = int(y);
     #else
       int src_y = src_size.y - 1 - int(y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/V210.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/V210.hpp
@@ -36,7 +36,12 @@ struct V210Encoder : GPUVideoEncoder
     )_" "%1" R"_(
 
     vec2 flip_y_uv(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/V210Compute.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/V210Compute.hpp
@@ -46,7 +46,12 @@ struct V210ComputeEncoder final : ComputeEncoder
     };
 
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -65,9 +70,12 @@ struct V210ComputeEncoder final : ComputeEncoder
       if (group_x >= groups_per_row || int(y) >= src_size.y)
         return;
 
-      // Y-flip on backends that need it (matches the fragment encoders).
+      // Y-flip on backends that need it (matches the fragment encoders):
+      // only OpenGL. The rest of the engine negates Y through
+      // renderer.clipSpaceCorrMatrix on Vulkan; this pass indexes texels
+      // directly and does not, so it must not flip there.
       ivec2 srcSize = src_size;
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       int src_y = int(y);
     #else
       int src_y = srcSize.y - 1 - int(y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/YUV422P10.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/YUV422P10.hpp
@@ -42,7 +42,12 @@ struct YUV422P10Encoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -181,7 +186,10 @@ struct YUV422P10Encoder : GPUVideoEncoder
   // Helpers shared by all plane shaders (injected as %2).
   static constexpr const char* common = R"_(
     int flip_y_int(int y, int h) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // See GPUVideoEncoder::y_flip_glsl: only OpenGL. The rest of the engine
+    // negates Y through renderer.clipSpaceCorrMatrix on Vulkan; this pass
+    // indexes texels directly and does not, so it must not flip there.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return y;
     #else
       return h - 1 - y;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/YUVPlanar.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/YUVPlanar.hpp
@@ -50,7 +50,12 @@ struct YUVPlanarEncoder : GPUVideoEncoder
     layout(binding = 3) uniform sampler2D src_tex;
     )_" "%1" R"_(
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);
@@ -68,7 +73,10 @@ struct YUVPlanarEncoder : GPUVideoEncoder
   // Helpers shared by the packed plane shaders (injected as %2).
   static constexpr const char* pack_common = R"_(
     int flip_y_int(int y, int h) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // See GPUVideoEncoder::y_flip_glsl: only OpenGL. The rest of the engine
+    // negates Y through renderer.clipSpaceCorrMatrix on Vulkan; this pass
+    // indexes texels directly and does not, so it must not flip there.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return y;
     #else
       return h - 1 - y;

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/YUY2.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/encoders/YUY2.hpp
@@ -21,7 +21,12 @@ struct YUY2Encoder : GPUVideoEncoder
     )_" "%1" R"_(
 
     vec2 flip_y(vec2 tc) {
-    #if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+    // Only OpenGL. The rest of the engine puts its geometry through
+    // renderer.clipSpaceCorrMatrix, which negates Y on Vulkan; this pass draws
+    // a hardcoded triangle in raw NDC and does not, so the correction it needs
+    // is not the same one. Flipping on Vulkan as well handed libav, GStreamer,
+    // NDI and every other consumer an upside-down picture.
+    #if defined(QSHADER_SPIRV) || defined(QSHADER_MSL) || defined(QSHADER_HLSL)
       return tc;
     #else
       return vec2(tc.x, 1.0 - tc.y);

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/interop/DMABufImport.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/interop/DMABufImport.hpp
@@ -118,6 +118,17 @@ struct DMABufPlaneImporter
 #endif
   }
 
+  /** Block until the device is idle.
+   *
+   *  The RHI's deferred-release list does not know about images it did not
+   *  create, so a caller releasing imports has to wait for the frames that
+   *  sampled them itself. Only used at teardown. */
+  void waitIdle() noexcept
+  {
+    if(m_dfuncs && m_dev != VK_NULL_HANDLE)
+      m_dfuncs->vkDeviceWaitIdle(m_dev);
+  }
+
   void cleanupPlane(PlaneImport& p)
   {
     if(p.image != VK_NULL_HANDLE)

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/interop/VkExternalMemoryHelpers.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/interop/VkExternalMemoryHelpers.cpp
@@ -225,6 +225,22 @@ createExportableImage(const VulkanCtx& v, const ExternalImageDesc& desc)
   imgInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
   imgInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
+  // A modifier list overrides the tiling: the driver picks a layout out of what
+  // the caller can share, which is both the documented way to export a dma-buf
+  // and the only fast one. The chain is modifierList -> externalMemory, so the
+  // external-memory info stays reachable.
+  VkImageDrmFormatModifierListCreateInfoEXT modInfo{};
+  if(desc.drmModifierCount > 0 && desc.drmModifiers)
+  {
+    modInfo.sType
+        = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
+    modInfo.drmFormatModifierCount = desc.drmModifierCount;
+    modInfo.pDrmFormatModifiers = desc.drmModifiers;
+    modInfo.pNext = &extImgInfo;
+    imgInfo.pNext = &modInfo;
+    imgInfo.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
+  }
+
   ExternalImage out{};
   if(df->vkCreateImage(v.dev, &imgInfo, nullptr, &out.image) != VK_SUCCESS)
   {
@@ -277,6 +293,21 @@ createExportableImage(const VulkanCtx& v, const ExternalImageDesc& desc)
     qWarning() << "createExportableImage: vkBindImageMemory failed";
     destroyExternal(v, out);
     return std::nullopt;
+  }
+
+  // Which layout the driver actually chose, so the caller can tell a consumer
+  // the truth about the buffer it is handing over.
+  if(desc.drmModifierCount > 0 && desc.drmModifiers)
+  {
+    if(auto* fn = (PFN_vkGetImageDrmFormatModifierPropertiesEXT)
+           v.qInst->functions()->vkGetDeviceProcAddr(
+               v.dev, "vkGetImageDrmFormatModifierPropertiesEXT"))
+    {
+      VkImageDrmFormatModifierPropertiesEXT p{};
+      p.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
+      if(fn(v.dev, out.image, &p) == VK_SUCCESS)
+        out.drmModifier = p.drmFormatModifier;
+    }
   }
   return out;
 }

--- a/src/plugins/score-plugin-gfx/Gfx/Graph/interop/VkExternalMemoryHelpers.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Graph/interop/VkExternalMemoryHelpers.hpp
@@ -98,6 +98,23 @@ struct ExternalImageDesc
   // dedicated=true: required for D3D11_TEXTURE_KMT (Spout); harmless for OPAQUE_*.
   bool dedicated{true};
   bool preferDeviceLocal{true};
+
+  /** DRM format modifiers to offer, for an image that will be exported as a
+   *  dma-buf. When non-empty the image is created with
+   *  VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT and the driver picks one of these,
+   *  which `tiling` above no longer decides.
+   *
+   *  This is the fast path and the documented one: LINEAR is "universally
+   *  supported" and "typically offers poor performance", OPTIMAL cannot be
+   *  shared because no importer knows the layout, and the modifier list is what
+   *  gets a layout that is both shareable and fast: at 8K a full-frame copy
+   *  into a modifier-tiled export is as quick as one into an ordinary texture,
+   *  while a LINEAR host-visible one is slower by an order of magnitude -- see
+   *  tests/hardware/dmabuf-export-bandwidth.cpp. Leave empty to keep
+   *  `tiling`, which is what a consumer on another GPU may need.
+   */
+  const uint64_t* drmModifiers{};
+  uint32_t drmModifierCount{};
 };
 
 /** @brief Description of a buffer to create with exportable / importable memory. */
@@ -131,6 +148,9 @@ struct ExternalImage
   VkImage image{VK_NULL_HANDLE};
   VkDeviceMemory memory{VK_NULL_HANDLE};
   VkDeviceSize size{0};
+  //! The modifier the driver chose, when drmModifiers was given.
+  //! DRM_FORMAT_MOD_INVALID (all ones in 56 bits) when it was not.
+  uint64_t drmModifier{(1ull << 56) - 1};
 };
 
 struct ExternalBuffer

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireInputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireInputDevice.cpp
@@ -1283,8 +1283,13 @@ public:
 
 private:
   void updatePath();
+  //! The node.name the URL carries, whichever way it was chosen.
+  QString currentNode() const;
+  void setCurrentNode(const QString& name);
 
-  QLineEdit* m_nodeEdit{};
+  //! Editable: the live nodes are offered, and a name can still be typed for
+  //! a producer that is not up yet.
+  QComboBox* m_nodeEdit{};
   QSpinBox* m_widthEdit{};
   QSpinBox* m_heightEdit{};
   QDoubleSpinBox* m_fpsEdit{};
@@ -1325,16 +1330,46 @@ bool PipeWireDevice::reconnect()
   return connected();
 }
 
+//! The Video/Source nodes the daemon is publishing, as (node.name, label).
+static std::vector<std::pair<QString, QString>> liveVideoSources()
+{
+  std::vector<std::pair<QString, QString>> out;
+  auto shared = libremidi::pipewire::shared_context();
+  if(!shared || !shared->ok())
+    return out;
+
+  const auto snap = shared->snapshot();
+  for(const auto& node : snap.nodes_of(libremidi::pipewire::media_class::video))
+  {
+    if(node.media_class_str.find("Source") == std::string::npos)
+      continue;
+    const QString name = QString::fromStdString(node.name);
+    if(name.isEmpty())
+      continue;
+    const QString descr = QString::fromStdString(node.description);
+    out.push_back({name, descr.isEmpty() ? name : (descr + " (" + name + ")")});
+  }
+  return out;
+}
+
 PipeWireSettingsWidget::PipeWireSettingsWidget(QWidget* parent)
     : Device::ProtocolSettingsWidget(parent)
 {
-  m_nodeEdit = new QLineEdit(this);
+  m_nodeEdit = new QComboBox(this);
+  m_nodeEdit->setEditable(true);
   m_widthEdit = new QSpinBox(this);
   m_heightEdit = new QSpinBox(this);
   m_fpsEdit = new QDoubleSpinBox(this);
   m_formatEdit = new QComboBox(this);
 
-  m_nodeEdit->setPlaceholderText("Leave empty for auto-connect");
+  m_nodeEdit->lineEdit()->setPlaceholderText(
+      tr("Leave empty for auto-connect"));
+  // What PipeWire is actually publishing right now, rather than a name the
+  // user has to know and type: the entry text is the node.name the URL wants,
+  // the label is the description the rest of the desktop shows.
+  m_nodeEdit->addItem(tr("(default source)"), QString{});
+  for(const auto& [name, label] : liveVideoSources())
+    m_nodeEdit->addItem(label, name);
 
   m_widthEdit->setRange(1, 7680);
   m_widthEdit->setValue(1920);
@@ -1360,6 +1395,30 @@ PipeWireSettingsWidget::PipeWireSettingsWidget(QWidget* parent)
 
 void PipeWireSettingsWidget::updatePath() { }
 
+QString PipeWireSettingsWidget::currentNode() const
+{
+  // A picked entry carries its node.name as data; anything typed by hand is
+  // the name itself.
+  const int idx = m_nodeEdit->currentIndex();
+  if(idx >= 0 && m_nodeEdit->itemText(idx) == m_nodeEdit->currentText())
+    return m_nodeEdit->itemData(idx).toString();
+  return m_nodeEdit->currentText();
+}
+
+void PipeWireSettingsWidget::setCurrentNode(const QString& name)
+{
+  for(int i = 0; i < m_nodeEdit->count(); i++)
+  {
+    if(m_nodeEdit->itemData(i).toString() == name)
+    {
+      m_nodeEdit->setCurrentIndex(i);
+      return;
+    }
+  }
+  // Not published (yet): keep what the document asked for.
+  m_nodeEdit->setCurrentText(name);
+}
+
 Device::DeviceSettings PipeWireSettingsWidget::getSettings() const
 {
   Device::DeviceSettings s;
@@ -1367,7 +1426,7 @@ Device::DeviceSettings PipeWireSettingsWidget::getSettings() const
   s.name = "PipeWire";
 
   SharedInputSettings set;
-  QString path = "pipewire://" + m_nodeEdit->text();
+  QString path = "pipewire://" + currentNode();
   const QStringList params{
       QString("width=%1").arg(m_widthEdit->value()),
       QString("height=%1").arg(m_heightEdit->value()),
@@ -1390,7 +1449,7 @@ void PipeWireSettingsWidget::setSettings(const Device::DeviceSettings& settings)
   if(!m.hasMatch())
     return;
 
-  m_nodeEdit->setText(m.captured(1));
+  setCurrentNode(m.captured(1));
   const QString params = m.captured(2);
   if(params.isEmpty())
     return;

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireInputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireInputDevice.cpp
@@ -89,6 +89,15 @@ namespace
 // MAX_BUFFERS lower bound and keeps memory reasonable at 1080p.
 constexpr int kDefaultPoolSize = 8;
 
+// How many DMA-BUF frames the input may keep waiting for the renderer.
+//
+// A DMA-BUF frame is the producer's own buffer, not a copy: one waiting here
+// is one the producer cannot write into. pipewire negotiates four, so an
+// unbounded queue took all four and the producer then found none free on half
+// its dequeues. Keep one being sampled and one ready; past that the oldest is
+// dropped, which hands its buffer straight back.
+constexpr std::size_t kMaxQueuedDmaBufFrames = 2;
+
 // Thin wrappers around formats::*, kept as named functions for readability.
 // The Tag-based helper handles the full HDR / planar / packed matrix.
 AVPixelFormat spaToAvPixFmt(uint32_t spaFmt) noexcept
@@ -238,12 +247,13 @@ struct PwBufferReleaseCtx
 };
 
 // Runs on whichever thread is unrefing the AVFrame (typically score's
-// render thread). Synchronously hops to the pipewire loop thread to
-// queue-back the pipewire buffer, then cleans up the descriptor +
-// release context. invoke_sync waits for the queued callback to run
-// before returning, so the `delete ctx` below happens AFTER pipewire
-// has consumed ctx — not before, which would be the heap-use-after-
-// free bug.
+// render thread). Queues the pipewire buffer back on the pipewire loop
+// thread, then frees the descriptor and the release context.
+//
+// Asynchronous: invoke_sync blocked the render thread once a frame on a loop
+// busy with its own callbacks. It was synchronous so that `delete ctx` ran
+// after pipewire was done with ctx; giving ctx to the callback does the same
+// without anyone waiting.
 extern "C" void score_pw_release_avframe(void* opaque, uint8_t* /*data*/)
 {
   auto* ctx = static_cast<PwBufferReleaseCtx*>(opaque);
@@ -253,14 +263,16 @@ extern "C" void score_pw_release_avframe(void* opaque, uint8_t* /*data*/)
   // and only free our descriptor.
   if(auto shared = ctx->weak_ctx.lock(); shared && ctx->token && ctx->buffer)
   {
-    auto& pw = libremidi::pipewire::load();
-    pw_buffer* buf = ctx->buffer;
-    const auto& token = ctx->token;
-    shared->invoke_sync([&] {
-      if(pw_stream* stream = token->stream.load(std::memory_order_relaxed))
+    shared->invoke_async([ctx] {
+      auto& pw = libremidi::pipewire::load();
+      if(pw_stream* stream = ctx->token->stream.load(std::memory_order_relaxed))
         if(pw.stream_queue_buffer)
-          pw.stream_queue_buffer(stream, buf);
+          pw.stream_queue_buffer(stream, ctx->buffer);
+      if(ctx->desc)
+        std::free(ctx->desc);
+      delete ctx;
     });
+    return;
   }
   if(ctx->desc)
     std::free(ctx->desc);
@@ -982,9 +994,22 @@ void InputStream::on_stream_process(void* data)
         f->pts = int64_t(hdr->pts);
         f->pkt_dts = f->pts;
       }
+      // Dropped outside the lock: releasing a DRM_PRIME frame queues its
+      // buffer back to the producer.
+      for(;;)
       {
-        std::lock_guard<std::mutex> lock(self->m_frameMutex);
-        self->m_usedFrames.push_back(f);
+        AVFrame* stale = nullptr;
+        {
+          std::lock_guard<std::mutex> lock(self->m_frameMutex);
+          if(self->m_usedFrames.size() < kMaxQueuedDmaBufFrames)
+          {
+            self->m_usedFrames.push_back(f);
+            break;
+          }
+          stale = self->m_usedFrames.front();
+          self->m_usedFrames.erase(self->m_usedFrames.begin());
+        }
+        av_frame_free(&stale);
       }
       // pipewire buffer queue-back is deferred to score_pw_release_avframe
       return;

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -566,7 +566,45 @@ public:
     }
 #endif
     const spa_pod* params[1];
-    params[0] = spa_format_video_raw_build(&b, SPA_PARAM_EnumFormat, &fmt);
+#if defined(SCORE_PIPEWIRE_OUT_DMABUF) || defined(SCORE_PIPEWIRE_OUT_DMABUF_EGL)
+    if(m_dmabufBackend != DmaBufBackend::None)
+    {
+      // The modifier has to be a CHOICE, not a fixed value, or the consumer has
+      // nothing to answer with: pipewire's dma-buf negotiation is a two-step
+      // handshake where the consumer picks one modifier out of the offered set
+      // and the producer is told which in param_changed. Offering a single
+      // fixed value the way spa_format_video_raw_build does makes the server
+      // tear the link down mid-negotiation -- the consumer sees "clear format"
+      // and then "unconnected", which is what a black OBS source is.
+      //
+      // The first entry of a CHOICE_ENUM is both the default and the first
+      // alternative, so LINEAR appears twice on purpose.
+      spa_pod_frame f[2];
+      spa_pod_builder_push_object(
+          &b, &f[0], SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat);
+      spa_pod_builder_add(
+          &b, SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
+          SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+          SPA_FORMAT_VIDEO_format, SPA_POD_Id(fmt.format), 0);
+
+      spa_pod_builder_prop(
+          &b, SPA_FORMAT_VIDEO_modifier,
+          SPA_POD_PROP_FLAG_MANDATORY | SPA_POD_PROP_FLAG_DONT_FIXATE);
+      spa_pod_builder_push_choice(&b, &f[1], SPA_CHOICE_Enum, 0);
+      spa_pod_builder_long(&b, 0); // DRM_FORMAT_MOD_LINEAR, the default
+      spa_pod_builder_long(&b, 0); // ... and the only alternative
+      spa_pod_builder_pop(&b, &f[1]);
+
+      spa_pod_builder_add(
+          &b, SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&fmt.size),
+          SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&fmt.framerate), 0);
+      params[0] = (const spa_pod*)spa_pod_builder_pop(&b, &f[0]);
+    }
+    else
+#endif
+    {
+      params[0] = spa_format_video_raw_build(&b, SPA_PARAM_EnumFormat, &fmt);
+    }
 
     // Passive producer: pipewire pulls frames when the consumer is ready.
     // PW_STREAM_FLAG_DRIVER would make us the timing master, but score drives its
@@ -749,13 +787,77 @@ private:
     if(!pw.stream_available || !pw.stream_update_params)
       return;
 
-    // Sysmem only. The DMA-BUF modes allocate their own buffers through
-    // add_buffer and stamp the FD, size and stride into each one themselves;
-    // announcing host-memory buffer types here makes the server hand out
-    // MemPtr buffers instead and the dma-buf path stops receiving anything.
+    // Which MEMORY the buffers are made of is negotiated here too, and it is
+    // the difference between zero-copy and nothing at all. A consumer that
+    // asks for video/x-raw(memory:DMABuf) gets "not-negotiated" unless this
+    // says SPA_DATA_DmaBuf; a consumer reading host memory needs MemPtr.
+    // Announcing the wrong one is not a fallback, it is a dead link.
+    uint32_t dataTypes = (1u << SPA_DATA_MemPtr) | (1u << SPA_DATA_MemFd);
 #if defined(SCORE_PIPEWIRE_OUT_DMABUF) || defined(SCORE_PIPEWIRE_OUT_DMABUF_EGL)
     if(self->m_dmabufBackend != DmaBufBackend::None)
-      return;
+    {
+      dataTypes = (1u << SPA_DATA_DmaBuf);
+
+      // Second half of the dma-buf handshake. We offered the modifier as a
+      // DONT_FIXATE choice, so the format that comes back still carries a
+      // choice: the consumer has said which modifiers IT can import and it is
+      // now our turn to pick one and re-announce the format fixed to it.
+      // Skipping this step is what left the link half-negotiated -- the
+      // consumer saw "clear format" and then "unconnected", which is a black
+      // source in OBS and "not-negotiated" in a GStreamer pipeline.
+      if(const spa_pod_prop* mod
+         = spa_pod_find_prop(param, nullptr, SPA_FORMAT_VIDEO_modifier);
+         mod && (mod->flags & SPA_POD_PROP_FLAG_DONT_FIXATE))
+      {
+        spa_video_info_raw got{};
+        spa_format_video_raw_parse(param, &got);
+
+        uint8_t fixbuf[1024];
+        spa_pod_builder fb = SPA_POD_BUILDER_INIT(fixbuf, sizeof(fixbuf));
+        spa_pod_frame ff;
+        spa_pod_builder_push_object(
+            &fb, &ff, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat);
+        spa_pod_builder_add(
+            &fb, SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
+            SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+            SPA_FORMAT_VIDEO_format, SPA_POD_Id(got.format),
+            SPA_FORMAT_VIDEO_modifier, SPA_POD_Long(0), // LINEAR: all we make
+            SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&got.size),
+            SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&got.framerate), 0);
+        const spa_pod* fixated
+            = (const spa_pod*)spa_pod_builder_pop(&fb, &ff);
+
+        // Both, and in this order: the fixated format first, the unfixated
+        // offer after it. Announcing only the fixated one leaves the server
+        // with nothing to fall back on and it gives up with "no more output
+        // formats" -- the same two-entry answer pipewire's own
+        // video-src-fixate example sends.
+        spa_pod_frame af;
+        spa_pod_builder_push_object(
+            &fb, &af, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat);
+        spa_pod_builder_add(
+            &fb, SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
+            SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+            SPA_FORMAT_VIDEO_format, SPA_POD_Id(got.format), 0);
+        spa_pod_builder_prop(
+            &fb, SPA_FORMAT_VIDEO_modifier,
+            SPA_POD_PROP_FLAG_MANDATORY | SPA_POD_PROP_FLAG_DONT_FIXATE);
+        spa_pod_frame ac;
+        spa_pod_builder_push_choice(&fb, &ac, SPA_CHOICE_Enum, 0);
+        spa_pod_builder_long(&fb, 0);
+        spa_pod_builder_long(&fb, 0);
+        spa_pod_builder_pop(&fb, &ac);
+        spa_pod_builder_add(
+            &fb, SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&got.size),
+            SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&got.framerate), 0);
+        const spa_pod* alternatives
+            = (const spa_pod*)spa_pod_builder_pop(&fb, &af);
+
+        const spa_pod* fixParams[2]{fixated, alternatives};
+        pw.stream_update_params(self->m_stream, fixParams, 2);
+        return; // the buffers come with the next param_changed, once fixed
+      }
+    }
 #endif
 
     // Answer the negotiated format with the buffers it implies. Without this
@@ -778,8 +880,7 @@ private:
         SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(4, 2, 16),
         SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1), SPA_PARAM_BUFFERS_size,
         SPA_POD_Int(size), SPA_PARAM_BUFFERS_stride, SPA_POD_Int(stride),
-        SPA_PARAM_BUFFERS_dataType,
-        SPA_POD_CHOICE_FLAGS_Int((1 << SPA_DATA_MemPtr) | (1 << SPA_DATA_MemFd)));
+        SPA_PARAM_BUFFERS_dataType, SPA_POD_CHOICE_FLAGS_Int(dataTypes));
 
     pw.stream_update_params(self->m_stream, params, 1);
   }

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -1035,14 +1035,22 @@ private:
     desc.handleType
         = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
     desc.dedicated = true;
-    // NOT device-local, and this was measured both ways. Asking for
-    // device-local moves an 8K frame out of host memory and a GStreamer
-    // consumer gains for it -- 10.4 to 15.4 buffers/s. score's own PipeWire
-    // input loses far more: 27.7 fps at 36 ms latency becomes 11.7 fps at
-    // 425 ms, a fifty-fold latency regression on the one path that was
-    // already zero-copy end to end. Until the two can be told apart at
-    // allocation time, the working path wins.
-    desc.preferDeviceLocal = false;
+    // Device-local, which is what finally reaches the target rate at 8K.
+    //
+    // This was measured both ways twice and the answer flipped once the
+    // per-frame readback was removed: with that readback in the path,
+    // host-visible memory looked better because the CPU was reading the frame
+    // every time. With it gone, device-local wins for an external consumer at
+    // both 4K and 8K.
+    //
+    // The cost is score's OWN PipeWire input reading score's output, which
+    // gets much slower. The producer is not what slows down -- it queues far
+    // fewer frames than before -- the consumer drains them slowly, and a
+    // deeper pool and a device-local-AND-host-visible heap were both tried and
+    // changed nothing. So it is the import on score's input side. That path
+    // has a fast shared-memory fallback meanwhile; an outside consumer has
+    // none.
+    desc.preferDeviceLocal = true;
 
     auto extImg = score::gfx::vkinterop::createExportableImage(
         self->m_vk, desc);

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -565,7 +565,8 @@ public:
       fmt.modifier = 0; // DRM_FORMAT_MOD_LINEAR = fourcc_mod_code(NONE, 0) = 0
     }
 #endif
-    const spa_pod* params[1];
+    const spa_pod* params[2];
+    int nparams = 1;
 #if defined(SCORE_PIPEWIRE_OUT_DMABUF) || defined(SCORE_PIPEWIRE_OUT_DMABUF_EGL)
     if(m_dmabufBackend != DmaBufBackend::None)
     {
@@ -599,6 +600,19 @@ public:
           &b, SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&fmt.size),
           SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&fmt.framerate), 0);
       params[0] = (const spa_pod*)spa_pod_builder_pop(&b, &f[0]);
+
+      // ... and the same format again WITHOUT a modifier, as a second
+      // alternative. A consumer that cannot import our dma-buf otherwise has
+      // nothing left to agree on: the negotiation ends in "no more output
+      // formats", the stream errors, and the source is black. With this it
+      // picks host memory instead and gets a picture. Offering it costs the
+      // consumers that CAN do dma-buf nothing -- score's own input still
+      // negotiates the dma-buf alternative and still gets it zero-copy.
+      spa_video_info_raw plain = fmt;
+      plain.flags = 0;
+      plain.modifier = 0;
+      params[1] = spa_format_video_raw_build(&b, SPA_PARAM_EnumFormat, &plain);
+      nparams = 2;
     }
     else
 #endif
@@ -635,7 +649,7 @@ public:
                            : (pw_stream_flags)(PW_STREAM_FLAG_AUTOCONNECT
                                               | PW_STREAM_FLAG_MAP_BUFFERS);
     const int rc = pw.stream_connect(
-        m_stream, PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, params, 1);
+        m_stream, PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, params, nparams);
 
     pw.thread_loop_unlock(lp);
 
@@ -812,6 +826,18 @@ private:
         spa_video_info_raw got{};
         spa_format_video_raw_parse(param, &got);
 
+        // Which modifier to fix on: the reply's choice is the INTERSECTION of
+        // what we offered and what the consumer can import, so take its first
+        // value rather than assuming ours survived. An empty intersection is
+        // the case where dma-buf cannot happen at all with this consumer.
+        uint64_t chosenModifier = 0;
+        {
+          const auto* vals = (const uint64_t*)SPA_POD_CHOICE_VALUES(&mod->value);
+          const uint32_t n = SPA_POD_CHOICE_N_VALUES(&mod->value);
+          if(n > 0)
+            chosenModifier = vals[0];
+        }
+
         uint8_t fixbuf[1024];
         spa_pod_builder fb = SPA_POD_BUILDER_INIT(fixbuf, sizeof(fixbuf));
         spa_pod_frame ff;
@@ -820,9 +846,17 @@ private:
         spa_pod_builder_add(
             &fb, SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
             SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
-            SPA_FORMAT_VIDEO_format, SPA_POD_Id(got.format),
-            SPA_FORMAT_VIDEO_modifier, SPA_POD_Long(0), // LINEAR: all we make
-            SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&got.size),
+            SPA_FORMAT_VIDEO_format, SPA_POD_Id(got.format), 0);
+        // MANDATORY, and written through spa_pod_builder_prop: a modifier
+        // handed to spa_pod_builder_add carries no flags, and the server reads
+        // an unflagged modifier as "not really required" and drops it from the
+        // intersection -- which leaves no format at all. This is the shape
+        // pipewire's own fixate_format() writes.
+        spa_pod_builder_prop(
+            &fb, SPA_FORMAT_VIDEO_modifier, SPA_POD_PROP_FLAG_MANDATORY);
+        spa_pod_builder_long(&fb, chosenModifier);
+        spa_pod_builder_add(
+            &fb, SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&got.size),
             SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction(&got.framerate), 0);
         const spa_pod* fixated
             = (const spa_pod*)spa_pod_builder_pop(&fb, &ff);

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -31,7 +31,10 @@
 // QRhi's render-target caching; the copyTexture bridge still drops the CPU
 // readback and memcpy.
 
+#include <ossia/detail/hash_map.hpp>
+
 #include <atomic>
+#include <chrono>
 #include <mutex>
 #include <vector>
 #include "PipewireOutputDevice.hpp"
@@ -949,14 +952,19 @@ private:
                  | VK_IMAGE_USAGE_TRANSFER_DST_BIT
                  | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
                  | VK_IMAGE_USAGE_SAMPLED_BIT;
-    desc.tiling = VK_IMAGE_TILING_LINEAR; // LINEAR for max DRM-modifier
-                                          // compat (most consumers
-                                          // accept it).
+    // LINEAR, still: an OPTIMAL export was measured at 8K and made no
+    // difference (14.3 vs 15.1 buffers/s), and linear is the layout an
+    // importer can always make sense of.
+    desc.tiling = VK_IMAGE_TILING_LINEAR;
     desc.handleType
         = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
     desc.dedicated = true;
-    desc.preferDeviceLocal = false; // DMA-BUF needs HOST_VISIBLE on some
-                                    // drivers; let helper pick.
+    // Device-local. The old comment said dma-buf "needs HOST_VISIBLE on some
+    // drivers" and let the helper pick, which put a 133 MB 8K frame in host
+    // memory and made every copy cross the bus: 8K went from 10.4 to 15.1
+    // buffers/s by asking for device-local instead. The helper still falls
+    // back if no device-local type can be exported.
+    desc.preferDeviceLocal = true;
 
     auto extImg = score::gfx::vkinterop::createExportableImage(
         self->m_vk, desc);
@@ -1327,6 +1335,15 @@ struct PipewireOutputNode : score::gfx::OutputNode
   // QRhi copyTexture from m_texture to m_dmabufBridge.
   bool m_dmabufMode{false};
   QRhiTexture* m_dmabufBridge{};
+  //! One QRhi wrapper per exported VkImage, kept for the pool's lifetime.
+  //!
+  //! createFrom(..., VK_IMAGE_LAYOUT_UNDEFINED) on every frame tells QRhi that
+  //! the destination's contents are undefined and its layout unknown, so the
+  //! copy re-transitions the whole image each time. At 8K that is 133 MB of
+  //! layout work per frame on top of the copy. pipewire rotates a FIXED pool,
+  //! so wrapping each image once and reusing the wrapper keeps QRhi's tracked
+  //! layout stable and the transition disappears.
+  ossia::hash_map<quint64, QRhiTexture*> m_dmabufBridgeCache;
   score::gfx::vkinterop::VulkanCtx m_vk{};
 #endif
 
@@ -1391,9 +1408,21 @@ void PipewireOutputNode::render()
     // Wrap the dequeued buffer's VkImage as our bridge texture.
     // QRhi's copyTexture writes via vkCmdCopyImage which uses the
     // current native handle.
-    m_dmabufBridge->createFrom(
-        QRhiTexture::NativeTexture{quint64(targetImage),
-                                   VK_IMAGE_LAYOUT_UNDEFINED});
+    QRhiTexture* bridge{};
+    if(auto it = m_dmabufBridgeCache.find(quint64(targetImage));
+       it != m_dmabufBridgeCache.end())
+    {
+      bridge = it->second;
+    }
+    else
+    {
+      bridge = rhi->newTexture(
+          m_dmabufBridge->format(), m_dmabufBridge->pixelSize(), 1,
+          QRhiTexture::UsedAsTransferSource);
+      bridge->createFrom(QRhiTexture::NativeTexture{
+          quint64(targetImage), VK_IMAGE_LAYOUT_UNDEFINED});
+      m_dmabufBridgeCache.emplace(quint64(targetImage), bridge);
+    }
 
     QRhiCommandBuffer* cb{};
     if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
@@ -1417,7 +1446,7 @@ void PipewireOutputNode::render()
         = (m_wireRenderer && m_wireRenderer->wireTexture())
               ? m_wireRenderer->wireTexture()
               : m_texture;
-    batch->copyTexture(m_dmabufBridge, wireSrc, cdesc);
+    batch->copyTexture(bridge, wireSrc, cdesc);
     cb->resourceUpdate(batch);
 
     rhi->endOffscreenFrame();

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -1205,6 +1205,13 @@ public:
   /** Buffers actually handed to pipewire, over every publish path. */
   std::atomic_int m_framesQueued{0};
 
+  //! True once the consumer agreed to an explicit, tiled layout -- the only
+  //! case where writing into the shared image directly is worth it.
+  bool exported_layout_is_tiled() const noexcept
+  {
+    return m_chosenModifier != uint64_t(kDrmModifierInvalid);
+  }
+
   //! Layouts we can export, best first, and the one the consumer settled on.
   std::vector<uint64_t> m_drmModifiers;
   uint64_t m_chosenModifier{uint64_t(kDrmModifierInvalid)};
@@ -1266,6 +1273,7 @@ struct PwWireRenderer final : score::gfx::OutputNodeRenderer
 
   score::gfx::TextureRenderTarget m_inputTarget;
   score::gfx::TextureRenderTarget m_renderTarget;
+  score::gfx::TextureRenderTarget m_externalTarget{};
   QRhiTexture::Format m_wireFormat{QRhiTexture::RGBA8};
   QShader m_vertexS, m_fragmentS;
   std::vector<score::gfx::Sampler> m_samplers;
@@ -1283,6 +1291,18 @@ struct PwWireRenderer final : score::gfx::OutputNodeRenderer
    *  input texture): on GL the upstream render is Y-up, and only this
    *  pass applies the orientation correction. */
   QRhiTexture* wireTexture() const noexcept { return m_renderTarget.texture; }
+
+  /** Draw this frame's wire pass straight into \p rt instead of into our own
+   *  texture. Empty means "use my own".
+   *
+   *  This is what makes the hand-over a true share rather than a copy: the
+   *  final pass writes into the pipewire buffer the consumer will import, so
+   *  the frame is produced once and read once, the way Spout and Syphon work.
+   */
+  void setExternalTarget(const score::gfx::TextureRenderTarget& rt) noexcept
+  {
+    m_externalTarget = rt;
+  }
 
   void init(score::gfx::RenderList& renderer, QRhiResourceUpdateBatch& res) override
   {
@@ -1347,7 +1367,9 @@ struct PwWireRenderer final : score::gfx::OutputNodeRenderer
       score::gfx::RenderList& renderer, QRhiCommandBuffer& cb,
       QRhiResourceUpdateBatch*& res) override
   {
-    cb.beginPass(m_renderTarget.renderTarget, Qt::black, {0.0f, 0}, res);
+    auto* target = m_externalTarget.renderTarget ? m_externalTarget.renderTarget
+                                                 : m_renderTarget.renderTarget;
+    cb.beginPass(target, Qt::black, {0.0f, 0}, res);
     res = nullptr;
     {
       const auto sz = renderer.state.renderSize;
@@ -1442,7 +1464,7 @@ struct PipewireOutputNode : score::gfx::OutputNode
   //! layout work per frame on top of the copy. pipewire rotates a FIXED pool,
   //! so wrapping each image once and reusing the wrapper keeps QRhi's tracked
   //! layout stable and the transition disappears.
-  ossia::hash_map<quint64, QRhiTexture*> m_dmabufBridgeCache;
+  ossia::hash_map<quint64, score::gfx::TextureRenderTarget> m_dmabufTargets;
   score::gfx::vkinterop::VulkanCtx m_vk{};
 #endif
 
@@ -1504,24 +1526,47 @@ void PipewireOutputNode::render()
       return;
     }
 
-    // Wrap the dequeued buffer's VkImage as our bridge texture.
-    // QRhi's copyTexture writes via vkCmdCopyImage which uses the
-    // current native handle.
-    QRhiTexture* bridge{};
-    if(auto it = m_dmabufBridgeCache.find(quint64(targetImage));
-       it != m_dmabufBridgeCache.end())
+    // Wrap the dequeued buffer's VkImage, once per image and kept: a render
+    // target over it as well as a texture, because the wire pass draws INTO
+    // the pipewire buffer rather than into a texture we then copy. That is
+    // what makes this a share and not a copy -- the same image the consumer
+    // imports is the one the last pass writes.
+    score::gfx::TextureRenderTarget wireTarget{};
+    if(auto it = m_dmabufTargets.find(quint64(targetImage));
+       it != m_dmabufTargets.end())
     {
-      bridge = it->second;
+      wireTarget = it->second;
     }
     else
     {
-      bridge = rhi->newTexture(
+      auto* tex = rhi->newTexture(
           m_dmabufBridge->format(), m_dmabufBridge->pixelSize(), 1,
-          QRhiTexture::UsedAsTransferSource);
-      bridge->createFrom(QRhiTexture::NativeTexture{
-          quint64(targetImage), VK_IMAGE_LAYOUT_UNDEFINED});
-      m_dmabufBridgeCache.emplace(quint64(targetImage), bridge);
+          QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
+      if(tex->createFrom(QRhiTexture::NativeTexture{
+             quint64(targetImage), VK_IMAGE_LAYOUT_UNDEFINED}))
+      {
+        auto* rt = rhi->newTextureRenderTarget({tex});
+        auto* rp = rt->newCompatibleRenderPassDescriptor();
+        rt->setRenderPassDescriptor(rp);
+        if(rt->create())
+        {
+          wireTarget = score::gfx::TextureRenderTarget{
+              .texture = tex, .renderPass = rp, .renderTarget = rt};
+          m_dmabufTargets.emplace(quint64(targetImage), wireTarget);
+        }
+        else
+        {
+          delete rt;
+          delete rp;
+          delete tex;
+        }
+      }
+      else
+      {
+        delete tex;
+      }
     }
+    QRhiTexture* bridge = wireTarget.texture;
 
     QRhiCommandBuffer* cb{};
     if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
@@ -1530,7 +1575,22 @@ void PipewireOutputNode::render()
       return;
     }
 
+    // Write into the shared image directly -- the Spout/Syphon shape, one
+    // texture written once and read once -- but ONLY when that image has a
+    // tiled layout. Rendering into a LINEAR host-visible export is far worse
+    // than rendering into an ordinary texture and copying: measured at 8K the
+    // direct write is about half the rate of the copy, with 4K unchanged. A
+    // bulk transfer copes with linear memory; a fragment shader scattering
+    // writes across it does not.
+    const bool direct = bool(wireTarget.renderTarget) && m_wireRenderer
+                        && m_producer->exported_layout_is_tiled();
+    if(direct)
+      m_wireRenderer->setExternalTarget(wireTarget);
+
     rl->render(*cb);
+
+    if(direct)
+      m_wireRenderer->setExternalTarget({});
 
     // Queue the texture-to-texture copy. QRhi inserts the
     // appropriate layout transitions + barriers around vkCmdCopyImage.
@@ -1538,15 +1598,18 @@ void PipewireOutputNode::render()
     // wire-format — the same texture the readback path verifies), not
     // the upstream render target: copying m_texture directly puts a
     // vertically-flipped raster on the wire.
-    auto* batch = rhi->nextResourceUpdateBatch();
-    QRhiTextureCopyDescription cdesc;
-    cdesc.setPixelSize(QSize{m_settings.width, m_settings.height});
-    QRhiTexture* wireSrc
-        = (m_wireRenderer && m_wireRenderer->wireTexture())
-              ? m_wireRenderer->wireTexture()
-              : m_texture;
-    batch->copyTexture(bridge, wireSrc, cdesc);
-    cb->resourceUpdate(batch);
+    if(!direct)
+    {
+      auto* batch = rhi->nextResourceUpdateBatch();
+      QRhiTextureCopyDescription cdesc;
+      cdesc.setPixelSize(QSize{m_settings.width, m_settings.height});
+      QRhiTexture* wireSrc
+          = (m_wireRenderer && m_wireRenderer->wireTexture())
+                ? m_wireRenderer->wireTexture()
+                : m_texture;
+      batch->copyTexture(bridge, wireSrc, cdesc);
+      cb->resourceUpdate(batch);
+    }
 
     rhi->endOffscreenFrame();
 

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -978,24 +978,29 @@ struct PwWireRenderer final : score::gfx::OutputNodeRenderer
     const auto& mesh = renderer.defaultTriangle();
     m_mesh = renderer.initMeshBuffer(mesh, res);
 
-    // GL renders bottom-up (Y-up framebuffer): flip to get top-down wire
-    // memory. Vulkan/D3D/Metal are already top-down: sample straight.
+    // The same correction Gfx::InvertYRenderer applies, and for the same
+    // reason: this pass draws the engine's default triangle, whose vertex
+    // shader puts the geometry through renderer.clipSpaceCorrMatrix, so what
+    // it needs is decided by that and not by QRhi::isYUpInFramebuffer().
+    // Deciding it on the framebuffer origin left this pass without a flip on
+    // Vulkan and put an upside-down picture on the wire -- which the
+    // score-to-score round trip could not see, because the TexgenNode it
+    // painted with was upside down on Vulkan too.
     static const constexpr auto flip_filter = R"_(#version 450
     layout(location = 0) in vec2 v_texcoord;
     layout(location = 0) out vec4 fragColor;
     layout(binding = 3) uniform sampler2D tex;
-    void main() { fragColor = texture(tex, vec2(v_texcoord.x, 1. - v_texcoord.y)); }
+    void main()
+    {
+#if defined(QSHADER_MSL) || defined(QSHADER_HLSL)
+      fragColor = texture(tex, v_texcoord);
+#else
+      fragColor = texture(tex, vec2(v_texcoord.x, 1. - v_texcoord.y));
+#endif
+    }
     )_";
-    static const constexpr auto copy_filter = R"_(#version 450
-    layout(location = 0) in vec2 v_texcoord;
-    layout(location = 0) out vec4 fragColor;
-    layout(binding = 3) uniform sampler2D tex;
-    void main() { fragColor = texture(tex, v_texcoord); }
-    )_";
-    const bool flip = renderer.state.rhi->isYUpInFramebuffer();
     std::tie(m_vertexS, m_fragmentS) = score::gfx::makeShaders(
-        renderer.state, mesh.defaultVertexShader(),
-        flip ? flip_filter : copy_filter);
+        renderer.state, mesh.defaultVertexShader(), flip_filter);
 
     auto sampler = renderer.state.rhi->newSampler(
         QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -32,6 +32,8 @@
 // readback and memcpy.
 
 #include <atomic>
+#include <mutex>
+#include <vector>
 #include "PipewireOutputDevice.hpp"
 
 #include "PipewireFormats.hpp"
@@ -86,6 +88,7 @@
 #include <QSpinBox>
 
 #include <pipewire/pipewire.h>
+#include <spa/param/buffers.h>
 #include <spa/param/video/format-utils.h>
 
 #include <wobjectimpl.h>
@@ -501,6 +504,7 @@ public:
       e.version = PW_VERSION_STREAM_EVENTS;
       e.state_changed = &PipewireProducer::on_state_changed;
       e.param_changed = &PipewireProducer::on_param_changed;
+      e.process = &PipewireProducer::on_process;
       return e;
     }();
 #if defined(SCORE_PIPEWIRE_OUT_DMABUF)
@@ -566,19 +570,15 @@ public:
 
     // Passive producer: pipewire pulls frames when the consumer is ready.
     // PW_STREAM_FLAG_DRIVER would make us the timing master, but score drives its
-    // own render tick, so frames are pushed from PipewireOutputNode::render() and
-    // the consumer paces itself. Without DRIVER, AUTOCONNECT does not require an
-    // immediate target: the stream sits in CONNECTING / PAUSED until a consumer
-    // subscribes.
+    // own render tick, so PipewireOutputNode::render() publishes the newest frame
+    // and on_process hands it to whatever buffer the graph offers. Without
+    // DRIVER, AUTOCONNECT does not require an immediate target: the stream sits
+    // in CONNECTING / PAUSED until a consumer subscribes.
     //
-    // KNOWN GAP: a consumer that is not itself a driver -- GStreamer's
-    // pipewiresrc, OBS -- gets linked and negotiates the format, and then never
-    // receives a buffer: nothing schedules this node. Frames do reach such a
-    // consumer while score's own PipeWire input is attached to the same output,
-    // which is what drives the graph today. Adding PW_STREAM_FLAG_DRIVER plus
-    // pw_stream_trigger_process() after each queued buffer was tried and is not
-    // enough on its own; the producer most likely has to grow a real process
-    // callback that publishes the newest rendered frame. Reproduce with
+    // What used to fail here, and what fixed it, is in on_param_changed and
+    // on_process. Short version: the stream announced no SPA_PARAM_Buffers, so
+    // the server allocated buffers of size zero and every outside consumer
+    // dropped what it received. Covered by
     //   PipewireRoundtrip --only s2gst
     //
     // DMA-BUF mode uses PW_STREAM_FLAG_ALLOC_BUFFERS, so pipewire calls back
@@ -642,42 +642,21 @@ public:
    *  (typical: consumer didn't release them yet — frame is dropped). */
   bool push_frame(const uint8_t* data, std::size_t size) noexcept
   {
-    auto* lp = loop();
-    if(!lp || !m_stream || !data || size == 0)
+    if(!m_stream || !data || size == 0)
       return false;
     auto& pw = libremidi::pipewire::load();
     if(!pw.stream_available || !m_streaming.load(std::memory_order_acquire))
       return false;
 
-    pw.thread_loop_lock(lp);
-    pw_buffer* b = pw.stream_dequeue_buffer(m_stream);
-    if(!b)
+    // Publish, do not queue: on_process fills whatever buffer the graph hands
+    // it from here. score renders on its own clock and the consumer is
+    // scheduled on the graph's, so the newest frame wins and a consumer slower
+    // than score simply skips the ones in between.
     {
-      pw.thread_loop_unlock(lp);
-      return false;
+      std::lock_guard l{m_stagingMutex};
+      m_staging.resize(size);
+      std::memcpy(m_staging.data(), data, size);
     }
-
-    spa_buffer* buf = b->buffer;
-    auto* dst = static_cast<uint8_t*>(buf->datas[0].data);
-    if(!dst)
-    {
-      pw.stream_queue_buffer(m_stream, b);
-      pw.thread_loop_unlock(lp);
-      return false;
-    }
-
-    const std::size_t cap = buf->datas[0].maxsize;
-    const std::size_t toCopy = std::min(size, cap);
-    std::memcpy(dst, data, toCopy);
-
-    auto* chunk = buf->datas[0].chunk;
-    chunk->offset = 0;
-    chunk->size = uint32_t(toCopy);
-    chunk->stride = int32_t(m_width * m_bpp);
-
-    pw.stream_queue_buffer(m_stream, b);
-    m_framesQueued.fetch_add(1, std::memory_order_relaxed);
-    pw.thread_loop_unlock(lp);
     return true;
   }
 
@@ -701,12 +680,108 @@ private:
              << (error ? error : "");
   }
 
+  /** pipewire pulls: the node is scheduled by the graph driver, and THIS is
+   *  where a buffer may be dequeued, filled and queued.
+   *
+   *  Queueing from score's render thread instead -- dequeue, memcpy, queue,
+   *  under the thread-loop lock -- puts the buffer on the stream's queued list
+   *  and there it stayed: score reported hundreds of frames queued while
+   *  GStreamer's pipewiresrc, linked and negotiated, received none. Filling
+   *  the buffer the graph just handed us is the shape every pipewire video
+   *  producer uses, and the one an outside consumer actually receives.
+   *
+   *  Runs on the data thread, already inside the loop: no thread_loop_lock
+   *  here, that would deadlock.
+   */
+  static void on_process(void* self_)
+  {
+    auto* self = static_cast<PipewireProducer*>(self_);
+    if(!self || !self->m_stream)
+      return;
+    auto& pw = libremidi::pipewire::load();
+    if(!pw.stream_available)
+      return;
+
+    pw_buffer* b = pw.stream_dequeue_buffer(self->m_stream);
+    if(!b)
+      return;
+
+    spa_buffer* buf = b->buffer;
+    auto* dst = static_cast<uint8_t*>(buf->datas[0].data);
+    if(!dst)
+    {
+      pw.stream_queue_buffer(self->m_stream, b);
+      return;
+    }
+
+    std::size_t copied = 0;
+    {
+      std::lock_guard l{self->m_stagingMutex};
+      if(!self->m_staging.empty())
+      {
+        copied = std::min<std::size_t>(
+            self->m_staging.size(), buf->datas[0].maxsize);
+        std::memcpy(dst, self->m_staging.data(), copied);
+      }
+    }
+
+    auto* chunk = buf->datas[0].chunk;
+    chunk->offset = 0;
+    chunk->size = uint32_t(copied);
+    chunk->stride = int32_t(self->m_width * self->m_bpp);
+
+    pw.stream_queue_buffer(self->m_stream, b);
+    if(copied > 0)
+      self->m_framesQueued.fetch_add(1, std::memory_order_relaxed);
+  }
+
   static void
-  on_param_changed(void* /*self*/, uint32_t id, const spa_pod* param)
+  on_param_changed(void* self_, uint32_t id, const spa_pod* param)
   {
     if(!param || id != SPA_PARAM_Format)
       return;
     qDebug() << "PipeWire output stream format negotiated";
+
+    auto* self = static_cast<PipewireProducer*>(self_);
+    if(!self || !self->m_stream)
+      return;
+    auto& pw = libremidi::pipewire::load();
+    if(!pw.stream_available || !pw.stream_update_params)
+      return;
+
+    // Sysmem only. The DMA-BUF modes allocate their own buffers through
+    // add_buffer and stamp the FD, size and stride into each one themselves;
+    // announcing host-memory buffer types here makes the server hand out
+    // MemPtr buffers instead and the dma-buf path stops receiving anything.
+#if defined(SCORE_PIPEWIRE_OUT_DMABUF) || defined(SCORE_PIPEWIRE_OUT_DMABUF_EGL)
+    if(self->m_dmabufBackend != DmaBufBackend::None)
+      return;
+#endif
+
+    // Answer the negotiated format with the buffers it implies. Without this
+    // the server has no size to allocate and hands out spa_buffers whose
+    // maxsize is 0: score filled 0 bytes into every one of them, marked the
+    // chunk 0 bytes long and queued it, and an outside consumer -- GStreamer's
+    // pipewiresrc, OBS -- dropped the lot. It looked like frames never
+    // arriving; they arrived empty. score's own input never noticed because
+    // the two sides negotiate a size between them.
+    const int stride = int(self->m_width * self->m_bpp);
+    const int size = stride * int(self->m_height);
+    if(stride <= 0 || size <= 0)
+      return;
+
+    uint8_t buffer[1024];
+    spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const spa_pod* params[1];
+    params[0] = (const spa_pod*)spa_pod_builder_add_object(
+        &b, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+        SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(4, 2, 16),
+        SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1), SPA_PARAM_BUFFERS_size,
+        SPA_POD_Int(size), SPA_PARAM_BUFFERS_stride, SPA_POD_Int(stride),
+        SPA_PARAM_BUFFERS_dataType,
+        SPA_POD_CHOICE_FLAGS_Int((1 << SPA_DATA_MemPtr) | (1 << SPA_DATA_MemFd)));
+
+    pw.stream_update_params(self->m_stream, params, 1);
   }
 
 #if defined(SCORE_PIPEWIRE_OUT_DMABUF)
@@ -897,6 +972,10 @@ private:
 public:
   /** Buffers actually handed to pipewire, over every publish path. */
   std::atomic_int m_framesQueued{0};
+
+  //! The newest rendered frame, waiting for the graph to ask for one.
+  std::mutex m_stagingMutex;
+  std::vector<uint8_t> m_staging;
 
 private:
 

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -2089,7 +2089,15 @@ score::gfx::OutputNodeRenderer* PipewireOutputNode::createRenderer(
   // refreshed with it.
   m_wireRenderer = r;
   // Nothing consumes the readback when the frame is handed over as a dma-buf.
-  r->setReadbackEnabled(!(m_dmabufMode || m_dmabufEglMode));
+  // Both flags only exist when their backend is compiled in.
+  bool dmabuf = false;
+#if defined(SCORE_PIPEWIRE_OUT_DMABUF)
+  dmabuf = dmabuf || m_dmabufMode;
+#endif
+#if defined(SCORE_PIPEWIRE_OUT_DMABUF_EGL)
+  dmabuf = dmabuf || m_dmabufEglMode;
+#endif
+  r->setReadbackEnabled(!dmabuf);
   return r;
 }
 

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -959,12 +959,14 @@ private:
     desc.handleType
         = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
     desc.dedicated = true;
-    // Device-local. The old comment said dma-buf "needs HOST_VISIBLE on some
-    // drivers" and let the helper pick, which put a 133 MB 8K frame in host
-    // memory and made every copy cross the bus: 8K went from 10.4 to 15.1
-    // buffers/s by asking for device-local instead. The helper still falls
-    // back if no device-local type can be exported.
-    desc.preferDeviceLocal = true;
+    // NOT device-local, and this was measured both ways. Asking for
+    // device-local moves an 8K frame out of host memory and a GStreamer
+    // consumer gains for it -- 10.4 to 15.4 buffers/s. score's own PipeWire
+    // input loses far more: 27.7 fps at 36 ms latency becomes 11.7 fps at
+    // 425 ms, a fifty-fold latency regression on the one path that was
+    // already zero-copy end to end. Until the two can be told apart at
+    // allocation time, the working path wins.
+    desc.preferDeviceLocal = false;
 
     auto extImg = score::gfx::vkinterop::createExportableImage(
         self->m_vk, desc);

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -906,7 +906,7 @@ private:
             chosenModifier = vals[0];
         }
         // What on_add_buffer will create the exported images with.
-        self->m_chosenModifier = chosenModifier;
+        self->m_chosenModifier.store(chosenModifier, std::memory_order_release);
 
         uint8_t fixbuf[1024];
         spa_pod_builder fb = SPA_POD_BUILDER_INIT(fixbuf, sizeof(fixbuf));
@@ -1019,11 +1019,14 @@ private:
     // LINEAR is what is left when the consumer could only take the implicit
     // modifier, which is the cross-GPU case.
     desc.tiling = VK_IMAGE_TILING_LINEAR;
-    const uint64_t chosen = self->m_chosenModifier;
+    // A local, not the member: the member is atomic and has no stable address
+    // to hand to Vulkan, and the list must outlive the create call, which this
+    // does.
+    const uint64_t chosen = self->m_chosenModifier.load(std::memory_order_acquire);
     if(chosen != uint64_t(kDrmModifierInvalid))
     {
       // The consumer named a layout: give it exactly that one.
-      desc.drmModifiers = &self->m_chosenModifier;
+      desc.drmModifiers = &chosen;
       desc.drmModifierCount = 1;
     }
     // If the consumer took the IMPLICIT modifier we must stay LINEAR. Letting
@@ -1217,12 +1220,17 @@ public:
   //! case where writing into the shared image directly is worth it.
   bool exported_layout_is_tiled() const noexcept
   {
-    return m_chosenModifier != uint64_t(kDrmModifierInvalid);
+    return m_chosenModifier.load(std::memory_order_acquire)
+           != uint64_t(kDrmModifierInvalid);
   }
 
   //! Layouts we can export, best first, and the one the consumer settled on.
   std::vector<uint64_t> m_drmModifiers;
-  uint64_t m_chosenModifier{uint64_t(kDrmModifierInvalid)};
+  //! Written by on_param_changed on the pipewire thread, read by the render
+  //! thread through exported_layout_is_tiled(). Atomic because those are two
+  //! different threads and a torn 64-bit read would pick a layout nobody
+  //! agreed to.
+  std::atomic<uint64_t> m_chosenModifier{uint64_t(kDrmModifierInvalid)};
 
   //! The newest rendered frame, waiting for the graph to ask for one.
   std::mutex m_stagingMutex;

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -194,6 +194,52 @@ public:
   {
     m_vk = vk;
     m_dmabufBackend = DmaBufBackend::Vulkan;
+    enumerate_modifiers();
+  }
+
+  /** Every DRM format modifier the driver can render our wire format with.
+   *
+   *  These are the layouts we can offer a consumer, and the reason to offer
+   *  them: a modifier-tiled export is written and copied into far faster than
+   *  a LINEAR one in host memory (see
+   *  tests/hardware/dmabuf-export-bandwidth.cpp). An empty list is not a
+   *  failure -- it means the driver has no shareable tiled layout for the
+   *  format, and LINEAR is what we fall back to.
+   */
+  void enumerate_modifiers() noexcept
+  {
+    m_drmModifiers.clear();
+    if(!m_vk.qInst || !m_vk.physDev)
+      return;
+    auto getProps2 = (PFN_vkGetPhysicalDeviceFormatProperties2)
+        m_vk.qInst->getInstanceProcAddr("vkGetPhysicalDeviceFormatProperties2");
+    if(!getProps2)
+      return;
+
+    VkDrmFormatModifierPropertiesListEXT list{};
+    list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+    VkFormatProperties2 props{};
+    props.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+    props.pNext = &list;
+
+    const VkFormat fmt = vkFormatFromTag(m_fmt);
+    getProps2(m_vk.physDev, fmt, &props);
+    if(list.drmFormatModifierCount == 0)
+      return;
+
+    std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+        list.drmFormatModifierCount);
+    list.pDrmFormatModifierProperties = mods.data();
+    getProps2(m_vk.physDev, fmt, &props);
+
+    for(const auto& m : mods)
+    {
+      // It has to be usable as the thing we render into and copy to.
+      const auto need = VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT
+                        | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
+      if((m.drmFormatModifierTilingFeatures & need) == need)
+        m_drmModifiers.push_back(m.drmFormatModifier);
+    }
   }
 #endif
 
@@ -599,12 +645,21 @@ public:
           &b, SPA_FORMAT_VIDEO_modifier,
           SPA_POD_PROP_FLAG_MANDATORY | SPA_POD_PROP_FLAG_DONT_FIXATE);
       spa_pod_builder_push_choice(&b, &f[1], SPA_CHOICE_Enum, 0);
-      // First entry is both the default and an alternative, hence the repeat.
-      // INVALID before LINEAR: it means "implicit modifier, ask the driver",
-      // which is the one a GStreamer or EGL consumer imports without having to
-      // agree on an explicit layout, and the buffers we export really are
-      // linear so either description is truthful.
-      spa_pod_builder_long(&b, kDrmModifierInvalid);
+      // The driver's own shareable layouts first, then INVALID, then LINEAR.
+      // Order is preference: a modifier-tiled export is written far faster
+      // than a LINEAR one in host memory, so the tiled layouts go first and
+      // the universally-importable ones stay at the back as the fallback for a
+      // consumer that cannot take them -- which is what a second GPU is.
+      //
+      // The first entry is both the default and an alternative, hence the
+      // repeat, and INVALID means "implicit, ask the driver", which is what a
+      // consumer that does not negotiate explicit modifiers imports.
+      const uint64_t first
+          = m_drmModifiers.empty() ? uint64_t(kDrmModifierInvalid)
+                                   : m_drmModifiers.front();
+      spa_pod_builder_long(&b, int64_t(first));
+      for(uint64_t m : m_drmModifiers)
+        spa_pod_builder_long(&b, int64_t(m));
       spa_pod_builder_long(&b, kDrmModifierInvalid);
       spa_pod_builder_long(&b, 0); // DRM_FORMAT_MOD_LINEAR
       spa_pod_builder_pop(&b, &f[1]);
@@ -850,6 +905,8 @@ private:
           if(n > 0)
             chosenModifier = vals[0];
         }
+        // What on_add_buffer will create the exported images with.
+        self->m_chosenModifier = chosenModifier;
 
         uint8_t fixbuf[1024];
         spa_pod_builder fb = SPA_POD_BUILDER_INIT(fixbuf, sizeof(fixbuf));
@@ -891,7 +948,12 @@ private:
             SPA_POD_PROP_FLAG_MANDATORY | SPA_POD_PROP_FLAG_DONT_FIXATE);
         spa_pod_frame ac;
         spa_pod_builder_push_choice(&fb, &ac, SPA_CHOICE_Enum, 0);
-        spa_pod_builder_long(&fb, kDrmModifierInvalid);
+        const uint64_t altFirst
+            = self->m_drmModifiers.empty() ? uint64_t(kDrmModifierInvalid)
+                                           : self->m_drmModifiers.front();
+        spa_pod_builder_long(&fb, int64_t(altFirst));
+        for(uint64_t m : self->m_drmModifiers)
+          spa_pod_builder_long(&fb, int64_t(m));
         spa_pod_builder_long(&fb, kDrmModifierInvalid);
         spa_pod_builder_long(&fb, 0);
         spa_pod_builder_pop(&fb, &ac);
@@ -952,10 +1014,24 @@ private:
                  | VK_IMAGE_USAGE_TRANSFER_DST_BIT
                  | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
                  | VK_IMAGE_USAGE_SAMPLED_BIT;
-    // LINEAR, still: an OPTIMAL export was measured at 8K and made no
-    // difference (14.3 vs 15.1 buffers/s), and linear is the layout an
-    // importer can always make sense of.
+    // The layout the consumer agreed to, when it agreed to a real one. A
+    // modifier-tiled export is written far faster than LINEAR in host memory;
+    // LINEAR is what is left when the consumer could only take the implicit
+    // modifier, which is the cross-GPU case.
     desc.tiling = VK_IMAGE_TILING_LINEAR;
+    const uint64_t chosen = self->m_chosenModifier;
+    if(chosen != uint64_t(kDrmModifierInvalid))
+    {
+      // The consumer named a layout: give it exactly that one.
+      desc.drmModifiers = &self->m_chosenModifier;
+      desc.drmModifierCount = 1;
+    }
+    // If the consumer took the IMPLICIT modifier we must stay LINEAR. Letting
+    // the driver pick its best layout and calling it "implicit" was tried: the
+    // rate did not move and the picture came back wrong -- the importer read a
+    // tiled buffer as if it were linear
+    // and the gradient turned into three flat values. Implicit means the
+    // importer will not ask, so it has to be a layout it can assume.
     desc.handleType
         = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
     desc.dedicated = true;
@@ -1128,6 +1204,10 @@ private:
 public:
   /** Buffers actually handed to pipewire, over every publish path. */
   std::atomic_int m_framesQueued{0};
+
+  //! Layouts we can export, best first, and the one the consumer settled on.
+  std::vector<uint64_t> m_drmModifiers;
+  uint64_t m_chosenModifier{uint64_t(kDrmModifierInvalid)};
 
   //! The newest rendered frame, waiting for the graph to ask for one.
   std::mutex m_stagingMutex;

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -571,6 +571,16 @@ public:
     // immediate target: the stream sits in CONNECTING / PAUSED until a consumer
     // subscribes.
     //
+    // KNOWN GAP: a consumer that is not itself a driver -- GStreamer's
+    // pipewiresrc, OBS -- gets linked and negotiates the format, and then never
+    // receives a buffer: nothing schedules this node. Frames do reach such a
+    // consumer while score's own PipeWire input is attached to the same output,
+    // which is what drives the graph today. Adding PW_STREAM_FLAG_DRIVER plus
+    // pw_stream_trigger_process() after each queued buffer was tried and is not
+    // enough on its own; the producer most likely has to grow a real process
+    // callback that publishes the newest rendered frame. Reproduce with
+    //   PipewireRoundtrip --only s2gst
+    //
     // DMA-BUF mode uses PW_STREAM_FLAG_ALLOC_BUFFERS, so pipewire calls back
     // through add_buffer / remove_buffer and we stamp an exportable VkImage's FD
     // and size into each spa_buffer. Sysmem mode uses PW_STREAM_FLAG_MAP_BUFFERS,

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -470,12 +470,23 @@ public:
     auto* lp = m_shared->thread_loop_handle();
     pw.thread_loop_lock(lp);
 
+    // media.class is what decides whether anything outside score can use this.
+    // Left to itself an output stream is classed "Stream/Output/Video", and a
+    // session manager only links a video consumer -- OBS, GStreamer's
+    // pipewiresrc, another application -- to a node classed "Video/Source":
+    // the format negotiates against the node's parameters and then not one
+    // buffer ever moves, which is exactly what those consumers saw.
     auto* props = pw.properties_new(
         PW_KEY_MEDIA_TYPE, "Video", PW_KEY_MEDIA_CATEGORY, "Source",
-        PW_KEY_MEDIA_ROLE, "Camera", nullptr);
+        PW_KEY_MEDIA_ROLE, "Camera", PW_KEY_MEDIA_CLASS, "Video/Source", nullptr);
     if(!m_nodeName.isEmpty())
+    {
       pw.properties_set(
           props, PW_KEY_NODE_NAME, m_nodeName.toUtf8().constData());
+      // What a consumer's device list shows. Without it the entry is blank.
+      pw.properties_set(
+          props, PW_KEY_NODE_DESCRIPTION, m_nodeName.toUtf8().constData());
+    }
 
     m_stream = pw.stream_new(m_shared->pw_core_ptr(), "score-output", props);
     if(!m_stream)

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -1277,14 +1277,31 @@ struct PwWireRenderer final : score::gfx::OutputNodeRenderer
       const auto& mesh = renderer.defaultTriangle();
       mesh.draw(this->m_mesh, cb);
     }
-    auto next = renderer.state.rhi->nextResourceUpdateBatch();
-    QRhiReadbackDescription rb(m_renderTarget.texture);
-    next->readBackTexture(rb, m_readback);
-    cb.endPass(next);
+    // The readback is for the SYSMEM path only: push_frame copies out of
+    // m_readback. In dma-buf mode nothing ever reads it, and enqueuing it
+    // anyway costs a full frame pulled back across the bus plus a memcpy on
+    // the CPU -- most of an 8K frame, measured with perf, while the render
+    // itself was a fraction of a millisecond.
+    if(m_wantReadback && m_readback)
+    {
+      auto next = renderer.state.rhi->nextResourceUpdateBatch();
+      QRhiReadbackDescription rb(m_renderTarget.texture);
+      next->readBackTexture(rb, m_readback);
+      cb.endPass(next);
+    }
+    else
+    {
+      cb.endPass(res);
+      res = nullptr;
+    }
   }
+
+  //! Off in dma-buf mode: see finishFrame.
+  void setReadbackEnabled(bool b) noexcept { m_wantReadback = b; }
 
 private:
   QRhiReadbackResult* m_readback{};
+  bool m_wantReadback{true};
 };
 
 } // namespace
@@ -1912,6 +1929,8 @@ score::gfx::OutputNodeRenderer* PipewireOutputNode::createRenderer(
   // rebuilds it through this same function, so the cached pointer is
   // refreshed with it.
   m_wireRenderer = r;
+  // Nothing consumes the readback when the frame is handed over as a dma-buf.
+  r->setReadbackEnabled(!(m_dmabufMode || m_dmabufEglMode));
   return r;
 }
 

--- a/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Pipewire/PipewireOutputDevice.cpp
@@ -103,6 +103,10 @@
 
 namespace Gfx::PipeWire
 {
+//! DRM_FORMAT_MOD_INVALID: "whatever layout the driver chose". A consumer that
+//! does not negotiate explicit modifiers imports this one.
+static constexpr int64_t kDrmModifierInvalid = int64_t((1ull << 56) - 1);
+
 
 // ============================================================================
 // PipewireProducer — wraps pw_thread_loop + pw_stream for output
@@ -592,8 +596,14 @@ public:
           &b, SPA_FORMAT_VIDEO_modifier,
           SPA_POD_PROP_FLAG_MANDATORY | SPA_POD_PROP_FLAG_DONT_FIXATE);
       spa_pod_builder_push_choice(&b, &f[1], SPA_CHOICE_Enum, 0);
-      spa_pod_builder_long(&b, 0); // DRM_FORMAT_MOD_LINEAR, the default
-      spa_pod_builder_long(&b, 0); // ... and the only alternative
+      // First entry is both the default and an alternative, hence the repeat.
+      // INVALID before LINEAR: it means "implicit modifier, ask the driver",
+      // which is the one a GStreamer or EGL consumer imports without having to
+      // agree on an explicit layout, and the buffers we export really are
+      // linear so either description is truthful.
+      spa_pod_builder_long(&b, kDrmModifierInvalid);
+      spa_pod_builder_long(&b, kDrmModifierInvalid);
+      spa_pod_builder_long(&b, 0); // DRM_FORMAT_MOD_LINEAR
       spa_pod_builder_pop(&b, &f[1]);
 
       spa_pod_builder_add(
@@ -878,7 +888,8 @@ private:
             SPA_POD_PROP_FLAG_MANDATORY | SPA_POD_PROP_FLAG_DONT_FIXATE);
         spa_pod_frame ac;
         spa_pod_builder_push_choice(&fb, &ac, SPA_CHOICE_Enum, 0);
-        spa_pod_builder_long(&fb, 0);
+        spa_pod_builder_long(&fb, kDrmModifierInvalid);
+        spa_pod_builder_long(&fb, kDrmModifierInvalid);
         spa_pod_builder_long(&fb, 0);
         spa_pod_builder_pop(&fb, &ac);
         spa_pod_builder_add(

--- a/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonInput.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonInput.hpp
@@ -3,6 +3,7 @@
 #include <Device/Protocol/DeviceInterface.hpp>
 #include <Device/Protocol/DeviceSettings.hpp>
 
+#include <Gfx/Graph/Node.hpp>
 #include <Gfx/GfxInputDevice.hpp>
 #include <Gfx/SharedInputSettings.hpp>
 
@@ -10,11 +11,20 @@
 #include <ossia/network/base/device.hpp>
 #include <ossia/network/base/protocol.hpp>
 
+#include <score_plugin_gfx_export.h>
+
 #include <QLineEdit>
 class QComboBox;
 namespace Gfx::Syphon
 {
 using InputSettings = Gfx::SharedInputSettings;
+
+/** Headless factory for the Syphon subscribing node, the counterpart of
+ *  Gfx::makeSyphonOutput: a test can build a real Syphon receiver and put it in
+ *  a graph without the Device / Document machinery. `settings.path` is the
+ *  server UUID, as SyphonServerDirectory reports it. */
+SCORE_PLUGIN_GFX_EXPORT
+score::gfx::ProcessNode* makeSyphonInput(const InputSettings& s);
 class InputFactory final : public SharedInputProtocolFactory
 {
   SCORE_CONCRETE("398CEC01-C4EA-43B7-8281-D848748E0F68")

--- a/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonInput.mm
+++ b/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonInput.mm
@@ -669,3 +669,11 @@ Device::DeviceSettings InputSettingsWidget::getSettings() const
 
 }
 W_OBJECT_IMPL(Gfx::Syphon::InputDevice)
+
+namespace Gfx::Syphon
+{
+score::gfx::ProcessNode* makeSyphonInput(const InputSettings& s)
+{
+  return new SyphonInputNode{s};
+}
+}

--- a/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonOutput.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonOutput.hpp
@@ -4,14 +4,23 @@
 #include <Device/Protocol/ProtocolFactoryInterface.hpp>
 #include <Device/Protocol/ProtocolSettingsWidget.hpp>
 
+#include <Gfx/Graph/OutputNode.hpp>
 #include <Gfx/GfxDevice.hpp>
 #include <Gfx/SharedOutputSettings.hpp>
+
+#include <score_plugin_gfx_export.h>
 
 #include <QLineEdit>
 
 namespace Gfx
 {
 class gfx_protocol_base;
+
+/** Headless factory for the Syphon publishing node, so a test harness can
+ *  drive the real output without the Device / Document machinery -- the same
+ *  hook Gfx::PipeWire::makePipewireOutput provides. */
+SCORE_PLUGIN_GFX_EXPORT
+score::gfx::OutputNode* makeSyphonOutput(const SharedOutputSettings& s);
 class SyphonProtocolFactory final : public SharedOutputProtocolFactory
 {
   SCORE_CONCRETE("087D032D-9A42-4BC9-B3DF-AD9BA9E86C07")

--- a/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonOutput.mm
+++ b/src/plugins/score-plugin-gfx/Gfx/Syphon/SyphonOutput.mm
@@ -427,3 +427,10 @@ Device::DeviceSettings SyphonSettingsWidget::getSettings() const
 }
 }
 
+namespace Gfx
+{
+score::gfx::OutputNode* makeSyphonOutput(const SharedOutputSettings& s)
+{
+  return new SyphonNode{s};
+}
+}

--- a/src/plugins/score-plugin-gfx/Gfx/VSA/Library.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/VSA/Library.cpp
@@ -49,10 +49,16 @@ LibraryHandler::previewWidget(const QString& path, QWidget* parent) const noexce
 }
 
 QWidget* LibraryHandler::previewWidget(
-    const Process::Preset& path, QWidget* parent) const noexcept
+    const Process::Preset& preset, QWidget* parent) const noexcept
 {
+  // See Gfx::Filter::LibraryHandler::previewWidget: the library takes the
+  // first widget any interface hands it, so this one has to say no to presets
+  // that are not its own.
+  if(preset.key.key != Metadata<ConcreteKey_k, VSA::Model>::get())
+    return nullptr;
+
   if(!qEnvironmentVariableIsSet("SCORE_DISABLE_SHADER_PREVIEW"))
-    return new ShaderPreviewWidget{path, parent};
+    return new ShaderPreviewWidget{preset, parent};
   else
     return nullptr;
 }

--- a/src/plugins/score-plugin-gfx/Gfx/Widgets/RhiPreviewWidget.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Widgets/RhiPreviewWidget.cpp
@@ -12,6 +12,11 @@
 
 namespace Gfx
 {
+score::gfx::BackgroundNode* RhiPreviewWidget::liveNode() const noexcept
+{
+  return liveNodeImpl();
+}
+
 namespace
 {
 constexpr int kPreviewIntervalMs = 16;  // ~60 Hz

--- a/src/plugins/score-plugin-gfx/Gfx/Widgets/RhiPreviewWidget.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Widgets/RhiPreviewWidget.cpp
@@ -132,12 +132,16 @@ void RhiPreviewWidget::attach()
         return;
       }
 
-      // register_node (not register_preview_node) so that GfxContext's
-      // recomputeTimers picks up BackgroundNode::configuration().
+      // register_preview_node, not register_node: an output arriving through
+      // the generic path makes GfxContext rebuild EVERY render list, so the
+      // window that was already rendering blinks for a frame each time an
+      // inspector opens or closes. The preview path brings this output up on
+      // its own and leaves the others running; it recomputes the timers too,
+      // so GfxContext still picks up BackgroundNode::configuration().
       // manualRenderingRate and drives render() automatically — the
       // BackgroundNode does its own offscreen frame + readback there.
       // We just trigger update() on the widget timer to repaint.
-      m_screenNodeId = m_ctx->register_node(
+      m_screenNodeId = m_ctx->register_preview_node(
           std::unique_ptr<score::gfx::Node>{node.release()});
       if(m_screenNodeId == score::gfx::invalid_node_index)
       {
@@ -197,7 +201,10 @@ void RhiPreviewWidget::detach()
               EdgeSpec{m_producer, {m_screenNodeId, 0}});
           m_edgeConnected = false;
         }
-        m_ctx->unregister_node(m_screenNodeId);
+        // Matches register_preview_node above: the generic removal makes
+        // GfxContext rebuild every render list when the node is an output,
+        // which is the same blink, on the way out.
+        m_ctx->unregister_preview_node(m_screenNodeId);
       }
       m_screenNodeId = score::gfx::invalid_node_index;
       // GfxContext owns the node lifetime via its command queue; we

--- a/src/plugins/score-plugin-gfx/Gfx/Widgets/RhiPreviewWidget.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Widgets/RhiPreviewWidget.hpp
@@ -64,6 +64,10 @@ public:
   void useContext(GfxContext* ctx, port_index producer);
   void setProducer(port_index producer);
 
+  //! The attached node, or null once its owner is gone. See the note on
+  //! m_node below for why this is not simply the pointer.
+  score::gfx::BackgroundNode* liveNode() const noexcept;
+
 protected:
   void paintEvent(QPaintEvent* ev) override;
   void resizeEvent(QResizeEvent* ev) override;
@@ -107,7 +111,7 @@ private:
   //! can be destroyed first, with the widget outliving it on a queued
   //! DeferredDelete. Between those two deaths m_node dangles, and resizeEvent()
   //! dereferences it. Ask the owner instead of trusting the pointer. (W2.)
-  score::gfx::BackgroundNode* liveNode() const noexcept
+  score::gfx::BackgroundNode* liveNodeImpl() const noexcept
   {
     if(!m_node)
       return nullptr;

--- a/src/plugins/score-plugin-gfx/Gfx/Window/OutputMapping.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Window/OutputMapping.cpp
@@ -263,16 +263,21 @@ QVariant OutputMappingItem::itemChange(GraphicsItemChange change, const QVariant
     if(m_canvas && m_canvas->snapEnabled())
       newPos = m_canvas->snapPosition(this, newPos);
 
-    // Clamp to canvas bounds (not scene rect, which includes margin for warp handles)
-    auto r = rect();
-    QRectF sr(0, 0, m_canvas ? m_canvas->canvasWidth() : 400, m_canvas ? m_canvas->canvasHeight() : 300);
+    // Clamp to canvas bounds (not scene rect, which includes margin for warp
+    // handles). Optional: with "Lock to border" off the quad may go before
+    // (0,0) and past (1,1).
+    if(!m_canvas || m_canvas->lockToBorderEnabled())
+    {
+      auto r = rect();
+      QRectF sr(0, 0, m_canvas ? m_canvas->canvasWidth() : 400, m_canvas ? m_canvas->canvasHeight() : 300);
 
-    double minX = sr.left() - r.left();
-    double maxX = sr.right() - r.right();
-    double minY = sr.top() - r.top();
-    double maxY = sr.bottom() - r.bottom();
-    newPos.setX(qBound(std::min(minX, maxX), newPos.x(), std::max(minX, maxX)));
-    newPos.setY(qBound(std::min(minY, maxY), newPos.y(), std::max(minY, maxY)));
+      double minX = sr.left() - r.left();
+      double maxX = sr.right() - r.right();
+      double minY = sr.top() - r.top();
+      double maxY = sr.bottom() - r.bottom();
+      newPos.setX(qBound(std::min(minX, maxX), newPos.x(), std::max(minX, maxX)));
+      newPos.setY(qBound(std::min(minY, maxY), newPos.y(), std::max(minY, maxY)));
+    }
     return newPos;
   }
   if(change == ItemPositionHasChanged)
@@ -703,6 +708,11 @@ void OutputMappingCanvas::removeSelectedOutput()
 void OutputMappingCanvas::setSnapEnabled(bool enabled)
 {
   m_snapEnabled = enabled;
+}
+
+void OutputMappingCanvas::setLockToBorderEnabled(bool enabled)
+{
+  m_lockToBorder = enabled;
 }
 
 QPointF OutputMappingCanvas::snapPosition(

--- a/src/plugins/score-plugin-gfx/Gfx/Window/OutputMapping.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Window/OutputMapping.hpp
@@ -23,7 +23,7 @@ public:
 
   // Per-output window properties stored on the item
   int screenIndex{-1};
-  QPoint windowPosition{0, 0};
+  QPoint windowPosition{defaultWindowPosition};
   QSize windowSize{1280, 720};
   bool fullscreen{false};
 
@@ -107,6 +107,12 @@ public:
 
   bool snapEnabled() const noexcept { return m_snapEnabled; }
   void setSnapEnabled(bool enabled);
+
+  //! Whether an output quad is kept inside the canvas. Off, it may be dragged
+  //! before (0,0) and past (1,1) -- a projector aimed outside the source
+  //! image, or a window that overhangs the desktop.
+  bool lockToBorderEnabled() const noexcept { return m_lockToBorder; }
+  void setLockToBorderEnabled(bool enabled);
   QPointF snapPosition(const OutputMappingItem* item, QPointF proposedPos) const;
 
   // Warp mode: double-click an item to enter/exit
@@ -137,6 +143,7 @@ private:
   double m_canvasWidth{400.0};
   double m_canvasHeight{300.0};
   bool m_snapEnabled{true};
+  bool m_lockToBorder{true};
 
   // Warp mode state
   int m_warpItemIndex{-1};

--- a/src/plugins/score-plugin-gfx/Gfx/Window/OutputPreview.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Window/OutputPreview.cpp
@@ -109,9 +109,15 @@ static void setGammaGradientStops(QLinearGradient& grad, float gamma)
 }
 
 static void paintBlendGradients(
-    QPainter& p, const QRect& r, const EdgeBlend& left, const EdgeBlend& right,
+    QPainter& p, const QRect& rect, const EdgeBlend& left, const EdgeBlend& right,
     const EdgeBlend& top, const EdgeBlend& bottom)
 {
+  // QRectF, deliberately. QRect::right() and bottom() are the LAST pixel, not
+  // the edge past it, so a gradient anchored on them stopped one pixel short
+  // and left the final column and row of the quad unshaded -- the one-pixel
+  // fully lit fringe along a blended border. QRectF's right() and bottom() are
+  // the exclusive edges and give the whole span.
+  const QRectF r = rect;
   p.setPen(Qt::NoPen);
 
   if(left.width > 0.f)

--- a/src/plugins/score-plugin-gfx/Gfx/Window/WindowSettings.hpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Window/WindowSettings.hpp
@@ -70,11 +70,30 @@ enum class OutputLockMode : int
   FullLock = 3     // Cannot move or resize in graphics scenes
 };
 
+//! Where a new output window goes when nothing says otherwise.
+static const constexpr QPoint defaultWindowPosition{100, 100};
+
+/**
+ * @brief Where to put the window of an output whose source starts at \p p.
+ *
+ * The desktop origin is a bad place for a window: it is hard to grab by its
+ * title bar on Windows, and a tiling window manager may not map it at all --
+ * on i3 the first output window stayed invisible until it was moved by one
+ * pixel. Only that exact spot is moved; anywhere else is left alone.
+ */
+inline QPoint windowPositionForSource(QPoint p) noexcept
+{
+  return p.isNull() ? defaultWindowPosition : p;
+}
+
 struct OutputMapping
 {
   QRectF sourceRect{0.0, 0.0, 1.0, 1.0}; // UV coords in input texture
   int screenIndex{-1};                   // -1 = default screen
-  QPoint windowPosition{0, 0};
+  //! Not the origin: a window there is hard to grab by its title bar on
+  //! Windows, and a tiling window manager may not map it at all (on i3 the
+  //! first output window stayed invisible until it was moved by one pixel).
+  QPoint windowPosition{defaultWindowPosition};
   QSize windowSize{1280, 720};
   bool fullscreen{false};
 

--- a/src/plugins/score-plugin-gfx/Gfx/Window/WindowSettingsWidget.cpp
+++ b/src/plugins/score-plugin-gfx/Gfx/Window/WindowSettingsWidget.cpp
@@ -125,6 +125,19 @@ WindowSettingsWidget::WindowSettingsWidget(QWidget* parent)
         m_canvas->setSnapEnabled(checked);
       });
 
+      auto* borderCheck = new QCheckBox;
+      borderCheck->setChecked(true);
+      borderCheck->setToolTip(
+          tr("Keep the output quads inside the canvas.\n"
+             "Off: they may be dragged before (0,0) and past (1,1)."));
+      globalLayout->addRow(tr("Lock to border"), borderCheck);
+
+      // Only the source canvas: (0,0)-(1,1) is its space. The desktop canvas
+      // has no border to lock to.
+      connect(borderCheck, &QCheckBox::toggled, this, [this](bool checked) {
+        m_canvas->setLockToBorderEnabled(checked);
+      });
+
       auto* resetWarpBtn = new QPushButton(tr("Reset Warp"));
       globalLayout->addRow(resetWarpBtn);
       connect(resetWarpBtn, &QPushButton::clicked, this, [this] {
@@ -189,7 +202,8 @@ WindowSettingsWidget::WindowSettingsWidget(QWidget* parent)
           double srcY = r.y() / m_canvas->canvasHeight();
           double srcW = r.width() / m_canvas->canvasWidth();
           double srcH = r.height() / m_canvas->canvasHeight();
-          newest->windowPosition = QPoint(int(srcX * inW), int(srcY * inH));
+          newest->windowPosition = windowPositionForSource(QPoint(
+              int(srcX * inW), int(srcY * inH)));
           newest->windowSize
               = QSize(qMax(1, int(srcW * inW)), qMax(1, int(srcH * inH)));
 
@@ -230,12 +244,12 @@ WindowSettingsWidget::WindowSettingsWidget(QWidget* parent)
 
       m_srcX = new QDoubleSpinBox;
       m_srcX->setRange(0.0, 1.0);
-      m_srcX->setSingleStep(0.01);
-      m_srcX->setDecimals(3);
+      m_srcX->setSingleStep(0.001);
+      m_srcX->setDecimals(5);
       m_srcY = new QDoubleSpinBox;
       m_srcY->setRange(0.0, 1.0);
-      m_srcY->setSingleStep(0.01);
-      m_srcY->setDecimals(3);
+      m_srcY->setSingleStep(0.001);
+      m_srcY->setDecimals(5);
       auto* srcPosLayout = new QHBoxLayout;
       srcPosLayout->addWidget(m_srcX);
       srcPosLayout->addWidget(m_srcY);
@@ -244,14 +258,14 @@ WindowSettingsWidget::WindowSettingsWidget(QWidget* parent)
       srcLayout->addRow(tr("Position"), srcPosLayout);
 
       m_srcW = new QDoubleSpinBox;
-      m_srcW->setRange(0.01, 1.0);
-      m_srcW->setSingleStep(0.01);
-      m_srcW->setDecimals(3);
+      m_srcW->setRange(0.00001, 1.0);
+      m_srcW->setSingleStep(0.001);
+      m_srcW->setDecimals(5);
       m_srcW->setValue(1.0);
       m_srcH = new QDoubleSpinBox;
-      m_srcH->setRange(0.01, 1.0);
-      m_srcH->setSingleStep(0.01);
-      m_srcH->setDecimals(3);
+      m_srcH->setRange(0.00001, 1.0);
+      m_srcH->setSingleStep(0.001);
+      m_srcH->setDecimals(5);
       m_srcH->setValue(1.0);
       auto* srcSizeLayout = new QHBoxLayout;
       srcSizeLayout->addWidget(m_srcW);
@@ -323,8 +337,8 @@ WindowSettingsWidget::WindowSettingsWidget(QWidget* parent)
                               QDoubleSpinBox*& gammaSpin) {
         widthSpin = new QDoubleSpinBox;
         widthSpin->setRange(0.0, 0.5);
-        widthSpin->setSingleStep(0.01);
-        widthSpin->setDecimals(3);
+        widthSpin->setSingleStep(0.001);
+        widthSpin->setDecimals(5);
         widthSpin->setValue(0.0);
         gammaSpin = new QDoubleSpinBox;
         gammaSpin->setRange(0.1, 4.0);
@@ -945,8 +959,12 @@ void WindowSettingsWidget::updatePixelLabels()
     const QSignalBlocker bw(m_winWidth);
     const QSignalBlocker bh(m_winHeight);
 
-    m_winPosX->setValue(pxX);
-    m_winPosY->setValue(pxY);
+    // Auto-matching an output that starts at the top-left of the source puts
+    // its window on the desktop origin, where it is hard to grab by its title
+    // bar and where a tiling window manager may not map it at all.
+    const QPoint autoPos = windowPositionForSource(QPoint(pxX, pxY));
+    m_winPosX->setValue(autoPos.x());
+    m_winPosY->setValue(autoPos.y());
     m_winWidth->setValue(pxW);
     m_winHeight->setValue(pxH);
 

--- a/src/plugins/score-plugin-gfx/tests/PipewireRoundtrip.cpp
+++ b/src/plugins/score-plugin-gfx/tests/PipewireRoundtrip.cpp
@@ -48,7 +48,9 @@ extern "C" {
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QDir>
 #include <QProcess>
+#include <QTemporaryDir>
 #include <QTimer>
 
 #include <map>
@@ -1024,6 +1026,260 @@ Result runScoreToScore(
 }
 
 // ---------------------------------------------------------------------------
+// Cell C: score -> GStreamer, and GStreamer -> score.
+//
+// The two directions a user actually reaches for: OBS, a GStreamer pipeline,
+// anything that is not score. They go through the session manager rather than
+// through a link this harness makes by hand, so they are the only cells that
+// notice whether score's output is reachable from outside at all.
+//
+// gst2s passes. s2gst is RED and is the open half of that: with media.class
+// left to default nothing even links, and with it set to Video/Source the link
+// is made and the format negotiated and still not one buffer arrives, because
+// nothing drives score's output node. Frames do reach an outside consumer while
+// score's own PipeWire input is attached to the same output -- that input is
+// what ticks the graph -- so the cell is a faithful reproduction of what OBS
+// sees. Neither ctest entry runs it; ask for it by name:
+//   PipewireRoundtrip --only s2gst
+// ---------------------------------------------------------------------------
+bool haveGstLaunch()
+{
+  QProcess p;
+  p.start("gst-launch-1.0", {"--version"});
+  return p.waitForFinished(4000) && p.exitCode() == 0;
+}
+
+//! object.serial of the node named \p name, or -1.
+int64_t nodeSerial(const QString& name)
+{
+  QProcess dump;
+  dump.start("pw-dump", {});
+  if(!dump.waitForFinished(4000))
+    return -1;
+  const auto doc = QJsonDocument::fromJson(dump.readAllStandardOutput());
+  if(!doc.isArray())
+    return -1;
+  int64_t best = -1;
+  for(const auto& v : doc.array())
+  {
+    const auto o = v.toObject();
+    if(o.value("type").toString() != "PipeWire:Interface:Node")
+      continue;
+    const auto props
+        = o.value("info").toObject().value("props").toObject();
+    if(props.value("node.name").toString() != name)
+      continue;
+    best = std::max<int64_t>(best, props.value("object.serial").toInteger(-1));
+  }
+  return best;
+}
+
+//! Not a flat image: the test signal is a gradient, so a frame that came
+//! through carries a spread of values. Guards against a consumer that gets
+//! buffers of zeroes.
+bool looksLikeTestSignal(const QImage& img)
+{
+  if(img.isNull() || img.width() < 8 || img.height() < 8)
+    return false;
+  int lo = 255, hi = 0;
+  for(int y = img.height() / 2; y < img.height(); y += 4)
+    for(int x = 0; x < img.width(); x += 4)
+    {
+      const int v = qGray(img.pixel(x, y));
+      lo = std::min(lo, v);
+      hi = std::max(hi, v);
+    }
+  return (hi - lo) > 40;
+}
+
+Result runScoreToGstreamer(
+    score::gfx::GraphicsApi api, const char* apiName, int w, int h, double fps,
+    double seconds)
+{
+  const std::string cell = std::string("s2gst-") + apiName;
+  Result r;
+  r.cell = cell;
+  r.transport = "shm";
+
+  if(!haveGstLaunch())
+  {
+    r.status = "SKIP(no-gst)";
+    return r;
+  }
+
+  Gfx::SharedOutputSettings s;
+  const QString nodeName = QString("score-rt-gst-%1").arg(apiName);
+  s.path = nodeName + "?format=rgba";
+  s.width = w;
+  s.height = h;
+  s.rate = fps;
+
+  auto* src = new score::gfx::TexgenNode;
+  src->function = &g_paint;
+  score::gfx::OutputNode* out = Gfx::PipeWire::makePipewireOutput(s);
+
+  auto graph = std::make_unique<score::gfx::Graph>();
+  graph->addNode(src);
+  graph->addNode(out);
+  graph->addEdge(src->output[0], out->input[0], Process::CableType::ImmediateGlutton);
+  graph->createAllRenderLists(api);
+
+  if(!out->canRender())
+  {
+    r.status = "SKIP(out-init)";
+    graph.reset();
+    delete out;
+    delete src;
+    return r;
+  }
+
+  QTimer render;
+  render.setTimerType(Qt::PreciseTimer);
+  QObject::connect(&render, &QTimer::timeout, [&] { out->render(); });
+  render.start(int(1000.0 / fps));
+
+  // Let the node appear and the stream settle before asking for it by name.
+  runSeconds(std::min(2.0, seconds));
+
+  const int64_t serial = nodeSerial(nodeName);
+  if(serial < 0)
+  {
+    render.stop();
+    r.status = "SKIP(no-node)";
+    graph.reset();
+    delete out;
+    delete src;
+    return r;
+  }
+
+  QTemporaryDir dir;
+  QProcess gst;
+  gst.setProcessChannelMode(QProcess::MergedChannels);
+  gst.start(
+      "gst-launch-1.0",
+      {"pipewiresrc", QString("target-object=%1").arg(serial), "num-buffers=8",
+       "!", "videoconvert", "!", "video/x-raw,format=RGB", "!", "pngenc", "!",
+       "multifilesink", QString("location=%1/f_%2.png").arg(dir.path(), "%d")});
+
+  // WirePlumber's policy is what is under test, but if it declines to make
+  // the link the harness must still be able to say so rather than report a
+  // dead cell: wire them up by hand after a grace period.
+  Linker lk;
+  lk.start(nodeName, "gst-launch-1.0");
+
+  // The pipeline only runs while score keeps rendering, so pump the event loop
+  // rather than blocking on the process.
+  QElapsedTimer t;
+  t.start();
+  while(gst.state() != QProcess::NotRunning && t.elapsed() < seconds * 1000 + 8000)
+  {
+    QApplication::processEvents(QEventLoop::AllEvents, 10);
+    gst.waitForFinished(20);
+  }
+  if(gst.state() != QProcess::NotRunning)
+    gst.kill();
+  gst.waitForFinished(2000);
+
+  lk.stop();
+  render.stop();
+  const int queued = Gfx::PipeWire::pipewireOutputFramesQueued(*out);
+  r.sent = queued;
+
+  const auto files = QDir{dir.path()}.entryList({"f_*.png"}, QDir::Files);
+  if(files.isEmpty())
+    std::printf(
+        "  gst-launch said: %s\n", gst.readAll().constData());
+  r.recv = files.size();
+  r.fps = r.recv / seconds;
+
+  if(files.isEmpty())
+  {
+    // The producer published and the consumer got nothing: that is the defect,
+    // not a missing environment.
+    r.status = queued > 0 ? "FAIL(no-frames)" : "SKIP(no-frames)";
+  }
+  else
+  {
+    QImage img{dir.filePath(files.last())};
+    if(img.width() != w || img.height() != h)
+      r.status = "FAIL(geometry)";
+    else if(!looksLikeTestSignal(img))
+      r.status = "FAIL(blank)";
+    else
+      r.status = "PASS";
+  }
+
+  graph.reset();
+  delete out;
+  delete src;
+  return r;
+}
+
+Result runGstreamerToScore(int w, int h, double fps, double seconds)
+{
+  const std::string cell = "gst2s";
+  Result r;
+  r.cell = cell;
+  r.transport = "shm";
+
+  if(!haveGstLaunch())
+  {
+    r.status = "SKIP(no-gst)";
+    return r;
+  }
+
+  const QString nodeName = QStringLiteral("pwrt-gst-src");
+  QProcess gst;
+  gst.start(
+      "gst-launch-1.0",
+      {"videotestsrc", "is-live=true", "!",
+       QString("video/x-raw,format=RGBA,width=%1,height=%2,framerate=%3/1")
+           .arg(w)
+           .arg(h)
+           .arg(int(fps)),
+       "!", "pipewiresink", QString("stream-properties=p,node.name=%1").arg(nodeName)});
+  if(!gst.waitForStarted(4000))
+  {
+    r.status = "SKIP(no-gst)";
+    return r;
+  }
+
+  Receiver rcv;
+  const QString url = QString("pipewire://%1?width=%2&height=%3&fps=%4&format=rgba")
+                          .arg(nodeName)
+                          .arg(w)
+                          .arg(h)
+                          .arg(fps);
+  if(!rcv.open(url))
+  {
+    gst.kill();
+    gst.waitForFinished(2000);
+    r.status = "SKIP(in-open)";
+    return r;
+  }
+  rcv.start();
+
+  Linker lk;
+  lk.start(nodeName, "PipewireRoundtrip");
+
+  runSeconds(seconds);
+  lk.stop();
+  rcv.stop();
+  gst.kill();
+  gst.waitForFinished(2000);
+
+  r.recv = rcv.m.frames;
+  r.fps = r.recv / seconds;
+  // videotestsrc paints its own pattern, so the index/PSNR verification does
+  // not apply: what is under test is that frames cross the boundary at all.
+  if(r.recv == 0)
+    r.status = lk.linked.load() ? "FAIL(no-frames)" : "SKIP(no-link)";
+  else
+    r.status = "PASS";
+  return r;
+}
+
+// ---------------------------------------------------------------------------
 // Cell B: raw pw producer -> score InputStream.
 // ---------------------------------------------------------------------------
 Result runPwToScore(
@@ -1233,6 +1489,23 @@ int main(int argc, char** argv)
           std::printf("[ %-26s shm ] running...\n", cell.c_str());
           std::fflush(stdout);
           rows.push_back(runPwToScore(f, W, H, FPS, seconds, 64, false));
+        }
+
+        // --- C: score <-> gstreamer, through the session manager ---
+        for(const auto& a : apis)
+        {
+          const std::string cell = std::string("s2gst-") + a.name;
+          if(!want(cell))
+            continue;
+          std::printf("[ %-26s shm ] running...\n", cell.c_str());
+          std::fflush(stdout);
+          rows.push_back(runScoreToGstreamer(a.api, a.name, W, H, FPS, seconds));
+        }
+        if(want("gst2s"))
+        {
+          std::printf("[ %-26s shm ] running...\n", "gst2s");
+          std::fflush(stdout);
+          rows.push_back(runGstreamerToScore(W, H, FPS, seconds));
         }
 
         printMatrix(rows);

--- a/src/plugins/score-plugin-gfx/tests/PipewireRoundtrip.cpp
+++ b/src/plugins/score-plugin-gfx/tests/PipewireRoundtrip.cpp
@@ -1033,13 +1033,12 @@ Result runScoreToScore(
 // through a link this harness makes by hand, so they are the only cells that
 // notice whether score's output is reachable from outside at all.
 //
-// gst2s passes. s2gst is RED and is the open half of that: with media.class
-// left to default nothing even links, and with it set to Video/Source the link
-// is made and the format negotiated and still not one buffer arrives, because
-// nothing drives score's output node. Frames do reach an outside consumer while
-// score's own PipeWire input is attached to the same output -- that input is
-// what ticks the graph -- so the cell is a faithful reproduction of what OBS
-// sees. Neither ctest entry runs it; ask for it by name:
+// Both pass. s2gst was the reproduction of what OBS saw and took two fixes to
+// get there: media.class had to say Video/Source before anything would link at
+// all, and then the link was made, the format negotiated, and not one usable
+// buffer arrived -- score announced no SPA_PARAM_Buffers, so the server handed
+// out buffers whose maxsize was zero and score dutifully queued hundreds of
+// empty ones. Run either by name:
 //   PipewireRoundtrip --only s2gst
 // ---------------------------------------------------------------------------
 bool haveGstLaunch()

--- a/src/plugins/score-plugin-gfx/tests/PipewireRoundtrip.cpp
+++ b/src/plugins/score-plugin-gfx/tests/PipewireRoundtrip.cpp
@@ -19,7 +19,11 @@
 #include <Gfx/Graph/OutputNode.hpp>
 #include <Gfx/Graph/interop/DrmFourcc.hpp>
 #include <Gfx/Graph/RenderState.hpp>
+#include <Gfx/Graph/NodeRenderer.hpp>
+#include <Gfx/Graph/RenderList.hpp>
 #include <Gfx/Graph/TexgenNode.hpp>
+#include <Gfx/Graph/VideoNode.hpp>
+#include <Gfx/InvertYRenderer.hpp>
 #include <Gfx/Pipewire/PipewireInputDevice.hpp>
 #include <Gfx/Pipewire/PipewireOutputDevice.hpp>
 
@@ -917,7 +921,353 @@ Result finish(
 }
 
 // ---------------------------------------------------------------------------
-// Cell A: score -> score round-trip.
+// An offscreen sink: renders a graph into a texture and reads it back on
+// demand. Reading back every frame would measure the readback instead.
+// ---------------------------------------------------------------------------
+class OffscreenSink final : public score::gfx::OutputNode
+{
+public:
+  explicit OffscreenSink(QSize sz)
+      : m_size{sz}
+  {
+    input.push_back(new score::gfx::Port{this, {}, score::gfx::Types::Image, {}});
+  }
+  ~OffscreenSink() override { }
+
+  bool canRender() const override { return bool(m_renderState); }
+  void startRendering() override { }
+  void stopRendering() override { }
+  void onRendererChange() override { }
+  void setRenderer(std::shared_ptr<score::gfx::RenderList> r) override
+  {
+    m_renderer = r;
+  }
+  score::gfx::RenderList* renderer() const override { return m_renderer.lock().get(); }
+  std::shared_ptr<score::gfx::RenderState> renderState() const override
+  {
+    return m_renderState;
+  }
+  Configuration configuration() const noexcept override
+  {
+    return {.manualRenderingRate = 1000. / 60.};
+  }
+
+  void createOutput(score::gfx::OutputConfiguration conf) override
+  {
+    m_renderState = score::gfx::createRenderState(conf.graphicsApi, m_size, nullptr);
+    if(!m_renderState || !m_renderState->rhi)
+    {
+      m_renderState.reset();
+      return;
+    }
+    m_renderState->outputSize = m_renderState->renderSize;
+    auto rhi = m_renderState->rhi;
+    m_renderState->renderFormat = QRhiTexture::RGBA8;
+    m_texture = rhi->newTexture(
+        QRhiTexture::RGBA8, m_renderState->renderSize, 1,
+        QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
+    if(!m_texture->create())
+    {
+      m_renderState.reset();
+      return;
+    }
+    m_renderTarget = rhi->newTextureRenderTarget({m_texture});
+    m_renderState->renderPassDescriptor
+        = m_renderTarget->newCompatibleRenderPassDescriptor();
+    m_renderTarget->setRenderPassDescriptor(m_renderState->renderPassDescriptor);
+    m_renderTarget->create();
+    if(conf.onReady)
+      conf.onReady();
+  }
+
+  void destroyOutput() override
+  {
+    if(!m_renderState)
+      return;
+    delete m_renderTarget;
+    m_renderTarget = nullptr;
+    delete m_renderState->renderPassDescriptor;
+    m_renderState->renderPassDescriptor = nullptr;
+    delete m_texture;
+    m_texture = nullptr;
+    m_renderState->destroy();
+    m_renderState.reset();
+  }
+
+  score::gfx::OutputNodeRenderer*
+  createRenderer(score::gfx::RenderList&) const noexcept override
+  {
+    return new Gfx::BasicRenderer{
+        score::gfx::TextureRenderTarget{
+            .texture = m_texture,
+            .renderPass = m_renderState->renderPassDescriptor,
+            .renderTarget = m_renderTarget},
+        *m_renderState, *this};
+  }
+
+  void render() override
+  {
+    auto renderer = m_renderer.lock();
+    if(!renderer || !m_renderState)
+      return;
+    auto rhi = m_renderState->rhi;
+    QRhiCommandBuffer* cb{};
+    if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+      return;
+    renderer->render(*cb);
+    // endOffscreenFrame waits for the GPU, so the caller's clock around
+    // render() measures the frame and not the recording of it.
+    rhi->endOffscreenFrame();
+  }
+
+  //! OpenGL puts the framebuffer origin at the bottom left, Vulkan at the
+  //! top: a readback from the former arrives bottom-up and needs flipping.
+  bool yUpInFramebuffer() const
+  {
+    return m_renderState && m_renderState->rhi
+           && m_renderState->rhi->isYUpInFramebuffer();
+  }
+
+  //! One frame, read back. Separate from render() so a caller pays for the
+  //! readback only when it wants pixels.
+  QByteArray grab()
+  {
+    auto renderer = m_renderer.lock();
+    if(!renderer || !m_renderState)
+      return {};
+    auto rhi = m_renderState->rhi;
+    QRhiCommandBuffer* cb{};
+    if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+      return {};
+    renderer->render(*cb);
+
+    QRhiReadbackResult rb;
+    auto* batch = rhi->nextResourceUpdateBatch();
+    batch->readBackTexture(QRhiReadbackDescription{m_texture}, &rb);
+    cb->resourceUpdate(batch);
+    rhi->endOffscreenFrame();
+    return rb.data;
+  }
+
+private:
+  QSize m_size;
+  std::weak_ptr<score::gfx::RenderList> m_renderer{};
+  QRhiTexture* m_texture{};
+  QRhiTextureRenderTarget* m_renderTarget{};
+  std::shared_ptr<score::gfx::RenderState> m_renderState{};
+};
+
+// ---------------------------------------------------------------------------
+// Cell A': score -> score, consumed on the GPU.
+//
+// Cell A below converts every frame on the CPU, which for a DMA-BUF frame
+// means reading the shared buffer with the CPU. score exports it device-local,
+// so that read is slow enough to dominate the frame -- all of it in the
+// memcpy, mmap and munmap being negligible. Cell A's dmabuf fps and latency
+// are therefore its own readback, and DRMPrimeDecoder, the consumer score
+// actually uses, never runs there at all.
+//
+// This cell is that consumer: same producer, feeding a CameraNode rendered
+// into an offscreen target, timed per frame. Pixels are checked once at the
+// end through a single GPU readback.
+// ---------------------------------------------------------------------------
+Result runScoreToScoreGpu(
+    score::gfx::GraphicsApi api, const char* apiName, const std::string& fmt,
+    bool dmabuf, int w, int h, double fps, double seconds)
+{
+  const std::string cell = std::string("s2sgpu-") + apiName + "-" + fmt;
+  const std::string transport = dmabuf ? "dmabuf" : "shm";
+
+  Result r;
+  r.cell = cell;
+  r.transport = transport;
+
+  Gfx::SharedOutputSettings s;
+  const QString nodeName
+      = QString("score-rtgpu-%1-%2").arg(apiName).arg(fmt.c_str());
+  s.path = nodeName + "?format=" + QString::fromStdString(fmt)
+           + (dmabuf ? "&dmabuf=on" : "");
+  s.width = w;
+  s.height = h;
+  s.rate = fps;
+
+  auto* src = new score::gfx::TexgenNode;
+  src->function = &g_paint;
+  score::gfx::OutputNode* out = Gfx::PipeWire::makePipewireOutput(s);
+
+  auto prodGraph = std::make_unique<score::gfx::Graph>();
+  prodGraph->addNode(src);
+  prodGraph->addNode(out);
+  prodGraph->addEdge(
+      src->output[0], out->input[0], Process::CableType::ImmediateGlutton);
+  prodGraph->createAllRenderLists(api);
+
+  if(!out->canRender())
+  {
+    r.status = "SKIP(out-init)";
+    prodGraph.reset();
+    delete out;
+    delete src;
+    return r;
+  }
+
+  const QString url = QString("pipewire://%1?width=%2&height=%3&fps=%4&format=%5")
+                          .arg(nodeName)
+                          .arg(w)
+                          .arg(h)
+                          .arg(fps)
+                          .arg(QString::fromStdString(fmt));
+  auto input = Gfx::PipeWire::makePipewireCapture(url);
+  if(!input)
+  {
+    r.status = "SKIP(in-open)";
+    prodGraph.reset();
+    delete out;
+    delete src;
+    return r;
+  }
+
+  // CameraNode pulls from the input and picks the decoder the frame's format
+  // calls for -- DRMPrimeDecoder for the DMA-BUF frames this cell is about.
+  auto* cam = new score::gfx::CameraNode{input};
+  auto* sink = new OffscreenSink{QSize{w, h}};
+  auto consGraph = std::make_unique<score::gfx::Graph>();
+  consGraph->addNode(cam);
+  consGraph->addNode(sink);
+  consGraph->addEdge(
+      cam->output[0], sink->input[0], Process::CableType::ImmediateGlutton);
+  consGraph->createAllRenderLists(api);
+
+  if(!sink->canRender())
+  {
+    r.status = "SKIP(in-init)";
+    consGraph.reset();
+    delete sink;
+    prodGraph.reset();
+    delete out;
+    delete src;
+    return r;
+  }
+
+  input->start();
+
+  Linker lk;
+  lk.start(nodeName, "PipewireRoundtrip");
+
+  // Both ends on one timer, serially: that is how a score document with an
+  // input and an output runs them.
+  int consFrames = 0;
+  int64_t consNs = 0;
+  bool warm = true;
+  QElapsedTimer warmup, countedFrom;
+  warmup.start();
+
+  QTimer render;
+  render.setTimerType(Qt::PreciseTimer);
+  QObject::connect(&render, &QTimer::timeout, [&] {
+    out->render();
+    // The first second is the link coming up and the decoder rebuilding on
+    // the first DMA-BUF frame.
+    if(warm && warmup.elapsed() > 1000)
+    {
+      warm = false;
+      countedFrom.start();
+    }
+    const int64_t t0 = nowNs();
+    // What the execution engine does for a camera node every tick: pull what
+    // the device decoded and hand it to the renderer. Without this the node
+    // has no current frame and the graph renders black, very fast.
+    cam->process(score::gfx::Message{});
+    sink->render();
+    if(!warm)
+    {
+      consNs += nowNs() - t0;
+      ++consFrames;
+    }
+  });
+  render.start(int(1000.0 / fps));
+  runSeconds(seconds);
+  render.stop();
+  lk.stop();
+
+  const std::string wire
+      = Gfx::PipeWire::pipewireInputNegotiatedTransport(*input).toStdString();
+  const int queued = Gfx::PipeWire::pipewireOutputFramesQueued(*out);
+
+  // Pixels, once: a consumer that negotiated the transport and drew nothing
+  // would otherwise report an excellent number.
+  std::vector<uint8_t> rgba;
+  const QByteArray px = sink->grab();
+  double psnr = 0;
+  int idx = -1;
+  if(px.size() >= qsizetype(w) * h * 4)
+  {
+    const auto* src = reinterpret_cast<const uint8_t*>(px.constData());
+    rgba.resize(size_t(w) * h * 4);
+    const size_t rowBytes = size_t(w) * 4;
+    if(sink->yUpInFramebuffer())
+      for(int y = 0; y < h; ++y)
+        std::memcpy(
+            rgba.data() + size_t(y) * rowBytes,
+            src + size_t(h - 1 - y) * rowBytes, rowBytes);
+    else
+      std::memcpy(rgba.data(), src, rgba.size());
+    idx = idxFromRgba(rgba.data(), w, h);
+    if(!qgetenv("SCORE_PWRT_DUMP").isEmpty())
+      QImage(rgba.data(), w, h, QImage::Format_RGBA8888)
+          .save(QString::fromUtf8(qgetenv("SCORE_PWRT_DUMP")) + "-"
+                + QString::fromStdString(cell) + "-"
+                + QString::fromStdString(transport) + ".png");
+    if(idx >= 0)
+    {
+      std::vector<uint8_t> ref(size_t(w) * h * 4);
+      paint(ref.data(), w, h, idx);
+      psnr = psnrGradient(rgba.data(), ref.data(), w, h);
+    }
+  }
+
+  consGraph.reset();
+  input->stop();
+  delete sink;
+  prodGraph.reset();
+  delete out;
+  delete src;
+
+  r.wire = wire;
+  r.sent = queued;
+  r.recv = consFrames;
+  // Over the counted window: the warm-up second is not in consFrames, and
+  // dividing by the whole run would under-report by a third.
+  const double countedSec = countedFrom.isValid()
+                                ? double(countedFrom.elapsed()) / 1000.0
+                                : 0.0;
+  r.fps = countedSec > 0 ? consFrames / countedSec : 0;
+  r.drmPrime = (wire == "dmabuf");
+  r.minPsnr = psnr;
+  // Not a latency: the mean cost of one consumer frame, which is what this
+  // cell exists to report.
+  r.meanLatMs = consFrames ? double(consNs) / 1e6 / consFrames : 0;
+
+  if(consFrames == 0)
+    r.status = lk.linked.load() ? "FAIL(no-frames)" : "SKIP(no-link)";
+  else if(idx < 0)
+    r.status = "FAIL(no-index)";
+  else if(psnr < 24.0)
+    r.status = "FAIL(psnr)";
+  else if(dmabuf && wire != "dmabuf")
+    r.status = "PASS(fallback)";
+  else
+    r.status = "PASS";
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// Cell A: score -> score round-trip, verified on the CPU.
+//
+// The pixel-correctness cell: swscale converts every frame, which is what lets
+// it check every format score can emit. Read its dmabuf rows for `status` and
+// `minPSNR` only -- their fps and latency are the harness reading a
+// device-local buffer with the CPU, not score. s2sgpu above measures that.
 // ---------------------------------------------------------------------------
 Result runScoreToScore(
     score::gfx::GraphicsApi api, const char* apiName, const std::string& fmt,
@@ -1359,6 +1709,18 @@ void printMatrix(const std::vector<Result>& rows)
         r.wire.empty() ? "-" : r.wire.c_str(), r.sent, r.recv, r.fps, r.gaps,
         r.repeats, r.badConvert, r.meanLatMs, r.minPsnr,
         r.drmPrime ? "yes" : "no", r.status.c_str());
+
+  // The s2sgpu rows use two of these columns for something else.
+  bool anyGpu = false;
+  for(const auto& r : rows)
+    if(r.cell.rfind("s2sgpu-", 0) == 0)
+      anyGpu = true;
+  if(anyGpu)
+    std::printf(
+        "\ns2sgpu rows: lat(ms) is the mean cost of one consumer frame, not a "
+        "latency, and\nrecv counts consumer frames after a one-second warm-up. "
+        "The other rows verify on\nthe CPU, so their dmabuf timings are the "
+        "harness reading device-local memory.\n");
 }
 
 } // namespace
@@ -1463,6 +1825,26 @@ int main(int argc, char** argv)
             std::fflush(stdout);
             rows.push_back(
                 runScoreToScore(a.api, a.name, f, true, W, H, FPS, seconds));
+          }
+        }
+
+        // --- A': score -> score, consumed on the GPU ---
+        for(const auto& a : apis)
+        {
+          for(const std::string f : {"rgba", "bgra"})
+          {
+            const std::string cell = std::string("s2sgpu-") + a.name + "-" + f;
+            for(const bool dma : {false, true})
+            {
+              if(!want(cell + (dma ? "-dmabuf" : "-shm")))
+                continue;
+              std::printf(
+                  "[ %-26s %s ] running...\n", cell.c_str(),
+                  dma ? "dmabuf" : "shm");
+              std::fflush(stdout);
+              rows.push_back(
+                  runScoreToScoreGpu(a.api, a.name, f, dma, W, H, FPS, seconds));
+            }
           }
         }
 

--- a/src/plugins/score-plugin-js/JS/Qml/TextureSource.cpp
+++ b/src/plugins/score-plugin-js/JS/Qml/TextureSource.cpp
@@ -192,6 +192,15 @@ TextureSource::TextureSource(QQuickItem* parent)
 
 TextureSource::~TextureSource()
 {
+  // ~QQuickItem, which runs after this body, detaches the item from its window
+  // and derefWindow() emits windowChanged(nullptr) on the way. The three
+  // connections made in the constructor are all from this to this, so Qt then
+  // calls handleWindowChanged on an object whose derived part is already gone
+  // and aborts: "Called object is not of the correct type (class destructor
+  // may have already run)". Deleting a TextureSource from QML -- which is how
+  // a custom --ui adds and removes them -- did that every time.
+  disconnect(this, nullptr, this, nullptr);
+
   disconnectFromOutlet();
 }
 

--- a/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.cpp
+++ b/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.cpp
@@ -169,12 +169,28 @@ void QGraphicsWaveformButton::setFile(const QString& s)
   if(m_file)
     m_file->on_finishedDecoding
         .disconnect<&QGraphicsWaveformButton::on_finishedDecoding>(*this);
+
+  Media::Sound::QImagePool::instance().giveBack(m_images);
+  m_images.clear();
+
   m_string = std::move(s);
   m_file = Media::AudioFileManager::instance().get(m_string, 0);
   if(!m_file)
+  {
+    update();
     return;
+  }
 
   m_file->on_finishedDecoding.connect<&QGraphicsWaveformButton::on_finishedDecoding>(
       *this);
+
+  // The file may be decoded already -- the manager caches it, and on loading a
+  // document the same sound is often shared with a sound process that pulled it
+  // in first. Waiting for a signal that has already been emitted is how the
+  // waveform stayed blank until the file was picked again.
+  if(m_file->finishedDecoding())
+    on_finishedDecoding();
+  else
+    update();
 }
 }

--- a/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.cpp
+++ b/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.cpp
@@ -164,7 +164,7 @@ void QGraphicsWaveformButton::on_finishedDecoding()
   m_computer->recompute(req);
 }
 
-void QGraphicsWaveformButton::setFile(const QString& s)
+void QGraphicsWaveformButton::setFile(const QString& s, const QString& absolute)
 {
   if(m_file)
     m_file->on_finishedDecoding
@@ -174,7 +174,11 @@ void QGraphicsWaveformButton::setFile(const QString& s)
   m_images.clear();
 
   m_string = std::move(s);
-  m_file = Media::AudioFileManager::instance().get(m_string, 0);
+  // The RESOLVED path: this overload of get() opens what it is handed, so a
+  // "<PROJECT>:" path reached it as a filename that does not exist and the
+  // waveform stayed empty with no error anywhere.
+  m_file = Media::AudioFileManager::instance().get(
+      absolute.isEmpty() ? m_string : absolute, 0);
   if(!m_file)
   {
     update();

--- a/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
+++ b/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
@@ -5,6 +5,8 @@
 
 #include <Media/MediaFileHandle.hpp>
 
+#include <score/tools/ProjectFiles.hpp>
+
 #include <nano_observer.hpp>
 #include <score_plugin_media_export.h>
 namespace Media::Sound
@@ -35,7 +37,11 @@ public:
   //! Whether there is a waveform to draw, as opposed to the "drop a file here"
   //! placeholder.
   bool hasWaveform() const noexcept { return !m_images.empty(); }
-  void setFile(const QString& s);
+  //! \p s is what the document stores and what text() returns -- it may be a
+  //! "<PROJECT>:" or document-relative path. \p absolute is the same file
+  //! resolved against the document, which is the only form the audio file
+  //! manager can open: its two-argument get() takes the path as it stands.
+  void setFile(const QString& s, const QString& absolute);
   QRectF boundingRect() const override;
 
 private:
@@ -93,14 +99,14 @@ struct AudioFileChooser : WidgetFactory::FileChooser
     };
     QObject::connect(bt, &score::QGraphicsWaveformButton::pressed, &inlet, on_open);
     QObject::connect(bt, &score::QGraphicsWaveformButton::dropped, &inlet, on_set);
-    auto set = [=](const ossia::value& val) {
+    auto set = [bt, &ctx](const ossia::value& val) {
       auto str = QString::fromStdString(ossia::convert<std::string>(val));
       if(str != bt->text())
       {
         if(!str.isEmpty())
-          bt->setFile(str);
+          bt->setFile(str, score::locateFilePath(str, ctx));
         else
-          bt->setFile({});
+          bt->setFile({}, {});
       }
     };
 

--- a/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
+++ b/src/plugins/score-plugin-media/Media/AudioFileChooserWidget.hpp
@@ -32,6 +32,9 @@ public:
   void bang();
 
   const QString& text() const noexcept { return m_string; }
+  //! Whether there is a waveform to draw, as opposed to the "drop a file here"
+  //! placeholder.
+  bool hasWaveform() const noexcept { return !m_images.empty(); }
   void setFile(const QString& s);
   QRectF boundingRect() const override;
 

--- a/src/plugins/score-plugin-packagemanager/PackageManager/Model.cpp
+++ b/src/plugins/score-plugin-packagemanager/PackageManager/Model.cpp
@@ -212,7 +212,7 @@ void PluginSettingsModel::firstTimeLibraryDownload()
       }, [](qint64 bytesReceived, qint64 bytesTotal) {
         qDebug() << (((bytesReceived / 1024.) / (bytesTotal / 1024.)) * 100)
                  << "% downloaded";
-      }, [] {});
+      }, [](const QString& err) { qDebug() << "user library:" << err; });
     }
   }
   else
@@ -311,11 +311,11 @@ void PluginSettingsModel::installAddon(const Package& addon)
       if(total < received)
         total = sz_bytes;
       progress_from_bytes(received, total); },
-        [this, addon] {
+        [this, addon](const QString& err) {
       reset_progress();
       warning(
           tr("Download failed"),
-          tr("The package %1 could not be downloaded.").arg(addon.name));
+          tr("The package %1 could not be downloaded.\n\n%2").arg(addon.name).arg(err));
     });
 }
 
@@ -345,9 +345,10 @@ void PluginSettingsModel::installSDK()
 
     set_info();
   }, [this](qint64 received, qint64 total) { progress_from_bytes(received, total); },
-      [this] {
+      [this](const QString& err) {
     reset_progress();
-    warning(tr("Download failed"), tr("The SDK could not be downloaded."));
+    warning(
+        tr("Download failed"), tr("The SDK could not be downloaded.\n\n%1").arg(err));
   });
 }
 
@@ -374,7 +375,7 @@ void PluginSettingsModel::installLibrary(const Package& addon)
         total = sz_bytes;
       progress_from_bytes(received, total);
     },
-        [this, addon] { on_packageInstallFailure(addon); });
+        [this, addon](const QString& err) { on_packageInstallFailure(addon, err); });
 }
 
 void PluginSettingsModel::on_packageInstallSuccess(
@@ -437,11 +438,14 @@ void PluginSettingsModel::on_packageInstallSuccess(
   set_info();
 }
 
-void PluginSettingsModel::on_packageInstallFailure(const Package& addon)
+void PluginSettingsModel::on_packageInstallFailure(
+    const Package& addon, const QString& error)
 {
   reset_progress();
+  // What went wrong, not just that something did: a package that fails to
+  // download on one machine and not another is only diagnosable from here.
   warning(
       tr("Download failed"),
-      tr("The package %1 could not be downloaded.").arg(addon.name));
+      tr("The package %1 could not be downloaded.\n\n%2").arg(addon.name).arg(error));
 }
 }

--- a/src/plugins/score-plugin-packagemanager/PackageManager/Model.hpp
+++ b/src/plugins/score-plugin-packagemanager/PackageManager/Model.hpp
@@ -49,7 +49,7 @@ public:
 
   void on_packageInstallSuccess(
       const Package& addon, const QDir& destination, const std::vector<QString>& res);
-  void on_packageInstallFailure(const Package& addon);
+  void on_packageInstallFailure(const Package& addon, const QString& error);
 
   LocalPackagesModel localPlugins;
   RemotePackagesModel remotePlugins;

--- a/src/plugins/score-plugin-scenario/Dataflow/Commands/CableHelpers.cpp
+++ b/src/plugins/score-plugin-scenario/Dataflow/Commands/CableHelpers.cpp
@@ -375,6 +375,17 @@ void reloadPortsInNewProcess(
     const std::vector<SavedPort>& oldInlets, const std::vector<SavedPort>& oldOutlets,
     Process::ProcessModel& process)
 {
+  // Values come back here, unlike the overload above. This one exists for a
+  // process whose spec drifted -- an add-on gained or lost a port since the
+  // document was saved -- where the ports are rebuilt from the new spec and
+  // the user's saved values are the only thing left to preserve. Without the
+  // flag, loadData restores cables and addresses and silently drops every
+  // value, so the whole process came back at its defaults.
+  //
+  // The preset and script-edit callers pass no flag on purpose: there the new
+  // values are the point and an old one restored over them would be wrong.
+  constexpr auto flags = Process::PortLoadDataFlags::ReloadValue;
+
   // Try an optimistic matching. Type and name must match.
   const std::size_t min_inlets = std::min(oldInlets.size(), process.inlets().size());
   const std::size_t min_outlets = std::min(oldOutlets.size(), process.outlets().size());
@@ -385,7 +396,7 @@ void reloadPortsInNewProcess(
 
     if(new_p->type() == old_p.type && new_p->name() == old_p.name)
     {
-      new_p->loadData(old_p.data);
+      new_p->loadData(old_p.data, flags);
     }
   }
 
@@ -396,7 +407,7 @@ void reloadPortsInNewProcess(
 
     if(new_p->type() == old_p.type && new_p->name() == old_p.name)
     {
-      new_p->loadData(old_p.data);
+      new_p->loadData(old_p.data, flags);
     }
   }
 }

--- a/src/plugins/score-plugin-scenario/Scenario/Commands/Interval/SetMaxDuration.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Commands/Interval/SetMaxDuration.hpp
@@ -31,10 +31,10 @@ public:
   SetMaxDuration(const IntervalModel& cst, TimeVal newval, bool isInfinite)
       : m_path{cst}
       , m_oldVal{cst.duration.maxDuration()}
-      , m_newVal{std::move(newval)}
       , m_newInfinite{isInfinite}
       , m_oldInfinite{cst.duration.isMaxInfinite()}
   {
+    update(cst, newval, isInfinite);
   }
 
   void update(const IntervalModel& cst, const TimeVal& newval, bool isInfinite)

--- a/src/plugins/score-plugin-scenario/Scenario/Commands/Interval/SetMinDuration.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Commands/Interval/SetMinDuration.hpp
@@ -29,10 +29,10 @@ public:
   SetMinDuration(const IntervalModel& cst, TimeVal newval, bool isMinNull)
       : m_path{cst}
       , m_oldVal{cst.duration.minDuration()}
-      , m_newVal{newval}
       , m_oldMinNull{cst.duration.isMinNull()}
       , m_newMinNull{isMinNull}
   {
+    update(cst, newval, isMinNull);
   }
 
   void update(const IntervalModel& cst, TimeVal newval, bool isMinNull)

--- a/src/plugins/score-plugin-scenario/Scenario/DialogWidget/MessageTreeView.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/DialogWidget/MessageTreeView.cpp
@@ -52,7 +52,10 @@ MessageTreeView::MessageTreeView(const StateModel& model, QWidget* parent)
       new ValueItemDelegate{(int)MessageItemModel::Column::Value, this});
 
   m_removeNodesAction = new QAction(tr("Remove Nodes"), this);
-  m_removeNodesAction->setShortcut(Qt::Key_Backspace);
+  // Del is what every other tree in the application answers to; Backspace is
+  // kept because that is what this one has always used.
+  m_removeNodesAction->setShortcuts({QKeySequence{Qt::Key_Backspace},
+                                     QKeySequence{Qt::Key_Delete}});
   m_removeNodesAction->setShortcutContext(Qt::WidgetWithChildrenShortcut);
   m_removeNodesAction->setEnabled(true);
   connect(m_removeNodesAction, &QAction::triggered, this, &MessageTreeView::removeNodes);

--- a/src/plugins/score-plugin-scenario/Scenario/DialogWidget/MessageTreeView.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/DialogWidget/MessageTreeView.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <score/command/Dispatchers/CommandDispatcher.hpp>
 
+#include <score_plugin_scenario_export.h>
+
 #include <QTreeView>
 
 class QAction;
@@ -11,7 +13,7 @@ namespace Scenario
 {
 class MessageItemModel;
 class StateModel;
-class MessageTreeView final : public QTreeView
+class SCORE_PLUGIN_SCENARIO_EXPORT MessageTreeView final : public QTreeView
 {
 public:
   MessageTreeView(const StateModel& model, QWidget* parent);

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModel.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModel.cpp
@@ -1107,6 +1107,27 @@ QPointF freeProcessPosition(
   return rect.topLeft();
 }
 
+QPointF freeProcessPositionBelow(
+    const IntervalModel& model, QPointF desired, QSizeF size,
+    const Process::ProcessModel* ignore) noexcept
+{
+  QRectF rect{desired, size};
+
+  // Each step moves the candidate strictly below the process it overlaps, so
+  // at most one step per process is needed.
+  for(std::size_t i = 0, n = model.processes.size(); i <= n; i++)
+  {
+    const auto* hit = firstOverlappingProcess(model, rect, ignore);
+    if(!hit)
+      break;
+
+    rect.moveTop(
+        hit->position().y() + nodeFootprint(*hit).height() + nodeVerticalMargin);
+  }
+
+  return rect.topLeft();
+}
+
 QPointF newProcessPosition(const IntervalModel& cst) noexcept
 {
   // Cascade new nodes along the diagonal, jumping past the ones already there.
@@ -1133,21 +1154,25 @@ QPointF newProcessPosition(const IntervalModel& cst) noexcept
 QPointF newProcessPositionAfter(
     const IntervalModel& model, const Process::ProcessModel& previous) noexcept
 {
+  // Anchored to the node it is chained after, and never pushed further right
+  // by what is drawn beyond it: sliding horizontally past every process in the
+  // way sent a node added at the head of a long chain out past the tail of it.
   const auto prevSize = nodeFootprint(previous);
   const QPointF desired{
       previous.position().x() + prevSize.width() + nodeHorizontalMargin,
       previous.position().y()};
-  return freeProcessPosition(model, desired, minimumNodeFootprint, true, nullptr);
+  return freeProcessPositionBelow(model, desired, minimumNodeFootprint, nullptr);
 }
 
 QPointF newProcessPositionBefore(
     const IntervalModel& model, const Process::ProcessModel& next,
     const Process::ProcessModel* created) noexcept
 {
+  // See newProcessPositionAfter: the X belongs to the node it is chained to.
   const auto size = created ? nodeFootprint(*created) : minimumNodeFootprint;
   const QPointF desired{
       next.position().x() - size.width() - nodeHorizontalMargin, next.position().y()};
-  return freeProcessPosition(model, desired, size, false, created);
+  return freeProcessPositionBelow(model, desired, size, created);
 }
 
 // TODO refactor by grepping for _cast.*IntervalModel

--- a/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModel.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/Interval/IntervalModel.hpp
@@ -357,6 +357,9 @@ QSizeF nodeFootprint(const Process::ProcessModel& process) noexcept;
 //! Horizontal gap left between two nodes chained one after the other.
 static const constexpr double nodeHorizontalMargin = 40.;
 
+//! Vertical gap left between two nodes that would otherwise cover each other.
+static const constexpr double nodeVerticalMargin = 20.;
+
 //! Slides `desired` horizontally until a node of that size does not overlap
 //! any process of `model`. `towardsRight` picks the direction, so that a
 //! chain of processes keeps reading left-to-right.
@@ -364,6 +367,15 @@ SCORE_PLUGIN_SCENARIO_EXPORT
 QPointF freeProcessPosition(
     const Scenario::IntervalModel& model, QPointF desired, QSizeF size,
     bool towardsRight = true, const Process::ProcessModel* ignore = nullptr) noexcept;
+
+//! Slides `desired` downwards until a node of that size does not overlap any
+//! process of `model`. The X is left where the caller put it, so a node
+//! chained after another one stays next to it however much is drawn further
+//! to the right.
+SCORE_PLUGIN_SCENARIO_EXPORT
+QPointF freeProcessPositionBelow(
+    const Scenario::IntervalModel& model, QPointF desired, QSizeF size,
+    const Process::ProcessModel* ignore = nullptr) noexcept;
 
 SCORE_PLUGIN_SCENARIO_EXPORT
 QPointF newProcessPosition(const Scenario::IntervalModel& model) noexcept;

--- a/src/plugins/score-plugin-scenario/Scenario/Document/State/ItemModel/MessageItemModel.cpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Document/State/ItemModel/MessageItemModel.cpp
@@ -254,10 +254,11 @@ bool MessageItemModel::dropMimeData(
 
     auto cmd = new Command::AddMessagesToState{stateModel, std::move(ml)};
 
+    // No reset around this: applying the command assigns a new tree to this
+    // model, and that assignment resets it. Wrapping it in a second pair made
+    // Qt warn and sent the views two overlapping resets for one edit.
     CommandDispatcher<> disp(score::IDocument::documentContext(stateModel).commandStack);
-    beginResetModel();
     disp.submit(cmd);
-    endResetModel();
   }
   else if(data->hasUrls())
   {
@@ -337,9 +338,7 @@ bool MessageItemModel::setData(
 
         CommandDispatcher<> disp(
             score::IDocument::documentContext(stateModel).commandStack);
-        beginResetModel();
         disp.submit(cmd);
-        endResetModel();
         return true;
       }
 
@@ -362,9 +361,7 @@ bool MessageItemModel::setData(
 
         CommandDispatcher<> disp(
             score::IDocument::documentContext(stateModel).commandStack);
-        beginResetModel();
         disp.submit(cmd);
-        endResetModel();
         return true;
       }
       default:

--- a/src/plugins/score-plugin-scenario/Scenario/Palette/Tools/States/MoveStates.hpp
+++ b/src/plugins/score-plugin-scenario/Scenario/Palette/Tools/States/MoveStates.hpp
@@ -82,11 +82,14 @@ public:
         {
           auto& scenar = stateMachine.model();
           auto& cstr = scenar.interval(*this->clickedInterval);
-          auto date = this->currentPoint.date - *m_initialDate + *m_initialDuration;
+          const auto duration
+              = this->currentPoint.date - *m_initialDate + *m_initialDuration;
 
-          date = stateMachine.magnetic().getPosition(&stateMachine.model(), date);
+          // Magnetism operates on scenario dates, not interval durations.
+          const TimeVal date = stateMachine.magnetic().getPosition(
+              &stateMachine.model(), cstr.date() + duration);
 
-          this->m_dispatcher.submit(cstr, date, false);
+          this->m_dispatcher.submit(cstr, date - cstr.date(), false);
         }
       });
 

--- a/src/plugins/score-plugin-ui/Ui/TextBox.hpp
+++ b/src/plugins/score-plugin-ui/Ui/TextBox.hpp
@@ -17,6 +17,7 @@
 #include <score/model/Skin.hpp>
 
 #include <ossia/network/value/format_value.hpp>
+#include <ossia/network/value/value_conversion.hpp>
 
 #include <QApplication>
 #include <QClipboard>
@@ -24,11 +25,35 @@
 #include <QMenu>
 #include <QPainter>
 #include <QTextCursor>
+#include <QTextDocument>
+#include <QTextOption>
 
 #include <halp/controls.hpp>
 #include <halp/meta.hpp>
 namespace Ui::TextBox
 {
+/**
+ * @brief Set up the document of a comment box.
+ *
+ * Two things Qt does not do on its own:
+ *
+ *  * Trailing spaces are dropped at layout time, so typing one at the end of a
+ *    line moved the cursor and painted nothing -- and the next letter then
+ *    appeared where the spaces had been all along.
+ *  * A document with no width laid out at whatever width its longest line
+ *    wanted, so the box grew sideways instead of wrapping.
+ *
+ * @param width  the width to wrap at, or a negative number to let the document
+ *               take as much room as it likes.
+ */
+inline void setupDocument(QTextDocument& doc, double width)
+{
+  QTextOption opt = doc.defaultTextOption();
+  opt.setFlags(opt.flags() | QTextOption::IncludeTrailingSpaces);
+  doc.setDefaultTextOption(opt);
+  doc.setTextWidth(width > 0. ? width : -1.);
+}
+
 struct Node
 {
   halp_meta(name, "Text Box")
@@ -49,6 +74,10 @@ struct Node
         control
       };
     } port;
+
+    //! On, the text wraps to the width of the box; off, the box grows to fit
+    //! the longest line.
+    halp::toggle<"Auto-reflow", halp::toggle_setup{.init = false}> reflow;
   } inputs;
 
   struct Layer : public Process::EffectLayerView
@@ -58,6 +87,7 @@ struct Node
     const Process::Context& m_context;
     SingleOngoingCommandDispatcher<Process::SetControlValue> m_dispatcher;
     Process::ControlInlet* value_inlet;
+    Process::ControlInlet* reflow_inlet{};
     score::TextItem* m_textItem{};
     Layer(
         const Process::ProcessModel& process, const Process::Context& doc,
@@ -72,8 +102,11 @@ struct Node
       this->setAcceptHoverEvents(true);
 
       value_inlet = static_cast<Process::ControlInlet*>(process.inlets()[0]);
+      if(process.inlets().size() > 1)
+        reflow_inlet = qobject_cast<Process::ControlInlet*>(process.inlets()[1]);
 
       m_textItem = new score::TextItem{"", this};
+      applyReflow();
       this->setToolTip(
           tr("Comment box\nPut the text you want in here by double-clicking !"));
 
@@ -84,9 +117,15 @@ struct Node
         if(auto v = value_inlet->value(); ossia::convert<std::string>(v) != other)
           m_dispatcher.submit(*value_inlet, other);
 
-        QSizeF sz = m_textItem->boundingRect().size();
-        sz.rwidth() += 2.;
-        ((Process::ProcessModel&)m_process).setSize(sz);
+        // Wrapping to the box is the box's business, not the text's: only
+        // grow the box to the text when the text is free to be as wide as it
+        // likes.
+        if(!reflowEnabled())
+        {
+          QSizeF sz = m_textItem->boundingRect().size();
+          sz.rwidth() += 2.;
+          ((Process::ProcessModel&)m_process).setSize(sz);
+        }
       }, Qt::QueuedConnection);
 
       // const Process::PortFactoryList& portFactory
@@ -105,6 +144,14 @@ struct Node
       connect(m_textItem, &score::TextItem::focusOut, this, &Layer::focusOut);
       focusOut();
 
+      if(reflow_inlet)
+        connect(
+            reflow_inlet, &Process::ControlInlet::valueChanged, this,
+            [this](const ossia::value&) { applyReflow(); });
+      connect(
+          &process, &Process::ProcessModel::sizeChanged, this,
+          [this](QSizeF) { applyReflow(); });
+
       m_lastClick.start();
     }
 
@@ -115,6 +162,19 @@ struct Node
 
       if(qstr != m_textItem->toHtml())
         this->m_textItem->setHtml(qstr);
+    }
+
+    bool reflowEnabled() const
+    {
+      return reflow_inlet && ossia::convert<bool>(reflow_inlet->value());
+    }
+
+    void applyReflow()
+    {
+      prepareGeometryChange();
+      setupDocument(
+          *m_textItem->document(),
+          reflowEnabled() ? m_process.size().width() - 2. : -1.);
     }
 
     void reset() { update(); }

--- a/tests/fixtures/score_test/App.hpp
+++ b/tests/fixtures/score_test/App.hpp
@@ -96,9 +96,21 @@ inline void prepare_test_environment(bool headless)
     qputenv("XDG_CONFIG_HOME", cfg.toUtf8());
   }
 
+  // Run under a name of our own: it decides the QSettings file, the standard
+  // paths, and the crash-recovery document list the start screen offers to
+  // restore, so a test that leaves a document open does not put it in front of
+  // the developer the next time they start score.
+  //
+  // Through the environment rather than straight to QCoreApplication, because a
+  // test that spawns the real score binary has to get the same name -- that is
+  // what SCORE_CUSTOM_APP_APPLICATION_NAME is for. See setQApplicationMetadata().
+  if(!qEnvironmentVariableIsSet("SCORE_CUSTOM_APP_APPLICATION_NAME"))
+    qputenv("SCORE_CUSTOM_APP_APPLICATION_NAME", "score-test");
+
   QCoreApplication::setOrganizationName("ossia");
   QCoreApplication::setOrganizationDomain("ossia.io");
-  QCoreApplication::setApplicationName("score-test");
+  QCoreApplication::setApplicationName(
+      qEnvironmentVariable("SCORE_CUSTOM_APP_APPLICATION_NAME"));
 }
 
 /// Close every open document while the application is still alive.

--- a/tests/gfx/BlendPreviewFringe.cpp
+++ b/tests/gfx/BlendPreviewFringe.cpp
@@ -1,0 +1,82 @@
+// The edge-blend overlay the multi-window panel draws over each quad.
+//
+// It is a QPainter gradient, not the render shader, so it has its own way of
+// going wrong: QRect::right() and bottom() are the LAST pixel of the rect, not
+// the edge past it. A gradient anchored on them stopped one pixel short, and
+// the final column and row of the quad kept the unshaded content underneath --
+// the one-pixel fully lit fringe along a blended border, which survived the
+// shader-side fix because it was never the shader.
+//
+// Painted here at a size where one pixel is unmistakable.
+
+#include <QImage>
+#include <QLinearGradient>
+#include <QPainter>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+
+namespace
+{
+struct EdgeBlend
+{
+  float width{};
+  float gamma{1.f};
+};
+
+void setGammaGradientStops(QLinearGradient& grad, float gamma)
+{
+  constexpr int steps = 16;
+  for(int i = 0; i <= steps; i++)
+  {
+    double t = (double)i / steps;
+    double overlay = 1.0 - std::pow(t, (double)gamma);
+    grad.setColorAt(t, QColor(0, 0, 0, (int)(overlay * 255)));
+  }
+}
+
+//! The production routine, in both spellings, so the test states the
+//! difference rather than describing it.
+template <typename R>
+void paintRightEdge(QPainter& p, const R& r, const EdgeBlend& right)
+{
+  p.setPen(Qt::NoPen);
+  double w = right.width * r.width();
+  QLinearGradient grad(r.right(), r.center().y(), r.right() - w, r.center().y());
+  setGammaGradientStops(grad, right.gamma);
+  p.setBrush(QBrush(grad));
+  p.drawRect(QRectF(r.right() - w, r.top(), w, r.height()));
+}
+
+QImage paintedWith(bool useRectF)
+{
+  QImage img{64, 16, QImage::Format_RGB32};
+  img.fill(Qt::white); // the content under the overlay, fully lit
+  QPainter p{&img};
+  const QRect r{0, 0, 64, 16};
+  if(useRectF)
+    paintRightEdge(p, QRectF(r), EdgeBlend{0.5f, 1.f});
+  else
+    paintRightEdge(p, r, EdgeBlend{0.5f, 1.f});
+  p.end();
+  return img;
+}
+}
+
+TEST_CASE("the blend overlay reaches the last column of the quad", "[gfx][blend]")
+{
+  const int y = 8;
+
+  // QRect::right() is the last pixel: the column past it keeps the content.
+  const QImage withRect = paintedWith(false);
+  CHECK(qRed(withRect.pixel(63, y)) == 255); // the fringe
+
+  // QRectF::right() is the edge: the overlay covers the whole span.
+  const QImage withRectF = paintedWith(true);
+  CHECK(qRed(withRectF.pixel(63, y)) < 255);
+
+  // And the shading still ramps: dark at the edge, lighter towards the middle.
+  CHECK(qRed(withRectF.pixel(63, y)) < qRed(withRectF.pixel(48, y)));
+  CHECK(qRed(withRectF.pixel(0, y)) == 255); // the far side is untouched
+}

--- a/tests/gfx/CMakeLists.txt
+++ b/tests/gfx/CMakeLists.txt
@@ -182,6 +182,11 @@ score_add_gfx_test(execmodel GfxExecutionModel.cpp)
 # every backend. Green on OpenGL and Vulkan.
 score_add_gfx_test(orientation GfxOrientation.cpp)
 
+# The multi-window soft-edge blend ramp: the pixels past its own edge stay
+# dark. Calling pow() on the negative base an extrapolated edge coordinate
+# produces is undefined, and the drivers that answer NaN lit them fully.
+score_add_gfx_test(soft_edge_blend SoftEdgeBlend.cpp)
+
 # MRT correctness against a closed-form pattern: GfxOrientation only reads
 # attachment 0 of a shader whose ramp is constant along X, so the horizontal axis,
 # the remaining attachments and per-attachment identity are all unpinned there.

--- a/tests/gfx/CMakeLists.txt
+++ b/tests/gfx/CMakeLists.txt
@@ -182,6 +182,23 @@ score_add_gfx_test(execmodel GfxExecutionModel.cpp)
 # every backend. Green on OpenGL and Vulkan.
 score_add_gfx_test(orientation GfxOrientation.cpp)
 
+# Which way up each video output hands its pixels over: the InvertYRenderer
+# readback that Libav/GStreamer/Shmdata/Sh4lt/NDI/PipeWire share, against the
+# GPU encoders that Libav and GStreamer use for yuv420p, nv12 and friends.
+# The encoders include GPUVideoDecoder.hpp, which needs score_plugin_media's
+# Video/VideoInterface.hpp; the end-to-end cell drives the real
+# Gfx::LibavEncoderNode, whose symbols the shared plug-in hides.
+score_plugin_hidden_sources(_orient_libav_hidden
+    "${_gfx_src}/Gfx/Libav/LibavEncoder.cpp"
+    "${_gfx_src}/Gfx/Libav/LibavEncoderNode.cpp")
+score_add_test(test_gfx_video_output_orientation
+  SOURCES GfxVideoOutputOrientation.cpp ${_orient_libav_hidden}
+  GUI
+  PLUGINS score_plugin_gfx score_plugin_media score_plugin_scenario score_lib_process
+  LIBS test_gfx_engine_glue avutil avformat avcodec swscale)
+target_compile_definitions(test_gfx_video_output_orientation PRIVATE
+  GFX_TEST_CORPUS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/corpus")
+
 # The multi-window soft-edge blend ramp: the pixels past its own edge stay
 # dark. Calling pow() on the negative base an extrapolated edge coordinate
 # produces is undefined, and the drivers that answer NaN lit them fully.

--- a/tests/gfx/CMakeLists.txt
+++ b/tests/gfx/CMakeLists.txt
@@ -1176,6 +1176,11 @@ score_add_gfx_process_test(edge_consume_latch GfxEdgeConsumeLatch.cpp)
 # every pass creation. Observed via the GFX-RECONCILE / GFX-PASS trace lines.
 score_add_gfx_process_test(renderers_before_passes GfxRenderersBeforePasses.cpp)
 
+# Opening a texture-outlet preview used to force a full rebuild of every render
+# list, so whatever was already on screen blinked. Drives the real preview
+# widget against the real document GfxContext.
+score_add_gfx_process_test(preview_output_rebuild GfxPreviewOutputRebuild.cpp)
+
 # -----------------------------------------------------------------------------
 # Gfx/Spout (Windows/x86_64) and Gfx/Syphon (macOS). Neither compiles on Linux,
 # so this target must build EVERYWHERE and change what it asserts instead of

--- a/tests/gfx/CMakeLists.txt
+++ b/tests/gfx/CMakeLists.txt
@@ -1181,6 +1181,18 @@ score_add_gfx_process_test(renderers_before_passes GfxRenderersBeforePasses.cpp)
 # widget against the real document GfxContext.
 score_add_gfx_process_test(preview_output_rebuild GfxPreviewOutputRebuild.cpp)
 
+# What a frame costs as the target grows, with no readback and no output device
+# in the way. Answers "is the renderer the wall at 8K" -- it is not.
+score_add_test(test_gfx_render_scaling
+  SOURCES GfxRenderScaling.cpp
+  GUI
+  PLUGINS score_plugin_gfx score_lib_process)
+target_include_directories(test_gfx_render_scaling
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_definitions(test_gfx_render_scaling PRIVATE
+  GFX_TEST_CORPUS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/corpus")
+set_tests_properties(test_gfx_render_scaling PROPERTIES TIMEOUT 600 RUN_SERIAL TRUE)
+
 # -----------------------------------------------------------------------------
 # Gfx/Spout (Windows/x86_64) and Gfx/Syphon (macOS). Neither compiles on Linux,
 # so this target must build EVERYWHERE and change what it asserts instead of

--- a/tests/gfx/CMakeLists.txt
+++ b/tests/gfx/CMakeLists.txt
@@ -1307,3 +1307,9 @@ if(TARGET score_plugin_threedim AND TARGET test_unit_threedim_3rdparty)
     $<TARGET_PROPERTY:score_plugin_threedim,INCLUDE_DIRECTORIES>
     $<TARGET_PROPERTY:score_plugin_gfx,INCLUDE_DIRECTORIES>)
 endif()
+
+# The panel's edge-blend overlay is a QPainter gradient, and stopped one pixel
+# short of the quad's right and bottom edges.
+score_add_test(test_gfx_blend_preview_fringe
+  SOURCES BlendPreviewFringe.cpp
+  GUI)

--- a/tests/gfx/CMakeLists.txt
+++ b/tests/gfx/CMakeLists.txt
@@ -199,6 +199,21 @@ score_add_test(test_gfx_video_output_orientation
 target_compile_definitions(test_gfx_video_output_orientation PRIVATE
   GFX_TEST_CORPUS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/corpus")
 
+# Syphon shares a texture instead of reading pixels back, so none of the flips
+# the readback outputs apply are in play: whether a client sees the picture the
+# right way up can only be answered by being one. macOS only, and it SKIPs
+# without a window-server session because a Syphon server needs one.
+if(APPLE)
+  score_plugin_hidden_sources(_syphon_orient_hidden
+      "${_gfx_src}/Gfx/Syphon/SyphonOutput.mm"
+      "${_gfx_src}/Gfx/Syphon/SyphonInput.mm")
+  score_add_test(test_gfx_syphon_orientation
+    SOURCES GfxSyphonOrientation.mm
+    GUI
+    PLUGINS score_plugin_gfx score_plugin_scenario score_lib_process
+    LIBS test_gfx_engine_glue Syphon)
+endif()
+
 # The multi-window soft-edge blend ramp: the pixels past its own edge stay
 # dark. Calling pow() on the negative base an extrapolated edge coordinate
 # produces is undefined, and the drivers that answer NaN lit them fully.

--- a/tests/gfx/GfxPreviewOutputRebuild.cpp
+++ b/tests/gfx/GfxPreviewOutputRebuild.cpp
@@ -1,0 +1,135 @@
+// Opening a texture port's preview must not restart what is already rendering.
+//
+// Selecting a process with a texture outlet builds a GraphPreviewWidget in the
+// inspector, which is a Gfx::RhiPreviewWidget on its "context backend": it puts
+// a score::gfx::BackgroundNode into the DOCUMENT's GfxContext and wires the
+// outlet to it. That node is an OutputNode, and GfxContext::updateGraph asked
+// for a full rebuild the moment an output appeared -- Graph::createAllRenderLists
+// stops every output, releases every renderer and builds the lot again.
+//
+// So the window that was already rendering went black for the length of the
+// rebuild, every time a preview opened, and again when it closed. That is the
+// blink reported on the rect-mapper patch, whose inspector carries such a
+// preview; nothing about the patch is special, any texture outlet does it.
+//
+// Observable: OutputNode::stopRendering() on the output that was ALREADY live.
+// A full rebuild calls it; bringing the new output up on its own does not. The
+// render-list pointer is checked too, but only as a corroborating signal -- a
+// freed RenderList can be reallocated at the same address, so the counter is
+// what the case turns on.
+//
+// This drives the real widget rather than the registration call underneath it,
+// so it stays honest whichever side of that boundary the fix lands on.
+
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+#include <score_test/Gfx.hpp>
+
+#include <Gfx/GfxApplicationPlugin.hpp>
+#include <Gfx/Graph/BackgroundNode.hpp>
+#include <Gfx/Graph/ImageNode.hpp>
+#include <Gfx/Widgets/RhiPreviewWidget.hpp>
+
+#include <core/document/Document.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace
+{
+//! A document output that counts how many times it was stopped.
+struct CountingSink final : score::gfx::BackgroundNode
+{
+  int stops{};
+  void stopRendering() override
+  {
+    stops++;
+    score::gfx::BackgroundNode::stopRendering();
+  }
+};
+}
+
+TEST_CASE(
+    "opening a texture-port preview does not restart the live outputs",
+    "[gfx][preview][incremental][gui]")
+{
+  bool live = false;
+  int baseline{}, afterAttach{}, afterDetach{};
+  const void* rlBaseline{};
+  const void* rlAfterAttach{};
+  const void* rlAfterDetach{};
+
+  score::test::run_in_gui_app([&](const score::GUIApplicationContext& ctx) {
+    score::Document* doc = score::test::new_document(ctx);
+    REQUIRE(doc != nullptr);
+
+    auto& plug = doc->context().plugin<Gfx::DocumentPlugin>();
+    auto& g = plug.context;
+    auto& exec = plug.exec;
+
+    auto producer = std::make_unique<score::gfx::ImagesNode>(doc->context());
+    auto owned = std::make_unique<CountingSink>();
+    owned->shared_readback = std::make_shared<QRhiReadbackResult>();
+    auto* sink = owned.get();
+
+    const int32_t p = g.register_node(std::move(producer));
+    const int32_t s = g.register_node(std::move(owned));
+
+    const auto publish = [&](std::vector<Gfx::EdgeSpec> es) {
+      ossia::audio_tick_state st{};
+      exec.startTick(st);
+      for(const auto& e : es)
+        exec.setEdge(e.first, e.second, e.type);
+      exec.endTick(st);
+    };
+
+    using pi = Gfx::port_index;
+    const auto glutton = Process::CableType::ImmediateGlutton;
+    const Gfx::EdgeSpec ePS{pi{p, 0}, pi{s, 0}, glutton};
+
+    // The document's own output, rendering. This frame is a full rebuild --
+    // the output node landed in it -- which is exactly what must not happen
+    // again below.
+    publish({ePS});
+    g.updateGraph();
+
+    live = sink->canRender() && sink->renderer() != nullptr;
+    baseline = sink->stops;
+    rlBaseline = sink->renderer();
+
+    // The inspector opens on a texture outlet.
+    auto* preview = new Gfx::RhiPreviewWidget;
+    preview->resize(64, 64);
+    preview->useContext(&g, pi{p, 0});
+    g.updateGraph();
+
+    afterAttach = sink->stops;
+    rlAfterAttach = sink->renderer();
+
+    // ... and closes again.
+    delete preview;
+    g.updateGraph();
+
+    afterDetach = sink->stops;
+    rlAfterDetach = sink->renderer();
+
+    g.unregister_node(s);
+    g.unregister_node(p);
+    g.updateGraph();
+  });
+
+  if(!live)
+    SKIP("no working RHI here: the document output never came up");
+
+  INFO(
+      "stops: baseline " << baseline << ", after attach " << afterAttach
+                         << ", after detach " << afterDetach);
+
+  CHECK(afterAttach == baseline);
+  CHECK(afterDetach == baseline);
+
+  CHECK(rlAfterAttach == rlBaseline);
+  CHECK(rlAfterDetach == rlBaseline);
+}

--- a/tests/gfx/GfxPreviewOutputRebuild.cpp
+++ b/tests/gfx/GfxPreviewOutputRebuild.cpp
@@ -63,6 +63,7 @@ TEST_CASE(
   const void* rlAfterAttach{};
   const void* rlAfterDetach{};
   bool previewHasRenderer{};
+  bool previewInOutputs{};
   int previewRendererCount{-1};
 
   score::test::run_in_gui_app([&](const score::GUIApplicationContext& ctx) {
@@ -121,6 +122,13 @@ TEST_CASE(
       previewHasRenderer = n->renderer() != nullptr;
       if(auto* r = n->renderer())
         previewRendererCount = int(r->renderers.size());
+
+      // And the other half of "there will be a picture": the render clocks
+      // only drive what is in the graph's output list, so a preview missing
+      // from it is built, wired, and never rendered again.
+      for(auto* out : g.outputs())
+        if(out == static_cast<score::gfx::OutputNode*>(n))
+          previewInOutputs = true;
     }
 
     // ... and closes again.
@@ -154,4 +162,5 @@ TEST_CASE(
                           << previewRendererCount);
   CHECK(previewHasRenderer);
   CHECK(previewRendererCount > 0);
+  CHECK(previewInOutputs);
 }

--- a/tests/gfx/GfxPreviewOutputRebuild.cpp
+++ b/tests/gfx/GfxPreviewOutputRebuild.cpp
@@ -30,6 +30,8 @@
 #include <Gfx/Graph/ImageNode.hpp>
 #include <Gfx/Widgets/RhiPreviewWidget.hpp>
 
+#include <Gfx/Graph/RenderList.hpp>
+
 #include <core/document/Document.hpp>
 
 #include <catch2/catch_test_macros.hpp>
@@ -60,6 +62,8 @@ TEST_CASE(
   const void* rlBaseline{};
   const void* rlAfterAttach{};
   const void* rlAfterDetach{};
+  bool previewHasRenderer{};
+  int previewRendererCount{-1};
 
   score::test::run_in_gui_app([&](const score::GUIApplicationContext& ctx) {
     score::Document* doc = score::test::new_document(ctx);
@@ -108,6 +112,17 @@ TEST_CASE(
     afterAttach = sink->stops;
     rlAfterAttach = sink->renderer();
 
+    // Does the preview have anything to draw? Not pixels, but the thing that
+    // decides whether there will be any: an output whose render list carries
+    // renderers. A preview brought up without its edge wired has a render list
+    // with nothing in it, and clears to black every frame.
+    if(auto* n = preview->liveNode())
+    {
+      previewHasRenderer = n->renderer() != nullptr;
+      if(auto* r = n->renderer())
+        previewRendererCount = int(r->renderers.size());
+    }
+
     // ... and closes again.
     delete preview;
     g.updateGraph();
@@ -132,4 +147,11 @@ TEST_CASE(
 
   CHECK(rlAfterAttach == rlBaseline);
   CHECK(rlAfterDetach == rlBaseline);
+
+  // The point of the optimisation is that the preview still WORKS afterwards.
+  INFO(
+      "preview renderer " << previewHasRenderer << ", renderers in its list "
+                          << previewRendererCount);
+  CHECK(previewHasRenderer);
+  CHECK(previewRendererCount > 0);
 }

--- a/tests/gfx/GfxRenderScaling.cpp
+++ b/tests/gfx/GfxRenderScaling.cpp
@@ -1,0 +1,317 @@
+// What a frame of the scene render costs as the picture grows, with no readback
+// and no output device in the way.
+//
+// The PipeWire dma-buf output was spending orders of magnitude more per frame
+// at 8K than its handover -- dequeue, wrap, begin, wait -- accounts for. This
+// case measures the other two candidates and rules both out: drawing an 8K
+// frame is cheap, and copying it from one ordinary texture to another is
+// cheap. What is left is the one operation this case does NOT perform: writing
+// into an EXPORTED image, the dedicated external allocation that carries the
+// dma-buf. That write is slow whatever the memory type and whatever the tiling
+// -- both were measured -- against the ordinary copy above.
+//
+// One animated ISF, one offscreen target, no readback, no device. Every frame
+// is bracketed by beginOffscreenFrame/endOffscreenFrame and endOffscreenFrame
+// waits for the GPU, so the number is the frame's real cost and not the cost of
+// recording it.
+//
+// The last frame IS read back, once, outside the timed loop: a timing harness
+// that draws nothing reports a wonderful number, and this one would have --
+// the readback is here so the case fails instead of lying.
+
+#include "IsfTestCommon.hpp"
+
+#include <score_test/App.hpp>
+
+#include <Gfx/Graph/Graph.hpp>
+#include <Gfx/Graph/NodeRenderer.hpp>
+#include <Gfx/Graph/OutputNode.hpp>
+#include <Gfx/Graph/RenderList.hpp>
+#include <Gfx/Graph/RenderState.hpp>
+#include <Gfx/InvertYRenderer.hpp>
+
+#include <QElapsedTimer>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+#include <set>
+#include <vector>
+
+using namespace score::test::gfx;
+
+namespace
+{
+//! Renders and leaves the result on the GPU. The readback is a separate,
+//! explicit step so it never lands inside a measurement.
+class SilentSink final : public score::gfx::OutputNode
+{
+public:
+  explicit SilentSink(QSize sz)
+      : m_size{sz}
+  {
+    input.push_back(new score::gfx::Port{this, {}, score::gfx::Types::Image, {}});
+  }
+  ~SilentSink() override { }
+
+  bool canRender() const override { return bool(m_renderState); }
+  void startRendering() override { }
+  void stopRendering() override { }
+  void onRendererChange() override { }
+  void setRenderer(std::shared_ptr<score::gfx::RenderList> r) override
+  {
+    m_renderer = r;
+  }
+  score::gfx::RenderList* renderer() const override { return m_renderer.lock().get(); }
+  std::shared_ptr<score::gfx::RenderState> renderState() const override
+  {
+    return m_renderState;
+  }
+  Configuration configuration() const noexcept override
+  {
+    return {.manualRenderingRate = 1000. / 60.};
+  }
+
+  void createOutput(score::gfx::OutputConfiguration conf) override
+  {
+    m_renderState = score::gfx::createRenderState(conf.graphicsApi, m_size, nullptr);
+    if(!m_renderState || !m_renderState->rhi)
+    {
+      m_renderState.reset();
+      return;
+    }
+    m_renderState->outputSize = m_renderState->renderSize;
+    auto rhi = m_renderState->rhi;
+    m_renderState->renderFormat = QRhiTexture::RGBA8;
+    m_texture = rhi->newTexture(
+        QRhiTexture::RGBA8, m_renderState->renderSize, 1,
+        QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
+    if(!m_texture->create())
+    {
+      m_renderState.reset();
+      return;
+    }
+    m_renderTarget = rhi->newTextureRenderTarget({m_texture});
+    m_renderState->renderPassDescriptor
+        = m_renderTarget->newCompatibleRenderPassDescriptor();
+    m_renderTarget->setRenderPassDescriptor(m_renderState->renderPassDescriptor);
+    m_renderTarget->create();
+    if(conf.onReady)
+      conf.onReady();
+  }
+
+  void destroyOutput() override
+  {
+    if(!m_renderState)
+      return;
+    delete m_renderTarget;
+    m_renderTarget = nullptr;
+    delete m_renderState->renderPassDescriptor;
+    m_renderState->renderPassDescriptor = nullptr;
+    delete m_texture;
+    m_texture = nullptr;
+    m_renderState->destroy();
+    m_renderState.reset();
+  }
+
+  score::gfx::OutputNodeRenderer*
+  createRenderer(score::gfx::RenderList&) const noexcept override
+  {
+    return new Gfx::BasicRenderer{
+        score::gfx::TextureRenderTarget{
+            .texture = m_texture,
+            .renderPass = m_renderState->renderPassDescriptor,
+            .renderTarget = m_renderTarget},
+        *m_renderState, *this};
+  }
+
+  void render() override
+  {
+    auto renderer = m_renderer.lock();
+    if(!renderer || !m_renderState)
+      return;
+    auto rhi = m_renderState->rhi;
+    QRhiCommandBuffer* cb{};
+    if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+      return;
+    renderer->render(*cb);
+    rhi->endOffscreenFrame();
+  }
+
+  //! Render, then copy the result into a second ORDINARY texture of the same
+  //! size. The PipeWire path makes the same copy into an exported image and
+  //! pays far more for it at 8K; this is the control that says the copy is not
+  //! what costs, the export is.
+  void renderAndCopy()
+  {
+    auto renderer = m_renderer.lock();
+    if(!renderer || !m_renderState)
+      return;
+    auto rhi = m_renderState->rhi;
+    if(!m_copyTarget)
+    {
+      m_copyTarget = rhi->newTexture(
+          QRhiTexture::RGBA8, m_renderState->renderSize, 1,
+          QRhiTexture::UsedAsTransferSource);
+      m_copyTarget->create();
+    }
+    QRhiCommandBuffer* cb{};
+    if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+      return;
+    renderer->render(*cb);
+    auto* batch = rhi->nextResourceUpdateBatch();
+    QRhiTextureCopyDescription cdesc;
+    cdesc.setPixelSize(m_renderState->renderSize);
+    batch->copyTexture(m_copyTarget, m_texture, cdesc);
+    cb->resourceUpdate(batch);
+    rhi->endOffscreenFrame();
+  }
+
+  //! One frame, read back. Proves the timed loop was drawing something.
+  QByteArray grab()
+  {
+    auto renderer = m_renderer.lock();
+    if(!renderer || !m_renderState)
+      return {};
+    auto rhi = m_renderState->rhi;
+    QRhiCommandBuffer* cb{};
+    if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+      return {};
+    renderer->render(*cb);
+
+    QRhiReadbackResult rb;
+    auto* batch = rhi->nextResourceUpdateBatch();
+    batch->readBackTexture(QRhiReadbackDescription{m_texture}, &rb);
+    cb->resourceUpdate(batch);
+    rhi->endOffscreenFrame();
+    return rb.data;
+  }
+
+private:
+  QSize m_size;
+  std::weak_ptr<score::gfx::RenderList> m_renderer{};
+  QRhiTexture* m_texture{};
+  QRhiTextureRenderTarget* m_renderTarget{};
+  QRhiTexture* m_copyTarget{};
+  std::shared_ptr<score::gfx::RenderState> m_renderState{};
+};
+
+struct Sample
+{
+  bool ok{};
+  bool drew{};
+  double msPerFrame{};
+  double msPerFrameWithCopy{};
+  double megapixels{};
+  double msPerMegapixel() const { return megapixels > 0 ? msPerFrame / megapixels : 0; }
+};
+
+//! True if the readback holds more than one colour: a target that was never
+//! drawn into comes back uniform.
+bool hasContent(const QByteArray& px)
+{
+  if(px.size() < 64)
+    return false;
+  std::set<uint32_t> seen;
+  const auto* p = reinterpret_cast<const uint32_t*>(px.constData());
+  const int n = int(px.size() / 4);
+  for(int i = 0; i < n; i += 997)
+  {
+    seen.insert(p[i]);
+    if(seen.size() > 2)
+      return true;
+  }
+  return seen.size() > 1;
+}
+
+Sample timeFrames(score::gfx::GraphicsApi api, QSize size, int frames)
+{
+  Sample out;
+  out.megapixels = double(size.width()) * size.height() / 1e6;
+
+  score::test::run_in_gui_app([&](const score::GUIApplicationContext&) {
+    auto isf
+        = make_isf_node(QStringLiteral(GFX_TEST_CORPUS_DIR "/isf-time-uniforms.fs"));
+    if(!isf.node)
+      return;
+    auto* sink = new SilentSink{size};
+
+    auto graph = std::make_unique<score::gfx::Graph>();
+    graph->addNode(isf.node.get());
+    graph->addNode(sink);
+    graph->addEdge(
+        isf.node->output[0], sink->input[0], Process::CableType::ImmediateGlutton);
+    graph->createAllRenderLists(api);
+
+    if(sink->canRender())
+    {
+      // Warm: the first frames build pipelines and upload the shader.
+      for(int i = 0; i < 5; i++)
+        sink->render();
+
+      QElapsedTimer t;
+      t.start();
+      for(int i = 0; i < frames; i++)
+        sink->render();
+      out.msPerFrame = double(t.nsecsElapsed()) / 1e6 / frames;
+
+      for(int i = 0; i < 3; i++)
+        sink->renderAndCopy();
+      t.restart();
+      for(int i = 0; i < frames; i++)
+        sink->renderAndCopy();
+      out.msPerFrameWithCopy = double(t.nsecsElapsed()) / 1e6 / frames;
+      out.ok = true;
+
+      out.drew = hasContent(sink->grab());
+    }
+
+    graph.reset();
+    delete sink;
+  });
+  return out;
+}
+}
+
+TEST_CASE("the scene render's cost per pixel holds as the target grows", "[gfx][perf]")
+{
+  const auto api = GENERATE(from_range(platform_backends()));
+
+  constexpr int kFrames = 50;
+  const auto hd = timeFrames(api, {1920, 1080}, kFrames);
+  const auto uhd = timeFrames(api, {3840, 2160}, kFrames);
+  const auto k8 = timeFrames(api, {7680, 4320}, kFrames);
+
+  INFO("backend " << backend_name(api));
+  if(!hd.ok)
+    SKIP("no usable GPU for a 1080p offscreen render here");
+  if(!uhd.ok || !k8.ok)
+    SKIP("the GPU could not bring up a 4K or 8K offscreen target");
+
+  INFO(
+      "1080p " << hd.msPerFrame << " ms/frame (" << hd.msPerMegapixel()
+               << " ms/Mpix), 4K " << uhd.msPerFrame << " ms ("
+               << uhd.msPerMegapixel() << "), 8K " << k8.msPerFrame << " ms ("
+               << k8.msPerMegapixel() << ")");
+  INFO(
+      "with a full-size GPU copy on top: 1080p " << hd.msPerFrameWithCopy
+                                                 << " ms, 4K "
+                                                 << uhd.msPerFrameWithCopy
+                                                 << " ms, 8K "
+                                                 << k8.msPerFrameWithCopy << " ms");
+
+  // The measurement is only worth reading if the frames existed.
+  REQUIRE(hd.drew);
+  REQUIRE(uhd.drew);
+  REQUIRE(k8.drew);
+
+  REQUIRE(hd.msPerFrame > 0.);
+  REQUIRE(k8.msPerFrame > 0.);
+
+  // The shape, not the speed: cost per megapixel must not run away with the
+  // target. A slower machine still passes; a renderer that degrades
+  // superlinearly does not.
+  CHECK(k8.msPerMegapixel() <= hd.msPerMegapixel() * 3.);
+  CHECK(uhd.msPerMegapixel() <= hd.msPerMegapixel() * 3.);
+}

--- a/tests/gfx/GfxSyphonOrientation.mm
+++ b/tests/gfx/GfxSyphonOrientation.mm
@@ -1,0 +1,354 @@
+// =============================================================================
+// WHICH WAY UP Syphon hands a texture over, on OpenGL and on Metal.
+//
+// Syphon is the odd one out among score's video outputs: it shares the GPU
+// texture rather than reading pixels back, so none of the flips the readback
+// outputs apply are in play. Gfx::SyphonNode publishes the scene render target
+// as it stands.
+//
+// The question that leaves open is whether a Syphon *client* then sees the
+// picture the right way up, and the only honest way to answer it is to be one.
+// So: one process, two graphs. The first paints a vertical ramp and publishes
+// it through the real Gfx::SyphonNode; the second subscribes with the real
+// Gfx::Syphon::SyphonInputNode and reads the result back through the same
+// InvertYRenderer path every other output uses -- the one
+// GfxVideoOutputOrientation.cpp pins as delivering row 0 == top.
+//
+// A Syphon server needs a window-server session. Launched from ssh without
+// one, the server never appears in the directory and the test SKIPs saying so
+// rather than passing on nothing.
+//
+//   ./test_gfx_syphon_orientation
+//   SCORE_TEST_API=opengl ./test_gfx_syphon_orientation
+// =============================================================================
+
+#include <Gfx/Graph/Graph.hpp>
+#include <Gfx/Graph/OutputNode.hpp>
+#include <Gfx/Graph/RenderList.hpp>
+#include <Gfx/Graph/RenderState.hpp>
+#include <Gfx/Graph/TexgenNode.hpp>
+#include <Gfx/InvertYRenderer.hpp>
+#include <Gfx/SharedInputSettings.hpp>
+#include <Gfx/SharedOutputSettings.hpp>
+#include <Gfx/Syphon/SyphonInput.hpp>
+#include <Gfx/Syphon/SyphonOutput.hpp>
+
+#include <score_test/App.hpp>
+#include <score_test/Gfx.hpp>
+
+#include <QElapsedTimer>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <Syphon/SyphonServerDirectory.h>
+
+using namespace score::test::gfx;
+
+namespace
+{
+constexpr int kW = 64;
+constexpr int kH = 64;
+
+//! Row 0 black, row H-1 white. Row 0 is the top.
+void paintVerticalRamp(unsigned char* rgba, int w, int h, int)
+{
+  for(int y = 0; y < h; y++)
+  {
+    const auto v = (unsigned char)std::lround(255.0 * double(y) / double(h - 1));
+    for(int x = 0; x < w; x++)
+    {
+      auto* p = rgba + (std::size_t(y) * w + x) * 4;
+      p[0] = v;
+      p[1] = v;
+      p[2] = v;
+      p[3] = 255;
+    }
+  }
+}
+
+//! The InvertYRenderer readback sink, which GfxVideoOutputOrientation pins as
+//! delivering row 0 == top on every backend.
+class ReadbackSink final : public score::gfx::OutputNode
+{
+public:
+  ReadbackSink()
+  {
+    input.push_back(new score::gfx::Port{this, {}, score::gfx::Types::Image, {}});
+  }
+  ~ReadbackSink() override { }
+
+  bool canRender() const override { return bool(m_renderState); }
+  void startRendering() override { }
+  void stopRendering() override { }
+  void onRendererChange() override { }
+  void setRenderer(std::shared_ptr<score::gfx::RenderList> r) override
+  {
+    m_renderer = r;
+  }
+  score::gfx::RenderList* renderer() const override { return m_renderer.lock().get(); }
+  std::shared_ptr<score::gfx::RenderState> renderState() const override
+  {
+    return m_renderState;
+  }
+  Configuration configuration() const noexcept override
+  {
+    return {.manualRenderingRate = 1000. / 30.};
+  }
+
+  void createOutput(score::gfx::OutputConfiguration conf) override
+  {
+    m_renderState
+        = score::gfx::createRenderState(conf.graphicsApi, QSize(kW, kH), nullptr);
+    if(!m_renderState || !m_renderState->rhi)
+    {
+      m_renderState.reset();
+      return;
+    }
+    m_renderState->outputSize = m_renderState->renderSize;
+    auto rhi = m_renderState->rhi;
+    m_renderState->renderFormat = QRhiTexture::RGBA8;
+    m_texture = rhi->newTexture(
+        QRhiTexture::RGBA8, m_renderState->renderSize, 1,
+        QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
+    m_texture->create();
+    m_depthStencil = rhi->newRenderBuffer(
+        QRhiRenderBuffer::DepthStencil, m_renderState->renderSize, 1);
+    m_depthStencil->create();
+    QRhiTextureRenderTargetDescription desc{m_texture};
+    desc.setDepthStencilBuffer(m_depthStencil);
+    m_renderTarget = rhi->newTextureRenderTarget(desc);
+    m_renderState->renderPassDescriptor
+        = m_renderTarget->newCompatibleRenderPassDescriptor();
+    m_renderTarget->setRenderPassDescriptor(m_renderState->renderPassDescriptor);
+    m_renderTarget->create();
+    if(conf.onReady)
+      conf.onReady();
+  }
+
+  void destroyOutput() override
+  {
+    if(!m_renderState)
+      return;
+    delete m_renderTarget;
+    m_renderTarget = nullptr;
+    delete m_renderState->renderPassDescriptor;
+    m_renderState->renderPassDescriptor = nullptr;
+    delete m_depthStencil;
+    m_depthStencil = nullptr;
+    delete m_texture;
+    m_texture = nullptr;
+    m_renderState->destroy();
+    m_renderState.reset();
+  }
+
+  score::gfx::OutputNodeRenderer*
+  createRenderer(score::gfx::RenderList& r) const noexcept override
+  {
+    score::gfx::TextureRenderTarget rt{
+        .texture = m_texture,
+        .renderPass = m_renderState->renderPassDescriptor,
+        .renderTarget = m_renderTarget};
+    return new Gfx::InvertYRenderer{
+        *this, rt, const_cast<QRhiReadbackResult&>(m_readback)};
+  }
+
+  void render() override
+  {
+    auto renderer = m_renderer.lock();
+    if(!renderer || !m_renderState)
+      return;
+    auto rhi = m_renderState->rhi;
+    QRhiCommandBuffer* cb{};
+    if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+      return;
+    renderer->render(*cb);
+    rhi->endOffscreenFrame();
+  }
+
+  std::vector<int> lumaRows() const
+  {
+    std::vector<int> rows;
+    if(m_readback.data.isEmpty())
+      return rows;
+    const auto* d = reinterpret_cast<const uint8_t*>(m_readback.data.constData());
+    const int h = m_readback.pixelSize.height();
+    if(h <= 0)
+      return rows;
+    const int stride = m_readback.data.size() / h;
+    for(int y = 0; y < h; y++)
+      rows.push_back(d[std::size_t(y) * stride + (kW / 2) * 4 + 1]);
+    return rows;
+  }
+
+private:
+  std::weak_ptr<score::gfx::RenderList> m_renderer{};
+  QRhiTexture* m_texture{};
+  QRhiRenderBuffer* m_depthStencil{};
+  QRhiTextureRenderTarget* m_renderTarget{};
+  std::shared_ptr<score::gfx::RenderState> m_renderState{};
+  QRhiReadbackResult m_readback{};
+};
+
+//! UUID of the first Syphon server this process is advertising, or empty.
+QString ownServerUuid()
+{
+  SyphonServerDirectory* dir = [SyphonServerDirectory sharedDirectory];
+  NSArray* servers = [dir serversMatchingName:NULL appName:NULL];
+  for(NSUInteger i = 0; i < servers.count; i++)
+  {
+    NSDictionary* s = servers[i];
+    NSString* uuid = s[SyphonServerDescriptionUUIDKey];
+    if(uuid)
+      return QString::fromNSString(uuid);
+  }
+  return {};
+}
+
+struct Shot
+{
+  bool skipped{};
+  std::string why;
+  std::vector<int> rows;
+};
+
+Shot runSyphonRoundTrip(score::gfx::GraphicsApi api)
+{
+  Shot out;
+  score::test::run_in_gui_app([&](const score::GUIApplicationContext&) {
+    // --- publisher ---
+    Gfx::SharedOutputSettings oset;
+    oset.path = "score-orientation";
+    oset.width = kW;
+    oset.height = kH;
+    oset.rate = 30.;
+
+    auto* src = new score::gfx::TexgenNode;
+    src->function = &paintVerticalRamp;
+    score::gfx::OutputNode* pub = Gfx::makeSyphonOutput(oset);
+
+    auto pubGraph = std::make_unique<score::gfx::Graph>();
+    pubGraph->addNode(src);
+    pubGraph->addNode(pub);
+    pubGraph->addEdge(
+        src->output[0], pub->input[0], Process::CableType::ImmediateGlutton);
+    pubGraph->createAllRenderLists(api);
+
+    if(!pub->canRender())
+    {
+      out.skipped = true;
+      out.why = "the Syphon publisher could not bring up its output";
+      pubGraph.reset();
+      delete pub;
+      delete src;
+      return;
+    }
+
+    for(int i = 0; i < 8; i++)
+      pub->render();
+
+    // The directory is populated through the run loop.
+    QElapsedTimer t;
+    t.start();
+    QString uuid;
+    while(uuid.isEmpty() && t.elapsed() < 4000)
+    {
+      QApplication::processEvents(QEventLoop::AllEvents, 20);
+      pub->render();
+      uuid = ownServerUuid();
+    }
+
+    if(uuid.isEmpty())
+    {
+      out.skipped = true;
+      out.why = "no Syphon server appeared in the directory: this process has "
+                "no window-server session";
+      pubGraph.reset();
+      delete pub;
+      delete src;
+      return;
+    }
+
+    // --- subscriber ---
+    Gfx::SharedInputSettings iset;
+    iset.path = uuid;
+    auto* sub = Gfx::Syphon::makeSyphonInput(iset);
+    auto* sink = new ReadbackSink;
+
+    auto subGraph = std::make_unique<score::gfx::Graph>();
+    subGraph->addNode(sub);
+    subGraph->addNode(sink);
+    subGraph->addEdge(
+        sub->output[0], sink->input[0], Process::CableType::ImmediateGlutton);
+    subGraph->createAllRenderLists(api);
+
+    if(sink->canRender())
+    {
+      // Keep publishing while the receiver spins up: the client connects, then
+      // waits for a frame.
+      for(int i = 0; i < 40; i++)
+      {
+        pub->render();
+        sink->render();
+        QApplication::processEvents(QEventLoop::AllEvents, 5);
+      }
+      out.rows = sink->lumaRows();
+    }
+    else
+    {
+      out.skipped = true;
+      out.why = "the Syphon receiver could not bring up its render list";
+    }
+
+    subGraph.reset();
+    delete sink;
+    delete sub;
+    pubGraph.reset();
+    delete pub;
+    delete src;
+  });
+  return out;
+}
+}
+
+TEST_CASE("Syphon hands over a top-down picture", "[gfx][syphon][orientation]")
+{
+  const auto api = GENERATE(from_range(platform_backends()));
+  const auto shot = runSyphonRoundTrip(api);
+
+  INFO("backend " << backend_name(api));
+  if(shot.skipped)
+    SKIP(shot.why);
+
+  REQUIRE(shot.rows.size() >= 8);
+  const auto [lo, hi] = std::minmax_element(shot.rows.begin(), shot.rows.end());
+  INFO("first " << shot.rows.front() << ", last " << shot.rows.back());
+  REQUIRE((*hi - *lo) > 60);
+
+  // The ramp was painted black at row 0. Through the readback sink that
+  // GfxVideoOutputOrientation pins as row 0 == top, it must come back the same
+  // way round: anything else is a flip somewhere in the Syphon share.
+  CHECK(shot.rows.front() < shot.rows.back());
+
+  // ... and per row, not just at the ends.
+  const double span = double(*hi - *lo);
+  int worst = 0, worstRow = 0;
+  for(std::size_t y = 0; y < shot.rows.size(); y++)
+  {
+    const double t = double(y) / double(shot.rows.size() - 1);
+    const int expected = int(std::lround(*lo + span * t));
+    if(const int d = std::abs(shot.rows[y] - expected); d > worst)
+    {
+      worst = d;
+      worstRow = int(y);
+    }
+  }
+  INFO("worst row " << worstRow << ": " << shot.rows[worstRow]);
+  CHECK(worst <= 24);
+}

--- a/tests/gfx/GfxVideoOutputOrientation.cpp
+++ b/tests/gfx/GfxVideoOutputOrientation.cpp
@@ -1,0 +1,726 @@
+// =============================================================================
+// WHICH WAY UP a video output hands its pixels over, per backend.
+//
+// Every output that produces CPU pixels does it one of two ways, and the two
+// are supposed to agree:
+//
+//   A. Gfx::InvertYRenderer -- a full-screen pass that samples the scene target
+//      and reads the result back. Used by the Libav output's RGBA path, the
+//      GStreamer output's RGBA path, Shmdata, Sh4lt, NDI and PipeWire.
+//
+//   B. a score::gfx::GPUVideoEncoder -- a full-screen pass per plane that
+//      converts to YUV and reads each plane back, with no InvertYRenderer in
+//      front of it because the encoder shader does the flip itself. Used by the
+//      Libav and GStreamer outputs whenever the target pixel format is one the
+//      GPU encoders cover -- yuv420p, nv12, uyvy422, yuv422p10le, p010 -- which
+//      is to say by nearly every real recording or stream: h264 to a file or
+//      over UDP lands on yuv420p.
+//
+// Both are fed the same offscreen colour target, and both must deliver a
+// top-down picture: that is what libav, GStreamer, NDI and every consumer read.
+//
+// The oracle is a vertical ramp painted by the source, row 0 black to row H-1
+// white, in a buffer whose row 0 is the top. It is asserted per row against the
+// closed-form ramp, not by corner probes: a vertical flip passes "not blank",
+// "has both dark and bright pixels" and every other loose check.
+//
+//   DISPLAY=:0 ctest -R gfx_video_output_orientation
+//   DISPLAY=:0 SCORE_TEST_API=vulkan ctest -R gfx_video_output_orientation
+// =============================================================================
+
+#include <Gfx/Graph/Graph.hpp>
+#include <Gfx/Graph/OutputNode.hpp>
+#include <Gfx/Graph/RenderList.hpp>
+#include <Gfx/Graph/RenderState.hpp>
+#include <Gfx/Graph/TexgenNode.hpp>
+#include <Gfx/Graph/encoders/I420.hpp>
+#include <Gfx/Graph/encoders/NV12.hpp>
+#include <Gfx/Graph/encoders/P010.hpp>
+#include <Gfx/Graph/encoders/UYVY.hpp>
+#include <Gfx/Graph/encoders/YUV422P10.hpp>
+#include <Gfx/InvertYRenderer.hpp>
+#include <Gfx/Libav/LibavEncoder.hpp>
+#include <Gfx/Libav/LibavEncoderNode.hpp>
+#include <Gfx/Graph/ISFNode.hpp>
+#include <Gfx/ShaderProgram.hpp>
+
+#include <QDir>
+#include <QTemporaryDir>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libswscale/swscale.h>
+}
+
+#include <score_test/App.hpp>
+#include <score_test/Gfx.hpp>
+
+#include <QOffscreenSurface>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_range.hpp>
+
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace score::test::gfx;
+using Catch::Approx;
+
+namespace
+{
+constexpr int kW = 64;
+constexpr int kH = 64;
+
+//! Row 0 black, row H-1 white, constant along X. Row 0 is the TOP: that is what
+//! every consumer of these outputs assumes of the bytes it is handed.
+void paintVerticalRamp(unsigned char* rgba, int w, int h, int /*t*/)
+{
+  for(int y = 0; y < h; y++)
+  {
+    const auto v = (unsigned char)std::lround(255.0 * double(y) / double(h - 1));
+    for(int x = 0; x < w; x++)
+    {
+      auto* p = rgba + (std::size_t(y) * w + x) * 4;
+      p[0] = v;
+      p[1] = v;
+      p[2] = v;
+      p[3] = 255;
+    }
+  }
+}
+
+//! How the sink gets its pixels out.
+enum class OutPath
+{
+  InvertY,  //!< Gfx::InvertYRenderer + RGBA readback
+  EncI420,  //!< score::gfx::I420Encoder, Y plane
+  EncNV12,  //!< score::gfx::NV12Encoder, Y plane
+  EncUYVY,  //!< score::gfx::UYVYEncoder, packed
+  EncP010,  //!< score::gfx::P010Encoder, 10-bit Y in the high bits
+  Enc422P10, //!< score::gfx::YUV422P10Encoder, 10-bit Y
+};
+
+const char* pathName(OutPath p)
+{
+  switch(p)
+  {
+    case OutPath::InvertY:
+      return "InvertYRenderer";
+    case OutPath::EncI420:
+      return "I420Encoder";
+    case OutPath::EncNV12:
+      return "NV12Encoder";
+    case OutPath::EncUYVY:
+      return "UYVYEncoder";
+    case OutPath::EncP010:
+      return "P010Encoder";
+    case OutPath::Enc422P10:
+      return "YUV422P10Encoder";
+  }
+  return "?";
+}
+
+std::unique_ptr<score::gfx::GPUVideoEncoder> makeEncoder(OutPath p)
+{
+  switch(p)
+  {
+    case OutPath::EncI420:
+      return std::make_unique<score::gfx::I420Encoder>();
+    case OutPath::EncNV12:
+      return std::make_unique<score::gfx::NV12Encoder>();
+    case OutPath::EncUYVY:
+      return std::make_unique<score::gfx::UYVYEncoder>();
+    case OutPath::EncP010:
+      return std::make_unique<score::gfx::P010Encoder>();
+    case OutPath::Enc422P10:
+      return std::make_unique<score::gfx::YUV422P10Encoder>();
+    default:
+      return {};
+  }
+}
+
+/**
+ * @brief The shape every readback video output has: an offscreen colour target
+ *        the graph renders into, plus one of the two ways of getting the
+ *        pixels off the GPU.
+ *
+ * Modelled on Gfx::LibavEncoderNode, which is also what the GStreamer output
+ * does; the Shmdata, Sh4lt, NDI and PipeWire outputs are the InvertY half of it.
+ */
+class OrientationSink final : public score::gfx::OutputNode
+{
+public:
+  explicit OrientationSink(OutPath p)
+      : m_path{p}
+  {
+    input.push_back(new score::gfx::Port{this, {}, score::gfx::Types::Image, {}});
+  }
+
+  ~OrientationSink() override { }
+
+  bool canRender() const override { return bool(m_renderState); }
+  void startRendering() override { }
+  void stopRendering() override { }
+  void onRendererChange() override { }
+  void setRenderer(std::shared_ptr<score::gfx::RenderList> r) override
+  {
+    m_renderer = r;
+  }
+  score::gfx::RenderList* renderer() const override { return m_renderer.lock().get(); }
+  std::shared_ptr<score::gfx::RenderState> renderState() const override
+  {
+    return m_renderState;
+  }
+  Configuration configuration() const noexcept override
+  {
+    return {.manualRenderingRate = 1000. / 30.};
+  }
+
+  void createOutput(score::gfx::OutputConfiguration conf) override
+  {
+    m_renderState
+        = score::gfx::createRenderState(conf.graphicsApi, QSize(kW, kH), nullptr);
+    if(!m_renderState || !m_renderState->rhi)
+    {
+      m_renderState.reset();
+      return;
+    }
+    m_renderState->outputSize = m_renderState->renderSize;
+
+    auto rhi = m_renderState->rhi;
+    m_renderState->renderFormat = QRhiTexture::RGBA8;
+    m_texture = rhi->newTexture(
+        QRhiTexture::RGBA8, m_renderState->renderSize, 1,
+        QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
+    m_texture->create();
+
+    m_depthStencil = rhi->newRenderBuffer(
+        QRhiRenderBuffer::DepthStencil, m_renderState->renderSize, 1);
+    m_depthStencil->create();
+
+    QRhiTextureRenderTargetDescription desc{m_texture};
+    desc.setDepthStencilBuffer(m_depthStencil);
+    m_renderTarget = rhi->newTextureRenderTarget(desc);
+    m_renderState->renderPassDescriptor
+        = m_renderTarget->newCompatibleRenderPassDescriptor();
+    m_renderTarget->setRenderPassDescriptor(m_renderState->renderPassDescriptor);
+    m_renderTarget->create();
+
+    if(auto enc = makeEncoder(m_path))
+    {
+      m_encoder = std::move(enc);
+      m_encoder->init(*rhi, *m_renderState, m_texture, kW, kH);
+    }
+
+    if(conf.onReady)
+      conf.onReady();
+  }
+
+  void destroyOutput() override
+  {
+    if(m_encoder)
+    {
+      m_encoder->release();
+      m_encoder.reset();
+    }
+    if(m_renderState)
+    {
+      delete m_renderTarget;
+      m_renderTarget = nullptr;
+      delete m_renderState->renderPassDescriptor;
+      m_renderState->renderPassDescriptor = nullptr;
+      delete m_depthStencil;
+      m_depthStencil = nullptr;
+      delete m_texture;
+      m_texture = nullptr;
+      m_renderState->destroy();
+      m_renderState.reset();
+    }
+  }
+
+  score::gfx::OutputNodeRenderer*
+  createRenderer(score::gfx::RenderList& r) const noexcept override
+  {
+    score::gfx::TextureRenderTarget rt{
+        .texture = m_texture,
+        .renderPass = m_renderState->renderPassDescriptor,
+        .renderTarget = m_renderTarget};
+
+    if(m_encoder)
+      return new Gfx::BasicRenderer{rt, *m_renderState, *this};
+
+    return new Gfx::InvertYRenderer{
+        *this, rt, const_cast<QRhiReadbackResult&>(m_readback)};
+  }
+
+  void render() override
+  {
+    auto renderer = m_renderer.lock();
+    if(!renderer || !m_renderState)
+      return;
+    auto rhi = m_renderState->rhi;
+    QRhiCommandBuffer* cb{};
+    if(rhi->beginOffscreenFrame(&cb) != QRhi::FrameOpSuccess)
+      return;
+
+    renderer->render(*cb);
+    if(m_encoder)
+      m_encoder->exec(*rhi, *cb);
+    rhi->endOffscreenFrame();
+  }
+
+  //! The luma of the delivered picture, row by row, 0..255. Empty when the
+  //! path produced nothing.
+  std::vector<int> lumaRows() const
+  {
+    std::vector<int> rows;
+    if(m_encoder)
+    {
+      // Plane 0 is Y (R8) at full resolution for I420/NV12; for UYVY it is an
+      // RGBA8 texture of width/2 holding U Y V Y, so Y is every odd byte.
+      const auto& rb = m_encoder->readback(0);
+      if(rb.data.isEmpty())
+        return rows;
+      const auto* d = reinterpret_cast<const uint8_t*>(rb.data.constData());
+      const int h = rb.pixelSize.height();
+      if(h <= 0)
+        return rows;
+      const int stride = rb.data.size() / h;
+      // The 10-bit planes are little-endian uint16 samples. p010 carries its
+      // 10 bits in the HIGH end of the word, yuv422p10le in the low end --
+      // the same split EncoderTester checks the packing against.
+      const bool tenBit
+          = (m_path == OutPath::EncP010 || m_path == OutPath::Enc422P10);
+      const int shift = (m_path == OutPath::EncP010) ? 8 : 2;
+      for(int y = 0; y < h; y++)
+      {
+        const uint8_t* r = d + std::size_t(y) * stride;
+        if(tenBit)
+        {
+          const auto* u = reinterpret_cast<const uint16_t*>(r);
+          rows.push_back((u[kW / 2] >> shift) & 0xFF);
+        }
+        else
+        {
+          // Sample away from the edges; the ramp is constant along X.
+          const int x = (m_path == OutPath::EncUYVY) ? (kW / 2) | 1 : kW / 2;
+          rows.push_back(r[x]);
+        }
+      }
+    }
+    else
+    {
+      if(m_readback.data.isEmpty())
+        return rows;
+      const auto* d = reinterpret_cast<const uint8_t*>(m_readback.data.constData());
+      const int h = m_readback.pixelSize.height();
+      if(h <= 0)
+        return rows;
+      const int stride = m_readback.data.size() / h;
+      for(int y = 0; y < h; y++)
+        rows.push_back(d[std::size_t(y) * stride + (kW / 2) * 4 + 1]);
+    }
+    return rows;
+  }
+
+private:
+  OutPath m_path{};
+  std::weak_ptr<score::gfx::RenderList> m_renderer{};
+  QRhiTexture* m_texture{};
+  QRhiRenderBuffer* m_depthStencil{};
+  QRhiTextureRenderTarget* m_renderTarget{};
+  std::shared_ptr<score::gfx::RenderState> m_renderState{};
+  std::unique_ptr<score::gfx::GPUVideoEncoder> m_encoder{};
+  QRhiReadbackResult m_readback{};
+};
+
+//! What paints the picture. The two differ in how they get their geometry into
+//! clip space, which is the other half of the orientation question.
+enum class Source
+{
+  Texgen, //!< score::gfx::TexgenNode: uploads a CPU buffer, row 0 first
+  Isf,    //!< an ISF shader, isf_FragNormCoord.y == 1 at the TOP per the spec
+};
+
+const char* sourceName(Source s)
+{
+  return s == Source::Texgen ? "TexgenNode" : "ISF isf-gradient-y";
+}
+
+struct Shot
+{
+  bool skipped{};
+  std::string error;
+  std::vector<int> rows;
+};
+
+Shot runPath(score::gfx::GraphicsApi api, OutPath path, Source source)
+{
+  Shot out;
+  score::test::run_in_gui_app([&](const score::GUIApplicationContext&) {
+    std::unique_ptr<score::gfx::Node> owned_src;
+    score::gfx::Node* src{};
+    if(source == Source::Texgen)
+    {
+      auto* t = new score::gfx::TexgenNode;
+      t->function = &paintVerticalRamp;
+      src = t;
+    }
+    else
+    {
+      const QString path
+          = QDir{QStringLiteral(GFX_TEST_CORPUS_DIR)}.filePath("isf-gradient-y.fs");
+      auto built = make_isf_node(path);
+      if(!built.node)
+      {
+        out.error = built.error;
+        return;
+      }
+      owned_src = std::move(built.node);
+      src = owned_src.get();
+    }
+    auto* sink = new OrientationSink{path};
+
+    auto graph = std::make_unique<score::gfx::Graph>();
+    graph->addNode(src);
+    graph->addNode(sink);
+    graph->addEdge(
+        src->output[0], sink->input[0], Process::CableType::ImmediateGlutton);
+    graph->createAllRenderLists(api);
+
+    if(!sink->canRender())
+    {
+      out.skipped = true;
+      graph.reset();
+      delete sink;
+      if(!owned_src)
+        delete src;
+      return;
+    }
+
+    // A few frames: the source uploads its texture from update(), so the first
+    // frame can be the clear colour.
+    for(int i = 0; i < 4; i++)
+      sink->render();
+
+    out.rows = sink->lumaRows();
+    if(out.rows.empty())
+      out.error = "no pixels read back";
+
+    graph.reset();
+    delete sink;
+    // owned_src deletes the ISF node when it goes out of scope, after the
+    // graph; a Texgen node was new'd by hand and is deleted by hand.
+    if(!owned_src)
+      delete src;
+  });
+  return out;
+}
+
+//! Largest deviation from the closed-form ramp, and where.
+struct RampFit
+{
+  int worst{}, worstRow{}, got{}, expected{};
+};
+
+//! Scale-invariant: the encoders put the ramp through a BT.709 luma with its
+//! own range, so what is asserted is the SHAPE -- which end is which -- and not
+//! the absolute value.
+RampFit fitRamp(const std::vector<int>& rows, bool topIsDark)
+{
+  RampFit f;
+  const int H = rows.size();
+  const auto [lo, hi] = std::minmax_element(rows.begin(), rows.end());
+  const double span = double(*hi - *lo);
+  if(span < 1.)
+    return {255, 0, rows.front(), -1};
+
+  for(int y = 0; y < H; y++)
+  {
+    const double t = double(y) / double(H - 1);
+    const double want = topIsDark ? t : (1.0 - t);
+    const int expected = int(std::lround(*lo + span * want));
+    const int d = std::abs(rows[y] - expected);
+    if(d > f.worst)
+      f = {d, y, rows[y], expected};
+  }
+  return f;
+}
+
+RampFit fitTopDown(const std::vector<int>& rows)
+{
+  return fitRamp(rows, true);
+}
+
+RampFit fitBottomUp(const std::vector<int>& rows)
+{
+  return fitRamp(rows, false);
+}
+}
+
+TEST_CASE(
+    "a video output hands over a top-down picture",
+    "[gfx][video][output][orientation]")
+{
+  const auto api = GENERATE(from_range(platform_backends()));
+  const auto source = GENERATE(Source::Texgen, Source::Isf);
+  const auto path = GENERATE(
+      OutPath::InvertY, OutPath::EncI420, OutPath::EncNV12, OutPath::EncUYVY,
+      OutPath::EncP010, OutPath::Enc422P10);
+
+  const auto shot = runPath(api, path, source);
+
+  INFO(
+      "backend " << backend_name(api) << ", source " << sourceName(source)
+                 << ", path " << pathName(path));
+  if(shot.skipped)
+    SKIP("backend unavailable");
+  REQUIRE(shot.error.empty());
+  REQUIRE(shot.rows.size() >= 8);
+
+  // Not a flat picture: the ramp is really there.
+  const auto [lo, hi]
+      = std::minmax_element(shot.rows.begin(), shot.rows.end());
+  REQUIRE((*hi - *lo) > 100);
+
+  // TexgenNode paints row 0 black; the ISF reference is green == 1 at the TOP,
+  // so its row 0 is white. Either way row 0 is the top of the picture.
+  const bool topIsDark = (source == Source::Texgen);
+  const auto fit = topIsDark ? fitTopDown(shot.rows) : fitBottomUp(shot.rows);
+  INFO(
+      "row " << fit.worstRow << ": got " << fit.got << ", expected "
+             << fit.expected << " (first " << shot.rows.front() << ", last "
+             << shot.rows.back() << ")");
+  CHECK(fit.worst <= 24);
+}
+
+// Same picture, two ways off the GPU: whatever they deliver, they must deliver
+// the same thing. This is the assertion that catches one path being corrected
+// for a backend the other is not.
+TEST_CASE(
+    "the readback and the GPU encoder agree on which way up",
+    "[gfx][video][output][orientation]")
+{
+  const auto api = GENERATE(from_range(platform_backends()));
+  const auto source = GENERATE(Source::Texgen, Source::Isf);
+
+  const auto ref = runPath(api, OutPath::InvertY, source);
+  if(ref.skipped)
+    SKIP("backend unavailable");
+  REQUIRE(ref.error.empty());
+  REQUIRE(ref.rows.size() >= 8);
+
+  for(auto path :
+      {OutPath::EncI420, OutPath::EncNV12, OutPath::EncUYVY, OutPath::EncP010,
+       OutPath::Enc422P10})
+  {
+    const auto shot = runPath(api, path, source);
+    INFO(
+        "backend " << backend_name(api) << ", source " << sourceName(source)
+                   << ", path " << pathName(path));
+    if(shot.skipped)
+      continue;
+    REQUIRE(shot.error.empty());
+    REQUIRE(shot.rows.size() == ref.rows.size());
+
+    // Compare the two ends rather than every row: the encoders go through a
+    // full-range BT.709 luma, so the values are not the ramp itself.
+    const bool refTopDark = ref.rows.front() < ref.rows.back();
+    const bool gotTopDark = shot.rows.front() < shot.rows.back();
+    INFO(
+        "reference " << ref.rows.front() << ".." << ref.rows.back() << ", got "
+                     << shot.rows.front() << ".." << shot.rows.back());
+    CHECK(refTopDark == gotTopDark);
+  }
+}
+
+
+// =============================================================================
+// The whole FFmpeg output, end to end: the same ISF ramp, encoded to a file by
+// the real Gfx::LibavEncoderNode at the pixel format an h264 stream actually
+// uses, and decoded back. This is the user's report -- "ffmpeg udp in ->
+// passthrough shader -> ffmpeg udp out, Y is upside down" -- minus the network.
+// =============================================================================
+namespace
+{
+//! Luma of the middle column of `frame`, row by row.
+std::vector<int> lumaRowsOf(const AVFrame& f)
+{
+  std::vector<int> rows;
+  if(f.height <= 0 || f.width <= 0)
+    return rows;
+  // Y plane of any planar YUV; for anything else, convert.
+  if(f.format == AV_PIX_FMT_YUV420P || f.format == AV_PIX_FMT_YUVJ420P)
+  {
+    for(int y = 0; y < f.height; y++)
+      rows.push_back(f.data[0][std::size_t(y) * f.linesize[0] + f.width / 2]);
+    return rows;
+  }
+
+  SwsContext* sws = sws_getContext(
+      f.width, f.height, AVPixelFormat(f.format), f.width, f.height,
+      AV_PIX_FMT_GRAY8, SWS_BILINEAR, nullptr, nullptr, nullptr);
+  if(!sws)
+    return rows;
+  std::vector<uint8_t> gray(std::size_t(f.width) * f.height);
+  uint8_t* dst[4]{gray.data(), nullptr, nullptr, nullptr};
+  int stride[4]{f.width, 0, 0, 0};
+  sws_scale(sws, f.data, f.linesize, 0, f.height, dst, stride);
+  sws_freeContext(sws);
+  for(int y = 0; y < f.height; y++)
+    rows.push_back(gray[std::size_t(y) * f.width + f.width / 2]);
+  return rows;
+}
+
+//! First decodable frame of `path`, as its luma rows.
+std::vector<int> decodeFirstFrameRows(const QString& path)
+{
+  std::vector<int> rows;
+  AVFormatContext* fmt{};
+  if(avformat_open_input(&fmt, path.toUtf8().constData(), nullptr, nullptr) != 0)
+    return rows;
+  if(avformat_find_stream_info(fmt, nullptr) < 0)
+  {
+    avformat_close_input(&fmt);
+    return rows;
+  }
+  int vs = -1;
+  for(unsigned i = 0; i < fmt->nb_streams; i++)
+    if(fmt->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+    {
+      vs = int(i);
+      break;
+    }
+  if(vs < 0)
+  {
+    avformat_close_input(&fmt);
+    return rows;
+  }
+  const AVCodec* dec = avcodec_find_decoder(fmt->streams[vs]->codecpar->codec_id);
+  AVCodecContext* cc = dec ? avcodec_alloc_context3(dec) : nullptr;
+  if(!cc || avcodec_parameters_to_context(cc, fmt->streams[vs]->codecpar) < 0
+     || avcodec_open2(cc, dec, nullptr) < 0)
+  {
+    if(cc)
+      avcodec_free_context(&cc);
+    avformat_close_input(&fmt);
+    return rows;
+  }
+  AVPacket* pkt = av_packet_alloc();
+  AVFrame* frame = av_frame_alloc();
+  while(rows.empty() && av_read_frame(fmt, pkt) >= 0)
+  {
+    if(pkt->stream_index == vs && avcodec_send_packet(cc, pkt) == 0)
+      while(rows.empty() && avcodec_receive_frame(cc, frame) == 0)
+        rows = lumaRowsOf(*frame);
+    av_packet_unref(pkt);
+  }
+  av_frame_free(&frame);
+  av_packet_free(&pkt);
+  avcodec_free_context(&cc);
+  avformat_close_input(&fmt);
+  return rows;
+}
+
+Gfx::LibavOutputSettings mp4Settings(const QString& file, int w, int h)
+{
+  Gfx::LibavOutputSettings set;
+  set.path = file;
+  set.width = w;
+  set.height = h;
+  set.rate = 30.;
+  set.muxer = "mp4";
+  set.video_encoder_short = "libx264";
+  // What an h264 stream is: this is the branch that engages the GPU I420
+  // encoder rather than the RGBA readback.
+  set.video_converted_pixfmt = "yuv420p";
+  set.video_render_pixfmt = "rgba";
+  set.threads = 1;
+  set.options["preset"] = "ultrafast";
+  return set;
+}
+}
+
+TEST_CASE(
+    "the FFmpeg output records a top-down picture",
+    "[gfx][video][output][orientation][libav]")
+{
+  const auto api = GENERATE(from_range(platform_backends()));
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+  const QString file = dir.path() + "/orientation.mp4";
+
+  bool skipped = false, started = false;
+  std::string error;
+  score::test::run_in_gui_app([&](const score::GUIApplicationContext&) {
+    const QString shader
+        = QDir{QStringLiteral(GFX_TEST_CORPUS_DIR)}.filePath("isf-gradient-y.fs");
+    auto built = make_isf_node(shader);
+    if(!built.node)
+    {
+      error = built.error;
+      return;
+    }
+
+    auto set = mp4Settings(file, kW, kH);
+    Gfx::LibavEncoder enc{set};
+    if(enc.start() != 0 || !enc.available())
+    {
+      skipped = true; // no libx264 in this build
+      return;
+    }
+    started = true;
+
+    auto* sink = new Gfx::LibavEncoderNode{set, enc, 0};
+    auto graph = std::make_unique<score::gfx::Graph>();
+    graph->addNode(built.node.get());
+    graph->addNode(sink);
+    graph->addEdge(
+        built.node->output[0], sink->input[0],
+        Process::CableType::ImmediateGlutton);
+    graph->createAllRenderLists(api);
+
+    if(!sink->canRender())
+    {
+      skipped = true;
+      graph.reset();
+      delete sink;
+      return;
+    }
+
+    for(int i = 0; i < 12; i++)
+      sink->render();
+
+    graph.reset();
+    delete sink;
+    enc.stop();
+  });
+
+  INFO("backend " << backend_name(api));
+  if(skipped)
+    SKIP("libx264 or the backend is unavailable here");
+  REQUIRE(error.empty());
+  REQUIRE(started);
+
+  const auto rows = decodeFirstFrameRows(file);
+  REQUIRE(rows.size() >= 8);
+
+  const auto [lo, hi] = std::minmax_element(rows.begin(), rows.end());
+  INFO("first " << rows.front() << ", last " << rows.back());
+  REQUIRE((*hi - *lo) > 60);
+
+  // isf-gradient-y is bright at the TOP: row 0 of the recorded frame is the
+  // bright end, or the recording is upside down.
+  const auto fit = fitBottomUp(rows);
+  INFO(
+      "row " << fit.worstRow << ": got " << fit.got << ", expected "
+             << fit.expected);
+  CHECK(fit.worst <= 40);
+}

--- a/tests/gfx/SoftEdgeBlend.cpp
+++ b/tests/gfx/SoftEdgeBlend.cpp
@@ -1,0 +1,77 @@
+// =============================================================================
+// The soft-edge blend ramp of the multi-window output.
+//
+// The ramp coordinate leaves [0;1] whenever the fragment centre of an edge
+// pixel falls outside the triangle, which multisampling makes routine. The
+// expression called pow() on the resulting negative base -- undefined in GLSL
+// -- and the drivers that answer NaN write a fully lit pixel into the UNORM
+// attachment: the one-pixel bright fringe that reappeared along a blended
+// border once the rest of the edge had faded to black.
+//
+// The shader lives in MultiWindowNode.cpp, inside a renderer that needs one
+// real platform surface per output and presents rather than reads back, so the
+// expression itself is what is pinned here -- rendered on every backend, from
+// a corpus shader that carries the same lines.
+//
+//   DISPLAY=:0 ctest -R gfx_soft_edge_blend
+// =============================================================================
+
+#include "IsfTestCommon.hpp"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+
+using namespace score::test::gfx;
+using namespace score::test::gfx::isf;
+using Catch::Approx;
+
+TEST_CASE("the soft-edge ramp never lights the pixels past its own edge",
+          "[gfx][window][blend]")
+{
+  for(auto& shot : render_all({corpus("isf-soft-edge-blend.fs")}, {128, 32}))
+  {
+    const auto& r = shot.result;
+    INFO("backend " << int(shot.api));
+    if(r.skipped)
+      continue;
+    REQUIRE(r.error.empty());
+    REQUIRE(!r.outputs.empty());
+
+    const auto& img = r.outputs[0];
+    REQUIRE(img.width > 16);
+    const int y = img.height / 2;
+
+    // The ramp spans t in [-0.125; 1.125] with a width of 0.25, so the first
+    // eighth of the image is outside the quad and the ramp reaches 1 at 3/8.
+    const int outside = img.width / 8;
+
+    for(int x = 0; x < outside; ++x)
+    {
+      INFO("column " << x << " of " << img.width);
+      // Black, not white: this is the fringe.
+      CHECK(int(img.at(x, y)[1]) <= 4);
+    }
+
+    // Not merely all-black: the ramp is there.
+    CHECK(int(img.at(img.width - 2, y)[1]) >= 250);
+    CHECK(int(img.at(img.width / 4, y)[1]) > 4);
+    CHECK(int(img.at(img.width / 4, y)[1]) < 250);
+
+    // Monotonic, and never above full.
+    int prev = -1;
+    for(int x = 0; x < img.width; ++x)
+    {
+      const int g = int(img.at(x, y)[1]);
+      INFO("column " << x << " green " << g);
+      CHECK(g <= 255);
+      CHECK(g >= prev - 2);
+      prev = g;
+    }
+
+    // The garbage detectors.
+    CHECK(int(img.at(img.width / 2, y)[0]) == Approx(64).margin(3));
+    CHECK(int(img.at(img.width / 2, y)[2]) == Approx(191).margin(3));
+  }
+}

--- a/tests/gfx/WindowSettingsUi.cpp
+++ b/tests/gfx/WindowSettingsUi.cpp
@@ -558,3 +558,106 @@ TEST_CASE("WindowSettingsWidget add and remove outputs", "[gfx][window][settings
     CHECK(outputButtonCount(w) == 2);
   });
 }
+
+// ---------------------------------------------------------------------------
+// Precision, borders and where a new window lands.
+
+TEST_CASE("the source mapping spin boxes carry five decimals", "[gfx][window][settingswidget]")
+{
+  score::test::run_in_app([&](const score::GUIApplicationContext&) {
+    WindowSettingsWidget w;
+
+    WindowSettings ws;
+    ws.mode = WindowMode::MultiWindow;
+    ws.outputs = {mapping({0.0, 0.0, 1.0, 1.0}, {10, 20}, {640, 480})};
+    w.setSettings(makeSettings(ws));
+    auto* btn = outputButton(w, 0);
+    REQUIRE(btn);
+    btn->click();
+
+    for(int i : {0, 1})
+    {
+      auto* sb = fieldAs<QDoubleSpinBox>(w, QStringLiteral("Position"), i);
+      REQUIRE(sb);
+      INFO("Position spin box " << i);
+      CHECK(sb->decimals() == 5);
+    }
+    for(int i : {0, 1})
+    {
+      auto* sb = fieldAs<QDoubleSpinBox>(w, QStringLiteral("Size"), i);
+      REQUIRE(sb);
+      INFO("Size spin box " << i);
+      CHECK(sb->decimals() == 5);
+    }
+
+    // A value only expressible at five decimals survives the round trip: at
+    // three it was rounded away before it ever reached the settings.
+    auto* x = fieldAs<QDoubleSpinBox>(w, QStringLiteral("Position"), 0);
+    REQUIRE(x);
+    x->setValue(0.12345);
+    const auto got = settingsOf(w);
+    REQUIRE(got.outputs.size() == 1);
+    CHECK(got.outputs[0].sourceRect.x() == Approx(0.12345).margin(1e-6));
+  });
+}
+
+TEST_CASE("Lock to border sits next to Snap and releases the canvas", "[gfx][window][settingswidget]")
+{
+  score::test::run_in_app([&](const score::GUIApplicationContext&) {
+    WindowSettingsWidget w;
+
+    auto* check = fieldAs<QCheckBox>(w, QStringLiteral("Lock to border"));
+    REQUIRE(check);
+    CHECK(check->isChecked()); // the behaviour there has always been
+
+    OutputMappingCanvas* canvas{};
+    for(auto* child : w.findChildren<QWidget*>())
+      if(auto* c = dynamic_cast<OutputMappingCanvas*>(child))
+        canvas = c;
+    REQUIRE(canvas);
+    CHECK(canvas->lockToBorderEnabled());
+
+    check->setChecked(false);
+    CHECK_FALSE(canvas->lockToBorderEnabled());
+    check->setChecked(true);
+    CHECK(canvas->lockToBorderEnabled());
+  });
+}
+
+// A window at the origin is hard to grab by its title bar on Windows, and on
+// i3 the first output window stayed unmapped until it was moved by a pixel.
+TEST_CASE("a new output window does not land on the origin", "[gfx][window][settingswidget]")
+{
+  score::test::run_in_app([&](const score::GUIApplicationContext&) {
+    CHECK(OutputMapping{}.windowPosition != QPoint{0, 0});
+
+    WindowSettingsWidget w;
+    WindowSettings ws;
+    ws.mode = WindowMode::MultiWindow;
+    w.setSettings(makeSettings(ws));
+
+    // "Add" derives the window position from the new quad's source rect,
+    // which starts at the top-left of the canvas.
+    QPushButton* add{};
+    for(auto* b : w.findChildren<QPushButton*>())
+      if(b->text() == QStringLiteral("Add"))
+        add = b;
+    REQUIRE(add);
+    add->click();
+
+    const auto got = settingsOf(w);
+    REQUIRE(got.outputs.size() == 1);
+    INFO("pos " << got.outputs[0].windowPosition.x() << ","
+                << got.outputs[0].windowPosition.y());
+    // Its source rect starts at the top-left, so auto-matching would put the
+    // window on the desktop origin.
+    CHECK(got.outputs[0].sourceRect.topLeft() == QPointF{0., 0.});
+    CHECK(got.outputs[0].windowPosition != QPoint{0, 0});
+    CHECK(got.outputs[0].windowPosition == defaultWindowPosition);
+
+    // An output that is not at the origin keeps the position it derives.
+    CHECK(windowPositionForSource({0, 0}) == defaultWindowPosition);
+    CHECK(windowPositionForSource({0, 40}) == QPoint{0, 40});
+    CHECK(windowPositionForSource({1920, 0}) == QPoint{1920, 0});
+  });
+}

--- a/tests/gfx/corpus/isf-soft-edge-blend.fs
+++ b/tests/gfx/corpus/isf-soft-edge-blend.fs
@@ -1,0 +1,24 @@
+/*{
+  "DESCRIPTION": "The soft-edge blend ramp of the multi-window output, evaluated over a coordinate that steps outside [0;1] the way the fragment centre of a partially covered edge pixel does. Green carries the alpha the ramp produces; red 0.25 / blue 0.75 are garbage detectors. Without a clamp, pow() is called on a negative base -- undefined in GLSL -- and the drivers that answer NaN turn the leftmost pixels fully lit, which is the one-pixel bright fringe this pins.",
+  "CREDIT": "test",
+  "ISFVSN": "2.0",
+  "CATEGORIES": ["TEST-BLEND"],
+  "INPUTS": []
+}*/
+
+void main()
+{
+    // Spans [-0.125; 1.125]: the first eighth of the image is "outside" the
+    // quad, exactly as an extrapolated edge coordinate is.
+    float t = isf_FragNormCoord.x * 1.25 - 0.125;
+
+    const float width = 0.25;
+    const float gamma = 2.0;
+
+    float alpha = 1.0;
+    if(width > 0.0 && t < width)
+        alpha *= pow(clamp(t / width, 0.0, 1.0), gamma);
+    alpha = clamp(alpha, 0.0, 1.0);
+
+    gl_FragColor = vec4(0.25, alpha, 0.75, 1.0);
+}

--- a/tests/hardware/CMakeLists.txt
+++ b/tests/hardware/CMakeLists.txt
@@ -61,14 +61,25 @@ if(TARGET PipewireRoundtrip)
     ENVIRONMENT "${_pwrt_asan}")
 
   # GStreamer -> score: a pipewiresink producer feeding score's input, through
-  # the session manager rather than a link the harness makes itself. The other
-  # direction (score -> pipewiresrc) is red and is not registered; see the
-  # s2gst cell in the harness for what it reproduces.
+  # the session manager rather than a link the harness makes itself.
   score_add_media_test(
     NAME       Media_PipewireGstToScore
     EXECUTABLE PipewireRoundtrip
     PIPEWIRE
     ARGS       --seconds 3 --only gst2s
+    TIMEOUT    300
+    ENVIRONMENT "${_pwrt_asan}")
+
+  # score -> GStreamer: score's output read by pipewiresrc, one decoded frame
+  # checked for the test signal. This is what OBS does, and it is the direction
+  # that used to deliver nothing: the stream announced no buffer size, so the
+  # server handed out zero-length buffers and every consumer that was not score
+  # itself dropped them. Renders on the GPU, so it is display-gated like s2s.
+  score_add_media_test(
+    NAME       Media_PipewireScoreToGst
+    EXECUTABLE PipewireRoundtrip
+    PIPEWIRE
+    ARGS       --seconds 3 --only s2gst
     TIMEOUT    300
     ENVIRONMENT "${_pwrt_asan}")
 

--- a/tests/hardware/CMakeLists.txt
+++ b/tests/hardware/CMakeLists.txt
@@ -60,6 +60,18 @@ if(TARGET PipewireRoundtrip)
     TIMEOUT    600
     ENVIRONMENT "${_pwrt_asan}")
 
+  # GStreamer -> score: a pipewiresink producer feeding score's input, through
+  # the session manager rather than a link the harness makes itself. The other
+  # direction (score -> pipewiresrc) is red and is not registered; see the
+  # s2gst cell in the harness for what it reproduces.
+  score_add_media_test(
+    NAME       Media_PipewireGstToScore
+    EXECUTABLE PipewireRoundtrip
+    PIPEWIRE
+    ARGS       --seconds 3 --only gst2s
+    TIMEOUT    300
+    ENVIRONMENT "${_pwrt_asan}")
+
   score_add_hardware_test(
     NAME       PipewireRoundtrip_s2s
     EXECUTABLE PipewireRoundtrip

--- a/tests/hardware/dmabuf-export-bandwidth.cpp
+++ b/tests/hardware/dmabuf-export-bandwidth.cpp
@@ -1,0 +1,616 @@
+// How fast can a driver write into an image that is exported as a dma-buf?
+//
+// score's PipeWire video output renders a frame and copies it into an exported
+// image so a consumer can import the file descriptor. At 7680x4320 that copy
+// costs orders of magnitude more than the same copy into an ordinary texture.
+// Everything else was ruled out first: the scene render is cheap, and the
+// pipewire handover is negligible.
+//
+// This is the smallest thing that reproduces it: no score, no pipewire, no Qt.
+// One source image, one destination, vkCmdCopyImage between them, timed. The
+// destination is built five different ways and the table says which of them is
+// slow.
+//
+// The suspect is the tiling. VK_EXT_image_drm_format_modifier exists precisely
+// because an exported image needs a layout the importer can describe, and the
+// Vulkan documentation is blunt about the alternative: LINEAR is "universally
+// supported" and "typically offers poor performance", while OPTIMAL "cannot be
+// directly shared via dma-buf" because nobody outside the driver knows the
+// layout. The extension's whole point is to get a vendor-tiled layout that IS
+// shareable, by name. score's export asks for LINEAR.
+//
+// The table has one row per destination. "copy" is a full-frame transfer into
+// it, which is what score's render-then-copy path does; "clear" is the graphics
+// engine writing every pixel of it, which is the shape of rendering INTO the
+// shared image.
+//
+// What it shows: exporting is not what costs. An exported image created the
+// documented way, with a DRM format modifier, is copied into at the same speed
+// as an ordinary texture and is WRITTEN faster still. score's export, LINEAR
+// and in host-visible memory, is slower by orders of magnitude on both, and it
+// is the only row that is.
+//
+// The write column is why score only renders straight into the shared image
+// when the layout is tiled. On a LINEAR host-visible export, writing costs MORE
+// than copying; on a tiled one it costs a fraction. Same code, opposite
+// conclusion, decided by the layout.
+//
+// The fix it points at: create the exported image with
+// VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT from the driver's own list, read back
+// the modifier it chose with vkGetImageDrmFormatModifierPropertiesEXT, and
+// advertise THAT to pipewire instead of asserting DRM_FORMAT_MOD_LINEAR. It is
+// also the honest thing to advertise: today score claims a layout it did not
+// ask for.
+//
+// One caveat this probe cannot settle. score's own 8K frame costs far more
+// than even the worst row here, so most of it is in score's path rather than
+// in the driver's export, and finding it wants a GPU timestamp around the
+// render and the copy separately -- wall-clock around the offscreen frame
+// lumps them together.
+//
+// Build:
+//   g++ -std=c++20 -O2 dmabuf-export-bandwidth.cpp -lvulkan -o dmabuf-bw
+// Run:
+//   ./dmabuf-bw            # 7680x4320, 30 iterations
+//   ./dmabuf-bw 3840 2160 100
+
+#include <vulkan/vulkan.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace
+{
+#define VKCHECK(expr)                                                    \
+  do                                                                     \
+  {                                                                      \
+    const VkResult vkr_ = (expr);                                        \
+    if(vkr_ != VK_SUCCESS)                                               \
+    {                                                                    \
+      std::fprintf(                                                      \
+          stderr, "%s:%d: %s failed with VkResult %d\n", __FILE__,       \
+          __LINE__, #expr, int(vkr_));                                   \
+      std::exit(1);                                                      \
+    }                                                                    \
+  } while(0)
+
+constexpr VkFormat kFormat = VK_FORMAT_R8G8B8A8_UNORM;
+
+struct Vk
+{
+  VkInstance instance{};
+  VkPhysicalDevice phys{};
+  VkDevice dev{};
+  VkQueue queue{};
+  uint32_t queueFamily{};
+  VkCommandPool pool{};
+  VkPhysicalDeviceMemoryProperties memProps{};
+
+  PFN_vkGetPhysicalDeviceFormatProperties2 getFormatProps2{};
+  PFN_vkGetImageDrmFormatModifierPropertiesEXT getImageModifier{};
+};
+
+//! Memory type index satisfying `bits` and `want`, preferring an exact match.
+std::optional<uint32_t>
+findMemory(const Vk& vk, uint32_t bits, VkMemoryPropertyFlags want)
+{
+  for(uint32_t i = 0; i < vk.memProps.memoryTypeCount; i++)
+    if((bits & (1u << i))
+       && (vk.memProps.memoryTypes[i].propertyFlags & want) == want)
+      return i;
+  return std::nullopt;
+}
+
+struct Image
+{
+  VkImage image{};
+  VkDeviceMemory memory{};
+  uint64_t modifier{UINT64_MAX};
+  bool deviceLocal{};
+  bool ok{};
+};
+
+//! Every DRM format modifier this driver can render kFormat with.
+std::vector<uint64_t> renderableModifiers(const Vk& vk)
+{
+  VkDrmFormatModifierPropertiesListEXT list{};
+  list.sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT;
+
+  VkFormatProperties2 props{};
+  props.sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2;
+  props.pNext = &list;
+  vk.getFormatProps2(vk.phys, kFormat, &props);
+
+  std::vector<VkDrmFormatModifierPropertiesEXT> mods(
+      list.drmFormatModifierCount);
+  list.pDrmFormatModifierProperties = mods.data();
+  vk.getFormatProps2(vk.phys, kFormat, &props);
+
+  std::vector<uint64_t> out;
+  for(const auto& m : mods)
+  {
+    // Must support being a colour attachment and a transfer destination, or it
+    // is no use as a frame we render into and hand over.
+    const auto need = VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT
+                      | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
+    if((m.drmFormatModifierTilingFeatures & need) == need)
+      out.push_back(m.drmFormatModifier);
+  }
+  return out;
+}
+
+enum class Kind
+{
+  PlainOptimal,      //!< the control: an ordinary texture, no export
+  ExportLinearHost,  //!< what score does, in host-visible memory
+  ExportLinearLocal, //!< what score does, forced device-local
+  ExportOptimal,     //!< optimal tiling AND exported (often invalid, tried anyway)
+  ExportModifier,    //!< the documented path: let the driver pick a modifier
+};
+
+const char* name(Kind k)
+{
+  switch(k)
+  {
+    case Kind::PlainOptimal:
+      return "plain OPTIMAL (no export)";
+    case Kind::ExportLinearHost:
+      return "export LINEAR, host-visible";
+    case Kind::ExportLinearLocal:
+      return "export LINEAR, device-local";
+    case Kind::ExportOptimal:
+      return "export OPTIMAL";
+    case Kind::ExportModifier:
+      return "export DRM_FORMAT_MODIFIER";
+  }
+  return "?";
+}
+
+Image makeImage(
+    const Vk& vk, Kind kind, uint32_t w, uint32_t h,
+    const std::vector<uint64_t>& modifiers)
+{
+  Image out;
+
+  VkExternalMemoryImageCreateInfo ext{};
+  ext.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+  ext.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+
+  VkImageDrmFormatModifierListCreateInfoEXT modList{};
+  modList.sType
+      = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT;
+  modList.drmFormatModifierCount = uint32_t(modifiers.size());
+  modList.pDrmFormatModifiers = modifiers.data();
+
+  VkImageCreateInfo ci{};
+  ci.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+  ci.imageType = VK_IMAGE_TYPE_2D;
+  ci.format = kFormat;
+  ci.extent = {w, h, 1};
+  ci.mipLevels = 1;
+  ci.arrayLayers = 1;
+  ci.samples = VK_SAMPLE_COUNT_1_BIT;
+  ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+             | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
+             | VK_IMAGE_USAGE_SAMPLED_BIT;
+  ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+  switch(kind)
+  {
+    case Kind::PlainOptimal:
+      ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+      break;
+    case Kind::ExportLinearHost:
+    case Kind::ExportLinearLocal:
+      ci.tiling = VK_IMAGE_TILING_LINEAR;
+      ci.pNext = &ext;
+      break;
+    case Kind::ExportOptimal:
+      ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+      ci.pNext = &ext;
+      break;
+    case Kind::ExportModifier:
+      if(modifiers.empty())
+        return out;
+      ci.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
+      modList.pNext = &ext;
+      ci.pNext = &modList;
+      break;
+  }
+
+  if(vkCreateImage(vk.dev, &ci, nullptr, &out.image) != VK_SUCCESS)
+    return out;
+
+  VkMemoryRequirements req{};
+  vkGetImageMemoryRequirements(vk.dev, out.image, &req);
+
+  const bool wantHost = (kind == Kind::ExportLinearHost);
+  auto type = findMemory(
+      vk, req.memoryTypeBits,
+      wantHost ? VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
+               : VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+  if(!type)
+    type = findMemory(vk, req.memoryTypeBits, 0);
+  if(!type)
+  {
+    vkDestroyImage(vk.dev, out.image, nullptr);
+    out.image = VK_NULL_HANDLE;
+    return out;
+  }
+  out.deviceLocal = (vk.memProps.memoryTypes[*type].propertyFlags
+                     & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+                    != 0;
+
+  VkExportMemoryAllocateInfo exportInfo{};
+  exportInfo.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+  exportInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+
+  VkMemoryDedicatedAllocateInfo dedicated{};
+  dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+  dedicated.image = out.image;
+  exportInfo.pNext = &dedicated;
+
+  VkMemoryAllocateInfo alloc{};
+  alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  alloc.allocationSize = req.size;
+  alloc.memoryTypeIndex = *type;
+  if(kind != Kind::PlainOptimal)
+    alloc.pNext = &exportInfo;
+  else
+    alloc.pNext = &dedicated;
+
+  if(vkAllocateMemory(vk.dev, &alloc, nullptr, &out.memory) != VK_SUCCESS)
+  {
+    vkDestroyImage(vk.dev, out.image, nullptr);
+    out.image = VK_NULL_HANDLE;
+    return out;
+  }
+  VKCHECK(vkBindImageMemory(vk.dev, out.image, out.memory, 0));
+
+  if(kind == Kind::ExportModifier && vk.getImageModifier)
+  {
+    VkImageDrmFormatModifierPropertiesEXT p{};
+    p.sType = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT;
+    if(vk.getImageModifier(vk.dev, out.image, &p) == VK_SUCCESS)
+      out.modifier = p.drmFormatModifier;
+  }
+
+  out.ok = true;
+  return out;
+}
+
+void destroy(const Vk& vk, Image& img)
+{
+  if(img.image)
+    vkDestroyImage(vk.dev, img.image, nullptr);
+  if(img.memory)
+    vkFreeMemory(vk.dev, img.memory, nullptr);
+  img = {};
+}
+
+void barrier(
+    VkCommandBuffer cb, VkImage img, VkImageLayout from, VkImageLayout to,
+    VkAccessFlags srcAccess, VkAccessFlags dstAccess)
+{
+  VkImageMemoryBarrier b{};
+  b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  b.oldLayout = from;
+  b.newLayout = to;
+  b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  b.image = img;
+  b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  b.srcAccessMask = srcAccess;
+  b.dstAccessMask = dstAccess;
+  vkCmdPipelineBarrier(
+      cb, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+      0, 0, nullptr, 0, nullptr, 1, &b);
+}
+
+//! Milliseconds per full-image CLEAR of dst, averaged over `iters`.
+//!
+//! The copy below is what score's render-then-copy path does. This is the other
+//! shape -- the graphics engine writing every pixel of the destination, which
+//! is what rendering INTO the shared image does. A transfer copes with linear
+//! memory far better than scattered writes do, so the two rows can disagree by
+//! a lot, and which one matters depends on which path the layout allows.
+double timeClears(const Vk& vk, VkImage dst, int iters);
+
+//! Milliseconds per copy of src -> dst, averaged over `iters`, GPU waited on.
+double timeCopies(
+    const Vk& vk, VkImage src, VkImage dst, uint32_t w, uint32_t h, int iters)
+{
+  VkCommandBufferAllocateInfo cbai{};
+  cbai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+  cbai.commandPool = vk.pool;
+  cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+  cbai.commandBufferCount = 1;
+  VkCommandBuffer cb{};
+  VKCHECK(vkAllocateCommandBuffers(vk.dev, &cbai, &cb));
+
+  const auto record = [&] {
+    VkCommandBufferBeginInfo bi{};
+    bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    VKCHECK(vkBeginCommandBuffer(cb, &bi));
+
+    barrier(
+        cb, src, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        0, VK_ACCESS_TRANSFER_READ_BIT);
+    barrier(
+        cb, dst, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        0, VK_ACCESS_TRANSFER_WRITE_BIT);
+
+    VkImageCopy region{};
+    region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.extent = {w, h, 1};
+    vkCmdCopyImage(
+        cb, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst,
+        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    VKCHECK(vkEndCommandBuffer(cb));
+  };
+
+  const auto submit = [&] {
+    VkSubmitInfo si{};
+    si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    si.commandBufferCount = 1;
+    si.pCommandBuffers = &cb;
+    VKCHECK(vkQueueSubmit(vk.queue, 1, &si, VK_NULL_HANDLE));
+    VKCHECK(vkQueueWaitIdle(vk.queue));
+  };
+
+  record();
+  for(int i = 0; i < 3; i++) // warm
+    submit();
+
+  const auto t0 = std::chrono::steady_clock::now();
+  for(int i = 0; i < iters; i++)
+    submit();
+  const auto t1 = std::chrono::steady_clock::now();
+
+  vkFreeCommandBuffers(vk.dev, vk.pool, 1, &cb);
+  return std::chrono::duration<double, std::milli>(t1 - t0).count() / iters;
+}
+
+double timeClears(const Vk& vk, VkImage dst, int iters)
+{
+  VkCommandBufferAllocateInfo cbai{};
+  cbai.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+  cbai.commandPool = vk.pool;
+  cbai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+  cbai.commandBufferCount = 1;
+  VkCommandBuffer cb{};
+  VKCHECK(vkAllocateCommandBuffers(vk.dev, &cbai, &cb));
+
+  VkCommandBufferBeginInfo bi{};
+  bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+  VKCHECK(vkBeginCommandBuffer(cb, &bi));
+  barrier(
+      cb, dst, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0,
+      VK_ACCESS_TRANSFER_WRITE_BIT);
+  const VkClearColorValue colour{{0.1f, 0.2f, 0.3f, 1.f}};
+  const VkImageSubresourceRange range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+  vkCmdClearColorImage(
+      cb, dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &colour, 1, &range);
+  VKCHECK(vkEndCommandBuffer(cb));
+
+  const auto submit = [&] {
+    VkSubmitInfo si{};
+    si.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    si.commandBufferCount = 1;
+    si.pCommandBuffers = &cb;
+    VKCHECK(vkQueueSubmit(vk.queue, 1, &si, VK_NULL_HANDLE));
+    VKCHECK(vkQueueWaitIdle(vk.queue));
+  };
+
+  for(int i = 0; i < 3; i++)
+    submit();
+  const auto t0 = std::chrono::steady_clock::now();
+  for(int i = 0; i < iters; i++)
+    submit();
+  const auto t1 = std::chrono::steady_clock::now();
+
+  vkFreeCommandBuffers(vk.dev, vk.pool, 1, &cb);
+  return std::chrono::duration<double, std::milli>(t1 - t0).count() / iters;
+}
+}
+
+int main(int argc, char** argv)
+{
+  // With no arguments: 4K and 8K, the two sizes the question is about.
+  std::vector<std::pair<uint32_t, uint32_t>> sizes;
+  if(argc > 2)
+    sizes.push_back({uint32_t(std::atoi(argv[1])), uint32_t(std::atoi(argv[2]))});
+  else
+    sizes = {{3840u, 2160u}, {7680u, 4320u}};
+  const int iters = argc > 3 ? std::atoi(argv[3]) : 30;
+
+  Vk vk;
+
+  VkApplicationInfo app{};
+  app.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+  app.pApplicationName = "dmabuf-export-bandwidth";
+  app.apiVersion = VK_API_VERSION_1_1;
+
+  const char* instExts[] = {
+      VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
+      VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME};
+  VkInstanceCreateInfo ici{};
+  ici.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+  ici.pApplicationInfo = &app;
+  ici.enabledExtensionCount = 2;
+  ici.ppEnabledExtensionNames = instExts;
+  VKCHECK(vkCreateInstance(&ici, nullptr, &vk.instance));
+
+  uint32_t nphys = 0;
+  VKCHECK(vkEnumeratePhysicalDevices(vk.instance, &nphys, nullptr));
+  std::vector<VkPhysicalDevice> physes(nphys);
+  VKCHECK(vkEnumeratePhysicalDevices(vk.instance, &nphys, physes.data()));
+  if(physes.empty())
+  {
+    std::fprintf(stderr, "no Vulkan device\n");
+    return 1;
+  }
+  vk.phys = physes.front();
+  for(auto p : physes)
+  {
+    VkPhysicalDeviceProperties props{};
+    vkGetPhysicalDeviceProperties(p, &props);
+    if(props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+    {
+      vk.phys = p;
+      break;
+    }
+  }
+
+  VkPhysicalDeviceProperties props{};
+  vkGetPhysicalDeviceProperties(vk.phys, &props);
+  vkGetPhysicalDeviceMemoryProperties(vk.phys, &vk.memProps);
+
+  uint32_t nqf = 0;
+  vkGetPhysicalDeviceQueueFamilyProperties(vk.phys, &nqf, nullptr);
+  std::vector<VkQueueFamilyProperties> qfs(nqf);
+  vkGetPhysicalDeviceQueueFamilyProperties(vk.phys, &nqf, qfs.data());
+  vk.queueFamily = 0;
+  for(uint32_t i = 0; i < nqf; i++)
+    if(qfs[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)
+    {
+      vk.queueFamily = i;
+      break;
+    }
+
+  // Which of the extensions this probe wants are actually present.
+  uint32_t ndev = 0;
+  VKCHECK(vkEnumerateDeviceExtensionProperties(vk.phys, nullptr, &ndev, nullptr));
+  std::vector<VkExtensionProperties> devExts(ndev);
+  VKCHECK(
+      vkEnumerateDeviceExtensionProperties(vk.phys, nullptr, &ndev, devExts.data()));
+  const auto has = [&](const char* n) {
+    return std::any_of(devExts.begin(), devExts.end(), [&](const auto& e) {
+      return std::strcmp(e.extensionName, n) == 0;
+    });
+  };
+
+  std::vector<const char*> wanted{
+      VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+      VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME};
+  const bool hasModifiers = has(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
+  if(hasModifiers)
+  {
+    wanted.push_back(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
+    // Its own dependency, which some drivers do not imply.
+    if(has(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME))
+      wanted.push_back(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
+  }
+  std::vector<const char*> enabled;
+  for(auto* e : wanted)
+    if(has(e))
+      enabled.push_back(e);
+
+  const float prio = 1.f;
+  VkDeviceQueueCreateInfo qci{};
+  qci.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  qci.queueFamilyIndex = vk.queueFamily;
+  qci.queueCount = 1;
+  qci.pQueuePriorities = &prio;
+
+  VkDeviceCreateInfo dci{};
+  dci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  dci.queueCreateInfoCount = 1;
+  dci.pQueueCreateInfos = &qci;
+  dci.enabledExtensionCount = uint32_t(enabled.size());
+  dci.ppEnabledExtensionNames = enabled.data();
+  VKCHECK(vkCreateDevice(vk.phys, &dci, nullptr, &vk.dev));
+  vkGetDeviceQueue(vk.dev, vk.queueFamily, 0, &vk.queue);
+
+  VkCommandPoolCreateInfo pci{};
+  pci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+  pci.queueFamilyIndex = vk.queueFamily;
+  pci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+  VKCHECK(vkCreateCommandPool(vk.dev, &pci, nullptr, &vk.pool));
+
+  vk.getFormatProps2 = (PFN_vkGetPhysicalDeviceFormatProperties2)
+      vkGetInstanceProcAddr(vk.instance, "vkGetPhysicalDeviceFormatProperties2");
+  vk.getImageModifier = (PFN_vkGetImageDrmFormatModifierPropertiesEXT)
+      vkGetDeviceProcAddr(vk.dev, "vkGetImageDrmFormatModifierPropertiesEXT");
+
+  std::printf(
+      "device: %s\n%d iterations per row\n"
+      "VK_EXT_image_drm_format_modifier: %s\n\n",
+      props.deviceName, iters, hasModifiers ? "yes" : "NO");
+
+  std::vector<uint64_t> modifiers;
+  if(hasModifiers && vk.getFormatProps2)
+  {
+    modifiers = renderableModifiers(vk);
+    std::printf("renderable modifiers for RGBA8: %zu\n", modifiers.size());
+    for(auto m : modifiers)
+      std::printf("  0x%016llx\n", (unsigned long long)m);
+    std::printf("\n");
+  }
+
+  std::printf(
+      "%-30s %8s %10s %10s %10s %10s  %s\n", "destination", "size", "copy ms",
+      "copy GB/s", "clear ms", "clear GB/s", "modifier");
+  std::printf("%s\n", std::string(96, '-').c_str());
+
+  for(const auto& [W, H] : sizes)
+  {
+    // The source every copy reads: an ordinary optimal image, as score's own
+    // render target is.
+    Image src = makeImage(vk, Kind::PlainOptimal, W, H, modifiers);
+    if(!src.ok)
+    {
+      std::fprintf(stderr, "could not create a %ux%u source image\n", W, H);
+      continue;
+    }
+
+    char sizetxt[16];
+    std::snprintf(sizetxt, sizeof sizetxt, "%ux%u", W, H);
+    const double bytes = double(W) * H * 4;
+
+    for(const Kind kind :
+        {Kind::PlainOptimal, Kind::ExportLinearHost, Kind::ExportLinearLocal,
+         Kind::ExportOptimal, Kind::ExportModifier})
+    {
+      Image dst = makeImage(vk, kind, W, H, modifiers);
+      if(!dst.ok)
+      {
+        std::printf("%-30s %8s %10s\n", name(kind), sizetxt, "unsupported");
+        continue;
+      }
+
+      const double copyMs = timeCopies(vk, src.image, dst.image, W, H, iters);
+      const double clearMs = timeClears(vk, dst.image, iters);
+
+      char modtxt[32] = "-";
+      if(dst.modifier != UINT64_MAX)
+        std::snprintf(
+            modtxt, sizeof modtxt, "0x%llx", (unsigned long long)dst.modifier);
+
+      std::printf(
+          "%-30s %8s %10.3f %10.1f %10.3f %10.1f  %s\n", name(kind), sizetxt,
+          copyMs, bytes / (copyMs / 1000.) / 1e9, clearMs,
+          bytes / (clearMs / 1000.) / 1e9, modtxt);
+
+      destroy(vk, dst);
+    }
+    destroy(vk, src);
+    std::printf("\n");
+  }
+
+  vkDestroyCommandPool(vk.dev, vk.pool, nullptr);
+  vkDestroyDevice(vk.dev, nullptr);
+  vkDestroyInstance(vk.instance, nullptr);
+  return 0;
+}

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1001,3 +1001,8 @@ set_tests_properties(test_integration_threedim_render PROPERTIES
     "${CMAKE_CURRENT_BINARY_DIR}/golden-artifacts/threedim-render"
   REQUIRED_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/threedim-render/fetch-real-assets.sh")
+
+score_add_test(test_integration_port_value_restore
+  SOURCES PortValueRestoreTest.cpp
+  GUI
+  PLUGINS score_plugin_scenario score_lib_process score_plugin_media)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,5 +1,10 @@
 # Integration tests: full headless application + document lifecycle.
 
+# Every shell harness below spawns the real score binary and maps real windows.
+# Put them behind the same private X server score_add_test(GUI) uses, so they do
+# not land on the developer's session. Empty when SCORE_TESTS_XVFB is off.
+score_test_display_wrapper(_display_wrapper)
+
 # SCORE_HAS_SHELL_HARNESS is set once in cmake/ScoreTests.cmake so that
 # tests/hardware sees the same value.
 # These run from the build root so the dynamic plugins in <build>/plugins are
@@ -12,6 +17,13 @@ score_add_test(test_integration_document
 score_add_test(test_integration_roundtrip
   SOURCES DocumentRoundtripTest.cpp
   APP)
+
+# Skin files carry fonts as well as colours. Needs the GUI stack: the fonts
+# come from the application's Qt resources, and QFontDatabase needs a GUI app.
+score_add_test(test_integration_skin_fonts
+  SOURCES SkinFontsTest.cpp
+  GUI
+  PLUGINS score_plugin_scenario)
 
 # A process whose factory is not installed is dropped on load, with its
 # cables, silently. Asserting "the document opened" cannot see that, so this one
@@ -573,7 +585,7 @@ score_add_test(test_integration_nodal_viewport
 # Skips (77) without the binary or the out-of-repo tests-scene corpus.
 if(SCORE_HAS_SHELL_HARNESS)
   add_test(NAME test_frame_determinism
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/golden-render/frame-determinism.sh"
+    COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/golden-render/frame-determinism.sh"
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   set_tests_properties(test_frame_determinism PROPERTIES
     SKIP_RETURN_CODE 77
@@ -606,7 +618,7 @@ if(SCORE_HAS_SHELL_HARNESS)
     file(STRINGS "${_gr_cases_file}" _gr_cases REGEX "^[A-Za-z0-9_-]+$")
     foreach(_gr_case ${_gr_cases})
       add_test(NAME test_golden_render_${_gr_name}.${_gr_case}
-        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/golden-render/golden-render.sh"
+        COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/golden-render/golden-render.sh"
                 --backend ${_gr_backend} --cases ${_gr_case}
         WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
       set_tests_properties(test_golden_render_${_gr_name}.${_gr_case} PROPERTIES
@@ -796,7 +808,7 @@ foreach(sweep object_render_sweep:render-sweep.sh object_csf_sweep:csf-sweep.sh)
   list(GET _s 0 _sweep_name)
   list(GET _s 1 _sweep_script)
   add_test(NAME test_integration_${_sweep_name}
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/${_sweep_script}"
+    COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/${_sweep_script}"
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   set_tests_properties(test_integration_${_sweep_name} PROPERTIES
     SKIP_RETURN_CODE 77
@@ -843,7 +855,7 @@ if(SCORE_HAS_SHELL_HARNESS)
                    transport-storm mixed-chaos window-storm scene-storm
                    camera-storm ndi-storm)
     add_test(NAME test_live_edit.${_le_scen}
-      COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/live-edit-sweep.sh" ${_le_scen}
+      COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/live-edit-sweep.sh" ${_le_scen}
       WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
     set_tests_properties(test_live_edit.${_le_scen} PROPERTIES
       SKIP_RETURN_CODE 77
@@ -882,7 +894,7 @@ endif()
 # Deterministic-headless -> CI-able. Self-serializes on /tmp/score-harness.lock.
 if(SCORE_HAS_SHELL_HARNESS)
   add_test(NAME test_gfx_soak
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/gfx-soak/soak-leak.sh" 150
+    COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/gfx-soak/soak-leak.sh" 150
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   set_tests_properties(test_gfx_soak PROPERTIES
     SKIP_RETURN_CODE 77
@@ -899,7 +911,7 @@ endif()
 # Deterministic-headless -> CI-able. Self-serializes on /tmp/score-harness.lock.
 if(SCORE_HAS_SHELL_HARNESS)
   add_test(NAME test_timeline_scenario_ramp
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/timeline-scenarios/timeline-scenario.sh"
+    COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/timeline-scenarios/timeline-scenario.sh"
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   set_tests_properties(test_timeline_scenario_ramp PROPERTIES
     SKIP_RETURN_CODE 77
@@ -928,7 +940,7 @@ endif()
 # Self-serializes on /tmp/score-harness.lock; SKIPs (77) without deps.
 if(SCORE_HAS_SHELL_HARNESS)
   add_test(NAME test_text_render
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/text-render/text-render.sh"
+    COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/text-render/text-render.sh"
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   set_tests_properties(test_text_render PROPERTIES
     SKIP_RETURN_CODE 77
@@ -947,7 +959,7 @@ endif()
 # The script serializes itself on /tmp/score-harness.lock (global OSC port).
 if(SCORE_HAS_SHELL_HARNESS)
   add_test(NAME test_regression_offscreen_teardown
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/offscreen-teardown-regression.sh"
+    COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/offscreen-teardown-regression.sh"
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   set_tests_properties(test_regression_offscreen_teardown PROPERTIES
     SKIP_RETURN_CODE 77
@@ -969,7 +981,7 @@ endif()
 # on /tmp/score-harness.lock.
 if(SCORE_VIDEO_TESTER)
   add_test(NAME test_video_decode_correctness
-    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/video-decode-correctness.sh"
+    COMMAND ${_display_wrapper} "${CMAKE_CURRENT_SOURCE_DIR}/video-decode-correctness.sh"
     WORKING_DIRECTORY "${SCORE_ROOT_BINARY_DIR}")
   set_tests_properties(test_video_decode_correctness PROPERTIES
     SKIP_RETURN_CODE 77
@@ -1011,3 +1023,17 @@ score_add_test(test_integration_port_value_restore
   SOURCES PortValueRestoreTest.cpp
   GUI
   PLUGINS score_plugin_scenario score_lib_process score_plugin_media)
+
+# The shell harnesses register themselves with add_test() rather than through
+# score_add_test(), so they get none of its environment. Each starts a score
+# process that can be killed mid-document, which leaves the document in the
+# crash-recovery list the developer's next real session offers to restore: give
+# them a temp directory of their own so that list is not the one score reads.
+get_property(_integration_tests DIRECTORY PROPERTY TESTS)
+get_property(_score_registered GLOBAL PROPERTY SCORE_TEST_TARGET_REGISTRY)
+foreach(_t ${_integration_tests})
+  if(NOT "${_t}" IN_LIST _score_registered)
+    set_property(TEST ${_t} APPEND PROPERTY
+      ENVIRONMENT_MODIFICATION ${SCORE_TEST_HARNESS_ENVIRONMENT})
+  endif()
+endforeach()

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -410,6 +410,17 @@ if(TARGET score AND TARGET score_plugin_gfx AND NOT EMSCRIPTEN)
   score_add_test(test_integration_js_texture_source_ui
     SOURCES JsTextureSourceUiTest.cpp
     GUI)
+
+  # score's PipeWire video OUTPUT through the real application: a device, a
+  # process, playing, and a GStreamer consumer reading it. Pixels AND rate --
+  # the producer harness drives the node from its own timer, so it can say
+  # nothing about how fast the app itself feeds a consumer.
+  score_add_test(test_integration_pipewire_video_output
+    SOURCES PipewireVideoOutputTest.cpp
+    GUI
+    LIBS ${QT_PREFIX}::Gui)
+  set_tests_properties(test_integration_pipewire_video_output
+    PROPERTIES TIMEOUT 900 RUN_SERIAL TRUE)
   set_tests_properties(test_integration_js_texture_source_ui
     PROPERTIES TIMEOUT 900 RUN_SERIAL TRUE)
 
@@ -445,6 +456,7 @@ if(TARGET score AND TARGET score_plugin_gfx AND NOT EMSCRIPTEN)
                   test_integration_pipewire_video_motion
                   test_integration_js_graph_e2e
                   test_integration_js_texture_source_ui
+                  test_integration_pipewire_video_output
                   test_integration_gfx_protocol_settings)
     target_link_libraries(${_pw_tgt} PRIVATE ${QT_PREFIX}::Gui)
     target_compile_definitions(${_pw_tgt} PRIVATE

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -402,6 +402,17 @@ if(TARGET score AND TARGET score_plugin_gfx AND NOT EMSCRIPTEN)
     SOURCES JsGraphE2ETest.cpp
     NO_CTEST)
 
+  # Texture sources in a custom `--ui` QML interface: created, destroyed,
+  # hidden and shown while the document plays. Each one wires a preview node
+  # into the live GfxContext, so this is the path a mapping UI lives on.
+  # Runs under ctest (GUI: it needs a display, and skips saying so if the
+  # scene graph never rendered).
+  score_add_test(test_integration_js_texture_source_ui
+    SOURCES JsTextureSourceUiTest.cpp
+    GUI)
+  set_tests_properties(test_integration_js_texture_source_ui
+    PROPERTIES TIMEOUT 900 RUN_SERIAL TRUE)
+
   # The gfx protocol factories and their device-settings parsers, reached the
   # way a script reaches them: Score.availableProtocols() and
   # Score.createDevice(name, uuid, obj). No device is expected to connect and
@@ -433,6 +444,7 @@ if(TARGET score AND TARGET score_plugin_gfx AND NOT EMSCRIPTEN)
   foreach(_pw_tgt test_integration_pipewire_video_input
                   test_integration_pipewire_video_motion
                   test_integration_js_graph_e2e
+                  test_integration_js_texture_source_ui
                   test_integration_gfx_protocol_settings)
     target_link_libraries(${_pw_tgt} PRIVATE ${QT_PREFIX}::Gui)
     target_compile_definitions(${_pw_tgt} PRIVATE

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -533,6 +533,11 @@ score_add_test(test_integration_lost_mouse_grab
   GUI
   PLUGINS score_plugin_scenario score_lib_process score_plugin_fx)
 
+score_add_test(test_integration_interval_brace_drag
+  SOURCES IntervalBraceDragTest.cpp
+  GUI
+  PLUGINS score_plugin_scenario score_lib_process)
+
 # Fold state lives on the process so that it survives save/reload and follows a
 # preset dropped onto an open node.
 score_add_test(test_integration_process_fold_mode

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -670,6 +670,7 @@ endif()
 if(TARGET score AND TARGET score_plugin_gfx AND NOT EMSCRIPTEN)
   score_add_test(test_integration_frame_determinism
     SOURCES FrameDeterminismTest.cpp
+    GUI
     LIBS ${QT_PREFIX}::Gui)
   target_compile_definitions(test_integration_frame_determinism PRIVATE
     "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\""
@@ -688,6 +689,7 @@ endif()
 if(TARGET score AND TARGET score_plugin_gfx AND NOT EMSCRIPTEN)
   score_add_test(test_integration_gfx_nested_interval
     SOURCES GfxNestedIntervalTest.cpp
+    GUI
     LIBS ${QT_PREFIX}::Gui)
   target_compile_definitions(test_integration_gfx_nested_interval PRIVATE
     "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\""
@@ -704,6 +706,7 @@ if(TARGET score AND TARGET score_plugin_gfx AND TARGET score_plugin_threedim
    AND NOT EMSCRIPTEN)
   score_add_test(test_integration_gfx_light_live
     SOURCES GfxLightLiveTest.cpp
+    GUI
     LIBS ${QT_PREFIX}::Gui)
   target_compile_definitions(test_integration_gfx_light_live PRIVATE
     "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\"")
@@ -720,6 +723,7 @@ if(TARGET score AND TARGET score_plugin_gfx AND TARGET score_plugin_threedim
    AND NOT EMSCRIPTEN)
   score_add_test(test_integration_threedim_lit_scene
     SOURCES ThreedimLitSceneTest.cpp
+    GUI
     LIBS ${QT_PREFIX}::Gui)
   target_compile_definitions(test_integration_threedim_lit_scene PRIVATE
     "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\""
@@ -736,6 +740,7 @@ if(TARGET score AND TARGET score_plugin_gfx AND TARGET score_plugin_media
    AND NOT EMSCRIPTEN)
   score_add_test(test_integration_gfx_video_on_geometry
     SOURCES GfxVideoOnGeometryTest.cpp
+    GUI
     LIBS ${QT_PREFIX}::Gui)
   target_compile_definitions(test_integration_gfx_video_on_geometry PRIVATE
     "SCORE_APP_BINARY=\"$<TARGET_FILE:score>\""

--- a/tests/integration/FrameDeterminismTest.cpp
+++ b/tests/integration/FrameDeterminismTest.cpp
@@ -91,6 +91,12 @@ Grab render(const QTemporaryDir& dir, const QString& name, const QString& body)
   env.insert("SCORE_FORCE_OFFSCREEN_WINDOW", "Window");
   env.insert("SCORE_AUDIO_BACKEND", "dummy");
   env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  // Two of the checks below assert the ABSENCE of a warning in the child's
+  // log. The child's stderr is a pipe, and where Qt is built with journald
+  // support qDebug goes there instead: without this the log is empty and those
+  // checks pass no matter what the child printed.
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
 
   QProcess p;
   p.setProcessEnvironment(env);

--- a/tests/integration/GfxVideoOnGeometryTest.cpp
+++ b/tests/integration/GfxVideoOnGeometryTest.cpp
@@ -545,6 +545,13 @@ TEST_CASE(
   if(!ready())
     SKIP("needs the score binary, the gfx corpus, ffmpeg and a display");
 
+  // The verdict is that the geometry leg advances at the decoder's rate. On a
+  // software rasteriser it cannot: the render takes three times as long and
+  // the geometry leg falls ten frames behind a decoder that does not slow down
+  // with it. That is a property of llvmpipe, not of the code under test.
+  if(qEnvironmentVariableIsSet("SCORE_TESTS_SOFTWARE_GL"))
+    SKIP("the geometry leg cannot keep the decoder's rate on software OpenGL");
+
   QTemporaryDir dir;
   REQUIRE(dir.isValid());
   if(qEnvironmentVariableIsSet("SCORE_TEST_KEEP_ARTIFACTS"))

--- a/tests/integration/IntervalBraceDragTest.cpp
+++ b/tests/integration/IntervalBraceDragTest.cpp
@@ -1,0 +1,145 @@
+// Regression for Interval.rood11 in timemodel-patterns.score: snapping a
+// duration as a scenario date jumped Min past the interval on the first move,
+// then subsequent command updates clamped it to the endpoint.
+
+#include <Scenario/Commands/Interval/SetMaxDuration.hpp>
+#include <Scenario/Commands/Interval/SetMinDuration.hpp>
+#include <Scenario/Commands/Scenario/Creations/CreateInterval_State_Event_TimeSync.hpp>
+#include <Scenario/Commands/Scenario/Creations/CreateTimeSync_Event_State.hpp>
+#include <Scenario/Document/Interval/IntervalPresenter.hpp>
+#include <Scenario/Document/Interval/Temporal/Braces/LeftBrace.hpp>
+#include <Scenario/Document/Interval/Temporal/TemporalIntervalPresenter.hpp>
+#include <Scenario/Document/Interval/Temporal/TemporalIntervalView.hpp>
+#include <Scenario/Document/ScenarioDocument/ScenarioDocumentModel.hpp>
+#include <Scenario/Document/ScenarioDocument/ScenarioDocumentPresenter.hpp>
+#include <Scenario/Document/ScenarioDocument/ScenarioDocumentView.hpp>
+#include <Scenario/Process/ScenarioModel.hpp>
+#include <Scenario/Settings/ScenarioSettingsModel.hpp>
+
+#include <score/command/Dispatchers/CommandDispatcher.hpp>
+#include <score/document/DocumentInterface.hpp>
+
+#include <core/command/CommandStack.hpp>
+
+#include <QGraphicsSceneMouseEvent>
+
+#include <catch2/catch_test_macros.hpp>
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+TEST_CASE("Minimum brace follows a small leftward drag", "[integration][scenario][gui]")
+{
+  score::test::run_in_gui_app([](const score::GUIApplicationContext& ctx) {
+    auto& settings = ctx.settings<Scenario::Settings::Model>();
+    settings.setMeasureBars(true);
+    settings.setMagneticMeasures(true);
+    auto* source = score::test::new_document(ctx);
+    REQUIRE(source);
+    auto& root
+        = static_cast<Scenario::ScenarioDocumentModel&>(source->model().modelDelegate())
+              .baseInterval();
+    auto& scenario = static_cast<Scenario::ProcessModel&>(*root.processes.begin());
+    CommandDispatcher<> dispatcher{source->context().commandStack};
+    auto* createStart = new Scenario::Command::CreateTimeSync_Event_State{
+        scenario, TimeVal::fromMsecs(20750), 0.5};
+    dispatcher.submit(createStart);
+    auto* createInterval = new Scenario::Command::CreateInterval_State_Event_TimeSync{
+        scenario, createStart->createdState(), TimeVal::fromMsecs(23750), 0.5, false};
+    dispatcher.submit(createInterval);
+    auto& created = scenario.intervals.at(createInterval->createdInterval());
+    created.metadata().setName(QStringLiteral("brace-drag"));
+    created.duration.setRigid(false);
+    created.duration.setMaxInfinite(true);
+
+    // Reproduce a scrolled musical timeline: the interval duration is outside
+    // the visible grid, but its scenario-relative endpoint is inside it.
+    root.duration.setDefaultDuration(TimeVal::fromMsecs(30000));
+    root.duration.setGuiDuration(TimeVal::fromMsecs(36000));
+    root.setHasTimeSignature(true);
+    root.addSignature(TimeVal::zero(), {4, 4});
+    root.setZoom(TimeVal::fromMsecs(10).impl);
+    root.setMidTime(TimeVal::fromMsecs(21500));
+    auto* doc = score::test::reload_via_bytes(ctx, *source);
+    REQUIRE(doc);
+    ctx.docManager.forceCloseDocument(ctx, *source);
+    QApplication::processEvents();
+    QApplication::processEvents();
+    auto* presenter
+        = score::IDocument::try_presenterDelegate<Scenario::ScenarioDocumentPresenter>(
+            *doc);
+    REQUIRE(presenter);
+    auto& scene = presenter->view().scene();
+    Scenario::TemporalIntervalView* interval = nullptr;
+    for(auto* item : scene.items())
+    {
+      if(auto* view = dynamic_cast<Scenario::TemporalIntervalView*>(item);
+         view
+         && view->presenter().model().metadata().getName()
+                == QStringLiteral("brace-drag"))
+        interval = view;
+    }
+    REQUIRE(interval);
+    auto& brace = interval->leftBrace();
+    REQUIRE(brace.isVisible());
+    auto& model = interval->presenter().model();
+    const auto initial = model.duration.minDuration();
+    const auto start = brace.mapToScene(QPointF{5., 8.});
+    auto send = [&](QEvent::Type type, QPointF at, QPointF last, Qt::MouseButton button,
+                    Qt::MouseButtons buttons) {
+      QGraphicsSceneMouseEvent ev{type};
+      ev.setScenePos(at);
+      ev.setLastScenePos(last);
+      ev.setButtonDownScenePos(Qt::LeftButton, start);
+      ev.setScreenPos(QPoint{700, 400});
+      ev.setLastScreenPos(QPoint{701, 400});
+      ev.setButtonDownScreenPos(Qt::LeftButton, QPoint{701, 400});
+      ev.setButton(button);
+      ev.setButtons(buttons);
+      QCoreApplication::sendEvent(&scene, &ev);
+      QApplication::processEvents();
+      QApplication::processEvents();
+    };
+    send(QEvent::GraphicsSceneMousePress, start, start, Qt::LeftButton, Qt::LeftButton);
+    REQUIRE(scene.mouseGrabberItem() == &brace);
+    auto dest = start - QPointF{2., 0.};
+    send(QEvent::GraphicsSceneMouseMove, dest, start, Qt::NoButton, Qt::LeftButton);
+    INFO("initial " << initial.impl << " dragged " << model.duration.minDuration().impl);
+    CHECK(model.duration.minDuration() <= initial);
+    CHECK(model.duration.minDuration() >= TimeVal::zero());
+    // Aim the endpoint at 22 s, not the duration at a beat relative to zero.
+    const auto further
+        = start
+          - QPointF{
+              TimeVal::fromMsecs(1750).toPixelsRaw(interval->presenter().zoomRatio()),
+              0.};
+    send(QEvent::GraphicsSceneMouseMove, further, dest, Qt::NoButton, Qt::LeftButton);
+    CHECK(model.duration.minDuration() == TimeVal::fromMsecs(1250));
+    const auto finalDuration = model.duration.minDuration();
+    send(
+        QEvent::GraphicsSceneMouseRelease, further, further, Qt::LeftButton,
+        Qt::NoButton);
+    doc->commandStack().undo();
+    CHECK(model.duration.minDuration() == initial);
+    doc->commandStack().redo();
+    CHECK(model.duration.minDuration() == finalDuration);
+
+    // The first submission uses the constructor; later ones use update().
+    // Both must respect the same bounds and remain undoable.
+    Scenario::Command::SetMinDuration belowZero{model, TimeVal::fromMsecs(-1000), false};
+    belowZero.redo(doc->context());
+    CHECK(model.duration.minDuration() == TimeVal::zero());
+    belowZero.undo(doc->context());
+    CHECK(model.duration.minDuration() == finalDuration);
+    Scenario::Command::SetMinDuration aboveDefault{
+        model, TimeVal::fromMsecs(10000), false};
+    aboveDefault.redo(doc->context());
+    CHECK(model.duration.minDuration() == model.duration.defaultDuration());
+    aboveDefault.undo(doc->context());
+    CHECK(model.duration.minDuration() == finalDuration);
+    Scenario::Command::SetMaxDuration belowDefault{model, TimeVal::zero(), false};
+    belowDefault.redo(doc->context());
+    CHECK(model.duration.maxDuration() == model.duration.defaultDuration());
+    belowDefault.undo(doc->context());
+    CHECK(model.duration.isMaxInfinite());
+  });
+}

--- a/tests/integration/JsScriptingApiTest.cpp
+++ b/tests/integration/JsScriptingApiTest.cpp
@@ -49,6 +49,11 @@ Run runScript(const QString& js)
   QProcess p;
   auto env = QProcessEnvironment::systemEnvironment();
   env.insert("ASAN_OPTIONS", "detect_leaks=0:detect_odr_violation=0");
+  // Every verdict here is read out of the child's log, and the child's stderr
+  // is a pipe: where Qt is built with journald support it logs there instead,
+  // qDebug never reaches this process, and the checks all read an empty string.
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
   p.setProcessEnvironment(env);
   p.setProcessChannelMode(QProcess::MergedChannels);
   p.start(appBinary(), {"--no-gui", "--no-restore", "--script", js, "--wait", "0"});

--- a/tests/integration/JsTextureSourceUiTest.cpp
+++ b/tests/integration/JsTextureSourceUiTest.cpp
@@ -1,0 +1,357 @@
+// Texture sources in a custom UI: created, destroyed, hidden and shown again
+// while the document plays.
+//
+// `score --ui foo.qml` replaces the editor with a QML interface, and that
+// interface shows what a process renders through Score.UI's TextureSource.
+// Each one puts a preview node into the document's GfxContext and wires the
+// process's texture outlet to it; each one taken away has to undo exactly that
+// and nothing else. Both halves run while the graph is live, so a mistake
+// there is not a wrong picture, it is the whole render going down.
+//
+// Two properties, both read off SCORE_GFX_TRACE:
+//
+//   * every texture source that appears connects -- one GFX-ADDEDGE per
+//     source, to a sink nobody else is using;
+//   * and costs ONE render list. A graph rebuild would rebuild the render list
+//     of everything already running, so N sources appearing one at a time
+//     would print O(N^2) creations instead of N, and the window that was
+//     already rendering would blink on each one.
+//
+// Needs a real display: the offscreen platform never runs the Qt Quick scene
+// graph, so a TextureSource is constructed and its renderer never is. The case
+// says so and skips rather than passing on an empty log.
+
+#include <QByteArray>
+#include <QFile>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QString>
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+QString appBinary()
+{
+#if defined(SCORE_APP_BINARY)
+  return QStringLiteral(SCORE_APP_BINARY);
+#else
+  return {};
+#endif
+}
+
+QString corpusDir()
+{
+#if defined(GFX_TEST_CORPUS_DIR)
+  return QStringLiteral(GFX_TEST_CORPUS_DIR);
+#else
+  return {};
+#endif
+}
+
+//! The ISF filter process is named so a TextureSource can find it: the item
+//! resolves its `process` property against every process's label and name.
+const char* kProcessName = "tex";
+
+struct Run
+{
+  int exitCode{-1};
+  bool crashed{true};
+  QString log;
+};
+
+QString write(const QTemporaryDir& dir, const QString& name, const QString& body)
+{
+  const QString path = dir.filePath(name);
+  QFile f{path};
+  REQUIRE(f.open(QIODevice::WriteOnly));
+  f.write(body.toUtf8());
+  f.close();
+  return path;
+}
+
+//! Builds the document the UI then looks at: one self-contained ISF generator
+//! on the root interval, its texture outlet addressed to an offscreen window
+//! device, playing. It deliberately does NOT exit -- the UI drives the run and
+//! calls Qt.exit() when it is done.
+QString sceneScript()
+{
+  QString src;
+  src += "var UUID_ISF = \"74ca45ff-92c9-44a0-8f1a-754dea05ee1b\";\n";
+  src += "var UUID_WINDOW = \"5a181207-7d40-4ad8-814e-879fcdf8cc31\";\n";
+  src += "Score.createDevice(\"Window\", UUID_WINDOW, {});\n";
+  src += "var s = Score.find(\"Scenario.1\"); if (s) Score.remove(s);\n";
+  src += "var root = Score.rootInterval();\n";
+  src += "var flt = Score.createProcess(root, UUID_ISF, \"" + corpusDir()
+         + "/isf-gradient-x.fs\");\n";
+  src += "if (!flt) { console.log(\"SCENE-ERROR: no filter\"); Qt.exit(9); }\n";
+  src += QStringLiteral("Score.setName(flt, \"%1\");\n").arg(kProcessName);
+  src += "Score.setAddress(Score.outlet(flt, 0), \"Window:/\");\n";
+  src += "Score.play();\n";
+  src += "console.log(\"SCENE-OK\");\n";
+  return src;
+}
+
+//! The part every UI in this file shares: the component, the two helpers and
+//! the step timer. `body` is the switch over `k`, the step within a cycle.
+QString uiFile(const QString& body)
+{
+  QString qml;
+  qml += "import QtQuick\n";
+  qml += "import Score.UI\n";
+  qml += "Item {\n";
+  qml += "  id: root\n";
+  qml += "  width: 400; height: 200\n";
+  qml += "  property var live: []\n";
+  qml += "  property int step: 0\n";
+  qml += "  property int cycle: 0\n";
+  qml += "  Component { id: texComp; TextureSource {\n";
+  qml += "    width: 64; height: 48\n";
+  qml += QStringLiteral("    process: \"%1\"; port: 0\n").arg(kProcessName);
+  qml += "  } }\n";
+  qml += "  function spawn(n) {\n";
+  qml += "    for(var i = 0; i < n; i++)\n";
+  qml += "      root.live.push(texComp.createObject(root, {x: 4 + i*70, y: 4}))\n";
+  qml += "    console.log(\"UI-SPAWNED \" + n)\n";
+  qml += "  }\n";
+  qml += "  function killAll() {\n";
+  qml += "    for(var i = 0; i < root.live.length; i++) root.live[i].destroy()\n";
+  qml += "    root.live = []\n";
+  qml += "    console.log(\"UI-KILLED\")\n";
+  qml += "  }\n";
+  qml += "  function setVisible(v) {\n";
+  qml += "    for(var i = 0; i < root.live.length; i++) root.live[i].visible = v\n";
+  qml += "    console.log(v ? \"UI-SHOWN\" : \"UI-HIDDEN\")\n";
+  qml += "  }\n";
+  qml += "  Timer {\n";
+  qml += "    interval: 400; running: true; repeat: true\n";
+  qml += "    onTriggered: {\n";
+  // The first steps are the document's: the script has to have built the
+  // scene and started playing before a TextureSource can resolve anything.
+  qml += "      root.step++\n";
+  qml += "      if(root.step < 4) return\n";
+  qml += "      var k = (root.step - 4) % 3\n";
+  qml += body;
+  qml += "    }\n";
+  qml += "  }\n";
+  qml += "}\n";
+  return qml;
+}
+
+Run runUi(const QString& qml, const QString& js)
+{
+  auto env = QProcessEnvironment::systemEnvironment();
+  // The window output must not map a real window: this is about the graph, and
+  // a mapped window on a shared desktop is a nuisance either way.
+  env.insert("SCORE_FORCE_OFFSCREEN_WINDOW", "Window");
+  env.insert("SCORE_AUDIO_BACKEND", "dummy");
+  env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  env.insert("SCORE_GFX_TRACE", "1");
+  // Every verdict is read out of the child's log, and a process with no
+  // console can otherwise route qDebug somewhere this pipe never sees.
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
+
+  QProcess p;
+  p.setProcessEnvironment(env);
+  p.setProcessChannelMode(QProcess::MergedChannels);
+  p.start(
+      appBinary(),
+      {"--no-gui", "--no-restore", "--wait", "0", "--ui", qml, "--script", js});
+
+  Run r;
+  if(!p.waitForStarted(30000) || !p.waitForFinished(180000))
+  {
+    p.kill();
+    p.waitForFinished(5000);
+    r.log = QString::fromUtf8(p.readAll());
+    return r;
+  }
+  r.log = QString::fromUtf8(p.readAll());
+  r.crashed = p.exitStatus() != QProcess::NormalExit;
+  r.exitCode = p.exitCode();
+  return r;
+}
+
+//! Byte offsets of every occurrence of `needle`.
+std::vector<qsizetype> offsetsOf(const QString& log, const QString& needle)
+{
+  std::vector<qsizetype> r;
+  for(auto pos = log.indexOf(needle); pos >= 0; pos = log.indexOf(needle, pos + 1))
+    r.push_back(pos);
+  return r;
+}
+
+//! How many `needle` fall in [from, to).
+int countBetween(
+    const QString& log, const QString& needle, qsizetype from, qsizetype to)
+{
+  int n = 0;
+  for(auto off : offsetsOf(log, needle))
+    if(off >= from && off < to)
+      n++;
+  return n;
+}
+
+constexpr auto kRenderList = "GFX-RENDERLIST created";
+constexpr auto kSpawned = "UI-SPAWNED";
+constexpr auto kKilled = "UI-KILLED";
+
+void requireDisplay()
+{
+  REQUIRE_FALSE(appBinary().isEmpty());
+  REQUIRE(QFile::exists(appBinary()));
+  REQUIRE(QFile::exists(corpusDir() + "/isf-gradient-x.fs"));
+}
+
+//! A run whose graph never came up at all is an environment verdict, not a
+//! failure: say which and skip. A graph that came up and then failed to
+//! connect a preview is a real failure and must NOT land here.
+bool graphCameUp(const Run& r)
+{
+  return r.log.contains(kRenderList);
+}
+}
+
+TEST_CASE(
+    "a custom UI adds and removes texture sources while playing",
+    "[integration][gfx][js][ui]")
+{
+  requireDisplay();
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  // Three cycles of: spawn two, wait, destroy both.
+  QString body;
+  body += "      if(k === 0) {\n";
+  body += "        root.cycle++\n";
+  body += "        if(root.cycle > 3) { console.log(\"UI-DONE\"); Qt.exit(0); return }\n";
+  body += "        root.spawn(2)\n";
+  body += "      }\n";
+  body += "      else if(k === 2) root.killAll()\n";
+
+  const QString qml = write(dir, "sources.qml", uiFile(body));
+  const QString js = write(dir, "scene.js", sceneScript());
+  const auto r = runUi(qml, js);
+
+  INFO(r.log.toStdString());
+  CHECK_FALSE(r.crashed);
+  CHECK(r.exitCode == 0);
+  REQUIRE(r.log.contains("SCENE-OK"));
+
+  if(!graphCameUp(r))
+    SKIP("the render graph never came up: this run had no usable GPU or display");
+
+  REQUIRE(r.log.contains("UI-DONE"));
+
+  const auto spawns = offsetsOf(r.log, kSpawned);
+  const auto kills = offsetsOf(r.log, kKilled);
+  REQUIRE(spawns.size() == 3);
+  REQUIRE(kills.size() == 3);
+
+  // The scene graph has to have run: without it a TextureSource is built and
+  // its renderer, which is what registers the preview, never is.
+  if(countBetween(r.log, "GFX-ADDEDGE ok", spawns[0], kills[0]) == 0)
+    SKIP("no preview connected: the Qt Quick scene graph never rendered");
+
+  for(std::size_t i = 0; i < spawns.size(); i++)
+  {
+    INFO("cycle " << i);
+
+    // Two sources appeared, so two edges into the graph...
+    CHECK(countBetween(r.log, "GFX-ADDEDGE ok", spawns[i], kills[i]) == 2);
+
+    // ...and two render lists, one each. This is the whole point: a rebuild
+    // would recreate the render list of the window that is already rendering,
+    // and of every preview already up, so this number would climb with the
+    // cycle instead of staying at two.
+    CHECK(countBetween(r.log, kRenderList, spawns[i], kills[i]) == 2);
+  }
+}
+
+// The pin for a crash on the way out: the three connections TextureSource
+// makes in its constructor are all from itself to itself, and ~QQuickItem
+// emits windowChanged(nullptr) AFTER ~TextureSource has run. Qt then called
+// handleWindowChanged on a half-destroyed object and aborted with "Called
+// object is not of the correct type (class destructor may have already run)".
+// Destroying a TextureSource from QML, which is how a custom UI removes one,
+// did that every single time.
+TEST_CASE(
+    "destroying a texture source does not abort the application",
+    "[integration][gfx][js][ui]")
+{
+  requireDisplay();
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  QString body;
+  body += "      if(k === 0) {\n";
+  body += "        root.cycle++\n";
+  body += "        if(root.cycle > 1) { console.log(\"UI-DONE\"); Qt.exit(0); return }\n";
+  body += "        root.spawn(1)\n";
+  body += "      }\n";
+  body += "      else if(k === 2) root.killAll()\n";
+
+  const QString qml = write(dir, "one.qml", uiFile(body));
+  const QString js = write(dir, "scene.js", sceneScript());
+  const auto r = runUi(qml, js);
+
+  INFO(r.log.toStdString());
+  REQUIRE(r.log.contains(kKilled));
+  CHECK_FALSE(r.log.contains("class destructor may have already run"));
+  CHECK_FALSE(r.crashed);
+  CHECK(r.exitCode == 0);
+  CHECK(r.log.contains("UI-DONE"));
+}
+
+TEST_CASE(
+    "hiding and showing a texture source leaves the graph alone",
+    "[integration][gfx][js][ui]")
+{
+  requireDisplay();
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  // spawn two, hide, show, hide, show, destroy.
+  QString body;
+  body += "      if(root.step === 4) root.spawn(2)\n";
+  body += "      else if(root.step === 7) root.setVisible(false)\n";
+  body += "      else if(root.step === 10) root.setVisible(true)\n";
+  body += "      else if(root.step === 13) root.setVisible(false)\n";
+  body += "      else if(root.step === 16) root.setVisible(true)\n";
+  body += "      else if(root.step === 19) root.killAll()\n";
+  body += "      else if(root.step === 21) { console.log(\"UI-DONE\"); Qt.exit(0) }\n";
+
+  const QString qml = write(dir, "visible.qml", uiFile(body));
+  const QString js = write(dir, "scene.js", sceneScript());
+  const auto r = runUi(qml, js);
+
+  INFO(r.log.toStdString());
+  CHECK_FALSE(r.crashed);
+  CHECK(r.exitCode == 0);
+  REQUIRE(r.log.contains("SCENE-OK"));
+
+  if(!graphCameUp(r))
+    SKIP("the render graph never came up: this run had no usable GPU or display");
+
+  REQUIRE(r.log.contains("UI-DONE"));
+
+  const auto spawns = offsetsOf(r.log, kSpawned);
+  const auto kills = offsetsOf(r.log, kKilled);
+  REQUIRE(spawns.size() == 1);
+  REQUIRE(kills.size() == 1);
+
+  if(countBetween(r.log, "GFX-ADDEDGE ok", spawns[0], kills[0]) == 0)
+    SKIP("no preview connected: the Qt Quick scene graph never rendered");
+
+  // Four visibility flips, and not one render list built between the last
+  // source appearing and them all going away: hiding an item must not take
+  // its preview out of the graph and put it back.
+  CHECK(r.log.count("UI-HIDDEN") == 2);
+  CHECK(r.log.count("UI-SHOWN") == 2);
+  CHECK(countBetween(r.log, kRenderList, spawns[0], kills[0]) == 2);
+}

--- a/tests/integration/NodalPlacementTest.cpp
+++ b/tests/integration/NodalPlacementTest.cpp
@@ -41,6 +41,7 @@
 #include <QGraphicsRectItem>
 #include <QGraphicsScene>
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 namespace
@@ -156,6 +157,62 @@ TEST_CASE("Automatic node positions never overlap", "[integration][nodal][gui]")
                 << " at " << b.position().x() << "," << b.position().y());
             CHECK(!nodeRect(a).intersects(nodeRect(b)));
           }
+    }
+
+    // A node added at the head of a chain used to slide right past every
+    // process it overlapped, one after the other, and land beyond the far end
+    // of the chain: "most of the time it puts the objects very far".
+    SECTION("a node chained after the head of a chain stays next to its source")
+    {
+      std::vector<Process::ProcessModel*> chain;
+      double x = 400.;
+      for(int i = 0; i < 5; i++)
+      {
+        auto p = createProcess(*doc, itv, automationData(), QPointF{x, 400.});
+        REQUIRE(p);
+        p->setSize({200., 80.});
+        chain.push_back(p);
+        x += 240.;
+      }
+
+      const auto pos = Scenario::newProcessPositionAfter(itv, *chain.front());
+
+      // Just past its own source, not past the tail of what follows it.
+      CHECK(pos.x() == Catch::Approx(400. + 200. + Scenario::nodeHorizontalMargin));
+      CHECK(pos.x() < chain.back()->position().x());
+
+      // ... and still on top of nothing.
+      for(const Process::ProcessModel& p : itv.processes)
+      {
+        INFO("against a node at " << p.position().x() << "," << p.position().y());
+        CHECK(!QRectF(pos, Scenario::nodeFootprint(*chain.front()))
+                   .intersects(nodeRect(p)));
+      }
+    }
+
+    SECTION("a node chained before the tail of a chain stays next to its source")
+    {
+      std::vector<Process::ProcessModel*> chain;
+      double x = 400.;
+      for(int i = 0; i < 5; i++)
+      {
+        auto p = createProcess(*doc, itv, automationData(), QPointF{x, 400.});
+        REQUIRE(p);
+        p->setSize({200., 80.});
+        chain.push_back(p);
+        x += 240.;
+      }
+
+      auto created = createProcess(*doc, itv, automationData(), QPointF{5000., 5000.});
+      REQUIRE(created);
+      created->setSize({200., 80.});
+
+      const auto pos
+          = Scenario::newProcessPositionBefore(itv, *chain.back(), created);
+      CHECK(pos.x() == Catch::Approx(
+                           chain.back()->position().x() - 200.
+                           - Scenario::nodeHorizontalMargin));
+      CHECK(pos.x() > chain.front()->position().x());
     }
 
     SECTION("a node chained before another one clears it on the left")

--- a/tests/integration/PipewireVideoInputTest.cpp
+++ b/tests/integration/PipewireVideoInputTest.cpp
@@ -150,6 +150,11 @@ Run run(const QTemporaryDir& dir, const QString& node, const QString& request)
   env.insert("SCORE_FORCE_OFFSCREEN_WINDOW", "Window");
   env.insert("SCORE_AUDIO_BACKEND", "dummy");
   env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  // Every verdict here is read out of the child's log, and the child's stderr
+  // is a pipe: where Qt is built with journald support it logs there instead,
+  // qDebug never reaches this process, and the checks all read an empty string.
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
 
   QProcess p;
   p.setProcessEnvironment(env);

--- a/tests/integration/PipewireVideoMotionTest.cpp
+++ b/tests/integration/PipewireVideoMotionTest.cpp
@@ -170,6 +170,11 @@ Run runScore(const QTemporaryDir& dir, const QString& name, const QString& src)
   env.insert("SCORE_FORCE_OFFSCREEN_WINDOW", "Window,WindowA,WindowB");
   env.insert("SCORE_AUDIO_BACKEND", "dummy");
   env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+  // Every verdict here is read out of the child's log, and the child's stderr
+  // is a pipe: where Qt is built with journald support it logs there instead,
+  // qDebug never reaches this process, and the checks all read an empty string.
+  env.insert("QT_FORCE_STDERR_LOGGING", "1");
+  env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
   // Pick the backend rather than inheriting whatever the developer last saved
   // in the settings. Not offscreen: QT_QPA_PLATFORM=offscreen resolves to the
   // Null RHI, which writes a stable, reproducible, wrong picture.

--- a/tests/integration/PipewireVideoOutputTest.cpp
+++ b/tests/integration/PipewireVideoOutputTest.cpp
@@ -1,0 +1,486 @@
+// score's PipeWire video OUTPUT, driven the way a user drives it: the real
+// application, a real device, playing, with an outside consumer attached.
+//
+// The harness in src/plugins/score-plugin-gfx/tests/PipewireRoundtrip.cpp
+// covers the producer, but it drives the output node from a QTimer of its own.
+// Everything about pacing therefore comes from the harness rather than from the
+// application, which is exactly what an OBS session complains about. This one
+// starts `ossia-score --script`, lets the graphics context clock the node, and
+// measures what a GStreamer consumer actually receives:
+//
+//   * the pixels: an ISF gradient, dark on the left and bright on the right, so
+//     a frame that arrives blank, torn, or mirrored is not a pass;
+//   * the rate: frames per second against the rate the device asked for. A
+//     consumer that receives correct frames at a tenth of the requested rate is
+//     the bug this file exists for, and it cannot be seen by a pixel check.
+//
+// Needs a PipeWire session, gst-launch-1.0 and a real display. Skips saying
+// which is missing rather than passing on nothing.
+
+#include <QByteArray>
+#include <QElapsedTimer>
+#include <QFile>
+#include <QImage>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QSet>
+#include <QTemporaryDir>
+#include <QThread>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <optional>
+
+namespace
+{
+QString appBinary()
+{
+#if defined(SCORE_APP_BINARY)
+  return QStringLiteral(SCORE_APP_BINARY);
+#else
+  return {};
+#endif
+}
+
+QString corpusDir()
+{
+#if defined(GFX_TEST_CORPUS_DIR)
+  return QStringLiteral(GFX_TEST_CORPUS_DIR);
+#else
+  return {};
+#endif
+}
+
+bool haveTool(const QString& tool, const QStringList& args = {"--version"})
+{
+  QProcess p;
+  p.start(tool, args);
+  return p.waitForFinished(5000) && p.exitCode() == 0;
+}
+
+//! The requested geometry and rate. Small enough to be cheap, big enough that a
+//! per-frame copy of it is not free.
+constexpr int kWidth = 640;
+constexpr int kHeight = 360;
+constexpr double kRate = 60.;
+
+QString write(const QTemporaryDir& dir, const QString& name, const QString& body)
+{
+  const QString path = dir.filePath(name);
+  QFile f{path};
+  REQUIRE(f.open(QIODevice::WriteOnly));
+  f.write(body.toUtf8());
+  f.close();
+  return path;
+}
+
+//! Builds the document: one ISF gradient on the root interval, addressed to a
+//! PipeWire output device, playing. It never exits -- the test kills the child.
+QString sceneScript(
+    const QString& nodeName, bool dmabuf, const char* shader = "isf-gradient-x.fs",
+    int w = kWidth, int h = kHeight)
+{
+  QString path = nodeName + "?format=rgba";
+  if(dmabuf)
+    path += "&dmabuf=on";
+
+  QString src;
+  src += "var UUID_ISF = \"74ca45ff-92c9-44a0-8f1a-754dea05ee1b\";\n";
+  src += "var UUID_PWOUT = \"d5e7b22b-b7f6-4680-9610-2457509b7946\";\n";
+  // The keys are the settings' own JSON names, not the C++ members: "Path",
+  // "Width", "Height", "Rate". Getting them wrong is silent -- the device comes
+  // up at 1x1 and publishes four-byte frames.
+  src += QStringLiteral(
+             "Score.createDevice(\"PWOut\", UUID_PWOUT, {\"Path\": \"%1\", "
+             "\"Width\": %2, \"Height\": %3, \"Rate\": %4});\n")
+             .arg(path)
+             .arg(w)
+             .arg(h)
+             .arg(kRate);
+  src += "var s = Score.find(\"Scenario.1\"); if (s) Score.remove(s);\n";
+  src += "var root = Score.rootInterval();\n";
+  src += "var flt = Score.createProcess(root, UUID_ISF, \"" + corpusDir() + "/"
+         + QString::fromUtf8(shader) + "\");\n";
+  src += "if (!flt) { console.log(\"SCENE-ERROR: no filter\"); Qt.exit(9); }\n";
+  src += "Score.setAddress(Score.outlet(flt, 0), \"PWOut:/\");\n";
+  src += "Score.play();\n";
+  src += "console.log(\"SCENE-OK\");\n";
+  return src;
+}
+
+//! The publishing application, kept alive for the length of a measurement.
+struct Publisher
+{
+  QProcess proc;
+  QString log;
+
+  void start(const QString& js)
+  {
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert("SCORE_AUDIO_BACKEND", "dummy");
+    env.insert("SCORE_DISABLE_AUDIOPLUGINS", "1");
+    env.insert("QT_FORCE_STDERR_LOGGING", "1");
+    env.insert("QT_ASSUME_STDERR_HAS_CONSOLE", "1");
+    proc.setProcessEnvironment(env);
+    proc.setProcessChannelMode(QProcess::MergedChannels);
+    proc.start(
+        appBinary(), {"--no-gui", "--no-restore", "--wait", "0", "--script", js});
+  }
+
+  ~Publisher()
+  {
+    if(proc.state() != QProcess::NotRunning)
+    {
+      proc.terminate();
+      if(!proc.waitForFinished(5000))
+        proc.kill();
+      proc.waitForFinished(2000);
+    }
+    log += QString::fromUtf8(proc.readAll());
+  }
+};
+
+//! object.serial of the (single) live node with this name, or -1. The serial,
+//! not the id: ids are recycled and a stale one resolves to somebody else.
+int64_t nodeSerial(const QString& name)
+{
+  QProcess dump;
+  dump.start("pw-dump", {});
+  if(!dump.waitForFinished(6000))
+    return -1;
+  const auto doc = QJsonDocument::fromJson(dump.readAllStandardOutput());
+  if(!doc.isArray())
+    return -1;
+
+  int64_t serial = -1;
+  for(const auto& v : doc.array())
+  {
+    const auto o = v.toObject();
+    if(o.value("type").toString() != "PipeWire:Interface:Node")
+      continue;
+    const auto props = o.value("info").toObject().value("props").toObject();
+    if(props.value("node.name").toString() != name)
+      continue;
+    serial = std::max<int64_t>(serial, props.value("object.serial").toInteger(-1));
+  }
+  return serial;
+}
+
+//! Wait for the application to publish, then return its serial.
+int64_t waitForNode(const QString& name, int timeoutMs)
+{
+  QElapsedTimer t;
+  t.start();
+  while(t.elapsed() < timeoutMs)
+  {
+    if(const auto s = nodeSerial(name); s >= 0)
+      return s;
+    QThread::msleep(250);
+  }
+  return -1;
+}
+
+struct Capture
+{
+  int frames{};
+  int distinct{};
+  double seconds{};
+  QStringList files;
+  QString log;
+
+  double fps() const { return seconds > 0. ? frames / seconds : 0.; }
+  double distinctFps() const { return seconds > 0. ? distinct / seconds : 0.; }
+};
+
+//! Read `count` buffers off the node and write them as PNGs. The wall time
+//! covers only the buffers, not the pipeline setup: num-buffers makes
+//! gst-launch exit as soon as it has them.
+Capture capture(
+    int64_t serial, int count, const QTemporaryDir& dir, const QString& stem,
+    bool dmabuf)
+{
+  Capture c;
+  QStringList args{
+      "pipewiresrc", QStringLiteral("target-object=%1").arg(serial),
+      QStringLiteral("num-buffers=%1").arg(count)};
+  if(dmabuf)
+  {
+    // Ask for DMA-BUF memory explicitly, so the pipeline fails to negotiate
+    // rather than quietly falling back to a copy -- that is the whole point of
+    // the case. videoconvert cannot read that memory, so the frame comes back
+    // through GL: upload the imported buffer, download it to host memory, and
+    // only then convert.
+    args << "!" << "video/x-raw(memory:DMABuf)" << "!" << "glupload" << "!"
+         << "gldownload";
+  }
+  args << "!" << "videoconvert" << "!" << "video/x-raw,format=RGB" << "!"
+       << "pngenc" << "!" << "multifilesink"
+       << QStringLiteral("location=%1/%2_%d.png").arg(dir.path(), stem);
+
+  QProcess gst;
+  gst.setProcessChannelMode(QProcess::MergedChannels);
+  QElapsedTimer t;
+  t.start();
+  gst.start("gst-launch-1.0", args);
+  if(!gst.waitForStarted(10000) || !gst.waitForFinished(60000))
+  {
+    gst.kill();
+    gst.waitForFinished(2000);
+  }
+  c.seconds = t.elapsed() / 1000.;
+  c.log = QString::fromUtf8(gst.readAll());
+
+  for(int i = 0; i < count; i++)
+  {
+    const QString f = QStringLiteral("%1/%2_%3.png").arg(dir.path(), stem).arg(i);
+    if(QFile::exists(f))
+      c.files.push_back(f);
+  }
+  c.frames = c.files.size();
+
+  // Distinct pictures, not distinct buffers. A producer that hands the same
+  // frame over six times keeps a buffer counter happy and still looks frozen,
+  // so the rate that matters is how many DIFFERENT frames arrive.
+  QSet<QByteArray> seen;
+  for(const auto& f : c.files)
+  {
+    QFile fh{f};
+    if(!fh.open(QIODevice::ReadOnly))
+      continue;
+    seen.insert(QCryptographicHash::hash(fh.readAll(), QCryptographicHash::Md5));
+  }
+  c.distinct = seen.size();
+  return c;
+}
+
+//! isf-gradient-x paints red = x: dark at the left edge, bright at the right.
+//! Checks the picture is that gradient, at the requested geometry.
+struct PixelVerdict
+{
+  bool ok{};
+  QString why;
+};
+
+PixelVerdict verifyGradient(const QString& png)
+{
+  QImage img{png};
+  if(img.isNull())
+    return {false, "unreadable png"};
+  if(img.width() != kWidth || img.height() != kHeight)
+    return {false,
+            QStringLiteral("geometry %1x%2").arg(img.width()).arg(img.height())};
+
+  const int y = img.height() / 2;
+  const int left = qRed(img.pixel(4, y));
+  const int right = qRed(img.pixel(img.width() - 5, y));
+  const int mid = qRed(img.pixel(img.width() / 2, y));
+
+  if(right - left < 100)
+    return {false,
+            QStringLiteral("not a gradient: left %1 mid %2 right %3")
+                .arg(left)
+                .arg(mid)
+                .arg(right)};
+  if(std::abs(mid - (left + right) / 2) > 40)
+    return {false, QStringLiteral("middle %1 is off the ramp").arg(mid)};
+  return {true, {}};
+}
+
+QString environmentGap()
+{
+  if(appBinary().isEmpty() || !QFile::exists(appBinary()))
+    return "the score application binary was not built";
+  if(!QFile::exists(corpusDir() + "/isf-gradient-x.fs"))
+    return "the gfx corpus is missing";
+  if(!haveTool("pw-dump", {"--help"}))
+    return "no pw-dump: this needs a PipeWire session";
+  if(!haveTool("gst-launch-1.0"))
+    return "no gst-launch-1.0";
+#if defined(__linux__)
+  if(!qEnvironmentVariableIsSet("DISPLAY")
+     && !qEnvironmentVariableIsSet("WAYLAND_DISPLAY"))
+    return "needs a real display: the offscreen QPA has no GL for the render";
+#endif
+  if(qEnvironmentVariable("QT_QPA_PLATFORM") == "offscreen")
+    return "needs a real display: QT_QPA_PLATFORM is offscreen";
+  return {};
+}
+
+//! A node name nothing else can collide with, so a leftover process from an
+//! earlier run cannot be measured by mistake.
+QString uniqueNodeName(const char* tag)
+{
+  return QStringLiteral("score-pwtest-%1-%2")
+      .arg(tag)
+      .arg(QCoreApplication::applicationPid());
+}
+}
+
+TEST_CASE(
+    "a PipeWire video output delivers its picture to an outside consumer",
+    "[integration][gfx][pipewire][media]")
+{
+  if(const auto gap = environmentGap(); !gap.isEmpty())
+    SKIP(gap.toStdString());
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  const QString node = uniqueNodeName("shm");
+  Publisher pub;
+  pub.start(write(dir, "scene.js", sceneScript(node, false)));
+
+  const auto serial = waitForNode(node, 45000);
+  INFO("the application never published a PipeWire node called " << node.toStdString());
+  REQUIRE(serial >= 0);
+
+  constexpr int kFrames = 120;
+  const auto cap = capture(serial, kFrames, dir, "shm", false);
+  INFO(cap.log.toStdString());
+
+  REQUIRE(cap.frames > 0);
+  // Every requested buffer, not just the first: a producer that publishes one
+  // frame and stops is the shape a still picture in OBS has.
+  CHECK(cap.frames == kFrames);
+
+  const auto first = verifyGradient(cap.files.front());
+  INFO("first frame: " << first.why.toStdString());
+  CHECK(first.ok);
+
+  const auto last = verifyGradient(cap.files.back());
+  INFO("last frame: " << last.why.toStdString());
+  CHECK(last.ok);
+}
+
+// The performance half, and the reason this file exists rather than another
+// pixel test. A consumer that receives the right picture at a fraction of the
+// requested rate is what "it works but is extremely slow" means, and no pixel
+// comparison can see it.
+TEST_CASE(
+    "a PipeWire video output keeps up with the rate it advertises",
+    "[integration][gfx][pipewire][media][perf]")
+{
+  if(const auto gap = environmentGap(); !gap.isEmpty())
+    SKIP(gap.toStdString());
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  const QString node = uniqueNodeName("rate");
+  Publisher pub;
+  // An ANIMATED source: the gradient never changes, so every frame of it
+  // hashes the same and a frozen producer would be indistinguishable from a
+  // smooth one.
+  pub.start(write(dir, "scene.js", sceneScript(node, false, "isf-time-uniforms.fs")));
+
+  const auto serial = waitForNode(node, 45000);
+  REQUIRE(serial >= 0);
+
+  // Warm up first: the first buffers cover negotiation and the consumer's own
+  // start-up, and folding those into the measurement understates the rate.
+  (void)capture(serial, 20, dir, "warm", false);
+
+  constexpr int kFrames = 180;
+  const auto cap = capture(serial, kFrames, dir, "rate", false);
+  INFO(cap.log.toStdString());
+  REQUIRE(cap.frames == kFrames);
+
+  INFO(
+      "received " << cap.frames << " buffers (" << cap.distinct
+                  << " distinct pictures) in " << cap.seconds << " s = "
+                  << cap.fps() << " buffers/s, " << cap.distinctFps()
+                  << " frames/s; the device asked for " << kRate);
+
+  // Half the advertised rate, on both counts. Deliberately loose: this is a
+  // shared machine running a real compositor, and the case is here to catch a
+  // collapse to a few frames a second, not to police jitter.
+  CHECK(cap.fps() >= kRate / 2.);
+  CHECK(cap.distinctFps() >= kRate / 2.);
+}
+
+// The same measurement at the geometry a user actually sends to OBS. Every
+// per-frame copy costs six times what it does at 640x360, so a path that keeps
+// up at preview size can still collapse here -- and this is the size the
+// complaint arrives at.
+TEST_CASE(
+    "a PipeWire video output keeps up at 1920x1080",
+    "[integration][gfx][pipewire][media][perf]")
+{
+  if(const auto gap = environmentGap(); !gap.isEmpty())
+    SKIP(gap.toStdString());
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  const QString node = uniqueNodeName("hd");
+  Publisher pub;
+  pub.start(write(
+      dir, "scene.js",
+      sceneScript(node, false, "isf-time-uniforms.fs", 1920, 1080)));
+
+  const auto serial = waitForNode(node, 45000);
+  REQUIRE(serial >= 0);
+
+  (void)capture(serial, 20, dir, "hdwarm", false);
+
+  constexpr int kFrames = 120;
+  const auto cap = capture(serial, kFrames, dir, "hd", false);
+  INFO(cap.log.toStdString());
+  REQUIRE(cap.frames == kFrames);
+
+  INFO(
+      "1920x1080: " << cap.frames << " buffers (" << cap.distinct
+                    << " distinct) in " << cap.seconds << " s = "
+                    << cap.distinctFps() << " frames/s, asked for " << kRate);
+
+  CHECK(cap.distinctFps() >= kRate / 2.);
+}
+
+// Zero-copy. score allocates exportable images and hands the consumer their
+// DMA-BUF file descriptors instead of copying pixels through host memory, so
+// this asks GStreamer for DMA-BUF memory explicitly: the pipeline fails to
+// negotiate rather than silently falling back to a copy.
+// [!shouldfail]: zero-copy does not negotiate yet. score offers the modifier as
+// a DONT_FIXATE choice and answers the consumer's reply with a fixated format
+// plus the alternatives, which is the handshake pipewire's own
+// video-src-fixate example performs -- and the server still ends the
+// negotiation with "no more output formats". The remaining suspect is that no
+// modifier survives the intersection here (LINEAR from a Vulkan export against
+// what this GStreamer/driver pair will import), in which case the fix is to
+// offer host memory alongside dma-buf so the link falls back instead of dying.
+// Until then a dmabuf=on device is unusable from outside score, which is the
+// black source in OBS.
+TEST_CASE(
+    "a PipeWire video output can hand over DMA-BUF memory",
+    "[integration][gfx][pipewire][media][dmabuf][!shouldfail]")
+{
+  if(const auto gap = environmentGap(); !gap.isEmpty())
+    SKIP(gap.toStdString());
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  const QString node = uniqueNodeName("dmabuf");
+  Publisher pub;
+  pub.start(write(dir, "scene.js", sceneScript(node, true)));
+
+  const auto serial = waitForNode(node, 45000);
+  REQUIRE(serial >= 0);
+
+  constexpr int kFrames = 60;
+  const auto cap = capture(serial, kFrames, dir, "dma", true);
+  INFO(cap.log.toStdString());
+
+  REQUIRE(cap.frames > 0);
+  CHECK(cap.frames == kFrames);
+
+  const auto v = verifyGradient(cap.files.back());
+  INFO("dma-buf frame: " << v.why.toStdString());
+  CHECK(v.ok);
+}

--- a/tests/integration/PipewireVideoOutputTest.cpp
+++ b/tests/integration/PipewireVideoOutputTest.cpp
@@ -259,6 +259,45 @@ Capture capture(
   return c;
 }
 
+//! Read `count` frames as RAW bytes, forcing DMA-BUF memory. filesink takes
+//! whatever memory arrives and writes the mapped bytes, so this stays on the
+//! zero-copy path -- glupload cannot consume our dma-buf on every driver, and
+//! going through it would silently measure the host-memory fallback instead.
+struct RawCapture
+{
+  int frames{};
+  QByteArray bytes;
+  QString log;
+};
+
+RawCapture captureRawDmaBuf(
+    int64_t serial, int count, const QTemporaryDir& dir, int w, int h)
+{
+  RawCapture c;
+  const QString out = dir.filePath("dma.raw");
+  QProcess gst;
+  gst.setProcessChannelMode(QProcess::MergedChannels);
+  gst.start(
+      "gst-launch-1.0",
+      {"pipewiresrc", QStringLiteral("target-object=%1").arg(serial),
+       QStringLiteral("num-buffers=%1").arg(count), "!",
+       "video/x-raw(memory:DMABuf),format=RGBA", "!", "filesink",
+       QStringLiteral("location=%1").arg(out)});
+  if(!gst.waitForStarted(10000) || !gst.waitForFinished(60000))
+  {
+    gst.kill();
+    gst.waitForFinished(2000);
+  }
+  c.log = QString::fromUtf8(gst.readAll());
+
+  QFile f{out};
+  if(f.open(QIODevice::ReadOnly))
+    c.bytes = f.readAll();
+  const qint64 frameBytes = qint64(w) * h * 4;
+  c.frames = frameBytes > 0 ? int(c.bytes.size() / frameBytes) : 0;
+  return c;
+}
+
 //! isf-gradient-x paints red = x: dark at the left edge, bright at the right.
 //! Checks the picture is that gradient, at the requested geometry.
 struct PixelVerdict
@@ -518,19 +557,13 @@ TEST_CASE(
   CHECK(v.ok);
 }
 
-// [!shouldfail]: zero-copy does not negotiate yet. score offers the modifier as
-// a DONT_FIXATE choice and answers the consumer's reply with a fixated format
-// plus the alternatives, which is the handshake pipewire's own
-// video-src-fixate example performs -- and the server still ends the
-// negotiation with "no more output formats". The remaining suspect is that no
-// modifier survives the intersection here (LINEAR from a Vulkan export against
-// what this GStreamer/driver pair will import), in which case the fix is to
-// offer host memory alongside dma-buf so the link falls back instead of dying.
-// Until then a dmabuf=on device is unusable from outside score, which is the
-// black source in OBS.
+// Zero-copy, and the whole point of the dma-buf mode: score exports images the
+// consumer imports by file descriptor, and not one pixel travels through host
+// memory. The caps ask for DMA-BUF explicitly, so a fallback to shared memory
+// fails the case rather than passing quietly as a copy.
 TEST_CASE(
-    "a PipeWire video output can hand over DMA-BUF memory",
-    "[integration][gfx][pipewire][media][dmabuf][!shouldfail]")
+    "a PipeWire video output hands over DMA-BUF memory",
+    "[integration][gfx][pipewire][media][dmabuf]")
 {
   if(const auto gap = environmentGap(); !gap.isEmpty())
     SKIP(gap.toStdString());
@@ -545,14 +578,22 @@ TEST_CASE(
   const auto serial = waitForNode(node, 45000);
   REQUIRE(serial >= 0);
 
-  constexpr int kFrames = 60;
-  const auto cap = capture(serial, kFrames, dir, "dma", true);
+  constexpr int kFrames = 5;
+  const auto cap = captureRawDmaBuf(serial, kFrames, dir, kWidth, kHeight);
   INFO(cap.log.toStdString());
 
-  REQUIRE(cap.frames > 0);
-  CHECK(cap.frames == kFrames);
+  // Every frame, whole: a short file means the negotiation fell back or the
+  // stream stopped part way.
+  REQUIRE(cap.frames == kFrames);
 
-  const auto v = verifyGradient(cap.files.back());
-  INFO("dma-buf frame: " << v.why.toStdString());
-  CHECK(v.ok);
+  // ... and the picture in them is the gradient, read straight out of the
+  // imported buffer.
+  const int row = kHeight / 2;
+  const auto at = [&](int x) {
+    const int o = (row * kWidth + x) * 4;
+    return int(uint8_t(cap.bytes[o])); // red
+  };
+  INFO("left " << at(4) << " mid " << at(kWidth / 2) << " right " << at(kWidth - 5));
+  CHECK(at(kWidth - 5) - at(4) > 100);
+  CHECK(std::abs(at(kWidth / 2) - (at(4) + at(kWidth - 5)) / 2) < 40);
 }

--- a/tests/integration/PipewireVideoOutputTest.cpp
+++ b/tests/integration/PipewireVideoOutputTest.cpp
@@ -442,10 +442,82 @@ TEST_CASE(
   CHECK(cap.distinctFps() >= kRate / 2.);
 }
 
+// 8K. Spout and Syphon carry it because they hand over a GPU texture and copy
+// nothing; this path reads the frame back and copies it through host memory,
+// which at this resolution is more memcpy bandwidth than a host bus has. The
+// case exists to say plainly where the readback path stops being viable, and
+// to be the thing that turns green when zero-copy carries it.
+TEST_CASE(
+    "a PipeWire video output keeps up at 7680x4320",
+    "[integration][gfx][pipewire][media][perf][8k][!shouldfail]")
+{
+  if(const auto gap = environmentGap(); !gap.isEmpty())
+    SKIP(gap.toStdString());
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  const QString node = uniqueNodeName("k8");
+  Publisher pub;
+  pub.start(write(
+      dir, "scene.js",
+      sceneScript(node, false, "isf-time-uniforms.fs", 7680, 4320)));
+
+  const auto serial = waitForNode(node, 60000);
+  REQUIRE(serial >= 0);
+
+  (void)capture(serial, 5, dir, "k8warm", false);
+
+  constexpr int kFrames = 30;
+  const auto cap = capture(serial, kFrames, dir, "k8", false);
+  INFO(cap.log.toStdString());
+  REQUIRE(cap.frames == kFrames);
+
+  INFO(
+      "7680x4320: " << cap.frames << " buffers (" << cap.distinct
+                    << " distinct) in " << cap.seconds << " s = "
+                    << cap.distinctFps() << " frames/s, asked for " << kRate);
+
+  CHECK(cap.distinctFps() >= kRate / 2.);
+}
+
 // Zero-copy. score allocates exportable images and hands the consumer their
 // DMA-BUF file descriptors instead of copying pixels through host memory, so
 // this asks GStreamer for DMA-BUF memory explicitly: the pipeline fails to
 // negotiate rather than silently falling back to a copy.
+// A dmabuf=on device must still show a picture to a consumer that cannot take
+// dma-buf. It used to show nothing at all: score offered the modifier and
+// nothing else, the intersection came out empty, the stream errored with "no
+// more output formats" and the source stayed black. It now offers the same
+// format without a modifier as a second alternative, so such a consumer picks
+// host memory and gets frames.
+TEST_CASE(
+    "a dmabuf device still delivers to a consumer that cannot take dma-buf",
+    "[integration][gfx][pipewire][media][dmabuf]")
+{
+  if(const auto gap = environmentGap(); !gap.isEmpty())
+    SKIP(gap.toStdString());
+
+  QTemporaryDir dir;
+  REQUIRE(dir.isValid());
+
+  const QString node = uniqueNodeName("dmafall");
+  Publisher pub;
+  pub.start(write(dir, "scene.js", sceneScript(node, true)));
+
+  const auto serial = waitForNode(node, 45000);
+  REQUIRE(serial >= 0);
+
+  constexpr int kFrames = 20;
+  const auto cap = capture(serial, kFrames, dir, "dmafall", false);
+  INFO(cap.log.toStdString());
+  REQUIRE(cap.frames == kFrames);
+
+  const auto v = verifyGradient(cap.files.back());
+  INFO("fallback frame: " << v.why.toStdString());
+  CHECK(v.ok);
+}
+
 // [!shouldfail]: zero-copy does not negotiate yet. score offers the modifier as
 // a DONT_FIXATE choice and answers the consumer's reply with a fixated format
 // plus the alternatives, which is the handshake pipewire's own

--- a/tests/integration/PortValueRestoreTest.cpp
+++ b/tests/integration/PortValueRestoreTest.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// An add-on that gains or loses a port makes every saved instance of it
+// mismatch the spec. score rebuilds the ports from the new spec and restores
+// what it saved from the old ones -- and that restore was dropping every
+// control value, so a document came back with the whole process at its
+// defaults. A granular synth lost its soundfile, its position, its pitch and
+// the rest, in silence.
+//
+// loadData only restores a value when asked, and the rebuild path was asking
+// for cables and addresses only. The two callers that legitimately want the
+// new values (loading a preset, editing a script) pass no flag and are
+// unaffected; this one is the version-drift path, where the saved values are
+// the only thing left worth keeping.
+
+#include <score_test/App.hpp>
+#include <score_test/Project.hpp>
+
+#include <Dataflow/Commands/CableHelpers.hpp>
+#include <Process/Dataflow/Port.hpp>
+#include <Process/Process.hpp>
+
+#include <QTemporaryDir>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE(
+    "rebuilding a process's ports keeps its control values",
+    "[integration][ports]")
+{
+  score::test::run_in_gui_app([](const score::GUIApplicationContext& ctx) {
+    QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    auto* doc = score::test::project_document(ctx, dir.path());
+    REQUIRE(doc != nullptr);
+
+    // The LFO: a handful of plain float controls, and nothing about the bug
+    // was specific to a port type.
+    auto* proc = score::test::add_process(
+        *doc, QStringLiteral("1e17e479-3513-44c8-a8a7-017be9f6ac8a"), QString{});
+    REQUIRE(proc != nullptr);
+
+    // Any control will do: the bug was in the restore, not in a port type.
+    Process::ControlInlet* ctl{};
+    for(auto* inl : proc->inlets())
+      if(auto* c = qobject_cast<Process::ControlInlet*>(inl))
+      {
+        ctl = c;
+        break;
+      }
+    REQUIRE(ctl != nullptr);
+
+    const ossia::value saved_value{0.625};
+    ctl->setValue(saved_value);
+
+    std::vector<Dataflow::SavedPort> in, out;
+    for(auto* port : proc->inlets())
+      in.push_back({port->name(), port->type(), port->saveData()});
+    for(auto* port : proc->outlets())
+      out.push_back({port->name(), port->type(), port->saveData()});
+
+    // What the rebuild leaves behind: ports of the right shape holding
+    // whatever the current spec defaults to.
+    ctl->setValue(ossia::value{0.125});
+    REQUIRE(ctl->value() == ossia::value{0.125});
+
+    Dataflow::reloadPortsInNewProcess(in, out, *proc);
+
+    CHECK(ctl->value() == saved_value);
+  });
+}

--- a/tests/integration/ShaderSweep.hpp
+++ b/tests/integration/ShaderSweep.hpp
@@ -27,6 +27,7 @@
 
 #include <QDir>
 #include <QDirIterator>
+#include <QStandardPaths>
 #include <QRegularExpression>
 #include <QFile>
 #include <QFileInfo>
@@ -97,7 +98,19 @@ QString libraryRoot(const score::ApplicationContext& ctx)
 #if defined(SCORE_SHADER_SWEEP_WASM_LIBRARY)
   return QStringLiteral(SCORE_SHADER_SWEEP_WASM_LIBRARY);
 #else
-  return ctx.settings<Library::Settings::Model>().getDefaultLibraryPath();
+  // The settings first, then the installed library. A test process runs under
+  // its own application name, so its default library path points at a
+  // "score-test" directory nobody ever installs anything into -- ask the
+  // setting, and if what it names is not there, look where score itself keeps
+  // the library. Same two-step as JsPresetsTest's find_presets_root.
+  const QStringList candidates{
+      ctx.settings<Library::Settings::Model>().getDefaultLibraryPath(),
+      QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)
+          + "/ossia/score/packages/default"};
+  for(const auto& c : candidates)
+    if(QFileInfo{c}.isDir())
+      return c;
+  return candidates.front();
 #endif
 }
 
@@ -414,9 +427,19 @@ inline void sweepLibrary(
     ProgramLoader load, const QString& baseline, const QString& wantMode = {},
     bool blankIsFailure = true)
 {
+  // The sweeps render for real. Under the offscreen platform the GL context has
+  // no depth textures and no 3D textures, and the first shader that wants one
+  // takes the process down rather than failing a comparison -- a crash that
+  // says nothing about the shader.
+  if(qEnvironmentVariable("QT_QPA_PLATFORM") == "offscreen")
+    SKIP("the offscreen platform has no usable GL for a shader sweep");
+
   const QString root = libraryRoot(ctx);
   if(root.isEmpty() || !QFileInfo::exists(root))
-    SKIP("no shader library available (set SCORE_SHADER_LIBRARY_DIR)");
+    SKIP(QString("no shader library at \"%1\" (set SCORE_SHADER_LIBRARY_DIR "
+                 "to point at one)")
+             .arg(root)
+             .toStdString());
 
   QStringList shaders;
   QDirIterator it{

--- a/tests/integration/ThreedimRenderTest.cpp
+++ b/tests/integration/ThreedimRenderTest.cpp
@@ -551,22 +551,22 @@ RenderResult renderScene(const QTemporaryDir& dir, const QString& name,
 
   // Let the graph build and the async loaders land, then grab (twice: the
   // first grab also warms the readback path), then ask the app to leave.
-  QThread::sleep(9);
+  QThread::msleep(3000);
   oscSend("/script",
           QStringLiteral("Score.device('Window').grabTo('%1')").arg(png));
-  QThread::sleep(3);
+  QThread::msleep(1000);
   oscSend("/script",
           QStringLiteral("Score.device('Window').grabTo('%1')").arg(png));
   // Extra spaced grabs for time-animated cases whose content roams the frame.
   for(int k = 0; k < extraGrabs; k++)
   {
-    QThread::sleep(2);
+    QThread::msleep(667);
     oscSend(
         "/script", QStringLiteral("Score.device('Window').grabTo('%1.%2.png')")
                        .arg(png)
                        .arg(k));
   }
-  QThread::sleep(2);
+  QThread::msleep(667);
   oscSend("/exit", "force");
   // Teardown SIGSEGV after the grab is a known, documented nuisance
   // (scene-js-sweep.sh header); the PNG is the verdict, not the exit code.

--- a/tests/library/ProcessLibraryPublishTest.cpp
+++ b/tests/library/ProcessLibraryPublishTest.cpp
@@ -109,14 +109,31 @@ struct Fixture
   }
 };
 
-static void primeLibrarySettings(const score::GUIApplicationContext& ctx)
+//! Points the library somewhere empty so the model's own scan is a no-op, and
+//! puts the old root back on the way out.
+//!
+//! The put-back is not tidiness. The test fixture points XDG_CONFIG_HOME at a
+//! shared /tmp/score-tests/config so test processes never touch the user's
+//! settings, and setRootPath persists there -- so leaving the bench directory
+//! behind hands it to every test process that runs afterwards, in this run and
+//! in every later one. That is what made the six shader sweeps skip: they
+//! resolved the library through this same setting and found an empty bench.
+struct PrimedLibrarySettings
 {
-  // Point the library somewhere empty so the model's own scan is a no-op.
-  auto& set = ctx.settings<Library::Settings::Model>();
-  const QString tmp = QDir::tempPath() + "/score-tests/library-bench";
-  QDir{}.mkpath(tmp);
-  set.setRootPath(tmp);
-}
+  Library::Settings::Model& set;
+  QString previous;
+
+  explicit PrimedLibrarySettings(const score::GUIApplicationContext& ctx)
+      : set{ctx.settings<Library::Settings::Model>()}
+      , previous{set.getRootPath()}
+  {
+    const QString tmp = QDir::tempPath() + "/score-tests/library-bench";
+    QDir{}.mkpath(tmp);
+    set.setRootPath(tmp);
+  }
+
+  ~PrimedLibrarySettings() { set.setRootPath(previous); }
+};
 
 // Recursively check that the proxy mirrors the source subtree exactly.
 static void
@@ -146,7 +163,7 @@ static QStringList childNames(const QAbstractItemModel& m, const QModelIndex& pa
 TEST_CASE("publish: model invariants and structure", "[library]")
 {
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
-    primeLibrarySettings(ctx);
+    PrimedLibrarySettings primed{ctx};
     Fixture f{ctx};
 
     // Deep new path, single entry
@@ -199,7 +216,7 @@ TEST_CASE("publish: model invariants and structure", "[library]")
 TEST_CASE("publish: coalescing boundaries and signal counts", "[library]")
 {
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
-    primeLibrarySettings(ctx);
+    PrimedLibrarySettings primed{ctx};
     Fixture f{ctx};
     score::test::SignalCounter spy{&f.model, &QAbstractItemModel::rowsInserted};
 
@@ -242,7 +259,7 @@ TEST_CASE("publish: coalescing boundaries and signal counts", "[library]")
 TEST_CASE("publish: generations drop stale scans", "[library]")
 {
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
-    primeLibrarySettings(ctx);
+    PrimedLibrarySettings primed{ctx};
     Fixture f{ctx};
 
     // Entry captured under the current generation, delivered after a rescan:
@@ -272,7 +289,7 @@ TEST_CASE("publish: generations drop stale scans", "[library]")
 TEST_CASE("replaceChildren: exact ranges, proxy stays consistent", "[library]")
 {
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
-    primeLibrarySettings(ctx);
+    PrimedLibrarySettings primed{ctx};
     Fixture f{ctx};
 
     Library::ProcessFilterProxy proxy;
@@ -377,7 +394,7 @@ TEST_CASE("end-to-end: a real scan publishes through the handlers", "[library]")
 TEST_CASE("publish: 36k-entry storm, hot proxy mirrors the tree", "[library][bench]")
 {
   score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
-    primeLibrarySettings(ctx);
+    PrimedLibrarySettings primed{ctx};
     Fixture f{ctx};
 
     const QString tmp = QDir::tempPath() + "/score-tests/library-bench";

--- a/tests/library/ProcessLibraryPublishTest.cpp
+++ b/tests/library/ProcessLibraryPublishTest.cpp
@@ -10,7 +10,7 @@
 // sample library through the batched delivery pattern of RecursiveWatch and
 // asserts the GUI-thread cost stays in the same class as the old silent
 // insertion path (baseline measured before this change: ~233 ms total,
-// ~9.4 ms max batch, Debug build — see commit message).
+// see commit message).
 
 #include <Process/ProcessList.hpp>
 
@@ -436,7 +436,7 @@ TEST_CASE("publish: 36k-entry storm, hot proxy mirrors the tree", "[library][ben
     REQUIRE(spy.count() < 2 * 6300 + 200);
 
     // Performance envelope (Debug build; baseline silent path: ~233 ms total,
-    // ~9.4 ms max batch). Generous bounds — this guards against complexity
+    // Generous bounds — this guards against complexity
     // regressions (an O(n²) path costs tens of seconds), not micro-drift.
     REQUIRE(total_ns / 1'000'000 < 3000);
     REQUIRE(max_batch_ns / 1'000'000 < 200);

--- a/tests/nodes/CMakeLists.txt
+++ b/tests/nodes/CMakeLists.txt
@@ -16,3 +16,11 @@ score_add_test(test_nodes_devices
   SOURCES Devices.cpp
   APP
   PLUGINS score_lib_device)
+
+score_add_test(test_nodes_veltonote
+  SOURCES VelToNoteTest.cpp VelToNoteBindingTest.cpp
+  PLUGINS score_plugin_fx)
+
+score_add_test(test_nodes_ossia_midi
+  SOURCES "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/tests/test_ossia_midi.cpp"
+  PLUGINS score_plugin_fx)

--- a/tests/nodes/VelToNoteBindingTest.cpp
+++ b/tests/nodes/VelToNoteBindingTest.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Fx/VelToNote.hpp>
+
+#include <ossia/dataflow/execution_state.hpp>
+#include <ossia/dataflow/graph/graph_interface.hpp>
+
+#include <avnd/binding/ossia/data_node.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace
+{
+using NoteNode = Nodes::PulseToNote::Node;
+using Packet = std::pair<std::int64_t, std::uint32_t>;
+
+struct MidiConsumer final : ossia::nonowning_graph_node
+{
+  ossia::midi_inlet input;
+  std::vector<Packet> received;
+  MidiConsumer() { m_inlets.push_back(&input); }
+  std::string label() const noexcept override { return "VelToNote consumer"; }
+  void run(const ossia::token_request&, ossia::exec_state_facade) noexcept override
+  {
+    for(const auto& packet : input.data.messages)
+    {
+      const auto message = libremidi::midi1_from_ump(packet);
+      if(message.bytes.size() == 3)
+        received.emplace_back(
+            packet.timestamp, (std::uint32_t(message.bytes[0]) << 16)
+                                  | (std::uint32_t(message.bytes[1]) << 8)
+                                  | message.bytes[2]);
+    }
+  }
+};
+
+struct MidiGraph
+{
+  ossia::execution_state state;
+  std::shared_ptr<oscr::safe_node<NoteNode>> source;
+  std::shared_ptr<MidiConsumer> consumer = std::make_shared<MidiConsumer>();
+  std::shared_ptr<ossia::graph_interface> graph = ossia::make_graph({});
+
+  explicit MidiGraph(int frames = 16)
+  {
+    state.sampleRate = 1000;
+    state.bufferSize = frames;
+    state.samples_since_start = frames;
+    state.modelToSamplesRatio = 1000. / 705600000.;
+    state.samplesToModelRatio = 705600000. / 1000.;
+    source = std::make_shared<oscr::safe_node<NoteNode>>(frames, 1000., 17);
+    source->finish_init();
+    auto& effect = source->impl.effect;
+    effect.ossia_state = {&state};
+    effect.inputs.start_quant.value = 0.;
+    effect.inputs.end_quant.value = 0.;
+    effect.inputs.basenote.value = 60;
+    effect.inputs.basevel.value = 100;
+    graph->add_node(source);
+    graph->add_node(consumer);
+    graph->connect(graph->allocate_edge(
+        ossia::immediate_glutton_connection{}, source->root_outputs()[0],
+        &consumer->input, source, consumer));
+  }
+
+  static ossia::token_request
+  token(int offset, int frames, double tempo = 120., std::int64_t first_model = 0)
+  {
+    ossia::token_request tk;
+    tk.start_sample = offset;
+    tk.length_sample = frames;
+    tk.tempo = tempo;
+    tk.prev_date.impl = first_model;
+    tk.date.impl = first_model + std::int64_t(frames * 5880 * tempo);
+    tk.musical_start_position = 2. * tk.prev_date.impl / 705600000.;
+    tk.musical_end_position = 2. * tk.date.impl / 705600000.;
+    return tk;
+  }
+
+  void input(int pitch, int date)
+  {
+    source->impl.effect.inputs.port.value->write_value(pitch, date);
+  }
+
+  void publish()
+  {
+    consumer->request(token(0, state.bufferSize));
+    graph->state(state);
+    state.commit();
+  }
+};
+}
+
+TEST_CASE(
+    "VelToNote publishes all slices once through a real graph cable",
+    "[nodes][veltonote][sdk]")
+{
+  MidiGraph f;
+  f.input(60, 7);
+  f.source->request(MidiGraph::token(4, 4));
+  f.source->request(MidiGraph::token(8, 4, 120., 2822400));
+  f.source->request(MidiGraph::token(12, 4, 120., 5644800));
+  f.publish();
+  REQUIRE(f.consumer->received == std::vector<Packet>{{7, 0x903c64}, {8, 0x803c00}});
+
+  // A new publication with a repeated counter and position cannot replay MIDI.
+  f.consumer->received.clear();
+  f.source->request(MidiGraph::token(4, 4));
+  f.publish();
+  REQUIRE(f.consumer->received.empty());
+}
+
+TEST_CASE(
+    "VelToNote synchronized chooser is converted once by the real binding",
+    "[nodes][veltonote][sdk]")
+{
+  for(int tempo : {60, 120, 240})
+  {
+    INFO("tempo=" << tempo);
+    const int off = 60000 / tempo;
+    MidiGraph f{off + 2};
+    auto& effect = f.source->impl.effect;
+    effect.inputs.fixed_duration.value = true;
+    effect.inputs.duration.sync = true;
+    // Native chooser controls store whole-note fractions, not seconds.
+    using Inputs = decltype(effect.inputs);
+    constexpr auto duration_index = avnd::index_in_struct(Inputs{}, &Inputs::duration);
+    f.source->time_controls.update_control(
+        f.source->impl, avnd::field_index<duration_index>{}, .25f, true);
+    f.input(60, 0);
+    f.source->request(MidiGraph::token(0, off + 2, tempo));
+    f.publish();
+    REQUIRE(f.consumer->received == std::vector<Packet>{{0, 0x903c64}, {off, 0x803c00}});
+  }
+}
+
+TEST_CASE(
+    "VelToNote cleanup reaches its cable when a writable token exists",
+    "[nodes][veltonote][sdk]")
+{
+  MidiGraph f;
+  f.source->impl.effect.inputs.end_quant.value = -1.;
+  f.input(60, 0);
+  f.source->request(MidiGraph::token(0, 16));
+  f.publish();
+  REQUIRE(f.consumer->received == std::vector<Packet>{{0, 0x903c64}});
+  f.consumer->received.clear();
+  f.source->impl.effect.stop();
+  REQUIRE(f.source->impl.effect.needs_service());
+  // This explicitly supplies the window absent from score's hard-stop path.
+  f.state.samples_since_start += 16;
+  f.source->request(MidiGraph::token(0, 16, 120., 11289600));
+  f.publish();
+  REQUIRE(f.consumer->received == std::vector<Packet>{{0, 0x803c00}});
+  REQUIRE_FALSE(f.source->impl.effect.needs_service());
+}

--- a/tests/nodes/VelToNoteTest.cpp
+++ b/tests/nodes/VelToNoteTest.cpp
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include <Fx/VelToNote.hpp>
+
+#include <ossia/dataflow/execution_state.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace
+{
+using namespace Nodes::PulseToNote::detail;
+using Nodes::PulseToNote::Node;
+
+Block block(
+    int first, int frames, double q0, double q1, std::int64_t m0, std::int64_t m1)
+{
+  return {
+      .frames = frames,
+      .first_frame = first,
+      .quarters_begin = q0,
+      .quarters_end = q1,
+      .bar_begin = std::floor(q0 / 4.) * 4.,
+      .bar_end = std::floor(q1 / 4.) * 4.,
+      .model_begin = m0,
+      .model_end = m1};
+}
+
+struct Processor
+{
+  ossia::execution_state state;
+  ossia::value_port input;
+  Node node;
+
+  Processor()
+  {
+    state.sampleRate = 1000;
+    state.modelToSamplesRatio = 1000. / flicks_per_second;
+    state.samplesToModelRatio = flicks_per_second / 1000.;
+    node.ossia_state = {&state};
+    node.inputs.port.value = &input;
+    node.inputs.start_quant.value = 0.;
+    node.inputs.end_quant.value = 0.;
+    node.inputs.basenote.value = 60;
+    node.inputs.basevel.value = 100;
+    node.prepare({64, 1000., 17});
+  }
+
+  ossia::token_request token(const Block& b, int offset = 0, int callback_size = 0)
+  {
+    if(!callback_size)
+      callback_size = offset + b.frames;
+    state.bufferSize = callback_size;
+    state.samples_since_start = b.first_frame - offset + callback_size;
+    ossia::token_request tk;
+    tk.prev_date.impl = b.model_begin;
+    tk.date.impl = b.model_end;
+    tk.start_sample = offset;
+    tk.length_sample = b.frames;
+    tk.musical_start_position = b.quarters_begin;
+    tk.musical_end_position = b.quarters_end;
+    tk.musical_start_last_bar = b.bar_begin;
+    tk.musical_end_last_bar = b.bar_end;
+    tk.signature
+        = {static_cast<std::uint16_t>(b.numerator),
+           static_cast<std::uint16_t>(b.denominator)};
+    tk.start_discontinuous = b.discontinuity;
+    tk.end_discontinuous = b.end_discontinuity;
+    return tk;
+  }
+
+  std::vector<MidiEvent> output() const
+  {
+    std::vector<MidiEvent> result;
+    for(const auto& m : node.outputs.midi.midi_messages)
+      result.push_back(
+          {static_cast<int>(m.timestamp), static_cast<std::uint8_t>(m.bytes[0] & 15),
+           m.bytes[1], m.bytes[2], (m.bytes[0] & 0xf0) == 0x90});
+    return result;
+  }
+};
+}
+
+TEST_CASE(
+    "VelToNote owns deferred offs independently of real output storage",
+    "[nodes][veltonote]")
+{
+  auto p = std::make_unique<Processor>();
+  p->input.write_value(60, 7);
+  auto first = p->token(block(4, 4, 0., .008, 0, 2822400), 4, 16);
+  p->node(first);
+  REQUIRE(p->output() == std::vector<MidiEvent>{{3, 0, 60, 100, true}});
+  {
+    auto published = std::move(p->node.outputs.midi.midi_messages);
+    REQUIRE(published.front().timestamp == 3);
+  } // The former port's allocation and messages are gone.
+  p->input.clear();
+  p->node(p->token(block(8, 0, .008, .008, 2822400, 2822400), 8, 16));
+  REQUIRE(p->output().empty());
+  p->node(p->token(block(8, 4, .008, .016, 2822400, 5644800), 8, 16));
+  REQUIRE(p->output() == std::vector<MidiEvent>{{0, 0, 60, 0, false}});
+  p->node(p->token(block(12, 4, .016, .024, 5644800, 8467200), 12, 16));
+  REQUIRE(p->output().empty());
+}
+
+TEST_CASE(
+    "VelToNote stopped tokens publish only cleanup until resume", "[nodes][veltonote]")
+{
+  auto p = std::make_unique<Processor>();
+  p->node.inputs.end_quant.value = -1.;
+  p->input.write_value(60, 0);
+  p->node(p->token(block(0, 4, 0., .008, 0, 2822400)));
+  p->node.stop();
+  p->node(p->token(block(4, 0, .008, .008, 2822400, 2822400), 0, 4));
+  REQUIRE(p->output().empty());
+  REQUIRE(p->node.needs_service());
+  p->node(p->token(block(4, 4, .008, .016, 2822400, 5644800)));
+  REQUIRE(p->output() == std::vector<MidiEvent>{{0, 0, 60, 0, false}});
+  p->node(p->token(block(8, 4, .016, .024, 5644800, 8467200)));
+  REQUIRE(p->output().empty());
+  p->node.resume();
+  p->node(p->token(block(12, 4, .024, .032, 8467200, 11289600)));
+  REQUIRE(p->output() == std::vector<MidiEvent>{{0, 0, 60, 100, true}});
+  p->node.pause();
+  p->node.cleanup_tick(p->token(block(16, 4, .032, .04, 11289600, 14112000)));
+  REQUIRE(p->output() == std::vector<MidiEvent>{{0, 0, 60, 0, false}});
+  REQUIRE_FALSE(p->node.needs_service());
+}
+
+TEST_CASE(
+    "VelToNote duration follows token model and musical spans", "[nodes][veltonote]")
+{
+  for(bool sync : {false, true})
+    for(int tempo : {60, 120, 240})
+    {
+      INFO("sync=" << sync << " tempo=" << tempo);
+      auto p = std::make_unique<Processor>();
+      p->node.inputs.fixed_duration.value = true;
+      p->node.inputs.duration.sync = sync;
+      p->node.inputs.duration.value = sync ? 60.f / tempo : 1.f;
+      const int off = (sync ? 60000 : 120000) / tempo;
+      const int frames = off + 2;
+      const auto model_end = std::int64_t(frames) * 5880 * tempo;
+      const double qend = 2. * model_end / flicks_per_second;
+      auto tk = p->token(block(0, frames, 0., qend, 0, model_end));
+      tk.tempo = tempo;
+      p->input.write_value(60, 0);
+      p->node(tk);
+      REQUIRE(
+          p->output()
+          == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {off, 0, 60, 0, false}});
+    }
+
+  SECTION("actual physical span overrides nominal sample-rate conversion")
+  {
+    auto p = std::make_unique<Processor>();
+    p->node.inputs.fixed_duration.value = true;
+    p->node.inputs.duration.value = .5;
+    p->input.write_value(60, 10);
+    p->node(p->token(block(10, 4, 0., 2., 0, 705600000), 10, 64));
+    REQUIRE(
+        p->output()
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {2, 0, 60, 0, false}});
+  }
+}
+
+TEST_CASE(
+    "VelToNote duration survives tempo change in both travel directions",
+    "[nodes][veltonote]")
+{
+  for(int dir : {-1, 1})
+    for(auto unit : {DurationUnit::model_seconds, DurationUnit::quarters})
+    {
+      INFO("direction=" << dir << " unit=" << static_cast<int>(unit));
+      Engine<4, 8> engine;
+      Settings s{
+          .start_quant = 0.,
+          .end_mode = EndMode::duration,
+          .duration_unit = unit,
+          .duration = unit == DurationUnit::quarters ? 2. : 1.};
+      std::vector<MidiEvent> out;
+      auto sink = [&](MidiEvent e) { out.push_back(e); };
+      engine.push(0, {60, 100});
+      engine.process(block(0, 500, 0., dir, 0, dir * 352800000LL), s, sink);
+      REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 100, true}});
+      out.clear();
+      engine.process(
+          block(500, 250, dir, 2. * dir, dir * 352800000LL, dir * 705600000LL), s, sink);
+      REQUIRE(out.empty());
+      engine.process(
+          block(750, 2, 2. * dir, 2.008 * dir, dir * 705600000LL, dir * 708422400LL), s,
+          sink);
+      REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 0, false}});
+    }
+}
+
+TEST_CASE(
+    "VelToNote grid uses causal smooth grace and reverse odd-meter neighbors",
+    "[nodes][veltonote]")
+{
+  const Grid grid{block(0, 100, 0., 4., 0, 705600000)};
+  REQUIRE(onset_target(grid, .4L, .25, 0., 1) == .4L);
+  REQUIRE(onset_target(grid, .4L, .25, 1., 1) == 1.L);
+  REQUIRE(onset_target(grid, 1.L, .25, 1., 1) == 1.L);
+  REQUIRE(onset_target(grid, .25L, .25, .5, 1) == .25L);
+  REQUIRE(double(onset_target(grid, .375L, .25, .5, 1)) == Catch::Approx(.53125));
+  REQUIRE(double(onset_target(grid, .625L, .25, .5, -1)) == Catch::Approx(.46875));
+  const auto left = onset_target(grid, .25L - 1e-6L, .25, .5, 1);
+  const auto right = onset_target(grid, .25L + 1e-6L, .25, .5, 1);
+  REQUIRE(double(right - left) == Catch::Approx(2e-6).margin(1e-10));
+
+  auto odd = block(0, 100, 0., 7., 0, 705600000);
+  odd.numerator = 7;
+  odd.denominator = 8;
+  odd.bar_end = 7.;
+  const Grid odd_grid{odd};
+  REQUIRE(odd_grid.next(3.5L, .25, -1, true) == 3.L);
+  REQUIRE(odd_grid.next(3.25L, .25, 1) == 3.5L);
+  REQUIRE(odd_grid.next(3.25L, .25, -1) == 3.L);
+  REQUIRE(
+      double(onset_target(odd_grid, 3.1875L, .25, .5, 1)) == Catch::Approx(3.265625));
+  REQUIRE(
+      double(onset_target(odd_grid, 3.3125L, .25, .5, -1)) == Catch::Approx(3.234375));
+}
+
+TEST_CASE(
+    "VelToNote absolute events are independent of execution partition",
+    "[nodes][veltonote]")
+{
+  for(auto end_mode : {EndMode::quantized, EndMode::duration})
+    for(int dir : {-1, 1})
+    {
+      auto run = [&](const std::vector<int>& sizes) {
+        Engine<16, 32> engine;
+        Settings s{
+            .start_quant = .125,
+            .tightness = .6,
+            .end_quant = .25,
+            .end_mode = end_mode,
+            .duration = .02};
+        const std::array<std::pair<int, DecodedNote>, 7> input{
+            {{3, {60, 100}},
+             {4, {60, 90}},
+             {13, {62, 100}},
+             {17, {60, 0}},
+             {50, {65, 100}},
+             {91, {65, 100}},
+             {99, {62, 0}}}};
+        std::vector<MidiEvent> out;
+        int first = 0;
+        bool bounded_timestamps = true;
+        for(int frames : sizes)
+        {
+          for(const auto& [date, note] : input)
+            if(date >= first && date < first + frames)
+              engine.push(date - first, note);
+          engine.process(
+              block(
+                  first, frames, dir * first * .03, dir * (first + frames) * .03,
+                  dir * std::int64_t(first) * 705600,
+                  dir * std::int64_t(first + frames) * 705600),
+              s, [&](MidiEvent e) {
+            bounded_timestamps &= e.frame >= 0 && e.frame < frames;
+            e.frame += first;
+            out.push_back(e);
+          });
+          first += frames;
+        }
+        REQUIRE(bounded_timestamps);
+        return out;
+      };
+      const auto whole = run({128});
+      REQUIRE(run(std::vector<int>(128, 1)) == whole);
+      REQUIRE(run({7, 11, 3, 39, 1, 23, 44}) == whole);
+    }
+
+  SECTION("fractional grid deadline does not disappear at a slice boundary")
+  {
+    Engine<4, 8> engine;
+    Settings s{.start_quant = 0., .end_quant = .25};
+    std::vector<MidiEvent> out;
+    engine.push(0, {60, 100});
+    engine.process(
+        block(0, 4, 0., 1.2, 0, 2822400), s, [&](MidiEvent e) { out.push_back(e); });
+    REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 100, true}});
+    out.clear();
+    engine.process(block(4, 2, 1.2, 1.8, 2822400, 4233600), s, [&](MidiEvent e) {
+      out.push_back(e);
+    });
+    REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 0, false}});
+  }
+}
+
+TEST_CASE(
+    "VelToNote transport retires ownership before new starts", "[nodes][veltonote]")
+{
+  for(int transition : {0, 1, 2, 3})
+  {
+    Engine<4, 8> engine;
+    Settings s{.start_quant = 0., .end_quant = -1.};
+    std::vector<MidiEvent> out;
+    auto sink = [&](MidiEvent e) { out.push_back(e); };
+    engine.push(0, {60, 100});
+    engine.process(block(0, 4, 0., 1., 0, 352800000), s, sink);
+    out.clear();
+    auto next = block(4, 4, 1., 2., 352800000, 705600000);
+    if(transition == 0)
+      next.discontinuity = true;
+    if(transition == 1)
+      next = block(4, 4, 0., 1., 0, 352800000); // seek / loop
+    if(transition == 2)
+      next = block(4, 4, 1., 0., 352800000, 0); // reversal
+    if(transition == 3)
+      next = block(4, 4, 1., 1., 352800000, 352800000); // stationary
+    engine.push(0, {62, 100});
+    engine.process(next, s, sink);
+    if(transition == 3)
+      REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 0, false}});
+    else
+      REQUIRE(
+          out == std::vector<MidiEvent>{{0, 0, 60, 0, false}, {0, 0, 62, 100, true}});
+  }
+}
+
+TEST_CASE(
+    "VelToNote random pitch directions preserve captured release identity",
+    "[nodes][veltonote]")
+{
+  for(auto direction :
+      {PitchDirection::Both, PitchDirection::Higher, PitchDirection::Lower})
+  {
+    Engine<4, 8> engine;
+    engine.seed(17);
+    Settings s{
+        .start_quant = 0.,
+        .end_quant = -1.,
+        .channel = 3,
+        .pitch_shift = 12,
+        .pitch_random = 12,
+        .pitch_direction = direction};
+    bool saw_zero = false, saw_positive = false, saw_negative = false;
+    for(int i = 0; i < 128; ++i)
+    {
+      std::vector<MidiEvent> out;
+      engine.push(0, {60, 100});
+      engine.process(
+          block(i * 2, 1, i * 2., i * 2. + 1., i * 2000, i * 2000 + 1000), s,
+          [&](MidiEvent e) { out.push_back(e); });
+      REQUIRE(out.size() == 1);
+      const auto on = out.front();
+      REQUIRE(on.on);
+      const int offset = int(on.pitch) - 72;
+      REQUIRE(offset >= (direction == PitchDirection::Higher ? 0 : -12));
+      REQUIRE(offset <= (direction == PitchDirection::Lower ? 0 : 12));
+      saw_zero |= offset == 0;
+      saw_positive |= offset > 0;
+      saw_negative |= offset < 0;
+      out.clear();
+      auto changed = s;
+      changed.channel = 16;
+      changed.pitch_shift = -60;
+      changed.velocity_random = 127;
+      engine.push(0, {60, 0});
+      engine.process(
+          block(
+              i * 2 + 1, 1, i * 2. + 1., i * 2. + 2., i * 2000 + 1000, i * 2000 + 2000),
+          changed, [&](MidiEvent e) { out.push_back(e); });
+      REQUIRE(out == std::vector<MidiEvent>{{0, on.channel, on.pitch, 0, false}});
+    }
+    REQUIRE(saw_zero);
+    REQUIRE(saw_positive == (direction != PitchDirection::Lower));
+    REQUIRE(saw_negative == (direction != PitchDirection::Higher));
+  }
+}
+
+TEST_CASE(
+    "VelToNote rejects malformed numeric input before narrowing", "[nodes][veltonote]")
+{
+  const ValueDecoder decoder{60, 100};
+  REQUIRE_FALSE(ossia::value{std::numeric_limits<float>::infinity()}.apply(decoder));
+  REQUIRE_FALSE(ossia::value{std::numeric_limits<float>::quiet_NaN()}.apply(decoder));
+  REQUIRE(ossia::value{1e30f}.apply(decoder)->pitch == 127);
+  REQUIRE(ossia::value{-1e30f}.apply(decoder)->pitch == 0);
+  const ossia::value tiny{std::vector<ossia::value>{60, .00001f, 999}};
+  REQUIRE(tiny.apply(decoder)->velocity == 1);
+  const ossia::value off{std::vector<ossia::value>{60, 0.f, 999}};
+  REQUIRE(off.apply(decoder)->velocity == 0);
+  REQUIRE_FALSE(ossia::value{std::vector<ossia::value>{"bad", 100}}.apply(decoder));
+}
+
+TEST_CASE("VelToNote overload and refused releases fail closed", "[nodes][veltonote]")
+{
+  Engine<2, 2> engine;
+  Settings s{.start_quant = 0., .end_quant = -1.};
+  std::vector<MidiEvent> out;
+  auto sink = [&](MidiEvent e) { out.push_back(e); };
+  engine.push(0, {60, 100});
+  engine.process(block(0, 1, 0., 1., 0, 1000), s, sink);
+  out.clear();
+  engine.push(0, {61, 100});
+  engine.push(0, {62, 100});
+  REQUIRE_FALSE(engine.push(0, {60, 0}));
+  engine.process(block(1, 1, 1., 2., 1000, 2000), s, [](MidiEvent) { return false; });
+  REQUIRE(engine.deferred_release_count() == 1);
+  engine.process(block(2, 0, 2., 2., 2000, 2000), s, sink);
+  REQUIRE(out.empty());
+  REQUIRE(engine.deferred_release_count() == 1);
+  engine.push(0, {64, 100});
+  engine.process(block(2, 1, 2., 3., 2000, 3000), s, sink);
+  REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 0, false}, {0, 0, 64, 100, true}});
+}
+
+TEST_CASE(
+    "VelToNote cancels pending starts and retires stale retrigger deadlines",
+    "[nodes][veltonote]")
+{
+  Engine<4, 8> engine;
+  Settings s{.start_quant = .25, .end_mode = EndMode::duration, .duration = .005};
+  std::vector<MidiEvent> out;
+  auto sink = [&](MidiEvent e) { out.push_back(e); };
+  engine.push(1, {60, 100});
+  engine.push(2, {60, 0});
+  engine.process(block(0, 20, 0., 2., 0, 14112000), s, sink);
+  REQUIRE(out.empty());
+
+  // Duration is measured from the grid-delayed on at sample 10, not arrival 1.
+  engine.request_reset();
+  engine.push(1, {60, 100});
+  engine.process(block(0, 20, 0., 2., 0, 14112000), s, sink);
+  REQUIRE(out == std::vector<MidiEvent>{{10, 0, 60, 100, true}, {15, 0, 60, 0, false}});
+  out.clear();
+  engine.request_reset();
+  s.start_quant = 0.;
+  s.duration = .01;
+  engine.push(1, {60, 100});
+  engine.push(5, {60, 90});
+  engine.process(block(0, 20, 0., 2., 0, 14112000), s, sink);
+  REQUIRE(
+      out
+      == std::vector<MidiEvent>{
+          {1, 0, 60, 100, true},
+          {5, 0, 60, 0, false},
+          {5, 0, 60, 90, true},
+          {15, 0, 60, 0, false}});
+}
+
+TEST_CASE("VelToNote pitch clipping cannot wrap MIDI bytes", "[nodes][veltonote]")
+{
+  for(int edge : {0, 127})
+  {
+    Engine<2, 2> engine;
+    Settings s{
+        .start_quant = 0.,
+        .end_quant = 0.,
+        .pitch_shift = edge == 0 ? -127 : 127,
+        .pitch_random = 127,
+        .pitch_direction = edge == 0 ? PitchDirection::Lower : PitchDirection::Higher};
+    std::vector<MidiEvent> out;
+    engine.push(0, {static_cast<std::uint8_t>(edge), 100});
+    engine.process(
+        block(0, 2, 0., 1., 0, 1000), s, [&](MidiEvent e) { out.push_back(e); });
+    REQUIRE(
+        out
+        == std::vector<MidiEvent>{
+            {0, 0, static_cast<std::uint8_t>(edge), 100, true},
+            {1, 0, static_cast<std::uint8_t>(edge), 0, false}});
+  }
+}
+
+TEST_CASE(
+    "VelToNote voice pool overload never evicts an owned release", "[nodes][veltonote]")
+{
+  Engine<1, 4> engine;
+  Settings s{.start_quant = 0., .end_quant = -1.};
+  std::vector<MidiEvent> out;
+  engine.push(0, {60, 100});
+  engine.push(1, {61, 100});
+  engine.push(2, {60, 0});
+  engine.process(
+      block(0, 3, 0., 1., 0, 1000), s, [&](MidiEvent e) { out.push_back(e); });
+  REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {2, 0, 60, 0, false}});
+  REQUIRE(engine.statistics().dropped_triggers == 1);
+}

--- a/tests/nodes/VelToNoteTest.cpp
+++ b/tests/nodes/VelToNoteTest.cpp
@@ -484,3 +484,112 @@ TEST_CASE(
   REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {2, 0, 60, 0, false}});
   REQUIRE(engine.statistics().dropped_triggers == 1);
 }
+
+// Quantized mode only. The grid here is one quarter, and the test blocks run
+// ten frames to the quarter, so a grid deadline lands on a multiple of ten and
+// a clamped one does not have to.
+TEST_CASE("VelToNote quantized minimum extends to the next grid point", "[nodes][veltonote]")
+{
+  const auto run = [](Bound lo, Bound hi) {
+    Engine<2, 2> engine;
+    Settings s{.start_quant = 0., .end_quant = 0.25, .min_duration = lo, .max_duration = hi};
+    std::vector<MidiEvent> out;
+    engine.push(0, {60, 100});
+    engine.process(
+        block(0, 40, 0., 4., 0, 28224000), s, [&](MidiEvent e) { out.push_back(e); });
+    return out;
+  };
+
+  SECTION("unbounded ends at the first grid point")
+  {
+    REQUIRE(
+        run({}, {})
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {10, 0, 60, 0, false}});
+  }
+  SECTION("a minimum past that grid point moves out to the next one")
+  {
+    // 1.5 quarters is not a grid point; the note holds to quarter 2, not to 1.5.
+    REQUIRE(
+        run({1.5, DurationUnit::quarters}, {})
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {20, 0, 60, 0, false}});
+  }
+  SECTION("a minimum already satisfied changes nothing")
+  {
+    REQUIRE(
+        run({0.5, DurationUnit::quarters}, {})
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {10, 0, 60, 0, false}});
+  }
+  SECTION("a minimum in seconds is converted with the slice's own tempo")
+  {
+    // The slice spans four quarters in 0.04 s, so 0.015 s is 1.5 quarters and
+    // lands on the same grid point as the musical case above.
+    REQUIRE(
+        run({0.015, DurationUnit::model_seconds}, {})
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {20, 0, 60, 0, false}});
+  }
+  SECTION("a maximum shorter than the grid clamps exactly, off the grid")
+  {
+    REQUIRE(
+        run({}, {0.5, DurationUnit::quarters})
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {5, 0, 60, 0, false}});
+  }
+  SECTION("a maximum longer than the grid changes nothing")
+  {
+    REQUIRE(
+        run({}, {3., DurationUnit::quarters})
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {10, 0, 60, 0, false}});
+  }
+  SECTION("a maximum below the minimum yields exactly the minimum")
+  {
+    REQUIRE(
+        run({1.5, DurationUnit::quarters}, {0.5, DurationUnit::quarters})
+        == std::vector<MidiEvent>{{0, 0, 60, 100, true}, {15, 0, 60, 0, false}});
+  }
+}
+
+TEST_CASE("VelToNote quantized bounds run from the note, not its arrival", "[nodes][veltonote]")
+{
+  Engine<2, 2> engine;
+  // Start quantization delays the on to quarter 1; the bound is measured there.
+  Settings s{
+      .start_quant = 0.25,
+      .tightness = 1.,
+      .end_quant = 0.25,
+      .max_duration = {0.5, DurationUnit::quarters}};
+  std::vector<MidiEvent> out;
+  engine.push(3, {60, 100});
+  engine.process(
+      block(0, 40, 0., 4., 0, 28224000), s, [&](MidiEvent e) { out.push_back(e); });
+  REQUIRE(out == std::vector<MidiEvent>{{10, 0, 60, 100, true}, {15, 0, 60, 0, false}});
+}
+
+TEST_CASE("VelToNote quantized bounds survive a meter change", "[nodes][veltonote]")
+{
+  // A meter change re-derives an active note's grid deadline. The ceiling has
+  // to be re-applied there too, or a signature change silently drops it.
+  const auto run = [](Bound hi) {
+    Engine<2, 2> engine;
+    Settings s{.start_quant = 0., .end_quant = 0.25, .max_duration = hi};
+    std::vector<MidiEvent> out;
+    auto sink = [&](MidiEvent e) { out.push_back(e); };
+    engine.push(0, {60, 100});
+    auto first = block(0, 2, 0., .2, 0, 1411200);
+    first.numerator = 4;
+    first.last_signature = 0.;
+    engine.process(first, s, sink);
+    REQUIRE(out == std::vector<MidiEvent>{{0, 0, 60, 100, true}});
+    out.clear();
+    auto second = block(2, 10, .2, 1.2, 1411200, 8467200);
+    second.numerator = 3;
+    second.last_signature = .2;
+    engine.process(second, s, sink);
+    return out;
+  };
+
+  // Ten frames to the quarter: the re-derived grid point is a whole quarter
+  // away, the ceiling is half of one.
+  REQUIRE(run({}) == std::vector<MidiEvent>{{8, 0, 60, 0, false}});
+  REQUIRE(
+      run({0.5, DurationUnit::quarters})
+      == std::vector<MidiEvent>{{3, 0, 60, 0, false}});
+}

--- a/tests/threedim/PrimitiveMeshes.cpp
+++ b/tests/threedim/PrimitiveMeshes.cpp
@@ -18,6 +18,9 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cmath>
+#include <set>
+#include <string>
+#include <cstdio>
 #include <limits>
 
 using Catch::Approx;
@@ -465,4 +468,47 @@ TEST_CASE("ArrayToMesh triangulation keeps the buffer self-consistent",
   CHECK(g.mesh.vertices >= 0);
   CHECK(g.mesh.vertices % 3 == 0);
   CHECK(g.mesh.buffers.main_buffer.element_count == g.mesh.vertices * 8);
+}
+
+// The shading model a primitive publishes, which decides whether a closed-form
+// render oracle can use one. createMesh ends with PerVertexNormalized, so a
+// corner shared by three faces carries ONE averaged normal, not three face
+// normals -- the cube is de-indexed to 36 corners but only 8 distinct normals
+// appear among them, and not one of them is axis-aligned:
+//
+//   +/-(0.577, 0.577, 0.577)   the two corners the triangulation treats
+//                              symmetrically
+//   permutations of            the other six, where the weighting of the
+//   (0.667, 0.667, -0.333)     adjoining triangles is not equal
+//
+// The cube is therefore SMOOTH-shaded: no face has a constant normal across
+// it. That is why tests/integration/ThreedimLitSceneTest.cpp reaches for the
+// Khronos Box asset instead of this primitive -- Box.glb is flat-shaded, one
+// constant normal per face, which is what makes its per-face expectations
+// closed-form. Swapping the asset for this primitive is not a substitution;
+// it is a different oracle.
+TEST_CASE("Cube normals are averaged at its corners", "[threedim][primitive]")
+{
+  Threedim::Cube cube;
+  cube.update();
+  auto s = checkLayout(cube.outputs);
+  REQUIRE(s.vertices == 36);
+
+  std::set<std::string> distinct;
+  int axisAligned = 0;
+  for(int64_t v = 0; v < s.vertices; v++)
+  {
+    const float* n = s.nrm + v * 3;
+    char buf[64];
+    std::snprintf(buf, sizeof buf, "%.3f %.3f %.3f", n[0], n[1], n[2]);
+    distinct.insert(buf);
+    for(int c = 0; c < 3; c++)
+      if(std::abs(std::abs(n[c]) - 1.f) < 1e-3f)
+        axisAligned++;
+  }
+
+  // One per corner, shared by every triangle that meets there.
+  CHECK(distinct.size() == 8);
+  // Not one face normal among them.
+  CHECK(axisAligned == 0);
 }

--- a/tests/tools/run-with-display.sh
+++ b/tests/tools/run-with-display.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Run "$@" against a private X server instead of the developer's session.
+#
+# A GUI test maps real windows: on the developer's display they flash over
+# whatever is on screen, steal focus, and -- for the tests that drive input --
+# grab the pointer and the keyboard. A throwaway Xvfb makes all of that
+# invisible, and a test that wedges with a grab held cannot lock the session.
+#
+# Vulkan still runs on the real GPU here, since the ICD does not go through the
+# X server to enumerate devices. OpenGL does: it falls back to llvmpipe, which
+# is slower but complete (GL 4.6 core).
+#
+# One server per test rather than one for the whole ctest run: with -j every
+# test gets its own, nothing has to agree on a display number, and there is no
+# server left behind when ctest is interrupted. Xvfb picks the number itself
+# through -displayfd, so parallel tests never race for one.
+#
+# Set SCORE_TESTS_NO_XVFB=1 to run on the inherited display instead, which is
+# what you want when watching a test to see what it actually draws.
+set -u
+
+if [ "${SCORE_TESTS_NO_XVFB:-0}" != "0" ] || ! command -v Xvfb >/dev/null 2>&1; then
+  exec "$@"
+fi
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/score-xvfb.XXXXXX")
+xpid=""
+cleanup() {
+  [ -n "$xpid" ] && kill "$xpid" 2>/dev/null
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+: > "$tmpdir/display"
+Xvfb -displayfd 3 -screen 0 1920x1080x24 -nolisten tcp \
+  3>"$tmpdir/display" >"$tmpdir/xvfb.log" 2>&1 &
+xpid=$!
+
+disp=""
+i=0
+while [ "$i" -lt 200 ]; do
+  disp=$(cat "$tmpdir/display" 2>/dev/null | tr -d '\n')
+  case "$disp" in
+    '' | *[!0-9]*) disp="" ;;
+    *) break ;;
+  esac
+  kill -0 "$xpid" 2>/dev/null || break
+  sleep 0.05
+  i=$((i + 1))
+done
+
+if [ -z "$disp" ]; then
+  echo "run-with-display.sh: Xvfb did not come up" >&2
+  sed 's/^/  /' "$tmpdir/xvfb.log" >&2
+  exit 1
+fi
+
+# WAYLAND_DISPLAY would otherwise win the platform auto-detection and put the
+# windows straight back on the developer's compositor; XAUTHORITY holds cookies
+# for their server, not this one.
+unset WAYLAND_DISPLAY
+unset XAUTHORITY
+DISPLAY=":$disp"
+export DISPLAY
+
+# Xvfb has no DRI3, so GLX here is llvmpipe whatever the machine has. Say so:
+# a test that measures render throughput cannot make its claim on a software
+# rasteriser and should skip rather than fail. Vulkan is not affected.
+SCORE_TESTS_SOFTWARE_GL=1
+export SCORE_TESTS_SOFTWARE_GL
+
+"$@"
+rc=$?
+exit "$rc"

--- a/tests/unit/AutomationValueTest.cpp
+++ b/tests/unit/AutomationValueTest.cpp
@@ -210,3 +210,77 @@ TEST_CASE("Automation serialization round-trips values, domain and address", "[a
     }
   });
 }
+
+// A curve whose first segment does not start at t = 0. CurveConversion only
+// carried the first segment's start point over to the ossia curve when it sat
+// exactly at 0, so anything before that segment fell back to y0 = 0 and the
+// segment itself was stretched back to the origin: the first segment was, in
+// effect, thrown away.
+TEST_CASE("Automation curve starting after zero holds its first value", "[automation][values]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+    QObject* owner = new QObject{&doc->model()};
+
+    Automation::ProcessModel proc{
+        TimeVal::fromMsecs(1000.), Id<Process::ProcessModel>{1}, owner};
+    proc.setMin(0.);
+    proc.setMax(1.);
+
+    // Nothing until t = 0.25, then 0.5 -> 1 over [0.25, 0.75].
+    auto& cm = proc.curve();
+    cm.clear();
+    auto seg = new Curve::LinearSegment{Id<Curve::SegmentModel>{1}, &cm};
+    seg->setStart({0.25, 0.5});
+    seg->setEnd({0.75, 1.});
+    cm.addSegment(seg);
+
+    auto curve = make_execution_curve(proc);
+
+    // Before the segment: its start value, held.
+    CHECK(curve->value_at(0.) == Approx(0.5f).margin(1e-6));
+    CHECK(curve->value_at(0.2) == Approx(0.5f).margin(1e-6));
+
+    // Inside it: interpolated across its own span, not stretched to the origin.
+    CHECK(curve->value_at(0.25) == Approx(0.5f).margin(1e-6));
+    CHECK(curve->value_at(0.5) == Approx(0.75f).margin(1e-6));
+    CHECK(curve->value_at(0.75) == Approx(1.f).margin(1e-6));
+
+    // After it: the last value, held.
+    CHECK(curve->value_at(1.) == Approx(1.f).margin(1e-6));
+  });
+}
+
+// The same for a curve with several segments, where only the first is offset.
+TEST_CASE("Automation curve offset from zero keeps every later segment", "[automation][values]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+    QObject* owner = new QObject{&doc->model()};
+
+    Automation::ProcessModel proc{
+        TimeVal::fromMsecs(1000.), Id<Process::ProcessModel>{1}, owner};
+    proc.setMin(0.);
+    proc.setMax(1.);
+
+    auto& cm = proc.curve();
+    cm.clear();
+    auto a = new Curve::LinearSegment{Id<Curve::SegmentModel>{1}, &cm};
+    a->setStart({0.2, 1.});
+    a->setEnd({0.6, 0.});
+    auto b = new Curve::LinearSegment{Id<Curve::SegmentModel>{2}, &cm};
+    b->setStart({0.6, 0.});
+    b->setEnd({1., 1.});
+    cm.addSegment(a);
+    cm.addSegment(b);
+
+    auto curve = make_execution_curve(proc);
+    CHECK(curve->value_at(0.) == Approx(1.f).margin(1e-6));
+    CHECK(curve->value_at(0.4) == Approx(0.5f).margin(1e-6));
+    CHECK(curve->value_at(0.6) == Approx(0.f).margin(1e-6));
+    CHECK(curve->value_at(0.8) == Approx(0.5f).margin(1e-6));
+    CHECK(curve->value_at(1.) == Approx(1.f).margin(1e-6));
+  });
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,14 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# Kabang / Minibang pitch modulation: pure math, no sampler around it.
+if(TARGET score_addon_synthimi)
+  score_add_test(test_unit_kabang_pitch_envelope
+    SOURCES KabangPitchEnvelopeTest.cpp)
+  target_include_directories(test_unit_kabang_pitch_envelope
+    PRIVATE "${SCORE_ROOT_SOURCE_DIR}/src/addons/score-addon-synthimi")
+endif()
+
 # The one right-click type-in box: two of them used to stay up, and taking one
 # down twice was a double free.
 score_add_test(test_unit_right_click_widget

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -589,6 +589,12 @@ score_add_test(test_unit_device_tree_reload
   APP
   PLUGINS score_plugin_deviceexplorer score_lib_device score_lib_state)
 
+# Cancelling a Learn takes back what it added without taking the device down.
+score_add_test(test_unit_learn_rollback
+  SOURCES LearnRollbackTest.cpp
+  APP
+  PLUGINS score_plugin_deviceexplorer score_lib_device score_lib_state)
+
 # Two processes that a user can add must not carry the same label.
 score_add_test(test_unit_process_name_uniqueness
   SOURCES ProcessNameUniquenessTest.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -61,6 +61,13 @@ score_add_test(test_unit_slider_defaults
   SOURCES SliderDefaultsTest.cpp
   APP)
 
+# Editing the messages of a state: one balanced reset per edit, so that the
+# execution component hears about it exactly once.
+score_add_test(test_unit_state_message_edit
+  SOURCES StateMessageEditTest.cpp
+  APP
+  PLUGINS score_plugin_scenario)
+
 # The one right-click type-in box: two of them used to stay up, and taking one
 # down twice was a double free.
 score_add_test(test_unit_right_click_widget

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -138,6 +138,10 @@ if(TARGET score_addon_synthimi)
   endif()
 endif()
 
+# A file control clicked twice used to open two dialogs, one after the other.
+score_add_test(test_unit_file_picker_reentrancy
+  SOURCES FilePickerReentrancyTest.cpp)
+
 # The one right-click type-in box: two of them used to stay up, and taking one
 # down twice was a double free.
 score_add_test(test_unit_right_click_widget

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -123,6 +123,19 @@ if(TARGET score_addon_synthimi)
     SOURCES KabangPitchEnvelopeTest.cpp)
   target_include_directories(test_unit_kabang_pitch_envelope
     PRIVATE "${SCORE_ROOT_SOURCE_DIR}/src/addons/score-addon-synthimi")
+
+  # Unlike the pitch-envelope case, this one needs DrumChannel, which drags in
+  # the addon's whole dependency chain: link the plug-in for its include dirs.
+  score_add_test(test_unit_minibang_no_sample
+    SOURCES MinibangNoSampleTest.cpp
+      "${SCORE_ROOT_SOURCE_DIR}/src/addons/score-addon-synthimi/Kabang/Kabang.cpp"
+      "${SCORE_ROOT_SOURCE_DIR}/src/addons/score-addon-synthimi/Kabang/Sampler.cpp"
+    PLUGINS score_addon_synthimi)
+  target_include_directories(test_unit_minibang_no_sample
+    PRIVATE "${SCORE_ROOT_SOURCE_DIR}/src/addons/score-addon-synthimi")
+  if(TARGET rubberband)
+    target_link_libraries(test_unit_minibang_no_sample PRIVATE rubberband)
+  endif()
 endif()
 
 # The one right-click type-in box: two of them used to stay up, and taking one

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,12 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# The comment box: trailing spaces and reflow, both QTextDocument behaviour.
+score_add_test(test_unit_textbox_layout
+  SOURCES TextBoxLayoutTest.cpp
+  APP
+  PLUGINS score_plugin_ui score_lib_process)
+
 # A colour control fed from an address whose unit is not rgba.
 score_add_test(test_unit_color_control_unit
   SOURCES ColorControlUnitTest.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,14 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# The PipeWire video input panel: a picker over the live nodes.
+if(TARGET score_plugin_gfx)
+  score_add_test(test_unit_pipewire_settings_widget
+    SOURCES PipewireSettingsWidgetTest.cpp
+    APP
+    PLUGINS score_plugin_gfx score_lib_device)
+endif()
+
 # The waveform a soundfile control draws for a file that is already decoded.
 if(TARGET score_plugin_media)
   score_add_test(test_unit_waveform_button

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,13 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# The preview widget the library shows beside a preset: only the handler that
+# owns the process answers.
+score_add_test(test_unit_library_preset_preview
+  SOURCES LibraryPresetPreviewTest.cpp
+  APP
+  PLUGINS score_plugin_library score_lib_process)
+
 # The Point2D View's axis mapping: an inverted range is a range.
 if(EXISTS "${SCORE_AVND_SOURCE_DIR}/../../../3rdparty/avendish/examples/Advanced/UI/2DView.hpp")
   score_add_test(test_unit_point2d_view

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -56,6 +56,11 @@ score_add_test(test_unit_graphics_combo
   SOURCES GraphicsComboTest.cpp
   APP)
 
+# Double-click on a control puts it back to the default the process declared.
+score_add_test(test_unit_slider_defaults
+  SOURCES SliderDefaultsTest.cpp
+  APP)
+
 # The one right-click type-in box: two of them used to stay up, and taking one
 # down twice was a double free.
 score_add_test(test_unit_right_click_widget

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,11 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# Where a node draws its outlets when it has no inlets to balance them.
+score_add_test(test_unit_outlet_layout
+  SOURCES OutletLayoutTest.cpp
+  APP)
+
 # The preview widget the library shows beside a preset: only the handler that
 # owns the process answers.
 score_add_test(test_unit_library_preset_preview

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,16 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# The Point2D View's axis mapping: an inverted range is a range.
+if(EXISTS "${SCORE_AVND_SOURCE_DIR}/../../../3rdparty/avendish/examples/Advanced/UI/2DView.hpp")
+  score_add_test(test_unit_point2d_view
+    SOURCES Point2DViewTest.cpp
+    APP
+    PLUGINS score_lib_process)
+  target_include_directories(test_unit_point2d_view
+    PRIVATE "${SCORE_ROOT_SOURCE_DIR}/3rdparty/avendish/examples/Advanced")
+endif()
+
 # The comment box: trailing spaces and reflow, both QTextDocument behaviour.
 score_add_test(test_unit_textbox_layout
   SOURCES TextBoxLayoutTest.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,11 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# A colour control fed from an address whose unit is not rgba.
+score_add_test(test_unit_color_control_unit
+  SOURCES ColorControlUnitTest.cpp
+  PLUGINS score_lib_process)
+
 # Kabang / Minibang pitch modulation: pure math, no sampler around it.
 if(TARGET score_addon_synthimi)
   score_add_test(test_unit_kabang_pitch_envelope

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -68,6 +68,14 @@ score_add_test(test_unit_state_message_edit
   APP
   PLUGINS score_plugin_scenario)
 
+# The waveform a soundfile control draws for a file that is already decoded.
+if(TARGET score_plugin_media)
+  score_add_test(test_unit_waveform_button
+    SOURCES WaveformButtonTest.cpp
+    APP
+    PLUGINS score_plugin_media score_lib_process)
+endif()
+
 # Where a node draws its outlets when it has no inlets to balance them.
 score_add_test(test_unit_outlet_layout
   SOURCES OutletLayoutTest.cpp

--- a/tests/unit/ColorControlUnitTest.cpp
+++ b/tests/unit/ColorControlUnitTest.cpp
@@ -119,3 +119,52 @@ TEST_CASE("a color.hsv address reaches a colour control as rgba")
   CHECK(v[1] == Catch::Approx(0.f).margin(1e-4));
   CHECK(v[2] == Catch::Approx(0.f).margin(1e-4));
 }
+
+// A colour sent without its alpha.
+//
+// The gfx uniform update used ossia::convert<vec4f>(list), which starts from a
+// zeroed vector and fills only what the list carries. Three floats therefore
+// wrote a zero into the fourth component, and on a colour that is alpha: an
+// OSC address carrying rgb turned the shape black. A cable never showed it,
+// because it carries all four.
+//
+// This pins the rule the uniform update follows now: take what the list
+// supplies, leave the rest alone.
+namespace
+{
+template <std::size_t N>
+void assign_prefix_ref(
+    std::array<float, N>& val, const std::vector<ossia::value>& v) noexcept
+{
+  const std::size_t n = std::min(v.size(), N);
+  for(std::size_t i = 0; i < n; i++)
+    val[i] = ossia::convert<float>(v[i]);
+}
+}
+
+TEST_CASE("a colour sent without alpha keeps the alpha it had", "[unit][color]")
+{
+  // What the old code did, for contrast: everything the list omits is zeroed.
+  CHECK(ossia::convert<ossia::vec4f>(std::vector<ossia::value>{1.f, 1.f, 1.f})[3]
+        == 0.f);
+
+  ossia::vec4f uniform{0.2f, 0.4f, 0.6f, 1.f};
+  assign_prefix_ref(uniform, std::vector<ossia::value>{1.f, 0.5f, 0.25f});
+
+  CHECK(uniform[0] == 1.f);
+  CHECK(uniform[1] == 0.5f);
+  CHECK(uniform[2] == 0.25f);
+  CHECK(uniform[3] == 1.f); // untouched, not zeroed
+
+  SECTION("a full rgba still overwrites everything")
+  {
+    assign_prefix_ref(uniform, std::vector<ossia::value>{0.f, 0.f, 0.f, 0.5f});
+    CHECK(uniform[3] == 0.5f);
+  }
+  SECTION("a longer list does not run past the uniform")
+  {
+    assign_prefix_ref(
+        uniform, std::vector<ossia::value>{1.f, 1.f, 1.f, 1.f, 9.f, 9.f});
+    CHECK(uniform[3] == 1.f);
+  }
+}

--- a/tests/unit/ColorControlUnitTest.cpp
+++ b/tests/unit/ColorControlUnitTest.cpp
@@ -168,3 +168,22 @@ TEST_CASE("a colour sent without alpha keeps the alpha it had", "[unit][color]")
     CHECK(uniform[3] == 1.f);
   }
 }
+
+// The time chooser's second component is its mode: 0 means the value is in
+// seconds, anything else means musical denominations. The port used to start
+// at 1 while the object declaring it (halp::time_chooser_t) declares
+// `sync{false}`, so a control's declared init was read as quarter notes and
+// converted against the tempo -- two seconds became two quarters.
+TEST_CASE("a time chooser starts in seconds, as its object declares", "[unit][ui]")
+{
+  Process::TimeChooser tc{0.f, 10.f, 2.f, "Duration", Id<Process::Port>{0}, nullptr};
+
+  const auto v = ossia::convert<ossia::vec2f>(tc.value());
+  CHECK(v[0] == 2.f);
+  CHECK(v[1] == 0.f);
+
+  // init mirrors it, so a reset does not flip the mode either.
+  const auto i = ossia::convert<ossia::vec2f>(tc.init());
+  CHECK(i[0] == 2.f);
+  CHECK(i[1] == 0.f);
+}

--- a/tests/unit/ColorControlUnitTest.cpp
+++ b/tests/unit/ColorControlUnitTest.cpp
@@ -1,0 +1,121 @@
+// A colour control driven from an address whose unit is color.rgb.
+//
+// Process::HSVSlider -- the colour control every shader and shape process
+// carries -- declares unit() == rgba for the UI, but never told the execution
+// port anything. value_port::effective_type() was therefore empty, and
+// adapt_value() converts nothing when it has no sink type: an OSC parameter
+// declared color.rgb wrote its three floats straight into a control that reads
+// four, while color.rgba happened to line up and worked.
+
+#include <Process/Dataflow/WidgetInlets.hpp>
+
+#include <ossia/dataflow/port.hpp>
+#include <ossia/network/base/parameter.hpp>
+#include <ossia/network/common/complex_type.hpp>
+#include <ossia/network/dataspace/color.hpp>
+#include <ossia/network/dataspace/dataspace_visitors.hpp>
+#include <ossia/network/generic/generic_device.hpp>
+#include <ossia/network/local/local.hpp>
+#include <ossia/network/value/value.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <memory>
+
+namespace
+{
+struct Fixture
+{
+  ossia::net::generic_device device{
+      std::make_unique<ossia::net::multiplex_protocol>(), "test"};
+
+  //! A device parameter carrying a colour in the given unit, the way an OSC
+  //! device declares one.
+  ossia::net::parameter_base& color_param(const char* name, ossia::unit_t u)
+  {
+    auto& node = ossia::net::create_node(device, name);
+    auto* p = node.create_parameter(ossia::underlying_type(u));
+    p->set_unit(u);
+    return *p;
+  }
+};
+}
+
+TEST_CASE("a colour control declares its unit to the execution port")
+{
+  Process::HSVSlider inlet{
+      ossia::vec4f{0.f, 0.f, 0.f, 1.f}, "Color", Id<Process::Port>{0}, nullptr};
+
+  ossia::value_inlet exec;
+  inlet.setupExecution(exec, nullptr);
+
+  const auto* u = (*exec).effective_unit();
+  REQUIRE(u != nullptr);
+  CHECK(*u == ossia::unit_t{ossia::rgba_u{}});
+}
+
+TEST_CASE("a color.rgb address reaches a colour control as rgba")
+{
+  Fixture f;
+  auto& param = f.color_param("rgb", ossia::unit_t{ossia::rgb_u{}});
+
+  Process::HSVSlider inlet{
+      ossia::vec4f{0.f, 0.f, 0.f, 1.f}, "Color", Id<Process::Port>{0}, nullptr};
+  ossia::value_inlet exec;
+  inlet.setupExecution(exec, nullptr);
+
+  (*exec).add_global_value(param, ossia::make_vec(1.f, 0.5f, 0.25f));
+
+  const auto& data = (*exec).get_data();
+  REQUIRE(data.size() == 1);
+  REQUIRE(data[0].value.get_type() == ossia::val_type::VEC4F);
+  const auto v = data[0].value.get<ossia::vec4f>();
+  CHECK(v[0] == Catch::Approx(1.f));
+  CHECK(v[1] == Catch::Approx(0.5f));
+  CHECK(v[2] == Catch::Approx(0.25f));
+  CHECK(v[3] == Catch::Approx(1.f)); // opaque, the neutral alpha rgb implies
+}
+
+// The case that already worked, kept so the two stay in step.
+TEST_CASE("a color.rgba address reaches a colour control unchanged")
+{
+  Fixture f;
+  auto& param = f.color_param("rgba", ossia::unit_t{ossia::rgba_u{}});
+
+  Process::HSVSlider inlet{
+      ossia::vec4f{0.f, 0.f, 0.f, 1.f}, "Color", Id<Process::Port>{0}, nullptr};
+  ossia::value_inlet exec;
+  inlet.setupExecution(exec, nullptr);
+
+  (*exec).add_global_value(param, ossia::make_vec(1.f, 0.5f, 0.25f, 0.75f));
+
+  const auto& data = (*exec).get_data();
+  REQUIRE(data.size() == 1);
+  REQUIRE(data[0].value.get_type() == ossia::val_type::VEC4F);
+  const auto v = data[0].value.get<ossia::vec4f>();
+  CHECK(v[0] == Catch::Approx(1.f));
+  CHECK(v[3] == Catch::Approx(0.75f));
+}
+
+// An address in another colour unit entirely has to arrive converted too.
+TEST_CASE("a color.hsv address reaches a colour control as rgba")
+{
+  Fixture f;
+  auto& param = f.color_param("hsv", ossia::unit_t{ossia::hsv_u{}});
+
+  Process::HSVSlider inlet{
+      ossia::vec4f{0.f, 0.f, 0.f, 1.f}, "Color", Id<Process::Port>{0}, nullptr};
+  ossia::value_inlet exec;
+  inlet.setupExecution(exec, nullptr);
+
+  // Pure red in HSV.
+  (*exec).add_global_value(param, ossia::make_vec(0.f, 1.f, 1.f));
+
+  const auto& data = (*exec).get_data();
+  REQUIRE(data.size() == 1);
+  REQUIRE(data[0].value.get_type() == ossia::val_type::VEC4F);
+  const auto v = data[0].value.get<ossia::vec4f>();
+  CHECK(v[0] == Catch::Approx(1.f).margin(1e-4));
+  CHECK(v[1] == Catch::Approx(0.f).margin(1e-4));
+  CHECK(v[2] == Catch::Approx(0.f).margin(1e-4));
+}

--- a/tests/unit/FilePickerReentrancyTest.cpp
+++ b/tests/unit/FilePickerReentrancyTest.cpp
@@ -1,0 +1,80 @@
+// Clicking a file control while its dialog is already up.
+//
+// QFileDialog::getOpenFileName runs a nested event loop, and that loop keeps
+// delivering clicks to the widget underneath: a second click queued a second
+// dialog, which appeared the instant the first closed. Same for
+// getExistingDirectory behind the folder controls.
+//
+// The dialogs themselves cannot be driven from a test, so what is pinned here
+// is the guard's rule: while a pick is in flight, another request is dropped
+// rather than queued. The lambda below stands in for the dialog and re-enters
+// exactly as a queued click does.
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace
+{
+// Mirrors the guard in openFileToImport / openFolderToImport. The flag lives
+// OUTSIDE the template deliberately: a static inside one is per callable type,
+// so it would only catch a repeat click on the same control and two different
+// controls could still stack dialogs. The first version of this test caught
+// exactly that.
+int pick_calls = 0;
+int picked = 0;
+
+inline bool& picking() noexcept
+{
+  static bool b = false;
+  return b;
+}
+
+template <typename Dialog, typename F>
+void guarded_pick(Dialog&& dialog, F onPicked)
+{
+  if(picking())
+    return;
+  picking() = true;
+  ++pick_calls;
+  const bool ok = dialog();
+  picking() = false;
+  if(ok)
+    onPicked();
+}
+}
+
+TEST_CASE("a second click cannot open a second file dialog", "[unit][ui]")
+{
+  pick_calls = 0;
+  picked = 0;
+
+  // The dialog re-enters once, the way a click delivered by its own nested
+  // event loop does.
+  bool reentered = false;
+  auto dialog = [&] {
+    if(!reentered)
+    {
+      reentered = true;
+      guarded_pick([] { return true; }, [] { ++picked; });
+    }
+    return true;
+  };
+
+  guarded_pick(dialog, [] { ++picked; });
+
+  CHECK(reentered);        // the re-entry really happened
+  CHECK(pick_calls == 1);  // and opened nothing
+  CHECK(picked == 1);      // the outer pick still delivered its result
+}
+
+TEST_CASE("a cancelled pick leaves the next one free", "[unit][ui]")
+{
+  pick_calls = 0;
+  picked = 0;
+
+  guarded_pick([] { return false; }, [] { ++picked; });
+  CHECK(picked == 0);
+
+  guarded_pick([] { return true; }, [] { ++picked; });
+  CHECK(pick_calls == 2);
+  CHECK(picked == 1);
+}

--- a/tests/unit/IsfImportersTest.cpp
+++ b/tests/unit/IsfImportersTest.cpp
@@ -921,3 +921,101 @@ TEST_CASE(
   const auto eight = raw_raster_vertex(R"(, "CLIP_DISTANCES": 8)");
   CHECK(contains(eight, "float gl_ClipDistance[8];"));
 }
+
+// ---------------------------------------------------------------------------
+// long_input DEFAULT
+//
+// ISF says a "long" input's DEFAULT names one of the entries of VALUES, not a
+// position in it. libisf read it as a position, so "Video Mixer" -- VALUES
+// [1..25], DEFAULT 17, LABELS with "Normal" at index 16 -- came up on
+// "Overlay". long_input::def stays an index, because every synthesized input
+// in libisf fills it in as one; the value is resolved at parse time.
+
+namespace
+{
+isf::long_input parse_long_input(const std::string& extraJson)
+{
+  const std::string src
+      = "/*{ \"ISFVSN\": \"2\", \"INPUTS\": [ { \"NAME\": \"mode\", \"TYPE\": "
+        "\"long\""
+        + extraJson
+        + " } ] }*/\n"
+          "void main() { isf_FragColor = vec4(float(mode)); }\n";
+  parser p{{}, src, 450, parser::ShaderType::ISF};
+  auto d = p.data();
+  REQUIRE(d.inputs.size() == 1);
+  auto* l = ossia::get_if<isf::long_input>(&d.inputs[0].data);
+  REQUIRE(l);
+  return *l;
+}
+}
+
+TEST_CASE("REGRESSION: a long input's DEFAULT is one of its VALUES")
+{
+  // Video Mixer, cut down to the entries that matter.
+  auto in = parse_long_input(
+      R"(, "VALUES": [1, 2, 3, 17, 18], "LABELS": ["Add", "Average", "Burn", "Normal", "Overlay"], "DEFAULT": 17)");
+
+  REQUIRE(in.values.size() == 5);
+  REQUIRE(in.def < in.labels.size());
+  CHECK(in.labels[in.def] == "Normal");
+}
+
+TEST_CASE("a long input whose VALUES are their own indices is unchanged")
+{
+  auto in = parse_long_input(
+      R"(, "VALUES": [0, 1, 2], "LABELS": ["a", "b", "c"], "DEFAULT": 1)");
+  CHECK(in.def == 1);
+  CHECK(in.labels[in.def] == "b");
+}
+
+TEST_CASE("a long input whose DEFAULT is in no VALUES falls back to a position")
+{
+  // Shaders in the wild do write a position here; reading it as one is better
+  // than dropping the author's intent on the floor.
+  auto in = parse_long_input(
+      R"(, "VALUES": [10, 20, 30], "LABELS": ["a", "b", "c"], "DEFAULT": 2)");
+  CHECK(in.def == 2);
+}
+
+TEST_CASE("a long input's DEFAULT out of every reading lands on the first entry")
+{
+  auto in = parse_long_input(
+      R"(, "VALUES": [10, 20, 30], "LABELS": ["a", "b", "c"], "DEFAULT": 99)");
+  CHECK(in.def < in.values.size());
+}
+
+TEST_CASE("a string-valued long input matches its DEFAULT by name")
+{
+  auto in = parse_long_input(
+      R"(, "VALUES": ["low", "mid", "high"], "LABELS": ["Low", "Mid", "High"], "DEFAULT": "high")");
+  REQUIRE(in.def < in.labels.size());
+  CHECK(in.labels[in.def] == "High");
+}
+
+TEST_CASE("a numeric long input keeps DEFAULT as the value it is")
+{
+  // No VALUES/LABELS: MIN/MAX mode, where DEFAULT has always been the value.
+  auto in = parse_long_input(R"(, "MIN": 0, "MAX": 100, "DEFAULT": 42)");
+  CHECK(in.values.empty());
+  CHECK(in.def == 42);
+}
+
+TEST_CASE("REGRESSION: writing a long input back out emits a VALUE, not a position")
+{
+  const std::string src
+      = "/*{ \"ISFVSN\": \"2\", \"INPUTS\": [ { \"NAME\": \"mode\", \"TYPE\": "
+        "\"long\", \"VALUES\": [1, 2, 3, 17, 18], \"LABELS\": [\"Add\", "
+        "\"Average\", \"Burn\", \"Normal\", \"Overlay\"], \"DEFAULT\": 17 } ] }*/\n"
+        "void main() { isf_FragColor = vec4(float(mode)); }\n";
+  parser p{{}, src, 450, parser::ShaderType::ISF};
+
+  const std::string written = p.write_isf();
+  parser again{{}, written, 450, parser::ShaderType::ISF};
+  auto d = again.data();
+  REQUIRE(d.inputs.size() == 1);
+  auto* l = ossia::get_if<isf::long_input>(&d.inputs[0].data);
+  REQUIRE(l);
+  REQUIRE(l->def < l->labels.size());
+  CHECK(l->labels[l->def] == "Normal");
+}

--- a/tests/unit/KabangPitchEnvelopeTest.cpp
+++ b/tests/unit/KabangPitchEnvelopeTest.cpp
@@ -1,0 +1,68 @@
+// Minibang / Kabang pitch modulation.
+//
+// Two defects lived in the same expression:
+//
+//   if(v.pitch_track >= 0.) penv *= v.pitch_track; else penv /= -v.pitch_track;
+//   pitch = clamp(v.pitch + 5.0 * penv * v.pitch_track, 1./5., 5.);
+//
+//  * Vel->Pitch multiplied the envelope twice, so with the knob at its default
+//    of 0 the pitch envelope contributed exactly nothing however it was set.
+//  * A negative Vel->Pitch divided by it: at -0.01 the envelope was multiplied
+//    by 100 and then by -0.01 again, which drove the ratio into the bottom of
+//    the clamp no matter what the Pitch knob said.
+
+#include <Kabang/PitchEnvelope.hpp>
+
+#include <catch2/catch_all.hpp>
+
+using kbng::pitch_scale;
+
+TEST_CASE("the pitch envelope is audible with Vel->Pitch at its default")
+{
+  // "P. Env" on, Vel->Pitch at 0: the envelope still moves the pitch.
+  const double at_rest = pitch_scale(1., 0., true, 0.);
+  const double at_peak = pitch_scale(1., 1., true, 0.);
+
+  CHECK(at_rest == Catch::Approx(1.));
+  CHECK(at_peak > at_rest);
+  CHECK(at_peak == Catch::Approx(4.)); // two octaves up at full envelope
+}
+
+TEST_CASE("a small negative Vel->Pitch barely changes anything")
+{
+  const double neutral = pitch_scale(1., 0.5, true, 0.);
+  const double nudged = pitch_scale(1., 0.5, true, -0.01);
+
+  CHECK(nudged == Catch::Approx(neutral).margin(0.03));
+  // What used to happen: straight to the bottom of the clamp.
+  CHECK(nudged > kbng::min_pitch_scale + 0.1);
+}
+
+TEST_CASE("Vel->Pitch scales the envelope's depth in both directions")
+{
+  const double base = pitch_scale(1., 1., true, 0.);
+
+  CHECK(pitch_scale(1., 1., true, 1.) > base);  // twice the depth
+  CHECK(pitch_scale(1., 1., true, -1.) == Catch::Approx(1.)); // fully cancelled
+  CHECK(pitch_scale(1., 1., true, -0.5) < base);
+}
+
+TEST_CASE("the envelope off leaves the Pitch knob alone")
+{
+  CHECK(pitch_scale(2., 1., false, 0.5) == Catch::Approx(2.));
+  CHECK(pitch_scale(0.5, 1., false, -0.5) == Catch::Approx(0.5));
+}
+
+TEST_CASE("the pitch ratio stays inside what the stretcher accepts")
+{
+  for(double pitch : {0.25, 1., 5.})
+    for(double env : {0., 0.5, 1.})
+      for(double track : {-1., -0.01, 0., 0.5, 1.})
+      {
+        const double v = pitch_scale(pitch, env, true, track);
+        INFO("pitch=" << pitch << " env=" << env << " track=" << track);
+        CHECK(v >= kbng::min_pitch_scale);
+        CHECK(v <= kbng::max_pitch_scale);
+        CHECK(std::isfinite(v));
+      }
+}

--- a/tests/unit/LearnRollbackTest.cpp
+++ b/tests/unit/LearnRollbackTest.cpp
@@ -1,0 +1,170 @@
+// Cancelling a "Learn" must not take the device down with it.
+//
+// The rollback used to be ReloadWholeDevice::undo: remove the device, build a
+// new one from the saved tree. Everything the outside world had attached to the
+// old one went with it -- with PipeWire, cancelling a learn that had added
+// nothing at all still dropped the user's MIDI cable.
+
+#include <Device/Node/DeviceNode.hpp>
+#include <Device/Protocol/DeviceInterface.hpp>
+
+#include <Explorer/Commands/Add/LoadDevice.hpp>
+#include <Explorer/DeviceList.hpp>
+#include <Explorer/DocumentPlugin/DeviceDocumentPlugin.hpp>
+#include <Explorer/DocumentPlugin/NodeUpdateProxy.hpp>
+#include <Explorer/Explorer/DeviceExplorerModel.hpp>
+#include <Explorer/Explorer/LearnRollback.hpp>
+
+#include <score/command/Dispatchers/CommandDispatcher.hpp>
+#include <score/document/DocumentContext.hpp>
+
+#include <core/document/Document.hpp>
+
+#include <QApplication>
+
+#include <catch2/catch_all.hpp>
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+
+#include <set>
+#include <string>
+
+#include "FakeDeviceProtocol.hpp"
+
+using namespace score::test::fake;
+
+namespace
+{
+struct Fixture
+{
+  score::Document* doc{};
+  Explorer::DeviceDocumentPlugin* plug{};
+
+  explicit Fixture(const score::GUIApplicationContext& ctx)
+  {
+    g_opts = {};
+    registerFakeProtocol(ctx);
+    doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+    plug = &doc->context().plugin<Explorer::DeviceDocumentPlugin>();
+  }
+
+  void addDevice(const Device::DeviceSettings& s)
+  {
+    CommandDispatcher<>{doc->context().commandStack}.submit(
+        new Explorer::Command::LoadDevice{*plug, Device::Node{s, nullptr}});
+  }
+
+  Device::Node* deviceNode(const QString& name) const
+  {
+    for(auto& n : plug->rootNode())
+      if(n.get<Device::DeviceSettings>().name == name)
+        return &n;
+    return nullptr;
+  }
+
+  std::set<std::string> tree(const QString& name) const
+  {
+    std::set<std::string> out;
+    if(auto* n = deviceNode(name))
+      for(auto& child : *n)
+        out.insert(child.displayName().toStdString());
+    return out;
+  }
+
+  Device::DeviceInterface* device(const QString& name) const
+  {
+    return plug->list().findDevice(name);
+  }
+
+  //! What a learn does: nodes appear in the device and in the explorer.
+  void learn(const QString& deviceName, const QStringList& names)
+  {
+    auto* n = deviceNode(deviceName);
+    REQUIRE(n);
+    for(const auto& name : names)
+    {
+      Device::AddressSettings as;
+      as.name = name;
+      as.value = ossia::value{0};
+      as.ioType = ossia::access_mode::BI;
+      plug->updateProxy.addAddress(Device::NodePath{*n}, as, n->childCount());
+    }
+  }
+};
+
+using Names = std::set<std::string>;
+}
+
+TEST_CASE("cancelling a learn that found nothing leaves the device alone", "[learn]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    Fixture f{ctx};
+    f.addDevice(fakeSettings("midi", {"note"}));
+
+    auto* before = f.device("midi");
+    REQUIRE(before);
+    REQUIRE(before->connected());
+    const int connects = g_opts.connectCount;
+
+    // The learn saw nothing; the user pressed Cancel.
+    const Device::Node saved = *f.deviceNode("midi");
+    Explorer::rollbackLearnedNodes(*f.plug, "midi", saved);
+
+    // Same device object, still connected, never reconnected: whatever was
+    // wired to it outside score is still wired to it.
+    CHECK(f.device("midi") == before);
+    CHECK(f.device("midi")->connected());
+    CHECK(g_opts.connectCount == connects);
+    CHECK(f.tree("midi") == Names{"note"});
+  });
+}
+
+TEST_CASE("cancelling a learn takes back what it added", "[learn]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    Fixture f{ctx};
+    f.addDevice(fakeSettings("midi", {"note"}));
+
+    auto* before = f.device("midi");
+    REQUIRE(before);
+    const Device::Node saved = *f.deviceNode("midi");
+    const int connects = g_opts.connectCount;
+
+    f.learn("midi", {"cc1", "cc2"});
+    REQUIRE(f.tree("midi") == Names{"note", "cc1", "cc2"});
+
+    Explorer::rollbackLearnedNodes(*f.plug, "midi", saved);
+
+    CHECK(f.tree("midi") == Names{"note"});
+    CHECK(f.device("midi") == before);
+    CHECK(f.device("midi")->connected());
+    CHECK(g_opts.connectCount == connects);
+  });
+}
+
+TEST_CASE("cancelling a learn does not touch what was already there", "[learn]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    Fixture f{ctx};
+    f.addDevice(fakeSettings("midi", {"note", "bend"}));
+
+    const Device::Node saved = *f.deviceNode("midi");
+    f.learn("midi", {"cc7"});
+
+    Explorer::rollbackLearnedNodes(*f.plug, "midi", saved);
+    CHECK(f.tree("midi") == Names{"note", "bend"});
+  });
+}
+
+TEST_CASE("rolling back a device that is gone does nothing", "[learn]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    Fixture f{ctx};
+    f.addDevice(fakeSettings("midi", {"note"}));
+    const Device::Node saved = *f.deviceNode("midi");
+
+    Explorer::rollbackLearnedNodes(*f.plug, "not-a-device", saved);
+    SUCCEED("no crash");
+  });
+}

--- a/tests/unit/LibraryPresetPreviewTest.cpp
+++ b/tests/unit/LibraryPresetPreviewTest.cpp
@@ -1,0 +1,92 @@
+// The preview widget the library panel shows next to a preset.
+//
+// Library::ProcessWidget asks every LibraryInterface in turn for a preview of
+// the selected preset and takes the first widget it is handed. The shader
+// handlers answered every preset, whoever it belonged to, so picking a preset
+// of an object with no video output at all put an empty black shader preview
+// on screen -- and it stayed there, showing the last shader that had been
+// selected.
+
+#include <Library/LibraryInterface.hpp>
+
+#include <Process/Preset.hpp>
+#include <Process/ProcessMetadata.hpp>
+
+#include <score/application/GUIApplicationContext.hpp>
+#include <score/plugins/InterfaceList.hpp>
+
+#include <QWidget>
+
+#include <catch2/catch_all.hpp>
+#include <score_test/App.hpp>
+
+namespace
+{
+// The Gfx ISF filter, which does own a shader preview.
+const auto isf_uuid = QStringLiteral("74ca45ff-92c9-44a0-8f1a-754dea05ee1b");
+// An automation: no video output, no shader, no preview.
+const auto automation_uuid = QStringLiteral("d2a67bd8-5d3f-404e-b6e9-e350cf2a833f");
+
+Process::Preset presetOf(const QString& uuid)
+{
+  Process::Preset p;
+  p.name = "test";
+  p.key.key = UuidKey<Process::ProcessModel>::fromString(uuid);
+  p.data = QByteArray{"{}"};
+  return p;
+}
+
+//! What Library::ProcessWidget does when a preset is selected.
+QWidget* firstPreviewFor(const Process::Preset& preset, QWidget& parent)
+{
+  for(auto& lib : score::GUIAppContext().interfaces<Library::LibraryInterfaceList>())
+    if(auto* w = lib.previewWidget(preset, &parent))
+      return w;
+  return nullptr;
+}
+}
+
+TEST_CASE("a preset of a process with no preview gets none", "[library][preview]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QWidget parent;
+    auto* w = firstPreviewFor(presetOf(automation_uuid), parent);
+    INFO("got " << (w ? w->metaObject()->className() : "nothing"));
+    CHECK(w == nullptr);
+    delete w;
+  });
+}
+
+TEST_CASE("an unknown process gets no preview either", "[library][preview]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QWidget parent;
+    auto* w = firstPreviewFor(
+        presetOf(QStringLiteral("00000000-0000-0000-0000-000000000000")), parent);
+    CHECK(w == nullptr);
+    delete w;
+  });
+}
+
+// The other half: the handler that does own a preview still gives one, so the
+// guard above cannot pass by turning the feature off.
+TEST_CASE("a shader preset still gets its preview", "[library][preview]")
+{
+  if(qEnvironmentVariableIsSet("SCORE_DISABLE_SHADER_PREVIEW"))
+    SKIP("shader previews are disabled in this environment");
+
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    // Only when the Gfx plug-in is actually here.
+    bool haveIsf = false;
+    for(auto& lib : ctx.interfaces<Library::LibraryInterfaceList>())
+      (void)lib, haveIsf = true;
+    if(!haveIsf)
+      return;
+
+    QWidget parent;
+    auto* w = firstPreviewFor(presetOf(isf_uuid), parent);
+    INFO("an ISF preset must be answered by the shader handler");
+    CHECK(w != nullptr);
+    delete w;
+  });
+}

--- a/tests/unit/MinibangNoSampleTest.cpp
+++ b/tests/unit/MinibangNoSampleTest.cpp
@@ -1,0 +1,39 @@
+// A note sent to Minibang before a sample is loaded.
+//
+// DrumChannel::trigger(ts, vel) declines to start a voice when there is no
+// sample to play -- no soundfile, or one that decoded to nothing -- and
+// returns null. The pitch-ratio overload next to it dereferenced that without
+// looking, and Minibang is its only caller: Kabang uses the two-argument form
+// and ignores the result, which is why only Minibang crashed.
+//
+// The root key is user-settable from zero, which would make pitch_ratio
+// infinite on the first note. Checked here too, since it is the same call.
+
+#include <Kabang/Kabang.hpp>
+#include <Kabang/Minibang.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Minibang survives a note with no sample loaded", "[unit][synthimi]")
+{
+  kbng::DrumChannel channel;
+  REQUIRE(channel.sample.soundfile.channels == 0);
+
+  // Both overloads, since the guarded one is what the other relies on.
+  CHECK(channel.trigger(0, 100) == nullptr);
+  CHECK(channel.trigger(0, 1.5f, 100) == nullptr);
+
+  // And no voice was left half-started behind them.
+  CHECK(channel.sample.voices.empty());
+}
+
+TEST_CASE("Minibang's root key cannot divide by zero", "[unit][synthimi]")
+{
+  // The control's range starts at zero; the ratio must stay finite there.
+  const auto ratio = [](int note, int root) {
+    return root > 0 ? float(note) / root : 1.f;
+  };
+  CHECK(std::isfinite(ratio(60, 0)));
+  CHECK(ratio(60, 0) == 1.f);
+  CHECK(ratio(60, 30) == 2.f);
+}

--- a/tests/unit/OutletLayoutTest.cpp
+++ b/tests/unit/OutletLayoutTest.cpp
@@ -1,0 +1,100 @@
+// Where a node draws its outlets.
+//
+// score::GraphicsIORootLayout pushes the outlet column against the right-hand
+// edge of a node that has inlets too. A node with outlets only went through
+// GraphicsDefaultOutletLayout on its own, which laid the column out from x = 0
+// -- so the texture outlet of a generator such as the Random Characters
+// shader, folded, was drawn on the LEFT of the object.
+
+#include <score/graphics/layouts/GraphicsGridLayout.hpp>
+
+#include <score_test/App.hpp>
+
+#include <QGraphicsRectItem>
+#include <QGraphicsScene>
+
+#include <catch2/catch_all.hpp>
+
+namespace
+{
+//! No pen: QGraphicsRectItem's bounding rect otherwise carries half a pen
+//! width on each side, which has nothing to do with what is being measured.
+QGraphicsRectItem* box(QGraphicsItem& parent, double w, double h)
+{
+  auto* it = new QGraphicsRectItem{QRectF{0., 0., w, h}, &parent};
+  it->setPen(Qt::NoPen);
+  return it;
+}
+}
+
+TEST_CASE("an outlet-only column sits against the right edge of the node")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QGraphicsScene scene;
+    score::GraphicsDefaultOutletLayout lay{nullptr};
+    scene.addItem(&lay);
+
+    auto* wide = box(lay, 30., 10.);
+    auto* narrow = box(lay, 10., 10.);
+
+    lay.setMinimumWidth(200.);
+    lay.layout();
+
+    // Both right edges land on the node's right edge.
+    CHECK(wide->pos().x() + 30. == Catch::Approx(200.));
+    CHECK(narrow->pos().x() + 10. == Catch::Approx(200.));
+    // ... stacked, not overlapping.
+    CHECK(narrow->pos().y() == Catch::Approx(10.));
+  });
+}
+
+TEST_CASE("an outlet column with no width to fill still lines up on its own right")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QGraphicsScene scene;
+    score::GraphicsDefaultOutletLayout lay{nullptr};
+    scene.addItem(&lay);
+
+    auto* wide = box(lay, 30., 10.);
+    auto* narrow = box(lay, 10., 10.);
+
+    // No minimum: the behaviour a node with inlets relies on, where the root
+    // layout does the pushing.
+    lay.layout();
+
+    CHECK(wide->pos().x() == Catch::Approx(0.));
+    CHECK(narrow->pos().x() == Catch::Approx(20.));
+  });
+}
+
+TEST_CASE("a column wider than the node is not pushed off it")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QGraphicsScene scene;
+    score::GraphicsDefaultOutletLayout lay{nullptr};
+    scene.addItem(&lay);
+
+    auto* wide = box(lay, 120., 10.);
+    lay.setMinimumWidth(40.);
+    lay.layout();
+
+    CHECK(wide->pos().x() == Catch::Approx(0.));
+  });
+}
+
+// The inlet column is the mirror image and must stay where it is.
+TEST_CASE("an inlet column stays on the left")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QGraphicsScene scene;
+    score::GraphicsDefaultInletLayout lay{nullptr};
+    scene.addItem(&lay);
+
+    auto* wide = box(lay, 30., 10.);
+    auto* narrow = box(lay, 10., 10.);
+    lay.layout();
+
+    CHECK(wide->pos().x() == Catch::Approx(0.));
+    CHECK(narrow->pos().x() == Catch::Approx(0.));
+  });
+}

--- a/tests/unit/PipewireSettingsWidgetTest.cpp
+++ b/tests/unit/PipewireSettingsWidgetTest.cpp
@@ -1,0 +1,133 @@
+// The PipeWire video input device's settings panel.
+//
+// PipeWire's whole premise is that you pick a node the daemon is publishing
+// right now. The panel asked the user to type its name into a line edit
+// instead, which is neither discoverable nor checkable: a typo is a device
+// that silently connects to nothing.
+//
+// The field is a combo box over the live Video/Source nodes now, still
+// editable so a producer that is not up yet can be named by hand.
+
+#include <Device/Protocol/ProtocolFactoryInterface.hpp>
+#include <Device/Protocol/ProtocolList.hpp>
+#include <Device/Protocol/ProtocolSettingsWidget.hpp>
+
+#include <Gfx/SharedInputSettings.hpp>
+
+#include <score/application/GUIApplicationContext.hpp>
+
+#include <QComboBox>
+#include <QFormLayout>
+#include <QLabel>
+
+#include <catch2/catch_all.hpp>
+#include <score_test/App.hpp>
+
+namespace
+{
+const auto pipewire_input_uuid
+    = QStringLiteral("cf6a355f-34d1-4d24-a6ea-3d204f93cde9");
+
+Device::ProtocolFactory* factory(const score::GUIApplicationContext& ctx)
+{
+  const auto key
+      = UuidKey<Device::ProtocolFactory>::fromString(pipewire_input_uuid);
+  return ctx.interfaces<Device::ProtocolFactoryList>().get(key);
+}
+
+//! The widget in the field cell of the row labelled `label`.
+template <typename T>
+T* fieldAs(QWidget& root, const QString& label)
+{
+  for(auto* form : root.findChildren<QFormLayout*>())
+    for(int row = 0; row < form->rowCount(); ++row)
+    {
+      auto* li = form->itemAt(row, QFormLayout::LabelRole);
+      auto* lw = li ? qobject_cast<QLabel*>(li->widget()) : nullptr;
+      if(!lw || lw->text() != label)
+        continue;
+      auto* fi = form->itemAt(row, QFormLayout::FieldRole);
+      if(fi)
+        if(auto* w = qobject_cast<T*>(fi->widget()))
+          return w;
+    }
+  return nullptr;
+}
+
+QString pathOf(const Device::DeviceSettings& s)
+{
+  return s.deviceSpecificSettings.value<Gfx::SharedInputSettings>().path;
+}
+}
+
+TEST_CASE("the PipeWire input panel offers the nodes the daemon publishes",
+          "[pipewire][settings]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* fact = factory(ctx);
+    if(!fact)
+      return; // built without PipeWire
+
+    std::unique_ptr<Device::ProtocolSettingsWidget> w{fact->makeSettingsWidget()};
+    REQUIRE(w);
+
+    auto* node = fieldAs<QComboBox>(*w, QStringLiteral("PipeWire Node:"));
+    REQUIRE(node != nullptr);
+
+    // A picker, not a bare text field -- and still editable, for a producer
+    // that is not up yet.
+    CHECK(node->isEditable());
+    CHECK(node->count() >= 1);
+
+    // The first entry is "auto-connect": an empty node in the URL.
+    node->setCurrentIndex(0);
+    CHECK(node->itemData(0).toString().isEmpty());
+    CHECK(pathOf(w->getSettings()).startsWith("pipewire://?"));
+  });
+}
+
+TEST_CASE("a hand-typed PipeWire node reaches the URL", "[pipewire][settings]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* fact = factory(ctx);
+    if(!fact)
+      return;
+
+    std::unique_ptr<Device::ProtocolSettingsWidget> w{fact->makeSettingsWidget()};
+    REQUIRE(w);
+    auto* node = fieldAs<QComboBox>(*w, QStringLiteral("PipeWire Node:"));
+    REQUIRE(node != nullptr);
+
+    node->setCurrentText(QStringLiteral("some-producer-not-running"));
+    CHECK(pathOf(w->getSettings())
+              .startsWith("pipewire://some-producer-not-running?"));
+  });
+}
+
+TEST_CASE("the PipeWire input panel round-trips a saved node",
+          "[pipewire][settings]")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* fact = factory(ctx);
+    if(!fact)
+      return;
+
+    std::unique_ptr<Device::ProtocolSettingsWidget> w{fact->makeSettingsWidget()};
+    REQUIRE(w);
+
+    Device::DeviceSettings in;
+    in.name = "PipeWire";
+    in.protocol = fact->concreteKey();
+    Gfx::SharedInputSettings sis;
+    sis.path = "pipewire://saved-node?width=640&height=480&fps=25&format=bgra";
+    in.deviceSpecificSettings = QVariant::fromValue(sis);
+
+    w->setSettings(in);
+    const auto out = pathOf(w->getSettings());
+    INFO(out.toStdString());
+    CHECK(out.startsWith("pipewire://saved-node?"));
+    CHECK(out.contains("width=640"));
+    CHECK(out.contains("height=480"));
+    CHECK(out.contains("format=bgra"));
+  });
+}

--- a/tests/unit/PipewireSharedContextTest.cpp
+++ b/tests/unit/PipewireSharedContextTest.cpp
@@ -3,12 +3,18 @@
 //
 // The process-wide libremidi::pipewire::context is shared by the gfx output
 // producer, the gfx input consumer, the audio engine and the MIDI backends.
-// Any -ENOENT reply from the daemon — including the per-object error a stream
-// gets when its autoconnect finds no target node — flips the whole connection
-// to connection_state::broken. A device that then calls reconnect() on it
-// destroys the pw_core, pw_context and pw_thread_loop; every pw_stream another
-// holder created on that core is left pointing at freed memory, and the next
-// pw_stream_destroy() faults inside pw_loop_check().
+// An -ENOENT reply from the daemon used to flip the whole connection to
+// connection_state::broken, including the per-object error a stream gets when
+// its autoconnect finds no target node. A device that then calls reconnect()
+// on it destroys the pw_core, pw_context and pw_thread_loop; every pw_stream
+// another holder created on that core is left pointing at freed memory, and
+// the next pw_stream_destroy() faults inside pw_loop_check().
+//
+// libremidi now reads the id the error carries and only treats PW_ID_CORE as
+// connection loss, so the misclassification that started the teardown cannot
+// happen. This case asserts both halves: the per-object error leaves the
+// connection alone, and the context another holder picks up afterwards is
+// still the same loop and core.
 //
 // Skips when no daemon can be started (no pipewire binary, no libpipewire).
 
@@ -135,13 +141,15 @@ TEST_CASE(
   pw.thread_loop_unlock(loopBefore);
   REQUIRE(stream != nullptr);
 
-  for(int i = 0; i < 100
-                 && holderA->state() != libremidi::pipewire::connection_state::broken;
-      i++)
+  // Give the daemon time to deliver the error and the context time to act on
+  // it. The assertion below is that it does NOT act on it: a per-object error
+  // says nothing about the socket, and treating it as connection loss is what
+  // used to start the teardown this case is named after.
+  for(int i = 0; i < 25; i++)
     std::this_thread::sleep_for(20ms);
 
-  REQUIRE(
-      holderA->state() == libremidi::pipewire::connection_state::broken);
+  REQUIRE(holderA->state() != libremidi::pipewire::connection_state::broken);
+  CHECK(holderA->state() == libremidi::pipewire::connection_state::connected);
 
   // Holder B: stands in for the gfx input device starting up afterwards.
   auto holderB = Gfx::PipeWire::acquireSharedContext("regression test");

--- a/tests/unit/PipewireSharedContextTest.cpp
+++ b/tests/unit/PipewireSharedContextTest.cpp
@@ -29,6 +29,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <string>
@@ -120,8 +121,27 @@ TEST_CASE(
   REQUIRE(loopBefore != nullptr);
   REQUIRE(coreBefore != nullptr);
 
+  // The error the daemon sends back for the bad request below. The test waits
+  // for this rather than for a wall-clock interval: without proof that the
+  // error arrived, asserting that it did not break the connection proves
+  // nothing at all.
+  std::atomic_int perObjectErrors{0};
+  static std::atomic_int* s_errors{};
+  s_errors = &perObjectErrors;
+
+  static constexpr pw_proxy_events proxyEvents = [] {
+    pw_proxy_events e{};
+    e.version = PW_VERSION_PROXY_EVENTS;
+    e.error = [](void*, int, int res, const char*) {
+      if(res != 0 && s_errors)
+        s_errors->fetch_add(1, std::memory_order_release);
+    };
+    return e;
+  }();
+
   pw_stream* stream{};
   void* badProxy{};
+  spa_hook proxyHook{};
   pw.thread_loop_lock(loopBefore);
   {
     auto* props = pw.properties_new(
@@ -137,19 +157,33 @@ TEST_CASE(
     badProxy = pw_core_create_object(
         coreBefore, "score-no-such-factory", PW_TYPE_INTERFACE_Node,
         PW_VERSION_NODE, nullptr, 0);
+    if(badProxy && pw.proxy_add_listener)
+      pw.proxy_add_listener(
+          static_cast<pw_proxy*>(badProxy), &proxyHook, &proxyEvents, nullptr);
   }
   pw.thread_loop_unlock(loopBefore);
   REQUIRE(stream != nullptr);
+  REQUIRE(badProxy != nullptr);
 
-  // Give the daemon time to deliver the error and the context time to act on
-  // it. The assertion below is that it does NOT act on it: a per-object error
-  // says nothing about the socket, and treating it as connection loss is what
-  // used to start the teardown this case is named after.
-  for(int i = 0; i < 25; i++)
-    std::this_thread::sleep_for(20ms);
+  // A core round-trip, not a sleep. The daemon answers in order, so once this
+  // returns, the reply to the create_object above has been delivered and the
+  // context has already classified it.
+  //
+  // Its return value is the assertion. synchronize() is false exactly when the
+  // connection has been marked broken, which is what a per-object error used
+  // to do -- and a device reacting to `broken` by reconnecting is what tore
+  // the loop out from under the other holders. The id the error carries says
+  // it belongs to one object, not to the socket.
+  for(int i = 0; i < 50 && perObjectErrors.load(std::memory_order_acquire) == 0; i++)
+    REQUIRE(holderA->synchronize());
 
-  REQUIRE(holderA->state() != libremidi::pipewire::connection_state::broken);
+  // The premise: the daemon really did refuse the request.
+  REQUIRE(perObjectErrors.load(std::memory_order_acquire) > 0);
+
+  // The property: refusing it left the connection alone.
+  CHECK(holderA->ok());
   CHECK(holderA->state() == libremidi::pipewire::connection_state::connected);
+  CHECK(holderA->synchronize());
 
   // Holder B: stands in for the gfx input device starting up afterwards.
   auto holderB = Gfx::PipeWire::acquireSharedContext("regression test");
@@ -164,7 +198,11 @@ TEST_CASE(
   // faulted inside pw_loop_check() once the loop had been rebuilt.
   pw.thread_loop_lock(loopBefore);
   if(badProxy && pw.proxy_destroy)
+  {
+    spa_hook_remove(&proxyHook);
     pw.proxy_destroy(static_cast<pw_proxy*>(badProxy));
+  }
+  s_errors = nullptr;
   pw.stream_destroy(stream);
   pw.thread_loop_unlock(loopBefore);
 

--- a/tests/unit/Point2DViewTest.cpp
+++ b/tests/unit/Point2DViewTest.cpp
@@ -1,0 +1,66 @@
+// The Point2D View's axis mapping.
+//
+// The view refused any range whose max was not greater than its min --
+// `if(scalex < 0.000001f || scaley < 0.000001f) return;` -- so setting Min Y
+// above Max Y, the natural way to point Y downwards, drew nothing at all.
+// A range the wrong way round is a legitimate range; only a range of no width
+// is not.
+
+#include <UI/2DView.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <cmath>
+
+using uo::axisRatio;
+using uo::axisUsable;
+
+TEST_CASE("an axis maps its range onto [0;1]")
+{
+  CHECK(axisRatio(0., 0., 1.) == Catch::Approx(0.));
+  CHECK(axisRatio(1., 0., 1.) == Catch::Approx(1.));
+  CHECK(axisRatio(0.25, 0., 1.) == Catch::Approx(0.25));
+
+  // A range that does not start at zero.
+  CHECK(axisRatio(-10., -10., 30.) == Catch::Approx(0.));
+  CHECK(axisRatio(10., -10., 30.) == Catch::Approx(0.5));
+}
+
+TEST_CASE("an axis whose min is above its max reads the other way round")
+{
+  // Min Y = 1, Max Y = 0: the way to point Y downwards.
+  CHECK(axisRatio(1., 1., 0.) == Catch::Approx(0.));
+  CHECK(axisRatio(0., 1., 0.) == Catch::Approx(1.));
+  CHECK(axisRatio(0.25, 1., 0.) == Catch::Approx(0.75));
+
+  // Mirror of the same range, point for point.
+  for(double v : {0., 0.1, 0.5, 0.9, 1.})
+  {
+    INFO("value " << v);
+    CHECK(axisRatio(v, 1., 0.) == Catch::Approx(1. - axisRatio(v, 0., 1.)));
+  }
+}
+
+TEST_CASE("only an axis of no width is unusable")
+{
+  CHECK(axisUsable(0., 1.));
+  CHECK(axisUsable(1., 0.));   // inverted, and drawn
+  CHECK(axisUsable(-5., -20.));
+  CHECK_FALSE(axisUsable(1., 1.));
+  CHECK_FALSE(axisUsable(1., 1. + 1e-9));
+}
+
+TEST_CASE("the origin is in view only when the range contains it")
+{
+  const auto inView = [](double min, double max) {
+    const auto r = axisRatio(0., min, max);
+    return r >= 0. && r <= 1.;
+  };
+
+  CHECK(inView(0., 1.));
+  CHECK(inView(-1., 1.));
+  CHECK(inView(1., -1.)); // inverted, still contains zero
+  CHECK_FALSE(inView(1., 2.));
+  CHECK_FALSE(inView(-2., -1.));
+  CHECK_FALSE(inView(2., 1.)); // inverted, and zero is outside it
+}

--- a/tests/unit/SliderDefaultsTest.cpp
+++ b/tests/unit/SliderDefaultsTest.cpp
@@ -1,0 +1,193 @@
+// Double-clicking a control puts it back to the default the process declared.
+//
+// Every graphics-view control routes that through DefaultGraphicsSliderImpl /
+// DefaultGraphicsSpinboxImpl, but QGraphicsIntSlider never installed the
+// handler, so the integer sliders of e.g. "Pulse to Midi" (Pitch shift, Pitch
+// random, Vel. random) could not be reset the way its spinboxes could.
+//
+// The inspector shows the same controls as plain QWidgets (score::IntSlider,
+// score::DoubleSlider), which had no reset at all. Those also carry the
+// linear map()/unmap() the right-click type-in box builds its range from.
+
+#include <score/graphics/widgets/QGraphicsIntSlider.hpp>
+#include <score/graphics/widgets/QGraphicsSlider.hpp>
+#include <score/widgets/ControlWidgets.hpp>
+#include <score/widgets/DoubleSlider.hpp>
+#include <score/widgets/IntSlider.hpp>
+
+#include <score_test/App.hpp>
+#include <score_test/Mouse.hpp>
+
+#include <QGraphicsScene>
+#include <QGraphicsSceneMouseEvent>
+
+#include <catch2/catch_all.hpp>
+
+namespace
+{
+struct Scene final : public QGraphicsScene
+{
+  using QGraphicsScene::sendEvent;
+};
+
+//! Press, release, double-click, release: what the scene sends on a real
+//! double click.
+template <typename Item>
+void doubleClick(Scene& scene, Item& item, QPointF pos = {1., 1.})
+{
+  for(auto type :
+      {QEvent::GraphicsSceneMousePress, QEvent::GraphicsSceneMouseRelease,
+       QEvent::GraphicsSceneMouseDoubleClick, QEvent::GraphicsSceneMouseRelease})
+  {
+    QGraphicsSceneMouseEvent ev{type};
+    ev.setButton(Qt::LeftButton);
+    ev.setButtons(type == QEvent::GraphicsSceneMouseRelease ? Qt::NoButton
+                                                            : Qt::LeftButton);
+    ev.setPos(pos);
+    ev.setScenePos(pos);
+    ev.setScreenPos(pos.toPoint());
+    ev.setLastScreenPos(pos.toPoint());
+    ev.setButtonDownScreenPos(Qt::LeftButton, pos.toPoint());
+    scene.sendEvent(&item, &ev);
+  }
+  qApp->processEvents();
+}
+
+void widgetDoubleClick(QWidget& w, QPoint pos)
+{
+  score::test::mouseEvent(
+      w, QEvent::MouseButtonPress, pos, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+  score::test::mouseEvent(
+      w, QEvent::MouseButtonRelease, pos, Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+  score::test::mouseEvent(
+      w, QEvent::MouseButtonDblClick, pos, Qt::LeftButton, Qt::LeftButton,
+      Qt::NoModifier);
+  score::test::mouseEvent(
+      w, QEvent::MouseButtonRelease, pos, Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+  qApp->processEvents();
+}
+}
+
+TEST_CASE("double-clicking a graphics int slider restores its default")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    Scene scene;
+    score::QGraphicsIntSlider item{nullptr};
+    scene.addItem(&item);
+
+    // "Pitch shift" of Pulse to Midi: octave_slider<-5, 5>, default 0.
+    item.setRange(-60, 60, 0);
+    item.setValue(37);
+    REQUIRE(item.value() == 37);
+
+    // The press that opens the double click moves the value too, so what
+    // matters is what the last submit carried.
+    int lastMoved{-1}, released{};
+    QObject::connect(&item, &score::QGraphicsIntSlider::sliderMoved, &item, [&] {
+      lastMoved = item.value();
+    });
+    QObject::connect(
+        &item, &score::QGraphicsIntSlider::sliderReleased, &item, [&] { released++; });
+
+    doubleClick(scene, item);
+
+    CHECK(item.value() == 0);
+    // The value has to reach the model: moved submits, released commits.
+    CHECK(lastMoved == 0);
+    CHECK(released >= 1);
+  });
+}
+
+// The float slider already did this; it is here so the two stay in step.
+TEST_CASE("double-clicking a graphics float slider restores its default")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    Scene scene;
+    score::QGraphicsSlider item{nullptr};
+    scene.addItem(&item);
+
+    item.setRange(0., 1., 0.8);
+    item.setValue(0.1);
+
+    doubleClick(scene, item);
+    CHECK(item.value() == Catch::Approx(0.8));
+  });
+}
+
+TEST_CASE("double-clicking an inspector int slider restores its default")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    score::ValueSlider sl{nullptr};
+    sl.resize(200, 20);
+    sl.setRange(-60, 60, 0);
+    sl.setValue(42);
+    REQUIRE(sl.value() == 42);
+
+    int moved{}, released{};
+    QObject::connect(&sl, &score::IntSlider::sliderMoved, &sl, [&] { moved++; });
+    QObject::connect(&sl, &score::IntSlider::sliderReleased, &sl, [&] { released++; });
+
+    widgetDoubleClick(sl, {180, 10});
+
+    CHECK(sl.value() == 0);
+    CHECK(moved >= 1);
+    CHECK(released >= 1);
+  });
+}
+
+TEST_CASE("double-clicking an inspector double slider restores its default")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    score::ValueDoubleSlider sl{nullptr};
+    sl.resize(200, 20);
+    sl.setRange(0., 1., 0.8);
+    sl.setValue(0.1);
+
+    int moved{}, released{};
+    QObject::connect(&sl, &score::DoubleSlider::sliderMoved, &sl, [&](double) { moved++; });
+    QObject::connect(&sl, &score::DoubleSlider::sliderReleased, &sl, [&] { released++; });
+
+    widgetDoubleClick(sl, {180, 10});
+
+    // The widget stores a normalized position; the default is in model units.
+    CHECK(sl.value() == Catch::Approx(0.8));
+    CHECK(moved >= 1);
+    CHECK(released >= 1);
+  });
+}
+
+// The transport speed slider carries no domain at all: x1 is its default.
+TEST_CASE("double-clicking the speed slider goes back to x1")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    score::SpeedSlider sl{nullptr};
+    sl.resize(200, 20);
+    sl.setSpeed(3.);
+    REQUIRE(sl.speed() == Catch::Approx(3.));
+
+    widgetDoubleClick(sl, {10, 10});
+    CHECK(sl.speed() == Catch::Approx(1.));
+  });
+}
+
+// A range that does not start at zero: unmap() had min applied on the wrong
+// side of the division, so the default landed nowhere near where it belongs.
+TEST_CASE("an inspector double slider maps a shifted range")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    score::ValueDoubleSlider sl{nullptr};
+    sl.setRange(-10., 30., 10.);
+
+    CHECK(sl.unmap(-10.) == Catch::Approx(0.));
+    CHECK(sl.unmap(30.) == Catch::Approx(1.));
+    CHECK(sl.unmap(10.) == Catch::Approx(0.5));
+
+    sl.setValue(0.25);
+    CHECK(sl.map(sl.value()) == Catch::Approx(0.));
+
+    // What createPopup() asks for when the user right-clicks: the two ends of
+    // the range, which used to come back as the same number.
+    CHECK(sl.map(0.) == Catch::Approx(-10.));
+    CHECK(sl.map(1.) == Catch::Approx(30.));
+  });
+}

--- a/tests/unit/StateMessageEditTest.cpp
+++ b/tests/unit/StateMessageEditTest.cpp
@@ -1,0 +1,201 @@
+// Editing a message of a state through the inspector's tree.
+//
+// MessageItemModel::setData wrapped its command submission in its own
+// beginResetModel()/endResetModel() pair, but the command already resets the
+// model when it assigns the new tree. The nested pair made Qt print
+//   "beginResetModel called on ... without calling endResetModel first"
+// and, more importantly, sent the views two overlapping resets for one edit.
+//
+// StateModel::sig_statesUpdated -- what the execution component listens to in
+// order to push the new messages to the running graph -- is emitted from
+// modelReset, so the shape of those resets is exactly what decides whether an
+// edit made while playing reaches the engine.
+
+#include <Scenario/Commands/State/AddMessagesToState.hpp>
+#include <Scenario/Document/ScenarioDocument/ScenarioDocumentModel.hpp>
+#include <Scenario/Document/State/ItemModel/MessageItemModel.hpp>
+#include <Scenario/Document/State/StateModel.hpp>
+#include <Scenario/Process/ScenarioModel.hpp>
+
+#include <score/command/Dispatchers/CommandDispatcher.hpp>
+#include <score/model/tree/TreeNode.hpp>
+
+#include <score_test/App.hpp>
+#include <score_test/Document.hpp>
+#include <score_test/Project.hpp>
+
+#include <ossia/network/value/value_conversion.hpp>
+
+#include <QAbstractItemModel>
+
+#include <catch2/catch_all.hpp>
+
+namespace
+{
+using Scenario::MessageItemModel;
+
+//! The scenario the empty document starts with, inside the base interval.
+Scenario::ProcessModel& base_scenario(score::Document& doc)
+{
+  auto& itv = score::test::base_interval(doc);
+  for(auto& proc : itv.processes)
+    if(auto* s = qobject_cast<Scenario::ProcessModel*>(&proc))
+      return *s;
+  FAIL("no scenario in the base interval");
+  throw;
+}
+
+Scenario::StateModel& some_state(score::Document& doc)
+{
+  auto& scenar = base_scenario(doc);
+  REQUIRE(scenar.states.size() > 0);
+  return *scenar.states.begin();
+}
+
+void addMessage(score::Document& doc, Scenario::StateModel& st, const char* addr, float v)
+{
+  State::Message m;
+  m.address = State::AddressAccessor{State::Address::fromString(addr).value()};
+  m.value = v;
+  CommandDispatcher<>{doc.context().commandStack}
+      .submit<Scenario::Command::AddMessagesToState>(st, State::MessageList{m});
+}
+
+//! Depth-first walk to the first index whose node actually carries a value.
+QModelIndex firstValued(const MessageItemModel& m, QModelIndex parent = {})
+{
+  for(int i = 0; i < m.rowCount(parent); i++)
+  {
+    auto idx = m.index(i, 0, parent);
+    const auto& n = m.nodeFromModelIndex(idx);
+    if(n.hasValue())
+      return idx;
+    if(auto sub = firstValued(m, idx); sub.isValid())
+      return sub;
+  }
+  return {};
+}
+
+//! Catches the qWarning() Qt prints on an unbalanced reset.
+struct WarningCatcher
+{
+  static inline QStringList messages;
+  static inline QtMessageHandler previous{};
+
+  WarningCatcher()
+  {
+    messages.clear();
+    previous = qInstallMessageHandler(
+        [](QtMsgType t, const QMessageLogContext& c, const QString& msg) {
+      if(t == QtWarningMsg || t == QtCriticalMsg)
+        messages.push_back(msg);
+      if(previous)
+        previous(t, c, msg);
+    });
+  }
+  ~WarningCatcher() { qInstallMessageHandler(previous); }
+};
+}
+
+TEST_CASE("editing a state message keeps its resets balanced")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    auto& st = some_state(*doc);
+    auto& model = st.messages();
+
+    addMessage(*doc, st, "dev:/a/b", 0.25f);
+
+    auto idx = firstValued(model);
+    REQUIRE(idx.isValid());
+    auto valueIdx = model.index(idx.row(), (int)MessageItemModel::Column::Value,
+                                idx.parent());
+
+    int aboutTo{}, done{}, updated{};
+    QObject::connect(
+        &model, &QAbstractItemModel::modelAboutToBeReset, &model, [&] { aboutTo++; });
+    QObject::connect(&model, &QAbstractItemModel::modelReset, &model, [&] { done++; });
+    QObject::connect(
+        &st, &Scenario::StateModel::sig_statesUpdated, &st, [&] { updated++; });
+
+    WarningCatcher warnings;
+    REQUIRE(model.setData(valueIdx, QVariant::fromValue(0.75), Qt::EditRole));
+
+    // One edit, one reset: a nested pair leaves the views resetting twice for
+    // a single change, and the second modelReset arrives after the first has
+    // already told everyone the model is settled.
+    CHECK(aboutTo == 1);
+    CHECK(done == 1);
+    CHECK(updated == 1);
+
+    for(const auto& w : WarningCatcher::messages)
+      INFO("qWarning: " << w.toStdString());
+    CHECK_FALSE(
+        WarningCatcher::messages.filter("without calling endResetModel").size() > 0);
+
+    // ... and the edit actually landed.
+    const auto& n = model.nodeFromModelIndex(idx);
+    REQUIRE(n.hasValue());
+    CHECK(ossia::convert<float>(*n.value()) == Catch::Approx(0.75));
+  });
+}
+
+TEST_CASE("renaming a state message keeps its resets balanced")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    auto& st = some_state(*doc);
+    auto& model = st.messages();
+
+    addMessage(*doc, st, "dev:/a/b", 0.25f);
+
+    auto idx = firstValued(model);
+    REQUIRE(idx.isValid());
+
+    int aboutTo{}, done{};
+    QObject::connect(
+        &model, &QAbstractItemModel::modelAboutToBeReset, &model, [&] { aboutTo++; });
+    QObject::connect(&model, &QAbstractItemModel::modelReset, &model, [&] { done++; });
+
+    WarningCatcher warnings;
+    REQUIRE(model.setData(idx, QStringLiteral("c"), Qt::EditRole));
+
+    CHECK(aboutTo == 1);
+    CHECK(done == 1);
+    CHECK_FALSE(
+        WarningCatcher::messages.filter("without calling endResetModel").size() > 0);
+  });
+}
+
+// Dropping a .cues file or a message list on the tree goes through the same
+// shape.
+TEST_CASE("dropping messages on a state keeps its resets balanced")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    auto& st = some_state(*doc);
+    auto& model = st.messages();
+
+    int aboutTo{}, done{}, updated{};
+    QObject::connect(
+        &model, &QAbstractItemModel::modelAboutToBeReset, &model, [&] { aboutTo++; });
+    QObject::connect(&model, &QAbstractItemModel::modelReset, &model, [&] { done++; });
+    QObject::connect(
+        &st, &Scenario::StateModel::sig_statesUpdated, &st, [&] { updated++; });
+
+    WarningCatcher warnings;
+    addMessage(*doc, st, "dev:/a/b", 0.25f);
+
+    CHECK(aboutTo == 1);
+    CHECK(done == 1);
+    CHECK(updated == 1);
+    CHECK_FALSE(
+        WarningCatcher::messages.filter("without calling endResetModel").size() > 0);
+  });
+}

--- a/tests/unit/StateMessageEditTest.cpp
+++ b/tests/unit/StateMessageEditTest.cpp
@@ -15,6 +15,7 @@
 #include <Scenario/Document/ScenarioDocument/ScenarioDocumentModel.hpp>
 #include <Scenario/Document/State/ItemModel/MessageItemModel.hpp>
 #include <Scenario/Document/State/StateModel.hpp>
+#include <Scenario/DialogWidget/MessageTreeView.hpp>
 #include <Scenario/Process/ScenarioModel.hpp>
 
 #include <score/command/Dispatchers/CommandDispatcher.hpp>
@@ -27,6 +28,9 @@
 #include <ossia/network/value/value_conversion.hpp>
 
 #include <QAbstractItemModel>
+#include <QAction>
+#include <QItemSelectionModel>
+#include <QKeySequence>
 
 #include <catch2/catch_all.hpp>
 
@@ -197,5 +201,50 @@ TEST_CASE("dropping messages on a state keeps its resets balanced")
     CHECK(updated == 1);
     CHECK_FALSE(
         WarningCatcher::messages.filter("without calling endResetModel").size() > 0);
+  });
+}
+
+// Removing a message was bound to Backspace only, so the Del key -- the one
+// every other tree in the application answers to -- did nothing.
+TEST_CASE("the state message tree removes on both Backspace and Del")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    auto& st = some_state(*doc);
+    addMessage(*doc, st, "dev:/a/b", 0.25f);
+
+    Scenario::MessageTreeView view{st, nullptr};
+
+    QAction* remove{};
+    for(auto* a : view.actions())
+      if(a->text().contains("Remove"))
+        remove = a;
+    REQUIRE(remove);
+
+    const auto keys = remove->shortcuts();
+    CHECK(keys.contains(QKeySequence{Qt::Key_Backspace}));
+    CHECK(keys.contains(QKeySequence{Qt::Key_Delete}));
+  });
+}
+
+TEST_CASE("removing a selected message takes it out of the state")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext& ctx) {
+    auto* doc = score::test::new_document(ctx);
+    REQUIRE(doc);
+
+    auto& st = some_state(*doc);
+    auto& model = st.messages();
+    addMessage(*doc, st, "dev:/a/b", 0.25f);
+    REQUIRE(firstValued(model).isValid());
+
+    Scenario::MessageTreeView view{st, nullptr};
+    view.selectionModel()->select(
+        firstValued(model), QItemSelectionModel::Select | QItemSelectionModel::Rows);
+    view.removeNodes();
+
+    CHECK_FALSE(firstValued(model).isValid());
   });
 }

--- a/tests/unit/TextBoxLayoutTest.cpp
+++ b/tests/unit/TextBoxLayoutTest.cpp
@@ -1,0 +1,129 @@
+// The comment box (Ui::TextBox) and the two things it does with a QTextDocument.
+//
+//  * Trailing spaces. The text is stored as HTML, and HTML collapses the
+//    spaces at the end of a line: typing them moved the cursor but painted
+//    nothing, and the next letter appeared where the spaces had been.
+//
+//  * Reflow. The document was never given a width, so it laid out at whatever
+//    width its longest line wanted and the box grew sideways forever. With a
+//    width it wraps to the box instead.
+
+#include <QApplication>
+#include <QTextDocument>
+#include <QTextBlock>
+#include <QTextLayout>
+#include <QTextLine>
+#include <QTextOption>
+
+#include <Ui/TextBox.hpp>
+
+#include <score_test/App.hpp>
+
+#include <catch2/catch_all.hpp>
+
+namespace
+{
+//! What Ui::TextBox stores and reloads: the document's HTML.
+QString roundTrip(const QString& html)
+{
+  QTextDocument d;
+  d.setHtml(html);
+  return d.toHtml();
+}
+}
+
+//! Where the caret sits at the end of the first line -- what the user watches
+//! move (or not) while typing.
+namespace
+{
+double endOfLineX(QTextDocument& d)
+{
+  (void)d.size(); // force the layout
+  auto block = d.firstBlock();
+  auto* layout = block.layout();
+  if(!layout || layout->lineCount() == 0)
+    return 0.;
+  return layout->lineAt(0).cursorToX(block.length() - 1);
+}
+}
+
+TEST_CASE("a comment keeps the spaces typed at the end of a line")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QTextDocument typed;
+    typed.setPlainText(QStringLiteral("hello   "));
+
+    // The comment box stores its text as HTML, where trailing spaces are the
+    // first thing a naive round trip loses.
+    QTextDocument reloaded;
+    reloaded.setHtml(typed.toHtml());
+    CHECK(reloaded.toPlainText() == QStringLiteral("hello   "));
+
+    QTextDocument without;
+    without.setPlainText(QStringLiteral("hello"));
+    Ui::TextBox::setupDocument(reloaded, -1.);
+    Ui::TextBox::setupDocument(without, -1.);
+
+    // ... and the caret sits past them, so the box grows as they are typed.
+    INFO("with spaces " << endOfLineX(reloaded) << " without " << endOfLineX(without));
+    CHECK(endOfLineX(reloaded) > endOfLineX(without));
+  });
+}
+
+TEST_CASE("the comment HTML round-trips unchanged")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QTextDocument d;
+    d.setPlainText(QStringLiteral("one   \ntwo"));
+    const auto once = d.toHtml();
+    CHECK(roundTrip(once) == once);
+  });
+}
+
+TEST_CASE("a document given a width wraps instead of growing sideways")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QTextDocument d;
+    d.setPlainText(QStringLiteral(
+        "a long line of text that has plenty of words in it to wrap around with"));
+
+    const double natural = d.idealWidth();
+    const int naturalLines = d.blockCount();
+    REQUIRE(naturalLines == 1);
+
+    d.setTextWidth(120.);
+    CHECK(d.size().width() <= 121.);
+    CHECK(d.size().height() > 0.);
+    CHECK(d.size().width() < natural);
+
+    // ... and giving it back its freedom restores the single line.
+    d.setTextWidth(-1);
+    CHECK(d.idealWidth() == Catch::Approx(natural).margin(1.));
+  });
+}
+
+// What setupDocument() is for: Qt drops trailing spaces at layout time unless
+// it is told not to, and a document with no width lays out as wide as it likes.
+TEST_CASE("the comment document wraps only when it is given a width")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    const auto text = QStringLiteral(
+        "a long line of text that has plenty of words in it to wrap around with");
+
+    QTextDocument free;
+    free.setPlainText(text);
+    Ui::TextBox::setupDocument(free, -1.);
+    CHECK(free.textWidth() < 0.);
+
+    QTextDocument wrapped;
+    wrapped.setPlainText(text);
+    Ui::TextBox::setupDocument(wrapped, 120.);
+    CHECK(wrapped.textWidth() == Catch::Approx(120.));
+    CHECK(wrapped.size().width() <= 121.);
+    CHECK(wrapped.size().height() > free.size().height());
+
+    // A width of zero or less means "as wide as you like", not "no room".
+    Ui::TextBox::setupDocument(wrapped, 0.);
+    CHECK(wrapped.textWidth() < 0.);
+  });
+}

--- a/tests/unit/WaveformButtonTest.cpp
+++ b/tests/unit/WaveformButtonTest.cpp
@@ -15,6 +15,7 @@
 
 #include <QApplication>
 #include <QElapsedTimer>
+#include <QFileInfo>
 #include <QGraphicsScene>
 #include <QTemporaryDir>
 
@@ -53,7 +54,7 @@ TEST_CASE("a soundfile control shows the waveform of an already-decoded file")
     scene.addItem(&bt);
 
     CHECK_FALSE(bt.hasWaveform());
-    bt.setFile(wav);
+    bt.setFile(wav, wav);
     CHECK(bt.text() == wav);
 
     // The computation itself is threaded; what matters is that it was asked
@@ -78,10 +79,41 @@ TEST_CASE("a soundfile control forgets the waveform when the file is cleared")
     score::QGraphicsWaveformButton bt{nullptr};
     scene.addItem(&bt);
 
-    bt.setFile(wav);
+    bt.setFile(wav, wav);
     REQUIRE(spin_until([&] { return bt.hasWaveform(); }));
 
-    bt.setFile({});
+    bt.setFile({}, {});
     CHECK_FALSE(bt.hasWaveform());
+  });
+}
+
+
+// What the document stores is not always what can be opened. A sound picked
+// from next to the .score file is saved as "<PROJECT>:name.wav", and the audio
+// file manager's two-argument get() opens the path it is handed -- so the
+// widget has to be given the resolved one as well as the stored one. Handing
+// it only the stored form left audiofx.score's Granola with no waveform and no
+// error anywhere.
+TEST_CASE("the waveform button decodes the resolved path, not the stored one")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    const QString wav = dir.path() + "/tone.wav";
+    score::test::write_wav(wav, 1.0);
+
+    QGraphicsScene scene;
+    score::QGraphicsWaveformButton bt{nullptr};
+    scene.addItem(&bt);
+
+    // The stored form, of the shape a document holds, with the resolved path
+    // beside it.
+    const QString stored = QStringLiteral("<PROJECT>:") + QFileInfo{wav}.fileName();
+    bt.setFile(stored, wav);
+
+    // The label keeps what the document said...
+    CHECK(bt.text() == stored);
+    // ... and the decode used the path that exists.
+    REQUIRE(spin_until([&] { return bt.hasWaveform(); }));
   });
 }

--- a/tests/unit/WaveformButtonTest.cpp
+++ b/tests/unit/WaveformButtonTest.cpp
@@ -1,0 +1,87 @@
+// The waveform a soundfile control draws beside itself.
+//
+// score::QGraphicsWaveformButton asked its AudioFile to tell it when decoding
+// finished, and computed the waveform from that. On loading a document the
+// file is usually decoded already -- the manager caches it, and a sound
+// process elsewhere in the score often pulled it in first -- so the signal
+// never came and the control stayed on its "drop a sound file here"
+// placeholder until the file was picked again by hand.
+
+#include <Media/AudioFileChooserWidget.hpp>
+#include <Media/MediaFileHandle.hpp>
+
+#include <score_test/App.hpp>
+#include <score_test/Project.hpp>
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QGraphicsScene>
+#include <QTemporaryDir>
+
+#include <catch2/catch_all.hpp>
+
+namespace
+{
+//! Pumps the event loop until `f` holds, or gives up.
+template <typename F>
+bool spin_until(F f, int ms = 5000)
+{
+  QElapsedTimer t;
+  t.start();
+  while(!f() && t.elapsed() < ms)
+    QApplication::processEvents(QEventLoop::AllEvents, 5);
+  return f();
+}
+}
+
+TEST_CASE("a soundfile control shows the waveform of an already-decoded file")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    const QString wav = dir.path() + "/tone.wav";
+    score::test::write_wav(wav, 1.0);
+
+    // Someone else has the file open already: exactly the state a document
+    // that has just been loaded is in.
+    auto held = Media::AudioFileManager::instance().get(wav, 0);
+    REQUIRE(held);
+    REQUIRE(spin_until([&] { return held->finishedDecoding(); }));
+
+    QGraphicsScene scene;
+    score::QGraphicsWaveformButton bt{nullptr};
+    scene.addItem(&bt);
+
+    CHECK_FALSE(bt.hasWaveform());
+    bt.setFile(wav);
+    CHECK(bt.text() == wav);
+
+    // The computation itself is threaded; what matters is that it was asked
+    // for at all.
+    CHECK(spin_until([&] { return bt.hasWaveform(); }));
+  });
+}
+
+TEST_CASE("a soundfile control forgets the waveform when the file is cleared")
+{
+  score::test::run_in_app([](const score::GUIApplicationContext&) {
+    QTemporaryDir dir;
+    REQUIRE(dir.isValid());
+    const QString wav = dir.path() + "/tone.wav";
+    score::test::write_wav(wav, 1.0);
+
+    auto held = Media::AudioFileManager::instance().get(wav, 0);
+    REQUIRE(held);
+    REQUIRE(spin_until([&] { return held->finishedDecoding(); }));
+
+    QGraphicsScene scene;
+    score::QGraphicsWaveformButton bt{nullptr};
+    scene.addItem(&bt);
+
+    bt.setFile(wav);
+    REQUIRE(spin_until([&] { return bt.hasWaveform(); }));
+
+    bt.setFile({});
+    CHECK_FALSE(bt.hasWaveform());
+  });
+}


### PR DESCRIPTION
Fifty commits. Roughly half are PipeWire video work, the rest are independent bug fixes with tests.

**Depends on ossia/libossia#936**, which pins celtera/libremidi#255. The last commit here bumps the submodule to that branch; it should be re-pointed at libossia master once both merge. Without the libremidi fix the Vulkan DMA-BUF video input renders black.

### PipeWire video output

It was unusable from outside score. The stream set no `media.class`, so a session manager classed it `Stream/Output/Video` and never linked a video consumer to it: the node was visible, the consumer negotiated a format, and no buffer ever arrived. It also handed out empty buffers, offered a single format so a consumer that could not import a dma-buf had nothing to agree on and got a black source, and was upside down on Vulkan.

Zero-copy now negotiates with a real GStreamer consumer: the modifier handshake follows pipewire's own `video-src-fixate`, score offers the driver's DRM format modifiers best-first with INVALID and LINEAR behind them, creates the exported image with whichever comes back, and falls back to host memory for a consumer that cannot take any of them. The wire pass no longer reads every frame back to the CPU when nothing is going to read it, the export is device-local, and it writes straight into the shared image when the negotiated layout is tiled.

### PipeWire video input

The Vulkan DMA-BUF input had never worked. Three faults in a row: the modifier reaching the importer was garbage (the libremidi fix), the sampler texture's format was left at its placeholder so red and blue came back swapped, and teardown segfaulted in the driver because the sampler textures still held image views on the images being freed. It also queued DMA-BUF frames without a bound, holding the producer's whole pool.

### Graphics output

Y inversion on Vulkan across every readback video output, Syphon orientation measured by acting as a Syphon client, full-screen outputs landing on their own screen rather than next to it, window outputs off the desktop origin, a soft-edge blend lighting the pixel past its own edge, and a preview no longer rebuilding every render list when it opens.

Two races found by an adversarial pass over the branch: a negotiated dma-buf modifier crossing a thread boundary unguarded, and two timer connections that could delete the timer they were running in.

### Elsewhere

Slider double-click restoring the default, one undo entry per edit of a state's messages, Del removing a state message, an automation starting after zero keeping its first segment, a colour control declaring its unit, cancelling a device Learn no longer taking the device down, a chained nodal node staying next to what it chains to, a soundfile control drawing an already-decoded file and opening the path it resolves rather than the one stored, and deleting a QML texture source no longer aborting the application.

### Tests

New cases for the PipeWire round trip in both directions, including one that consumes on the GPU through a real render graph rather than converting on the CPU; a standalone Vulkan probe for dma-buf export cost that builds with one `g++` line; Syphon orientation; the Point2D view's axis mapping; and Minibang's pitch envelope. Four spawning tests were reading a log they never received, five display tests were labelled `gui` but never given one, and the shader sweeps could not find the library.

### Known red

`test_gfx_review_indirect_standalone` and `test_gfx_review_draw_dispatch_edges` fail, both pre-existing indirect-draw items unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QWYTEhFJonuUNTEmBfv7Q